### PR TITLE
Create PunctureField class

### DIFF
--- a/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
@@ -278,6 +278,7 @@ struct EvolutionMetavars {
       CurvedScalarWave::Tags::BackgroundSpacetime<BackgroundSpacetime>,
       evolution::initial_data::Tags::InitialData,
       CurvedScalarWave::Worldtube::Tags::ExcisionSphere<volume_dim>,
+      CurvedScalarWave::Worldtube::Tags::PunctureFieldConfig,
       CurvedScalarWave::Worldtube::Tags::ExpansionOrder,
       CurvedScalarWave::Worldtube::Tags::WorldtubeRadiusParameters,
       CurvedScalarWave::Worldtube::Tags::BlackHoleRadiusParameters,
@@ -317,7 +318,8 @@ struct EvolutionMetavars {
           CurvedScalarWave::Worldtube::Tags::FaceCoordinatesCompute<
               volume_dim, Frame::Inertial, true>,
           CurvedScalarWave::Worldtube::Tags::GeodesicAccelerationCompute<3>,
-          CurvedScalarWave::Worldtube::Tags::PunctureFieldCompute<volume_dim>,
+          CurvedScalarWave::Worldtube::Tags::GeodesicPunctureFieldCompute<
+              volume_dim>,
           CurvedScalarWave::Worldtube::Tags::FaceQuantitiesCompute,
           ::domain::Tags::GridToInertialInverseJacobian<volume_dim>>>,
       ::evolution::dg::Initialization::Mortars<volume_dim>,

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
@@ -279,6 +279,7 @@ struct EvolutionMetavars {
       CurvedScalarWave::Tags::BackgroundSpacetime<BackgroundSpacetime>,
       evolution::initial_data::Tags::InitialData,
       CurvedScalarWave::Worldtube::Tags::ExcisionSphere<volume_dim>,
+      CurvedScalarWave::Worldtube::Tags::PunctureFieldConfig,
       CurvedScalarWave::Worldtube::Tags::ExpansionOrder,
       CurvedScalarWave::Worldtube::Tags::WorldtubeRadiusParameters,
       CurvedScalarWave::Worldtube::Tags::BlackHoleRadiusParameters,
@@ -318,7 +319,8 @@ struct EvolutionMetavars {
           CurvedScalarWave::Worldtube::Tags::FaceCoordinatesCompute<
               volume_dim, Frame::Inertial, true>,
           CurvedScalarWave::Worldtube::Tags::GeodesicAccelerationCompute<3>,
-          CurvedScalarWave::Worldtube::Tags::PunctureFieldCompute<volume_dim>,
+          CurvedScalarWave::Worldtube::Tags::GeodesicPunctureFieldCompute<
+              volume_dim>,
           CurvedScalarWave::Worldtube::Tags::FaceQuantitiesCompute,
           ::domain::Tags::GridToInertialInverseJacobian<volume_dim>>>,
       ::evolution::dg::Initialization::Mortars<volume_dim, system>,

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/IteratePunctureField.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/IteratePunctureField.hpp
@@ -55,7 +55,7 @@ struct IteratePunctureField {
         [&self_force_data = get(inbox.at(time_step_id)),
          &position_velocity = db::get<Tags::ParticlePositionVelocity<Dim>>(box),
          &centered_face_coordinates, charge = db::get<Tags::Charge>(box),
-         order = db::get<Tags::ExpansionOrder>(box)](
+         &puncture_field = db::get<Tags::PunctureFieldConfig>(box)](
             const auto iterated_puncture_field) {
           tnsr::I<double, Dim> iterated_acceleration{
               {self_force_data[0], self_force_data[1], self_force_data[2]}};
@@ -66,23 +66,23 @@ struct IteratePunctureField {
             iterated_puncture_field->emplace(face_size);
           }
 
-          puncture_field(make_not_null(&iterated_puncture_field->value()),
-                         centered_face_coordinates.value(),
-                         position_velocity[0], position_velocity[1],
-                         iterated_acceleration, 1., order);
+          puncture_field.apply_puncture(
+              make_not_null(&iterated_puncture_field->value()),
+              centered_face_coordinates.value(), position_velocity[0],
+              position_velocity[1], iterated_acceleration);
           Variables<tmpl::list<CurvedScalarWave::Tags::Psi,
                                ::Tags::dt<CurvedScalarWave::Tags::Psi>,
                                ::Tags::deriv<CurvedScalarWave::Tags::Psi,
                                              tmpl::size_t<3>, Frame::Inertial>>>
               acceleration_terms(face_size);
-          acceleration_terms_1(
+          puncture_field.apply_acceleration_terms(
               make_not_null(&acceleration_terms),
               centered_face_coordinates.value(), position_velocity[0],
               position_velocity[1], iterated_acceleration, self_force_data[3],
               self_force_data[4], self_force_data[5], self_force_data[6],
               self_force_data[7], self_force_data[8], self_force_data[9],
               self_force_data[10], self_force_data[11], self_force_data[12],
-              self_force_data[13], self_force_data[14], 1.);
+              self_force_data[13], self_force_data[14]);
           iterated_puncture_field->value() += acceleration_terms;
           iterated_puncture_field->value() *= charge;
         },

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/ReceiveWorldtubeData.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/ReceiveWorldtubeData.hpp
@@ -80,7 +80,7 @@ struct ReceiveWorldtubeData {
       const auto& puncture_field =
           db::get<Tags::MaxIterations>(box) > 1
               ? db::get<Tags::IteratedPunctureField<Dim>>(box)
-              : db::get<Tags::PunctureField<Dim>>(box);
+              : db::get<Tags::GeodesicPunctureField<Dim>>(box);
       ASSERT(puncture_field.has_value(),
              "The puncture field should be initialized!");
 

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/SendToWorldtube.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/SendToWorldtube.hpp
@@ -62,7 +62,7 @@ namespace CurvedScalarWave::Worldtube::Actions {
  *    - `tags_to_slice_on_face`
  *    - `Worldtube::Tags::ExpansionOrder`
  *    - `Worldtube::Tags::FaceCoordinates<Dim, Frame::Inertial, true>`
- *    - `Worldtube::Tags::PunctureField`
+ *    - `Worldtube::Tags::GeodesicPunctureField`
  *    - `Worldtube::Tags::ExcisionSphere`
  *    - `Tags::TimeStepId`
  */
@@ -117,7 +117,7 @@ struct SendToWorldtube {
     const auto& puncture_field =
         db::get<Tags::CurrentIteration>(box) > 0
             ? db::get<Tags::IteratedPunctureField<Dim>>(box).value()
-            : db::get<Tags::PunctureField<Dim>>(box).value();
+            : db::get<Tags::GeodesicPunctureField<Dim>>(box).value();
     const auto& psi_puncture = get<CurvedScalarWave::Tags::Psi>(puncture_field);
     const auto& dt_psi_puncture =
         get<::Tags::dt<CurvedScalarWave::Tags::Psi>>(puncture_field);

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/PunctureField.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/PunctureField.cpp
@@ -3,6 +3,8 @@
 
 #include "Evolution/Systems/CurvedScalarWave/Worldtube/PunctureField.hpp"
 
+#include <pup.h>
+
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/DynamicBuffer.hpp"
@@ -11,12 +13,55 @@
 #include "DataStructures/Variables.hpp"
 #include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "Utilities/EqualWithinRoundoff.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/Gsl.hpp"
 
 namespace CurvedScalarWave::Worldtube {
 
-void puncture_field(
-    gsl::not_null<Variables<tmpl::list<
+PunctureField::Schwarzschild::Schwarzschild(const size_t expansion_order_in,
+                                            const double black_hole_mass_in,
+                                            const Options::Context& /*context*/)
+    : expansion_order(expansion_order_in),
+      black_hole_mass(black_hole_mass_in) {}
+
+PunctureField::Kerr::Kerr(const size_t expansion_order_in,
+                          const double black_hole_mass_in,
+                          const double spin_along_z_axis_in,
+                          const Options::Context& /*context*/)
+    : expansion_order(expansion_order_in),
+      black_hole_mass(black_hole_mass_in),
+      spin_along_z_axis(spin_along_z_axis_in) {}
+
+PunctureField::PunctureField(const Schwarzschild& schwarzschild,
+                             const Options::Context& /*context*/)
+    : expansion_order_(schwarzschild.expansion_order),
+      black_hole_mass_(schwarzschild.black_hole_mass) {}
+
+PunctureField::PunctureField(const Kerr& kerr,
+                             const Options::Context& /*context*/)
+    : type_(Type::Kerr),
+      expansion_order_(kerr.expansion_order),
+      black_hole_mass_(kerr.black_hole_mass),
+      spin_along_z_axis_(kerr.spin_along_z_axis) {}
+
+void PunctureField::pup(PUP::er& p) {
+  p | type_;
+  p | expansion_order_;
+  p | black_hole_mass_;
+  p | spin_along_z_axis_;
+}
+
+PunctureField::Type PunctureField::type() const { return type_; }
+
+size_t PunctureField::expansion_order() const { return expansion_order_; }
+
+double PunctureField::black_hole_mass() const { return black_hole_mass_; }
+
+double PunctureField::spin_along_z_axis() const { return spin_along_z_axis_; }
+
+void PunctureField::apply_puncture(
+    const gsl::not_null<Variables<tmpl::list<
         CurvedScalarWave::Tags::Psi, ::Tags::dt<CurvedScalarWave::Tags::Psi>,
         ::Tags::deriv<CurvedScalarWave::Tags::Psi, tmpl::size_t<3>,
                       Frame::Inertial>>>*>
@@ -24,19 +69,58 @@ void puncture_field(
     const tnsr::I<DataVector, 3, Frame::Inertial>& centered_coords,
     const tnsr::I<double, 3>& particle_position,
     const tnsr::I<double, 3>& particle_velocity,
-    const tnsr::I<double, 3>& particle_acceleration, const double bh_mass,
-    const size_t order) {
-  if (order == 0) {
+    const tnsr::I<double, 3>& particle_acceleration) const {
+  if (type_ == Type::Kerr) {
+    ERROR("Kerr puncture not implemented yet");
+  }
+  if (expansion_order_ == 0) {
     puncture_field_0(result, centered_coords, particle_position,
-                     particle_velocity, particle_acceleration, bh_mass);
-  } else if (order == 1) {
+                     particle_velocity, particle_acceleration,
+                     black_hole_mass_);
+  } else if (expansion_order_ == 1) {
     puncture_field_1(result, centered_coords, particle_position,
-                     particle_velocity, particle_acceleration, bh_mass);
+                     particle_velocity, particle_acceleration,
+                     black_hole_mass_);
   } else {
     ERROR(
         "The puncture field is only implemented up to expansion order 1 but "
         "you requested order "
-        << order);
+        << expansion_order_);
   }
 }
+
+void PunctureField::apply_acceleration_terms(
+    const gsl::not_null<Variables<tmpl::list<
+        CurvedScalarWave::Tags::Psi, ::Tags::dt<CurvedScalarWave::Tags::Psi>,
+        ::Tags::deriv<CurvedScalarWave::Tags::Psi, tmpl::size_t<3>,
+                      Frame::Inertial>>>*>
+        result,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& centered_coords,
+    const tnsr::I<double, 3>& particle_position,
+    const tnsr::I<double, 3>& particle_velocity,
+    const tnsr::I<double, 3>& particle_acceleration, const double ft,
+    const double fx, const double fy, const double dt_ft, const double dt_fx,
+    const double dt_fy, const double Du_ft, const double Du_fx,
+    const double Du_fy, const double dt_Du_ft, const double dt_Du_fx,
+    const double dt_Du_fy) const {
+  if (type_ == Type::Kerr) {
+    ERROR("Kerr puncture not implemented yet");
+  }
+  if (expansion_order_ == 0) {
+    acceleration_terms_0(result, centered_coords, particle_position,
+                         particle_velocity, particle_acceleration, ft, fx, fy,
+                         dt_ft, dt_fx, dt_fy, black_hole_mass_);
+  } else if (expansion_order_ == 1) {
+    acceleration_terms_1(result, centered_coords, particle_position,
+                         particle_velocity, particle_acceleration, ft, fx, fy,
+                         dt_ft, dt_fx, dt_fy, Du_ft, Du_fx, Du_fy, dt_Du_ft,
+                         dt_Du_fx, dt_Du_fy, black_hole_mass_);
+  } else {
+    ERROR(
+        "The puncture field is only implemented up to expansion order 1 but "
+        "you requested order "
+        << expansion_order_);
+  }
+}
+
 }  // namespace CurvedScalarWave::Worldtube

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/PunctureField.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/PunctureField.cpp
@@ -3,6 +3,8 @@
 
 #include "Evolution/Systems/CurvedScalarWave/Worldtube/PunctureField.hpp"
 
+#include <pup.h>
+
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/DynamicBuffer.hpp"
@@ -11,12 +13,62 @@
 #include "DataStructures/Variables.hpp"
 #include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "Utilities/EqualWithinRoundoff.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/Gsl.hpp"
 
 namespace CurvedScalarWave::Worldtube {
 
-void puncture_field(
-    gsl::not_null<Variables<tmpl::list<
+PunctureField::Schwarzschild::Schwarzschild(const size_t expansion_order_in,
+                                            const double black_hole_mass_in,
+                                            const Options::Context& /*context*/)
+    : expansion_order(expansion_order_in),
+      black_hole_mass(black_hole_mass_in) {}
+
+PunctureField::Kerr::Kerr(const size_t expansion_order_in,
+                          const double black_hole_mass_in,
+                          const double spin_along_z_axis_in,
+                          const Options::Context& /*context*/)
+    : expansion_order(expansion_order_in),
+      black_hole_mass(black_hole_mass_in),
+      spin_along_z_axis(spin_along_z_axis_in) {}
+
+PunctureField::PunctureField(const Schwarzschild& schwarzschild,
+                             const Options::Context& /*context*/)
+    : expansion_order_(schwarzschild.expansion_order),
+      black_hole_mass_(schwarzschild.black_hole_mass) {
+  if (not equal_within_roundoff(spin_along_z_axis_, 0.0)) {
+    ERROR(
+        "Schwarzschild puncture requires SpinAlongZAxis = 0 but got "
+        "SpinAlongZAxis = "
+        << spin_along_z_axis_);
+  }
+}
+
+PunctureField::PunctureField(const Kerr& kerr,
+                             const Options::Context& /*context*/)
+    : type_(Type::Kerr),
+      expansion_order_(kerr.expansion_order),
+      black_hole_mass_(kerr.black_hole_mass),
+      spin_along_z_axis_(kerr.spin_along_z_axis) {}
+
+void PunctureField::pup(PUP::er& p) {
+  p | type_;
+  p | expansion_order_;
+  p | black_hole_mass_;
+  p | spin_along_z_axis_;
+}
+
+PunctureField::Type PunctureField::type() const { return type_; }
+
+size_t PunctureField::expansion_order() const { return expansion_order_; }
+
+double PunctureField::black_hole_mass() const { return black_hole_mass_; }
+
+double PunctureField::spin_along_z_axis() const { return spin_along_z_axis_; }
+
+void PunctureField::apply_puncture(
+    const gsl::not_null<Variables<tmpl::list<
         CurvedScalarWave::Tags::Psi, ::Tags::dt<CurvedScalarWave::Tags::Psi>,
         ::Tags::deriv<CurvedScalarWave::Tags::Psi, tmpl::size_t<3>,
                       Frame::Inertial>>>*>
@@ -24,19 +76,58 @@ void puncture_field(
     const tnsr::I<DataVector, 3, Frame::Inertial>& centered_coords,
     const tnsr::I<double, 3>& particle_position,
     const tnsr::I<double, 3>& particle_velocity,
-    const tnsr::I<double, 3>& particle_acceleration, const double bh_mass,
-    const size_t order) {
-  if (order == 0) {
+    const tnsr::I<double, 3>& particle_acceleration) const {
+  if (type_ == Type::Kerr) {
+    ERROR("Kerr puncture not implemented yet");
+  }
+  if (expansion_order_ == 0) {
     puncture_field_0(result, centered_coords, particle_position,
-                     particle_velocity, particle_acceleration, bh_mass);
-  } else if (order == 1) {
+                     particle_velocity, particle_acceleration,
+                     black_hole_mass_);
+  } else if (expansion_order_ == 1) {
     puncture_field_1(result, centered_coords, particle_position,
-                     particle_velocity, particle_acceleration, bh_mass);
+                     particle_velocity, particle_acceleration,
+                     black_hole_mass_);
   } else {
     ERROR(
         "The puncture field is only implemented up to expansion order 1 but "
         "you requested order "
-        << order);
+        << expansion_order_);
   }
 }
+
+void PunctureField::apply_acceleration_terms(
+    const gsl::not_null<Variables<tmpl::list<
+        CurvedScalarWave::Tags::Psi, ::Tags::dt<CurvedScalarWave::Tags::Psi>,
+        ::Tags::deriv<CurvedScalarWave::Tags::Psi, tmpl::size_t<3>,
+                      Frame::Inertial>>>*>
+        result,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& centered_coords,
+    const tnsr::I<double, 3>& particle_position,
+    const tnsr::I<double, 3>& particle_velocity,
+    const tnsr::I<double, 3>& particle_acceleration, const double ft,
+    const double fx, const double fy, const double dt_ft, const double dt_fx,
+    const double dt_fy, const double Du_ft, const double Du_fx,
+    const double Du_fy, const double dt_Du_ft, const double dt_Du_fx,
+    const double dt_Du_fy) const {
+  if (type_ == Type::Kerr) {
+    ERROR("Kerr puncture not implemented yet");
+  }
+  if (expansion_order_ == 0) {
+    acceleration_terms_0(result, centered_coords, particle_position,
+                         particle_velocity, particle_acceleration, ft, fx, fy,
+                         dt_ft, dt_fx, dt_fy, black_hole_mass_);
+  } else if (expansion_order_ == 1) {
+    acceleration_terms_1(result, centered_coords, particle_position,
+                         particle_velocity, particle_acceleration, ft, fx, fy,
+                         dt_ft, dt_fx, dt_fy, Du_ft, Du_fx, Du_fy, dt_Du_ft,
+                         dt_Du_fx, dt_Du_fy, black_hole_mass_);
+  } else {
+    ERROR(
+        "The puncture field is only implemented up to expansion order 1 but "
+        "you requested order "
+        << expansion_order_);
+  }
+}
+
 }  // namespace CurvedScalarWave::Worldtube

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/PunctureField.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/PunctureField.cpp
@@ -36,14 +36,7 @@ PunctureField::Kerr::Kerr(const size_t expansion_order_in,
 PunctureField::PunctureField(const Schwarzschild& schwarzschild,
                              const Options::Context& /*context*/)
     : expansion_order_(schwarzschild.expansion_order),
-      black_hole_mass_(schwarzschild.black_hole_mass) {
-  if (not equal_within_roundoff(spin_along_z_axis_, 0.0)) {
-    ERROR(
-        "Schwarzschild puncture requires SpinAlongZAxis = 0 but got "
-        "SpinAlongZAxis = "
-        << spin_along_z_axis_);
-  }
-}
+      black_hole_mass_(schwarzschild.black_hole_mass) {}
 
 PunctureField::PunctureField(const Kerr& kerr,
                              const Options::Context& /*context*/)

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/PunctureField.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/PunctureField.hpp
@@ -11,9 +11,179 @@
 #include "DataStructures/Variables.hpp"
 #include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "Options/Context.hpp"
+#include "Options/Options.hpp"
+#include "Options/String.hpp"
 #include "Utilities/Gsl.hpp"
 
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
 namespace CurvedScalarWave::Worldtube {
+/*!
+ * \brief Dispatcher to compute the puncture/singular field for a scalar charge
+ * on a generic orbit in Schwarzschild or Kerr spacetime. The Kerr puncture
+ * reduces to Schwarzsschild for zero spin but is faster to evaluate.
+ */
+class PunctureField {
+ public:
+  enum class Type { Schwarzschild, Kerr };
+
+  /*!
+   * \brief Use the Schwarzschild puncture field model.
+   */
+  struct Schwarzschild {
+    using type = Schwarzschild;
+    static constexpr Options::String help = {
+        "Use the Schwarzschild puncture field model."};
+
+    /*!
+     * \brief Puncture field expansion order. Currently orders 0 and 1 are
+     * implemented.
+     */
+    struct ExpansionOrder {
+      using type = size_t;
+      static constexpr Options::String help{
+          "Puncture field expansion order. Currently orders 0 and 1 are "
+          "implemented."};
+      static size_t upper_bound() { return 1; }
+    };
+
+    /*!
+     * \brief The mass of the central black hole.
+     */
+    struct BlackHoleMass {
+      using type = double;
+      static constexpr Options::String help{
+          "The mass of the central black hole."};
+      static double lower_bound() { return 0.; }
+    };
+
+    using options = tmpl::list<ExpansionOrder, BlackHoleMass>;
+
+    Schwarzschild() = default;
+    Schwarzschild(size_t expansion_order_in, double black_hole_mass_in,
+                  const Options::Context& context = {});
+
+    size_t expansion_order{};
+    double black_hole_mass{};
+  };
+
+  /*!
+   * \brief Use the Kerr puncture field model. This option is currently parsed
+   * but not yet implemented at runtime.
+   */
+  struct Kerr {
+    using type = Kerr;
+    static constexpr Options::String help = {
+        "Use the Kerr puncture field model. This option is currently parsed "
+        "but not yet implemented at runtime."};
+
+    /*!
+     * \brief Puncture field expansion order. Currently orders 0 and 1 are
+     * implemented.
+     */
+    struct ExpansionOrder {
+      using type = size_t;
+      static constexpr Options::String help{
+          "Puncture field expansion order. Currently orders 0 and 1 are "
+          "implemented."};
+      static size_t upper_bound() { return 1; }
+    };
+
+    /*!
+     * \brief The mass of the central black hole.
+     */
+    struct BlackHoleMass {
+      using type = double;
+      static constexpr Options::String help{
+          "The mass of the central black hole."};
+      static double lower_bound() { return 0.; }
+    };
+
+    /*!
+     * \brief The dimensionless z-component of the black-hole spin.
+     */
+    struct SpinAlongZAxis {
+      using type = double;
+      static constexpr Options::String help{
+          "The dimensionless z-component of the black-hole spin."};
+    };
+
+    using options = tmpl::list<ExpansionOrder, BlackHoleMass, SpinAlongZAxis>;
+
+    Kerr() = default;
+    Kerr(size_t expansion_order_in, double black_hole_mass_in,
+         double spin_along_z_axis_in, const Options::Context& context = {});
+
+    size_t expansion_order{};
+    double black_hole_mass{};
+    double spin_along_z_axis{};
+  };
+
+  using options = tmpl::list<
+      Options::Alternatives<tmpl::list<Schwarzschild>, tmpl::list<Kerr>>>;
+
+  static constexpr Options::String help = {
+      "Configuration and dispatcher for puncture-field expressions. Choose "
+      "either Schwarzschild or Kerr."};
+
+  PunctureField() = default;
+  explicit PunctureField(const Schwarzschild& schwarzschild,
+                         const Options::Context& context = {});
+  explicit PunctureField(const Kerr& kerr,
+                         const Options::Context& context = {});
+
+  void pup(PUP::er& p);
+
+  Type type() const;
+  size_t expansion_order() const;
+  double black_hole_mass() const;
+  double spin_along_z_axis() const;
+
+  /*!
+   * \brief Compute and write the puncture field and its derivatives for the
+   * configured puncture model and expansion order.
+   */
+  void apply_puncture(
+      gsl::not_null<Variables<tmpl::list<
+          CurvedScalarWave::Tags::Psi, ::Tags::dt<CurvedScalarWave::Tags::Psi>,
+          ::Tags::deriv<CurvedScalarWave::Tags::Psi, tmpl::size_t<3>,
+                        Frame::Inertial>>>*>
+          result,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& centered_coords,
+      const tnsr::I<double, 3>& particle_position,
+      const tnsr::I<double, 3>& particle_velocity,
+      const tnsr::I<double, 3>& particle_acceleration) const;
+
+  /*!
+   * \brief Compute and write the corrections to the
+   * puncture field for the configured puncture model and expansion order. These
+   * terms arise at non-geodesic accelerations such as the self-force.
+   */
+  void apply_acceleration_terms(
+      gsl::not_null<Variables<tmpl::list<
+          CurvedScalarWave::Tags::Psi, ::Tags::dt<CurvedScalarWave::Tags::Psi>,
+          ::Tags::deriv<CurvedScalarWave::Tags::Psi, tmpl::size_t<3>,
+                        Frame::Inertial>>>*>
+          result,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& centered_coords,
+      const tnsr::I<double, 3>& particle_position,
+      const tnsr::I<double, 3>& particle_velocity,
+      const tnsr::I<double, 3>& particle_acceleration, double ft, double fx,
+      double fy, double dt_ft, double dt_fx, double dt_fy, double Du_ft,
+      double Du_fx, double Du_fy, double dt_Du_ft, double dt_Du_fx,
+      double dt_Du_fy) const;
+
+ private:
+  Type type_{Type::Schwarzschild};
+  size_t expansion_order_{0};
+  double black_hole_mass_{1.};
+  double spin_along_z_axis_{0.};
+};
 /*!
  * \brief Computes the puncture/singular field \f$\Psi^\mathcal{P}\f$ of a
  * scalar charge on a generic orbit in Schwarzschild spacetime.
@@ -40,28 +210,6 @@ namespace CurvedScalarWave::Worldtube {
  * \note The expressions were computed with Mathematica and optimized by
  * applying common subexpression elimination with sympy. The memory allocations
  * of temporaries were optimized manually.
- */
-void puncture_field(
-    gsl::not_null<Variables<tmpl::list<
-        CurvedScalarWave::Tags::Psi, ::Tags::dt<CurvedScalarWave::Tags::Psi>,
-        ::Tags::deriv<CurvedScalarWave::Tags::Psi, tmpl::size_t<3>,
-                      Frame::Inertial>>>*>
-        result,
-
-    const tnsr::I<DataVector, 3, Frame::Inertial>& centered_coords,
-    const tnsr::I<double, 3>& particle_position,
-    const tnsr::I<double, 3>& particle_velocity,
-    const tnsr::I<double, 3>& particle_acceleration, double bh_mass,
-    size_t order);
-
-/*!
- * \brief Computes the puncture/singular field \f$\Psi^\mathcal{P}\f$ of a
- * scalar charge on a generic orbit in Schwarzschild spacetime.
- * described in \cite Detweiler2003.
- *
- * \details The appropriate expression can be found in Eq. (36) of
- * \cite Wittek:2024gxn. For non-geodesic orbits, there are
- * additional contributions, see `acceleration_terms_0`.
  */
 void puncture_field_0(
     gsl::not_null<Variables<tmpl::list<

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/PunctureField.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/PunctureField.hpp
@@ -23,23 +23,38 @@ class er;
 /// \endcond
 
 namespace CurvedScalarWave::Worldtube {
+/*!
+ * \brief Dispatcher to compute the puncture/singular field for a scalar charge
+ * on a generic orbit in Schwarzschild or Kerr spacetime. The Kerr puncture
+ * reduces to Schwarzsschild for zero spin but is faster to evaluate.
+ */
 class PunctureField {
  public:
   enum class Type { Schwarzschild, Kerr };
 
+  /*!
+   * \brief Use the Schwarzschild puncture field model.
+   */
   struct Schwarzschild {
     using type = Schwarzschild;
     static constexpr Options::String help = {
         "Use the Schwarzschild puncture field model."};
 
+    /*!
+     * \brief Puncture field expansion order. Currently orders 0 and 1 are
+     * implemented.
+     */
     struct ExpansionOrder {
       using type = size_t;
       static constexpr Options::String help{
-          "Puncture-field expansion order. Currently orders 0 and 1 are "
+          "Puncture field expansion order. Currently orders 0 and 1 are "
           "implemented."};
       static size_t upper_bound() { return 1; }
     };
 
+    /*!
+     * \brief The mass of the central black hole.
+     */
     struct BlackHoleMass {
       using type = double;
       static constexpr Options::String help{
@@ -57,20 +72,31 @@ class PunctureField {
     double black_hole_mass{};
   };
 
+  /*!
+   * \brief Use the Kerr puncture field model. This option is currently parsed
+   * but not yet implemented at runtime.
+   */
   struct Kerr {
     using type = Kerr;
     static constexpr Options::String help = {
         "Use the Kerr puncture field model. This option is currently parsed "
         "but not yet implemented at runtime."};
 
+    /*!
+     * \brief Puncture field expansion order. Currently orders 0 and 1 are
+     * implemented.
+     */
     struct ExpansionOrder {
       using type = size_t;
       static constexpr Options::String help{
-          "Puncture-field expansion order. Currently orders 0 and 1 are "
+          "Puncture field expansion order. Currently orders 0 and 1 are "
           "implemented."};
       static size_t upper_bound() { return 1; }
     };
 
+    /*!
+     * \brief The mass of the central black hole.
+     */
     struct BlackHoleMass {
       using type = double;
       static constexpr Options::String help{
@@ -78,6 +104,9 @@ class PunctureField {
       static double lower_bound() { return 0.; }
     };
 
+    /*!
+     * \brief The dimensionless z-component of the black-hole spin.
+     */
     struct SpinAlongZAxis {
       using type = double;
       static constexpr Options::String help{
@@ -115,6 +144,10 @@ class PunctureField {
   double black_hole_mass() const;
   double spin_along_z_axis() const;
 
+  /*!
+   * \brief Compute and write the puncture field and its derivatives for the
+   * configured puncture model and expansion order.
+   */
   void apply_puncture(
       gsl::not_null<Variables<tmpl::list<
           CurvedScalarWave::Tags::Psi, ::Tags::dt<CurvedScalarWave::Tags::Psi>,
@@ -126,6 +159,11 @@ class PunctureField {
       const tnsr::I<double, 3>& particle_velocity,
       const tnsr::I<double, 3>& particle_acceleration) const;
 
+  /*!
+   * \brief Compute and write the corrections to the
+   * puncture field for the configured puncture model and expansion order. These
+   * terms arise at non-geodesic accelerations such as the self-force.
+   */
   void apply_acceleration_terms(
       gsl::not_null<Variables<tmpl::list<
           CurvedScalarWave::Tags::Psi, ::Tags::dt<CurvedScalarWave::Tags::Psi>,

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/PunctureField.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/PunctureField.hpp
@@ -11,9 +11,141 @@
 #include "DataStructures/Variables.hpp"
 #include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "Options/Context.hpp"
+#include "Options/Options.hpp"
+#include "Options/String.hpp"
 #include "Utilities/Gsl.hpp"
 
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
 namespace CurvedScalarWave::Worldtube {
+class PunctureField {
+ public:
+  enum class Type { Schwarzschild, Kerr };
+
+  struct Schwarzschild {
+    using type = Schwarzschild;
+    static constexpr Options::String help = {
+        "Use the Schwarzschild puncture field model."};
+
+    struct ExpansionOrder {
+      using type = size_t;
+      static constexpr Options::String help{
+          "Puncture-field expansion order. Currently orders 0 and 1 are "
+          "implemented."};
+      static size_t upper_bound() { return 1; }
+    };
+
+    struct BlackHoleMass {
+      using type = double;
+      static constexpr Options::String help{
+          "The mass of the central black hole."};
+      static double lower_bound() { return 0.; }
+    };
+
+    using options = tmpl::list<ExpansionOrder, BlackHoleMass>;
+
+    Schwarzschild() = default;
+    Schwarzschild(size_t expansion_order_in, double black_hole_mass_in,
+                  const Options::Context& context = {});
+
+    size_t expansion_order{};
+    double black_hole_mass{};
+  };
+
+  struct Kerr {
+    using type = Kerr;
+    static constexpr Options::String help = {
+        "Use the Kerr puncture field model. This option is currently parsed "
+        "but not yet implemented at runtime."};
+
+    struct ExpansionOrder {
+      using type = size_t;
+      static constexpr Options::String help{
+          "Puncture-field expansion order. Currently orders 0 and 1 are "
+          "implemented."};
+      static size_t upper_bound() { return 1; }
+    };
+
+    struct BlackHoleMass {
+      using type = double;
+      static constexpr Options::String help{
+          "The mass of the central black hole."};
+      static double lower_bound() { return 0.; }
+    };
+
+    struct SpinAlongZAxis {
+      using type = double;
+      static constexpr Options::String help{
+          "The dimensionless z-component of the black-hole spin."};
+    };
+
+    using options = tmpl::list<ExpansionOrder, BlackHoleMass, SpinAlongZAxis>;
+
+    Kerr() = default;
+    Kerr(size_t expansion_order_in, double black_hole_mass_in,
+         double spin_along_z_axis_in, const Options::Context& context = {});
+
+    size_t expansion_order{};
+    double black_hole_mass{};
+    double spin_along_z_axis{};
+  };
+
+  using options = tmpl::list<
+      Options::Alternatives<tmpl::list<Schwarzschild>, tmpl::list<Kerr>>>;
+
+  static constexpr Options::String help = {
+      "Configuration and dispatcher for puncture-field expressions. Choose "
+      "either Schwarzschild or Kerr."};
+
+  PunctureField() = default;
+  explicit PunctureField(const Schwarzschild& schwarzschild,
+                         const Options::Context& context = {});
+  explicit PunctureField(const Kerr& kerr,
+                         const Options::Context& context = {});
+
+  void pup(PUP::er& p);
+
+  Type type() const;
+  size_t expansion_order() const;
+  double black_hole_mass() const;
+  double spin_along_z_axis() const;
+
+  void apply_puncture(
+      gsl::not_null<Variables<tmpl::list<
+          CurvedScalarWave::Tags::Psi, ::Tags::dt<CurvedScalarWave::Tags::Psi>,
+          ::Tags::deriv<CurvedScalarWave::Tags::Psi, tmpl::size_t<3>,
+                        Frame::Inertial>>>*>
+          result,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& centered_coords,
+      const tnsr::I<double, 3>& particle_position,
+      const tnsr::I<double, 3>& particle_velocity,
+      const tnsr::I<double, 3>& particle_acceleration) const;
+
+  void apply_acceleration_terms(
+      gsl::not_null<Variables<tmpl::list<
+          CurvedScalarWave::Tags::Psi, ::Tags::dt<CurvedScalarWave::Tags::Psi>,
+          ::Tags::deriv<CurvedScalarWave::Tags::Psi, tmpl::size_t<3>,
+                        Frame::Inertial>>>*>
+          result,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& centered_coords,
+      const tnsr::I<double, 3>& particle_position,
+      const tnsr::I<double, 3>& particle_velocity,
+      const tnsr::I<double, 3>& particle_acceleration, double ft, double fx,
+      double fy, double dt_ft, double dt_fx, double dt_fy, double Du_ft,
+      double Du_fx, double Du_fy, double dt_Du_ft, double dt_Du_fx,
+      double dt_Du_fy) const;
+
+ private:
+  Type type_{Type::Schwarzschild};
+  size_t expansion_order_{0};
+  double black_hole_mass_{1.};
+  double spin_along_z_axis_{0.};
+};
 /*!
  * \brief Computes the puncture/singular field \f$\Psi^\mathcal{P}\f$ of a
  * scalar charge on a generic orbit in Schwarzschild spacetime.
@@ -40,28 +172,6 @@ namespace CurvedScalarWave::Worldtube {
  * \note The expressions were computed with Mathematica and optimized by
  * applying common subexpression elimination with sympy. The memory allocations
  * of temporaries were optimized manually.
- */
-void puncture_field(
-    gsl::not_null<Variables<tmpl::list<
-        CurvedScalarWave::Tags::Psi, ::Tags::dt<CurvedScalarWave::Tags::Psi>,
-        ::Tags::deriv<CurvedScalarWave::Tags::Psi, tmpl::size_t<3>,
-                      Frame::Inertial>>>*>
-        result,
-
-    const tnsr::I<DataVector, 3, Frame::Inertial>& centered_coords,
-    const tnsr::I<double, 3>& particle_position,
-    const tnsr::I<double, 3>& particle_velocity,
-    const tnsr::I<double, 3>& particle_acceleration, double bh_mass,
-    size_t order);
-
-/*!
- * \brief Computes the puncture/singular field \f$\Psi^\mathcal{P}\f$ of a
- * scalar charge on a generic orbit in Schwarzschild spacetime.
- * described in \cite Detweiler2003.
- *
- * \details The appropriate expression can be found in Eq. (36) of
- * \cite Wittek:2024gxn. For non-geodesic orbits, there are
- * additional contributions, see `acceleration_terms_0`.
  */
 void puncture_field_0(
     gsl::not_null<Variables<tmpl::list<

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.cpp
@@ -153,22 +153,22 @@ void FaceCoordinatesCompute<Dim, Frame, Centered>::function(
 #endif  // defined(__GNUC__) && !defined(__clang__)
 
 template <size_t Dim>
-void PunctureFieldCompute<Dim>::function(
+void GeodesicPunctureFieldCompute<Dim>::function(
     const gsl::not_null<return_type*> result,
     const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
         inertial_face_coords_centered,
     const std::array<tnsr::I<double, Dim, ::Frame::Inertial>, 2>&
         particle_position_velocity,
     const tnsr::I<double, Dim>& particle_acceleration, const double charge,
-    const size_t expansion_order) {
+    const CurvedScalarWave::Worldtube::PunctureField& puncture_field) {
   if (inertial_face_coords_centered.has_value()) {
     if (not result->has_value()) {
       result->emplace(get<0>(inertial_face_coords_centered.value()).size());
     }
-    puncture_field(make_not_null(&(result->value())),
-                   inertial_face_coords_centered.value(),
-                   particle_position_velocity[0], particle_position_velocity[1],
-                   particle_acceleration, 1., expansion_order);
+    puncture_field.apply_puncture(
+        make_not_null(&(result->value())),
+        inertial_face_coords_centered.value(), particle_position_velocity[0],
+        particle_position_velocity[1], particle_acceleration);
     result->value() *= charge;
   } else {
     result->reset();
@@ -348,7 +348,7 @@ template struct BackgroundQuantitiesCompute<3>;
 template struct EvolvedParticlePositionVelocityCompute<3>;
 template struct GeodesicAccelerationCompute<3>;
 template struct ParticlePositionVelocityCompute<3>;
-template struct PunctureFieldCompute<3>;
+template struct GeodesicPunctureFieldCompute<3>;
 
 template struct FaceCoordinatesCompute<3, Frame::Grid, true>;
 template struct FaceCoordinatesCompute<3, Frame::Grid, false>;

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp
@@ -25,6 +25,7 @@
 #include "Domain/Tags.hpp"
 #include "Evolution/Systems/CurvedScalarWave/BackgroundSpacetime.hpp"
 #include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Worldtube/PunctureField.hpp"
 #include "IO/Logging/Verbosity.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "Options/Auto.hpp"
@@ -229,15 +230,10 @@ struct ObserveCoefficientsTrigger {
   using group = Worldtube;
 };
 
-/*!
- * \brief The internal expansion order of the worldtube solution.
- */
-struct ExpansionOrder {
-  using type = size_t;
+struct PunctureField {
+  using type = CurvedScalarWave::Worldtube::PunctureField;
   static constexpr Options::String help{
-      "The internal expansion order of the worldtube solution. Currently "
-      "orders 0 and 1 are implemented"};
-  static size_t upper_bound() { return 1; }
+      "Options controlling puncture-field evaluation."};
   using group = Worldtube;
 };
 
@@ -711,13 +707,29 @@ struct FaceQuantitiesCompute : FaceQuantities, db::ComputeTag {
 /// @}
 
 /*!
+ * \brief Configuration and dispatch object for puncture-field expressions.
+ */
+struct PunctureFieldConfig : db::SimpleTag {
+  using type = CurvedScalarWave::Worldtube::PunctureField;
+  static constexpr bool pass_metavariables = false;
+  using option_tags = tmpl::list<OptionTags::PunctureField>;
+  static type create_from_options(
+      const CurvedScalarWave::Worldtube::PunctureField& puncture_field) {
+    return puncture_field;
+  }
+};
+
+/*!
  * \brief The internal expansion order of the worldtube solution.
  */
 struct ExpansionOrder : db::SimpleTag {
   using type = size_t;
   static constexpr bool pass_metavariables = false;
-  using option_tags = tmpl::list<OptionTags::ExpansionOrder>;
-  static size_t create_from_options(const size_t order) { return order; }
+  using option_tags = tmpl::list<OptionTags::PunctureField>;
+  static size_t create_from_options(
+      const CurvedScalarWave::Worldtube::PunctureField& puncture_field) {
+    return puncture_field.expansion_order();
+  }
 };
 
 /// @{
@@ -727,7 +739,7 @@ struct ExpansionOrder : db::SimpleTag {
  * worldtube this holds a std::nullopt.
  */
 template <size_t Dim>
-struct PunctureField : db::SimpleTag {
+struct GeodesicPunctureField : db::SimpleTag {
   using type = std::optional<Variables<tmpl::list<
       CurvedScalarWave::Tags::Psi, ::Tags::dt<CurvedScalarWave::Tags::Psi>,
       ::Tags::deriv<CurvedScalarWave::Tags::Psi, tmpl::size_t<3>,
@@ -735,12 +747,13 @@ struct PunctureField : db::SimpleTag {
 };
 
 template <size_t Dim>
-struct PunctureFieldCompute : PunctureField<Dim>, db::ComputeTag {
-  using base = PunctureField<Dim>;
+struct GeodesicPunctureFieldCompute : GeodesicPunctureField<Dim>,
+                                      db::ComputeTag {
+  using base = GeodesicPunctureField<Dim>;
   using argument_tags =
       tmpl::list<FaceCoordinates<Dim, Frame::Inertial, true>,
                  ParticlePositionVelocity<Dim>, GeodesicAcceleration<Dim>,
-                 Charge, ExpansionOrder>;
+                 Charge, PunctureFieldConfig>;
   using return_type = std::optional<Variables<tmpl::list<
       CurvedScalarWave::Tags::Psi, ::Tags::dt<CurvedScalarWave::Tags::Psi>,
       ::Tags::deriv<CurvedScalarWave::Tags::Psi, tmpl::size_t<3>,
@@ -752,7 +765,7 @@ struct PunctureFieldCompute : PunctureField<Dim>, db::ComputeTag {
       const std::array<tnsr::I<double, Dim, ::Frame::Inertial>, 2>&
           particle_position_velocity,
       const tnsr::I<double, Dim>& particle_acceleration, double charge,
-      const size_t expansion_order);
+      const CurvedScalarWave::Worldtube::PunctureField& puncture_field);
 };
 /// @}
 

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/Tags.hpp
@@ -24,6 +24,7 @@
 #include "Domain/Tags.hpp"
 #include "Evolution/Systems/CurvedScalarWave/BackgroundSpacetime.hpp"
 #include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Worldtube/PunctureField.hpp"
 #include "IO/Logging/Verbosity.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "Options/Auto.hpp"
@@ -229,15 +230,10 @@ struct ObserveCoefficientsTrigger {
   using group = Worldtube;
 };
 
-/*!
- * \brief The internal expansion order of the worldtube solution.
- */
-struct ExpansionOrder {
-  using type = size_t;
+struct PunctureField {
+  using type = CurvedScalarWave::Worldtube::PunctureField;
   static constexpr Options::String help{
-      "The internal expansion order of the worldtube solution. Currently "
-      "orders 0 and 1 are implemented"};
-  static size_t upper_bound() { return 1; }
+      "Options controlling puncture-field evaluation."};
   using group = Worldtube;
 };
 
@@ -711,13 +707,29 @@ struct FaceQuantitiesCompute : FaceQuantities, db::ComputeTag {
 /// @}
 
 /*!
+ * \brief Configuration and dispatch object for puncture-field expressions.
+ */
+struct PunctureFieldConfig : db::SimpleTag {
+  using type = CurvedScalarWave::Worldtube::PunctureField;
+  static constexpr bool pass_metavariables = false;
+  using option_tags = tmpl::list<OptionTags::PunctureField>;
+  static type create_from_options(
+      const CurvedScalarWave::Worldtube::PunctureField& puncture_field) {
+    return puncture_field;
+  }
+};
+
+/*!
  * \brief The internal expansion order of the worldtube solution.
  */
 struct ExpansionOrder : db::SimpleTag {
   using type = size_t;
   static constexpr bool pass_metavariables = false;
-  using option_tags = tmpl::list<OptionTags::ExpansionOrder>;
-  static size_t create_from_options(const size_t order) { return order; }
+  using option_tags = tmpl::list<OptionTags::PunctureField>;
+  static size_t create_from_options(
+      const CurvedScalarWave::Worldtube::PunctureField& puncture_field) {
+    return puncture_field.expansion_order();
+  }
 };
 
 /// @{
@@ -727,7 +739,7 @@ struct ExpansionOrder : db::SimpleTag {
  * worldtube this holds a std::nullopt.
  */
 template <size_t Dim>
-struct PunctureField : db::SimpleTag {
+struct GeodesicPunctureField : db::SimpleTag {
   using type = std::optional<Variables<tmpl::list<
       CurvedScalarWave::Tags::Psi, ::Tags::dt<CurvedScalarWave::Tags::Psi>,
       ::Tags::deriv<CurvedScalarWave::Tags::Psi, tmpl::size_t<3>,
@@ -735,12 +747,13 @@ struct PunctureField : db::SimpleTag {
 };
 
 template <size_t Dim>
-struct PunctureFieldCompute : PunctureField<Dim>, db::ComputeTag {
-  using base = PunctureField<Dim>;
+struct GeodesicPunctureFieldCompute : GeodesicPunctureField<Dim>,
+                                      db::ComputeTag {
+  using base = GeodesicPunctureField<Dim>;
   using argument_tags =
       tmpl::list<FaceCoordinates<Dim, Frame::Inertial, true>,
                  ParticlePositionVelocity<Dim>, GeodesicAcceleration<Dim>,
-                 Charge, ExpansionOrder>;
+                 Charge, PunctureFieldConfig>;
   using return_type = std::optional<Variables<tmpl::list<
       CurvedScalarWave::Tags::Psi, ::Tags::dt<CurvedScalarWave::Tags::Psi>,
       ::Tags::deriv<CurvedScalarWave::Tags::Psi, tmpl::size_t<3>,
@@ -752,7 +765,7 @@ struct PunctureFieldCompute : PunctureField<Dim>, db::ComputeTag {
       const std::array<tnsr::I<double, Dim, ::Frame::Inertial>, 2>&
           particle_position_velocity,
       const tnsr::I<double, Dim>& particle_acceleration, double charge,
-      const size_t expansion_order);
+      const CurvedScalarWave::Worldtube::PunctureField& puncture_field);
 };
 /// @}
 

--- a/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
+++ b/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
@@ -143,7 +143,10 @@ EventsAndTriggersAtSlabs:
 
 Worldtube:
   ExcisionSphere: ExcisionSphereA
-  ExpansionOrder: 1
+  PunctureField:
+    Schwarzschild:
+      ExpansionOrder: 1
+      BlackHoleMass: 1.0
   Charge: *Charge
   SelfForceOptions: None
   WorldtubeRadiusOptions:

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/Test_Iterations.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/Test_Iterations.cpp
@@ -73,10 +73,10 @@ struct MockElementArray {
               db::AddSimpleTags<
                   domain::Tags::Element<Dim>, domain::Tags::Mesh<Dim>,
                   domain::Tags::Coordinates<Dim, Frame::Inertial>,
-                  Tags::PunctureField<Dim>, gr::Tags::Shift<DataVector, Dim>,
-                  gr::Tags::Lapse<DataVector>, ::Tags::TimeStepId,
-                  Tags::ParticlePositionVelocity<Dim>, Tags::FaceQuantities,
-                  Tags::CurrentIteration>,
+                  Tags::GeodesicPunctureField<Dim>,
+                  gr::Tags::Shift<DataVector, Dim>, gr::Tags::Lapse<DataVector>,
+                  ::Tags::TimeStepId, Tags::ParticlePositionVelocity<Dim>,
+                  Tags::FaceQuantities, Tags::CurrentIteration>,
               db::AddComputeTags<
                   Tags::FaceCoordinatesCompute<Dim, Frame::Inertial, true>>>>>,
       Parallel::PhaseActions<
@@ -124,9 +124,10 @@ struct MockMetavariables {
   using const_global_cache_tags = tmpl::list<
       domain::Tags::Domain<Dim>,
       CurvedScalarWave::Tags::BackgroundSpacetime<gr::Solutions::KerrSchild>,
-      Tags::ExcisionSphere<Dim>, Tags::WorldtubeRadius, Tags::ExpansionOrder,
-      Tags::MaxIterations, Tags::Charge, Tags::Mass, ::Tags::Time,
-      Tags::SelfForceTurnOnTime, Tags::SelfForceTurnOnInterval>;
+      Tags::ExcisionSphere<Dim>, Tags::WorldtubeRadius,
+      Tags::PunctureFieldConfig, Tags::ExpansionOrder, Tags::MaxIterations,
+      Tags::Charge, Tags::Mass, ::Tags::Time, Tags::SelfForceTurnOnTime,
+      Tags::SelfForceTurnOnInterval>;
 };
 
 void test_iterations(const size_t max_iterations) {
@@ -172,16 +173,22 @@ void test_iterations(const size_t max_iterations) {
     // before self force is turned on
     const double time = 1.;
     const double turn_on_time = 2.;
+    const auto puncture_field_options =
+        CurvedScalarWave::Worldtube::PunctureField{
+            CurvedScalarWave::Worldtube::PunctureField::Schwarzschild{
+                expansion_order, 1.}};
     tuples::TaggedTuple<
         domain::Tags::Domain<Dim>,
         CurvedScalarWave::Tags::BackgroundSpacetime<gr::Solutions::KerrSchild>,
-        Tags::ExcisionSphere<Dim>, Tags::WorldtubeRadius, Tags::ExpansionOrder,
-        Tags::MaxIterations, Tags::Charge, Tags::Mass, ::Tags::Time,
-        Tags::SelfForceTurnOnTime, Tags::SelfForceTurnOnInterval>
+        Tags::ExcisionSphere<Dim>, Tags::WorldtubeRadius,
+        Tags::PunctureFieldConfig, Tags::ExpansionOrder, Tags::MaxIterations,
+        Tags::Charge, Tags::Mass, ::Tags::Time, Tags::SelfForceTurnOnTime,
+        Tags::SelfForceTurnOnInterval>
         tuple_of_opts{shell.create_domain(),
                       kerr_schild,
                       excision_sphere,
                       excision_sphere.radius(),
+                      puncture_field_options,
                       expansion_order,
                       max_iterations,
                       charge,

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/Test_ReceiveWorldtubeData.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/Test_ReceiveWorldtubeData.cpp
@@ -62,7 +62,8 @@ struct MockElementArray {
           tmpl::list<ActionTesting::InitializeDataBox<
               db::AddSimpleTags<
                   domain::Tags::Element<Dim>, domain::Tags::Mesh<Dim>,
-                  Tags::PunctureField<Dim>, Tags::IteratedPunctureField<Dim>,
+                  Tags::GeodesicPunctureField<Dim>,
+                  Tags::IteratedPunctureField<Dim>,
                   gr::Tags::Shift<DataVector, Dim>, gr::Tags::Lapse<DataVector>,
                   ::Tags::TimeStepId, Tags::WorldtubeSolution<Dim>,
                   Tags::FaceCoordinates<Dim, Frame::Inertial, true>>,

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/Test_SendToWorldtube.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/ElementActions/Test_SendToWorldtube.cpp
@@ -70,8 +70,8 @@ struct MockElementArray {
               db::AddSimpleTags<
                   domain::Tags::Element<Dim>, domain::Tags::Mesh<Dim>,
                   domain::Tags::Coordinates<Dim, Frame::Inertial>,
-                  Tags::PunctureField<Dim>, gr::Tags::Shift<DataVector, Dim>,
-                  gr::Tags::Lapse<DataVector>,
+                  Tags::GeodesicPunctureField<Dim>,
+                  gr::Tags::Shift<DataVector, Dim>, gr::Tags::Lapse<DataVector>,
                   domain::Tags::InverseJacobian<Dim, Frame::ElementLogical,
                                                 Frame::Inertial>,
                   typename CurvedScalarWave::System<Dim>::variables_tag,
@@ -124,9 +124,10 @@ struct MockMetavariables {
   using dg_element_array = MockElementArray<MockMetavariables>;
   using const_global_cache_tags =
       tmpl::list<domain::Tags::Domain<Dim>, Tags::ExcisionSphere<Dim>,
-                 Tags::WorldtubeRadius, Tags::ExpansionOrder,
-                 Tags::MaxIterations, Tags::Charge, Tags::Mass, ::Tags::Time,
-                 Tags::SelfForceTurnOnTime, Tags::SelfForceTurnOnInterval>;
+                 Tags::WorldtubeRadius, Tags::PunctureFieldConfig,
+                 Tags::ExpansionOrder, Tags::MaxIterations, Tags::Charge,
+                 Tags::Mass, ::Tags::Time, Tags::SelfForceTurnOnTime,
+                 Tags::SelfForceTurnOnInterval>;
 };
 
 // This test checks that `SendToWorldtube` integrates the regular field on the
@@ -170,14 +171,19 @@ SPECTRE_TEST_CASE("Unit.CurvedScalarWave.Worldtube.SendToWorldtube", "[Unit]") {
     const auto& initial_refinements = shell.initial_refinement_levels();
     const auto& initial_extents = shell.initial_extents();
     // self force and therefore iterative scheme is turned off
+    const auto puncture_field_options =
+        CurvedScalarWave::Worldtube::PunctureField{
+            CurvedScalarWave::Worldtube::PunctureField::Schwarzschild{
+                expansion_order, 1.}};
     tuples::TaggedTuple<domain::Tags::Domain<Dim>, Tags::ExcisionSphere<Dim>,
-                        Tags::WorldtubeRadius, Tags::ExpansionOrder,
-                        Tags::MaxIterations, Tags::Charge, Tags::Mass,
-                        ::Tags::Time, Tags::SelfForceTurnOnTime,
+                        Tags::WorldtubeRadius, Tags::PunctureFieldConfig,
+                        Tags::ExpansionOrder, Tags::MaxIterations, Tags::Charge,
+                        Tags::Mass, ::Tags::Time, Tags::SelfForceTurnOnTime,
                         Tags::SelfForceTurnOnInterval>
         tuple_of_opts{shell.create_domain(),
                       excision_sphere,
                       excision_sphere.radius(),
+                      puncture_field_options,
                       expansion_order,
                       static_cast<size_t>(0),
                       0.1,

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_AccelerationTerms.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_AccelerationTerms.cpp
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <cstddef>
+#include <numbers>
 #include <random>
 
 #include "DataStructures/DataBox/Prefixes.hpp"
@@ -29,6 +30,77 @@ using deriv_psi_tag =
     ::Tags::deriv<Tags::Psi, tmpl::size_t<3>, Frame::Inertial>;
 using puncture_vars =
     Variables<tmpl::list<Tags::Psi, ::Tags::dt<Tags::Psi>, deriv_psi_tag>>;
+
+Worldtube::PunctureField make_schwarzschild_puncture_field(
+    const size_t order, const double bh_mass) {
+  return Worldtube::PunctureField{
+      Worldtube::PunctureField::Schwarzschild{order, bh_mass}};
+}
+
+void test_dispatch() {
+  MAKE_GENERATOR(gen);
+  std::uniform_real_distribution<double> theta_dist{0., std::numbers::pi};
+  std::uniform_real_distribution<double> phi_dist{0., 2. * std::numbers::pi};
+  std::uniform_real_distribution<double> pos_dist{2., 10.};
+  std::uniform_real_distribution<double> vel_acc_dist{-0.1, 0.1};
+  const size_t size = 8;
+  const double wt_radius = 0.1;
+  tnsr::I<DataVector, 3, Frame::Inertial> centered_coords(size);
+  for (size_t i = 0; i < size; ++i) {
+    const double theta = theta_dist(gen);
+    const double phi = phi_dist(gen);
+    centered_coords.get(0)[i] = wt_radius * sin(theta) * cos(phi);
+    centered_coords.get(1)[i] = wt_radius * sin(theta) * sin(phi);
+    centered_coords.get(2)[i] = wt_radius * cos(theta);
+  }
+  const auto random_position =
+      make_with_random_values<tnsr::I<double, 3, Frame::Inertial>>(
+          make_not_null(&gen), make_not_null(&pos_dist), 1);
+  const auto random_velocity =
+      make_with_random_values<tnsr::I<double, 3, Frame::Inertial>>(
+          make_not_null(&gen), make_not_null(&vel_acc_dist), 1);
+  const auto random_acceleration =
+      make_with_random_values<tnsr::I<double, 3, Frame::Inertial>>(
+          make_not_null(&gen), make_not_null(&vel_acc_dist), 1);
+  const auto random_self_force = make_with_random_values<Scalar<DataVector>>(
+      make_not_null(&gen), make_not_null(&vel_acc_dist), DataVector(12));
+  const double bh_mass = 1.2345;
+  for (size_t order = 0; order <= 1; ++order) {
+    CAPTURE(order);
+    puncture_vars expected{size};
+    puncture_vars dispatched{size};
+    const auto puncture_field =
+        make_schwarzschild_puncture_field(order, bh_mass);
+    if (order == 0) {
+      Worldtube::acceleration_terms_0(
+          make_not_null(&expected), centered_coords, random_position,
+          random_velocity, random_acceleration, get(random_self_force)[0],
+          get(random_self_force)[1], get(random_self_force)[2],
+          get(random_self_force)[3], get(random_self_force)[4],
+          get(random_self_force)[5], bh_mass);
+    } else {
+      Worldtube::acceleration_terms_1(
+          make_not_null(&expected), centered_coords, random_position,
+          random_velocity, random_acceleration, get(random_self_force)[0],
+          get(random_self_force)[1], get(random_self_force)[2],
+          get(random_self_force)[3], get(random_self_force)[4],
+          get(random_self_force)[5], get(random_self_force)[6],
+          get(random_self_force)[7], get(random_self_force)[8],
+          get(random_self_force)[9], get(random_self_force)[10],
+          get(random_self_force)[11], bh_mass);
+    }
+    puncture_field.apply_acceleration_terms(
+        make_not_null(&dispatched), centered_coords, random_position,
+        random_velocity, random_acceleration, get(random_self_force)[0],
+        get(random_self_force)[1], get(random_self_force)[2],
+        get(random_self_force)[3], get(random_self_force)[4],
+        get(random_self_force)[5], get(random_self_force)[6],
+        get(random_self_force)[7], get(random_self_force)[8],
+        get(random_self_force)[9], get(random_self_force)[10],
+        get(random_self_force)[11]);
+    CHECK_VARIABLES_APPROX(expected, dispatched);
+  }
+}
 
 // tests the derivative of the puncture field against a finite difference
 // calculation
@@ -136,6 +208,7 @@ void test_derivative() {
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.CurvedScalarWave.AccelerationTerms",
                   "[Unit][Evolution]") {
+  test_dispatch();
   test_derivative();
 }
 }  // namespace

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_AccelerationTerms.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_AccelerationTerms.cpp
@@ -30,6 +30,75 @@ using deriv_psi_tag =
 using puncture_vars =
     Variables<tmpl::list<Tags::Psi, ::Tags::dt<Tags::Psi>, deriv_psi_tag>>;
 
+Worldtube::PunctureField make_schwarzschild_puncture_field(const size_t order) {
+  return Worldtube::PunctureField{
+      Worldtube::PunctureField::Schwarzschild{order, 1.}};
+}
+
+void test_dispatch() {
+  MAKE_GENERATOR(gen);
+  std::uniform_real_distribution<double> theta_dist{0., M_PI};
+  std::uniform_real_distribution<double> phi_dist{0., 2. * M_PI};
+  std::uniform_real_distribution<double> pos_dist{2., 10.};
+  std::uniform_real_distribution<double> vel_acc_dist{-0.1, 0.1};
+  const size_t size = 8;
+  const double wt_radius = 0.1;
+  tnsr::I<DataVector, 3, Frame::Inertial> centered_coords(size);
+  for (size_t i = 0; i < size; ++i) {
+    const double theta = theta_dist(gen);
+    const double phi = phi_dist(gen);
+    centered_coords.get(0)[i] = wt_radius * sin(theta) * cos(phi);
+    centered_coords.get(1)[i] = wt_radius * sin(theta) * sin(phi);
+    centered_coords.get(2)[i] = wt_radius * cos(theta);
+  }
+  const auto random_position =
+      make_with_random_values<tnsr::I<double, 3, Frame::Inertial>>(
+          make_not_null(&gen), make_not_null(&pos_dist), 1);
+  const auto random_velocity =
+      make_with_random_values<tnsr::I<double, 3, Frame::Inertial>>(
+          make_not_null(&gen), make_not_null(&vel_acc_dist), 1);
+  const auto random_acceleration =
+      make_with_random_values<tnsr::I<double, 3, Frame::Inertial>>(
+          make_not_null(&gen), make_not_null(&vel_acc_dist), 1);
+  const auto random_self_force = make_with_random_values<Scalar<DataVector>>(
+      make_not_null(&gen), make_not_null(&vel_acc_dist), DataVector(12));
+
+  for (size_t order = 0; order <= 1; ++order) {
+    CAPTURE(order);
+    puncture_vars expected{size};
+    puncture_vars dispatched{size};
+    const auto puncture_field = make_schwarzschild_puncture_field(order);
+    if (order == 0) {
+      Worldtube::acceleration_terms_0(
+          make_not_null(&expected), centered_coords, random_position,
+          random_velocity, random_acceleration, get(random_self_force)[0],
+          get(random_self_force)[1], get(random_self_force)[2],
+          get(random_self_force)[3], get(random_self_force)[4],
+          get(random_self_force)[5], 1.);
+    } else {
+      Worldtube::acceleration_terms_1(
+          make_not_null(&expected), centered_coords, random_position,
+          random_velocity, random_acceleration, get(random_self_force)[0],
+          get(random_self_force)[1], get(random_self_force)[2],
+          get(random_self_force)[3], get(random_self_force)[4],
+          get(random_self_force)[5], get(random_self_force)[6],
+          get(random_self_force)[7], get(random_self_force)[8],
+          get(random_self_force)[9], get(random_self_force)[10],
+          get(random_self_force)[11], 1.);
+    }
+    puncture_field.apply_acceleration_terms(
+        make_not_null(&dispatched), centered_coords, random_position,
+        random_velocity, random_acceleration, get(random_self_force)[0],
+        get(random_self_force)[1], get(random_self_force)[2],
+        get(random_self_force)[3], get(random_self_force)[4],
+        get(random_self_force)[5], get(random_self_force)[6],
+        get(random_self_force)[7], get(random_self_force)[8],
+        get(random_self_force)[9], get(random_self_force)[10],
+        get(random_self_force)[11]);
+    CHECK_VARIABLES_APPROX(expected, dispatched);
+  }
+}
+
 // tests the derivative of the puncture field against a finite difference
 // calculation
 void test_derivative() {
@@ -136,6 +205,7 @@ void test_derivative() {
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.CurvedScalarWave.AccelerationTerms",
                   "[Unit][Evolution]") {
+  test_dispatch();
   test_derivative();
 }
 }  // namespace

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_AccelerationTerms.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_AccelerationTerms.cpp
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <cstddef>
+#include <numbers>
 #include <random>
 
 #include "DataStructures/DataBox/Prefixes.hpp"
@@ -30,15 +31,16 @@ using deriv_psi_tag =
 using puncture_vars =
     Variables<tmpl::list<Tags::Psi, ::Tags::dt<Tags::Psi>, deriv_psi_tag>>;
 
-Worldtube::PunctureField make_schwarzschild_puncture_field(const size_t order) {
+Worldtube::PunctureField make_schwarzschild_puncture_field(
+    const size_t order, const double bh_mass) {
   return Worldtube::PunctureField{
-      Worldtube::PunctureField::Schwarzschild{order, 1.}};
+      Worldtube::PunctureField::Schwarzschild{order, bh_mass}};
 }
 
 void test_dispatch() {
   MAKE_GENERATOR(gen);
-  std::uniform_real_distribution<double> theta_dist{0., M_PI};
-  std::uniform_real_distribution<double> phi_dist{0., 2. * M_PI};
+  std::uniform_real_distribution<double> theta_dist{0., std::numbers::pi};
+  std::uniform_real_distribution<double> phi_dist{0., 2. * std::numbers::pi};
   std::uniform_real_distribution<double> pos_dist{2., 10.};
   std::uniform_real_distribution<double> vel_acc_dist{-0.1, 0.1};
   const size_t size = 8;
@@ -62,19 +64,20 @@ void test_dispatch() {
           make_not_null(&gen), make_not_null(&vel_acc_dist), 1);
   const auto random_self_force = make_with_random_values<Scalar<DataVector>>(
       make_not_null(&gen), make_not_null(&vel_acc_dist), DataVector(12));
-
+  const double bh_mass = 1.2345;
   for (size_t order = 0; order <= 1; ++order) {
     CAPTURE(order);
     puncture_vars expected{size};
     puncture_vars dispatched{size};
-    const auto puncture_field = make_schwarzschild_puncture_field(order);
+    const auto puncture_field =
+        make_schwarzschild_puncture_field(order, bh_mass);
     if (order == 0) {
       Worldtube::acceleration_terms_0(
           make_not_null(&expected), centered_coords, random_position,
           random_velocity, random_acceleration, get(random_self_force)[0],
           get(random_self_force)[1], get(random_self_force)[2],
           get(random_self_force)[3], get(random_self_force)[4],
-          get(random_self_force)[5], 1.);
+          get(random_self_force)[5], bh_mass);
     } else {
       Worldtube::acceleration_terms_1(
           make_not_null(&expected), centered_coords, random_position,
@@ -84,7 +87,7 @@ void test_dispatch() {
           get(random_self_force)[5], get(random_self_force)[6],
           get(random_self_force)[7], get(random_self_force)[8],
           get(random_self_force)[9], get(random_self_force)[10],
-          get(random_self_force)[11], 1.);
+          get(random_self_force)[11], bh_mass);
     }
     puncture_field.apply_acceleration_terms(
         make_not_null(&dispatched), centered_coords, random_position,

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_PunctureField.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_PunctureField.cpp
@@ -27,6 +27,11 @@ using deriv_psi_tag =
 using puncture_vars =
     Variables<tmpl::list<Tags::Psi, ::Tags::dt<Tags::Psi>, deriv_psi_tag>>;
 
+Worldtube::PunctureField make_schwarzschild_puncture_field(const size_t order) {
+  return Worldtube::PunctureField{
+      Worldtube::PunctureField::Schwarzschild{order, 1.2345}};
+}
+
 std::array<tnsr::I<double, 3>, 3> get_circular_orbit_pos_vel_acc(
     const double orbit_radius, const double time) {
   const double angular_velocity = 1. / (sqrt(orbit_radius) * orbit_radius);
@@ -67,10 +72,10 @@ void test_circular_orbit() {
       get_circular_orbit_pos_vel_acc(orbit_radius, time_1);
   for (size_t order = 0; order <= 1; ++order) {
     CAPTURE(order);
+    const auto puncture_field = make_schwarzschild_puncture_field(order);
     puncture_vars puncture_t0{num_points};
-    Worldtube::puncture_field(make_not_null(&puncture_t0), sample_points,
-                              position_t0, velocity_t0, acceleration_t0, 1.,
-                              order);
+    puncture_field.apply_puncture(make_not_null(&puncture_t0), sample_points,
+                                  position_t0, velocity_t0, acceleration_t0);
     // rotate the sample points and check that the values don't change
     tnsr::I<DataVector, 3, Frame::Inertial> sample_points_rotated(num_points,
                                                                   0.);
@@ -82,9 +87,9 @@ void test_circular_orbit() {
         sample_points.get(1) * cos(orbit_speed * time_1);
     sample_points_rotated.get(2) = sample_points.get(2);
     puncture_vars puncture_t1{num_points};
-    Worldtube::puncture_field(make_not_null(&puncture_t1),
-                              sample_points_rotated, position_t1, velocity_t1,
-                              acceleration_t1, 1., order);
+    puncture_field.apply_puncture(make_not_null(&puncture_t1),
+                                  sample_points_rotated, position_t1,
+                                  velocity_t1, acceleration_t1);
     Approx local_approx = Approx::custom().epsilon(1.e-11).scale(1.);
     CHECK_ITERABLE_CUSTOM_APPROX(get<Tags::Psi>(puncture_t0).get(),
                                  get<Tags::Psi>(puncture_t1).get(),
@@ -119,6 +124,7 @@ void test_derivative() {
   const double wt_radius = 0.1;
   for (size_t order = 0; order <= 1; ++order) {
     CAPTURE(order);
+    const auto puncture_field = make_schwarzschild_puncture_field(order);
     const auto random_position =
         make_with_random_values<tnsr::I<double, 3, Frame::Inertial>>(
             make_not_null(&gen), make_not_null(&pos_dist), 1);
@@ -128,19 +134,19 @@ void test_derivative() {
     const auto random_acceleration =
         make_with_random_values<tnsr::I<double, 3, Frame::Inertial>>(
             make_not_null(&gen), make_not_null(&vel_acc_dist), 1);
-    const auto helper_func = [&random_position, &random_velocity,
-                              &random_acceleration,
-                              &order](const std::array<double, 3>& point) {
-      tnsr::I<DataVector, 3, Frame::Inertial> tensor_point(size_t(1));
-      tensor_point.get(0) = point.at(0);
-      tensor_point.get(1) = point.at(1);
-      tensor_point.get(2) = point.at(2);
-      puncture_vars singular_field{1};
-      Worldtube::puncture_field(make_not_null(&singular_field), tensor_point,
-                                random_position, random_velocity,
-                                random_acceleration, 1., order);
-      return get<Tags::Psi>(singular_field).get()[0];
-    };
+    const auto helper_func =
+        [&random_position, &random_velocity, &random_acceleration,
+         &puncture_field](const std::array<double, 3>& point) {
+          tnsr::I<DataVector, 3, Frame::Inertial> tensor_point(size_t(1));
+          tensor_point.get(0) = point.at(0);
+          tensor_point.get(1) = point.at(1);
+          tensor_point.get(2) = point.at(2);
+          puncture_vars singular_field{1};
+          puncture_field.apply_puncture(make_not_null(&singular_field),
+                                        tensor_point, random_position,
+                                        random_velocity, random_acceleration);
+          return get<Tags::Psi>(singular_field).get()[0];
+        };
     for (size_t i = 0; i < 20; ++i) {
       const auto theta = theta_dist(gen);
       const auto phi = phi_dist(gen);
@@ -154,9 +160,9 @@ void test_derivative() {
       }
       const double dx = 1e-4;
       puncture_vars singular_field{1};
-      Worldtube::puncture_field(make_not_null(&singular_field), tensor_point,
-                                random_position, random_velocity,
-                                random_acceleration, 1., order);
+      puncture_field.apply_puncture(make_not_null(&singular_field),
+                                    tensor_point, random_position,
+                                    random_velocity, random_acceleration);
       const auto& di_psi = get<deriv_psi_tag>(singular_field);
       for (size_t j = 0; j < 3; ++j) {
         const auto numerical_deriv_j =
@@ -167,10 +173,26 @@ void test_derivative() {
   }
 }
 
+void test_kerr() {
+  const auto puncture_field =
+      Worldtube::PunctureField{Worldtube::PunctureField::Kerr{1, 1., 0.5}};
+  puncture_vars singular_field{1};
+  const tnsr::I<DataVector, 3, Frame::Inertial> tensor_point(size_t{1}, 0.);
+  const tnsr::I<double, 3, Frame::Inertial> particle_position(0.);
+  const tnsr::I<double, 3, Frame::Inertial> particle_velocity(0.);
+  const tnsr::I<double, 3, Frame::Inertial> particle_acceleration(0.);
+  CHECK_THROWS_WITH(
+      puncture_field.apply_puncture(make_not_null(&singular_field),
+                                    tensor_point, particle_position,
+                                    particle_velocity, particle_acceleration),
+      Catch::Matchers::ContainsSubstring("Kerr puncture not implemented yet"));
+}
+
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.CurvedScalarWave.PunctureField",
                   "[Unit][Evolution]") {
   test_circular_orbit();
   test_derivative();
+  test_kerr();
 }
 }  // namespace
 }  // namespace CurvedScalarWave

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_PunctureField.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_PunctureField.cpp
@@ -29,7 +29,7 @@ using puncture_vars =
 
 Worldtube::PunctureField make_schwarzschild_puncture_field(const size_t order) {
   return Worldtube::PunctureField{
-      Worldtube::PunctureField::Schwarzschild{order, 1.}};
+      Worldtube::PunctureField::Schwarzschild{order, 1.2345}};
 }
 
 std::array<tnsr::I<double, 3>, 3> get_circular_orbit_pos_vel_acc(

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_PunctureField.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_PunctureField.cpp
@@ -27,6 +27,11 @@ using deriv_psi_tag =
 using puncture_vars =
     Variables<tmpl::list<Tags::Psi, ::Tags::dt<Tags::Psi>, deriv_psi_tag>>;
 
+Worldtube::PunctureField make_schwarzschild_puncture_field(const size_t order) {
+  return Worldtube::PunctureField{
+      Worldtube::PunctureField::Schwarzschild{order, 1.}};
+}
+
 std::array<tnsr::I<double, 3>, 3> get_circular_orbit_pos_vel_acc(
     const double orbit_radius, const double time) {
   const double angular_velocity = 1. / (sqrt(orbit_radius) * orbit_radius);
@@ -67,10 +72,10 @@ void test_circular_orbit() {
       get_circular_orbit_pos_vel_acc(orbit_radius, time_1);
   for (size_t order = 0; order <= 1; ++order) {
     CAPTURE(order);
+    const auto puncture_field = make_schwarzschild_puncture_field(order);
     puncture_vars puncture_t0{num_points};
-    Worldtube::puncture_field(make_not_null(&puncture_t0), sample_points,
-                              position_t0, velocity_t0, acceleration_t0, 1.,
-                              order);
+    puncture_field.apply_puncture(make_not_null(&puncture_t0), sample_points,
+                                  position_t0, velocity_t0, acceleration_t0);
     // rotate the sample points and check that the values don't change
     tnsr::I<DataVector, 3, Frame::Inertial> sample_points_rotated(num_points,
                                                                   0.);
@@ -82,9 +87,9 @@ void test_circular_orbit() {
         sample_points.get(1) * cos(orbit_speed * time_1);
     sample_points_rotated.get(2) = sample_points.get(2);
     puncture_vars puncture_t1{num_points};
-    Worldtube::puncture_field(make_not_null(&puncture_t1),
-                              sample_points_rotated, position_t1, velocity_t1,
-                              acceleration_t1, 1., order);
+    puncture_field.apply_puncture(make_not_null(&puncture_t1),
+                                  sample_points_rotated, position_t1,
+                                  velocity_t1, acceleration_t1);
     Approx local_approx = Approx::custom().epsilon(1.e-11).scale(1.);
     CHECK_ITERABLE_CUSTOM_APPROX(get<Tags::Psi>(puncture_t0).get(),
                                  get<Tags::Psi>(puncture_t1).get(),
@@ -119,6 +124,7 @@ void test_derivative() {
   const double wt_radius = 0.1;
   for (size_t order = 0; order <= 1; ++order) {
     CAPTURE(order);
+    const auto puncture_field = make_schwarzschild_puncture_field(order);
     const auto random_position =
         make_with_random_values<tnsr::I<double, 3, Frame::Inertial>>(
             make_not_null(&gen), make_not_null(&pos_dist), 1);
@@ -128,19 +134,19 @@ void test_derivative() {
     const auto random_acceleration =
         make_with_random_values<tnsr::I<double, 3, Frame::Inertial>>(
             make_not_null(&gen), make_not_null(&vel_acc_dist), 1);
-    const auto helper_func = [&random_position, &random_velocity,
-                              &random_acceleration,
-                              &order](const std::array<double, 3>& point) {
-      tnsr::I<DataVector, 3, Frame::Inertial> tensor_point(size_t(1));
-      tensor_point.get(0) = point.at(0);
-      tensor_point.get(1) = point.at(1);
-      tensor_point.get(2) = point.at(2);
-      puncture_vars singular_field{1};
-      Worldtube::puncture_field(make_not_null(&singular_field), tensor_point,
-                                random_position, random_velocity,
-                                random_acceleration, 1., order);
-      return get<Tags::Psi>(singular_field).get()[0];
-    };
+    const auto helper_func =
+        [&random_position, &random_velocity, &random_acceleration,
+         &puncture_field](const std::array<double, 3>& point) {
+          tnsr::I<DataVector, 3, Frame::Inertial> tensor_point(size_t(1));
+          tensor_point.get(0) = point.at(0);
+          tensor_point.get(1) = point.at(1);
+          tensor_point.get(2) = point.at(2);
+          puncture_vars singular_field{1};
+          puncture_field.apply_puncture(make_not_null(&singular_field),
+                                        tensor_point, random_position,
+                                        random_velocity, random_acceleration);
+          return get<Tags::Psi>(singular_field).get()[0];
+        };
     for (size_t i = 0; i < 20; ++i) {
       const auto theta = theta_dist(gen);
       const auto phi = phi_dist(gen);
@@ -154,9 +160,9 @@ void test_derivative() {
       }
       const double dx = 1e-4;
       puncture_vars singular_field{1};
-      Worldtube::puncture_field(make_not_null(&singular_field), tensor_point,
-                                random_position, random_velocity,
-                                random_acceleration, 1., order);
+      puncture_field.apply_puncture(make_not_null(&singular_field),
+                                    tensor_point, random_position,
+                                    random_velocity, random_acceleration);
       const auto& di_psi = get<deriv_psi_tag>(singular_field);
       for (size_t j = 0; j < 3; ++j) {
         const auto numerical_deriv_j =
@@ -167,10 +173,26 @@ void test_derivative() {
   }
 }
 
+void test_kerr() {
+  const auto puncture_field =
+      Worldtube::PunctureField{Worldtube::PunctureField::Kerr{1, 1., 0.5}};
+  puncture_vars singular_field{1};
+  const tnsr::I<DataVector, 3, Frame::Inertial> tensor_point(size_t{1}, 0.);
+  const tnsr::I<double, 3, Frame::Inertial> particle_position(0.);
+  const tnsr::I<double, 3, Frame::Inertial> particle_velocity(0.);
+  const tnsr::I<double, 3, Frame::Inertial> particle_acceleration(0.);
+  CHECK_THROWS_WITH(
+      puncture_field.apply_puncture(make_not_null(&singular_field),
+                                    tensor_point, particle_position,
+                                    particle_velocity, particle_acceleration),
+      Catch::Matchers::ContainsSubstring("Kerr puncture not implemented yet"));
+}
+
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.CurvedScalarWave.PunctureField",
                   "[Unit][Evolution]") {
   test_circular_orbit();
   test_derivative();
+  test_kerr();
 }
 }  // namespace
 }  // namespace CurvedScalarWave

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_Tags.cpp
@@ -627,8 +627,8 @@ void test_face_quantities_compute() {
 void test_puncture_field() {
   INFO("test_puncture_field");
   static constexpr size_t Dim = 3;
-  ::TestHelpers::db::test_compute_tag<Tags::PunctureFieldCompute<Dim>>(
-      "PunctureField");
+  ::TestHelpers::db::test_compute_tag<Tags::GeodesicPunctureFieldCompute<Dim>>(
+      "GeodesicPunctureField");
   MAKE_GENERATOR(gen);
   std::uniform_real_distribution<> dist(-1., 1.);
   const tnsr::I<double, Dim, Frame::Inertial> charge_pos{{7.1, 0., 0.}};
@@ -643,18 +643,21 @@ void test_puncture_field() {
           make_not_null(&gen), dist, DataVector(50));
   random_points.get(0) += charge_pos.get(0);
 
-  const size_t order = 1;
+  const auto puncture_field_options =
+      CurvedScalarWave::Worldtube::PunctureField{
+          CurvedScalarWave::Worldtube::PunctureField::Schwarzschild{1, 1.}};
   const auto box_abutting = db::create<
       db::AddSimpleTags<Tags::FaceCoordinates<Dim, Frame::Inertial, true>,
                         Tags::ParticlePositionVelocity<Dim>,
-                        Tags::GeodesicAcceleration<Dim>, Tags::ExpansionOrder,
-                        Tags::Charge>,
-      db::AddComputeTags<Tags::PunctureFieldCompute<Dim>>>(
+                        Tags::GeodesicAcceleration<Dim>,
+                        Tags::PunctureFieldConfig, Tags::Charge>,
+      db::AddComputeTags<Tags::GeodesicPunctureFieldCompute<Dim>>>(
       std::make_optional<tnsr::I<DataVector, Dim, Frame::Inertial>>(
           random_points),
-      pos_vel, charge_acc, order, charge);
+      pos_vel, charge_acc, puncture_field_options, charge);
 
-  const auto singular_field = get<Tags::PunctureField<Dim>>(box_abutting);
+  const auto singular_field =
+      get<Tags::GeodesicPunctureField<Dim>>(box_abutting);
 
   CHECK(singular_field.has_value());
   Variables<tmpl::list<CurvedScalarWave::Tags::Psi,
@@ -662,21 +665,57 @@ void test_puncture_field() {
                        ::Tags::deriv<CurvedScalarWave::Tags::Psi,
                                      tmpl::size_t<3>, Frame::Inertial>>>
       expected{};
-  puncture_field(make_not_null(&expected), random_points, charge_pos,
-                 charge_vel, charge_acc, 1., order);
+  puncture_field_options.apply_puncture(make_not_null(&expected), random_points,
+                                        charge_pos, charge_vel, charge_acc);
   expected *= charge;
   CHECK_VARIABLES_APPROX(singular_field.value(), expected);
   std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>> nullopt{};
   const auto box_not_abutting = db::create<
       db::AddSimpleTags<Tags::FaceCoordinates<Dim, Frame::Inertial, true>,
                         Tags::ParticlePositionVelocity<Dim>,
-                        Tags::GeodesicAcceleration<Dim>, Tags::ExpansionOrder,
-                        Tags::Charge>,
-      db::AddComputeTags<Tags::PunctureFieldCompute<Dim>>>(
-      nullopt, pos_vel, charge_acc, order, charge);
+                        Tags::GeodesicAcceleration<Dim>,
+                        Tags::PunctureFieldConfig, Tags::Charge>,
+      db::AddComputeTags<Tags::GeodesicPunctureFieldCompute<Dim>>>(
+      nullopt, pos_vel, charge_acc, puncture_field_options, charge);
   const auto puncture_field_nullopt =
-      get<Tags::PunctureField<Dim>>(box_not_abutting);
+      get<Tags::GeodesicPunctureField<Dim>>(box_not_abutting);
   CHECK(not puncture_field_nullopt.has_value());
+}
+
+void test_puncture_field_options() {
+  INFO("test_puncture_field_options");
+  {
+    const auto options =
+        TestHelpers::test_creation<CurvedScalarWave::Worldtube::PunctureField>(
+            "Schwarzschild:\n"
+            "  ExpansionOrder: 1\n"
+            "  BlackHoleMass: 2.0\n");
+    CHECK(options.type() ==
+          CurvedScalarWave::Worldtube::PunctureField::Type::Schwarzschild);
+    CHECK(options.expansion_order() == 1);
+    CHECK(options.black_hole_mass() == 2.0);
+    CHECK(options.spin_along_z_axis() == 0.0);
+  }
+  {
+    const auto options =
+        TestHelpers::test_creation<CurvedScalarWave::Worldtube::PunctureField>(
+            "Kerr:\n"
+            "  ExpansionOrder: 1\n"
+            "  BlackHoleMass: 1.2345\n"
+            "  SpinAlongZAxis: 0.7\n");
+    CHECK(options.type() ==
+          CurvedScalarWave::Worldtube::PunctureField::Type::Kerr);
+    CHECK(options.expansion_order() == 1);
+    CHECK(options.black_hole_mass() == 1.2345);
+    CHECK(options.spin_along_z_axis() == 0.7);
+  }
+  CHECK_THROWS_WITH(
+      TestHelpers::test_creation<CurvedScalarWave::Worldtube::PunctureField>(
+          "Schwarzschild:\n"
+          "  ExpansionOrder: 1\n"
+          "  BlackHoleMass: 1.0\n"
+          "  SpinAlongZAxis: 0.1\n"),
+      Catch::Matchers::ContainsSubstring("SpinAlongZAxis"));
 }
 
 void test_self_force_options() {
@@ -728,8 +767,6 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.CurvedScalarWave.Worldtube.Tags",
   CHECK(TestHelpers::test_option_tag<OptionTags::ExcisionSphere>("Worldtube") ==
         "Worldtube");
   CHECK(TestHelpers::test_option_tag<
-            CurvedScalarWave::Worldtube::OptionTags::ExpansionOrder>("0") == 0);
-  CHECK(TestHelpers::test_option_tag<
             CurvedScalarWave::Worldtube::OptionTags::Charge>("1.") == 1.);
   CHECK(TestHelpers::test_option_tag<
             CurvedScalarWave::Worldtube::OptionTags::Spin>("[0., 0., 0.5]") ==
@@ -738,6 +775,9 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.CurvedScalarWave.Worldtube.Tags",
 
   TestHelpers::db::test_simple_tag<
       CurvedScalarWave::Worldtube::Tags::ExpansionOrder>("ExpansionOrder");
+  TestHelpers::db::test_simple_tag<
+      CurvedScalarWave::Worldtube::Tags::PunctureFieldConfig>(
+      "PunctureFieldConfig");
   TestHelpers::db::test_simple_tag<CurvedScalarWave::Worldtube::Tags::Charge>(
       "Charge");
   TestHelpers::db::test_simple_tag<CurvedScalarWave::Worldtube::Tags::Spin>(
@@ -778,7 +818,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.CurvedScalarWave.Worldtube.Tags",
       "ParticlePositionVelocity");
   TestHelpers::db::test_simple_tag<Tags::EvolvedPosition<3>>("EvolvedPosition");
   TestHelpers::db::test_simple_tag<Tags::EvolvedVelocity<3>>("EvolvedVelocity");
-  TestHelpers::db::test_simple_tag<Tags::PunctureField<3>>("PunctureField");
+  TestHelpers::db::test_simple_tag<Tags::GeodesicPunctureField<3>>(
+      "GeodesicPunctureField");
   TestHelpers::db::test_simple_tag<Tags::IteratedPunctureField<3>>(
       "IteratedPunctureField");
   TestHelpers::db::test_simple_tag<Tags::ObserveCoefficientsTrigger>(
@@ -794,6 +835,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.CurvedScalarWave.Worldtube.Tags",
   TestHelpers::db::test_simple_tag<Tags::Verbosity>("Verbosity");
   test_excision_sphere_tag();
   test_self_force_options();
+  test_puncture_field_options();
   test_radius_options();
   test_initial_position_velocity_tag();
   test_compute_face_coordinates_grid();

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_Tags.cpp
@@ -701,12 +701,12 @@ void test_puncture_field_options() {
         TestHelpers::test_creation<CurvedScalarWave::Worldtube::PunctureField>(
             "Kerr:\n"
             "  ExpansionOrder: 1\n"
-            "  BlackHoleMass: 1.0\n"
+            "  BlackHoleMass: 1.2345\n"
             "  SpinAlongZAxis: 0.7\n");
     CHECK(options.type() ==
           CurvedScalarWave::Worldtube::PunctureField::Type::Kerr);
     CHECK(options.expansion_order() == 1);
-    CHECK(options.black_hole_mass() == 1.0);
+    CHECK(options.black_hole_mass() == 1.2345);
     CHECK(options.spin_along_z_axis() == 0.7);
   }
   CHECK_THROWS_WITH(

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Worldtube/Test_Tags.cpp
@@ -627,8 +627,8 @@ void test_face_quantities_compute() {
 void test_puncture_field() {
   INFO("test_puncture_field");
   static constexpr size_t Dim = 3;
-  ::TestHelpers::db::test_compute_tag<Tags::PunctureFieldCompute<Dim>>(
-      "PunctureField");
+  ::TestHelpers::db::test_compute_tag<Tags::GeodesicPunctureFieldCompute<Dim>>(
+      "GeodesicPunctureField");
   MAKE_GENERATOR(gen);
   std::uniform_real_distribution<> dist(-1., 1.);
   const tnsr::I<double, Dim, Frame::Inertial> charge_pos{{7.1, 0., 0.}};
@@ -643,18 +643,21 @@ void test_puncture_field() {
           make_not_null(&gen), dist, DataVector(50));
   random_points.get(0) += charge_pos.get(0);
 
-  const size_t order = 1;
+  const auto puncture_field_options =
+      CurvedScalarWave::Worldtube::PunctureField{
+          CurvedScalarWave::Worldtube::PunctureField::Schwarzschild{1, 1.}};
   const auto box_abutting = db::create<
       db::AddSimpleTags<Tags::FaceCoordinates<Dim, Frame::Inertial, true>,
                         Tags::ParticlePositionVelocity<Dim>,
-                        Tags::GeodesicAcceleration<Dim>, Tags::ExpansionOrder,
-                        Tags::Charge>,
-      db::AddComputeTags<Tags::PunctureFieldCompute<Dim>>>(
+                        Tags::GeodesicAcceleration<Dim>,
+                        Tags::PunctureFieldConfig, Tags::Charge>,
+      db::AddComputeTags<Tags::GeodesicPunctureFieldCompute<Dim>>>(
       std::make_optional<tnsr::I<DataVector, Dim, Frame::Inertial>>(
           random_points),
-      pos_vel, charge_acc, order, charge);
+      pos_vel, charge_acc, puncture_field_options, charge);
 
-  const auto singular_field = get<Tags::PunctureField<Dim>>(box_abutting);
+  const auto singular_field =
+      get<Tags::GeodesicPunctureField<Dim>>(box_abutting);
 
   CHECK(singular_field.has_value());
   Variables<tmpl::list<CurvedScalarWave::Tags::Psi,
@@ -662,21 +665,57 @@ void test_puncture_field() {
                        ::Tags::deriv<CurvedScalarWave::Tags::Psi,
                                      tmpl::size_t<3>, Frame::Inertial>>>
       expected{};
-  puncture_field(make_not_null(&expected), random_points, charge_pos,
-                 charge_vel, charge_acc, 1., order);
+  puncture_field_options.apply_puncture(make_not_null(&expected), random_points,
+                                        charge_pos, charge_vel, charge_acc);
   expected *= charge;
   CHECK_VARIABLES_APPROX(singular_field.value(), expected);
   std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>> nullopt{};
   const auto box_not_abutting = db::create<
       db::AddSimpleTags<Tags::FaceCoordinates<Dim, Frame::Inertial, true>,
                         Tags::ParticlePositionVelocity<Dim>,
-                        Tags::GeodesicAcceleration<Dim>, Tags::ExpansionOrder,
-                        Tags::Charge>,
-      db::AddComputeTags<Tags::PunctureFieldCompute<Dim>>>(
-      nullopt, pos_vel, charge_acc, order, charge);
+                        Tags::GeodesicAcceleration<Dim>,
+                        Tags::PunctureFieldConfig, Tags::Charge>,
+      db::AddComputeTags<Tags::GeodesicPunctureFieldCompute<Dim>>>(
+      nullopt, pos_vel, charge_acc, puncture_field_options, charge);
   const auto puncture_field_nullopt =
-      get<Tags::PunctureField<Dim>>(box_not_abutting);
+      get<Tags::GeodesicPunctureField<Dim>>(box_not_abutting);
   CHECK(not puncture_field_nullopt.has_value());
+}
+
+void test_puncture_field_options() {
+  INFO("test_puncture_field_options");
+  {
+    const auto options =
+        TestHelpers::test_creation<CurvedScalarWave::Worldtube::PunctureField>(
+            "Schwarzschild:\n"
+            "  ExpansionOrder: 1\n"
+            "  BlackHoleMass: 2.0\n");
+    CHECK(options.type() ==
+          CurvedScalarWave::Worldtube::PunctureField::Type::Schwarzschild);
+    CHECK(options.expansion_order() == 1);
+    CHECK(options.black_hole_mass() == 2.0);
+    CHECK(options.spin_along_z_axis() == 0.0);
+  }
+  {
+    const auto options =
+        TestHelpers::test_creation<CurvedScalarWave::Worldtube::PunctureField>(
+            "Kerr:\n"
+            "  ExpansionOrder: 1\n"
+            "  BlackHoleMass: 1.0\n"
+            "  SpinAlongZAxis: 0.7\n");
+    CHECK(options.type() ==
+          CurvedScalarWave::Worldtube::PunctureField::Type::Kerr);
+    CHECK(options.expansion_order() == 1);
+    CHECK(options.black_hole_mass() == 1.0);
+    CHECK(options.spin_along_z_axis() == 0.7);
+  }
+  CHECK_THROWS_WITH(
+      TestHelpers::test_creation<CurvedScalarWave::Worldtube::PunctureField>(
+          "Schwarzschild:\n"
+          "  ExpansionOrder: 1\n"
+          "  BlackHoleMass: 1.0\n"
+          "  SpinAlongZAxis: 0.1\n"),
+      Catch::Matchers::ContainsSubstring("SpinAlongZAxis"));
 }
 
 void test_self_force_options() {
@@ -728,8 +767,6 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.CurvedScalarWave.Worldtube.Tags",
   CHECK(TestHelpers::test_option_tag<OptionTags::ExcisionSphere>("Worldtube") ==
         "Worldtube");
   CHECK(TestHelpers::test_option_tag<
-            CurvedScalarWave::Worldtube::OptionTags::ExpansionOrder>("0") == 0);
-  CHECK(TestHelpers::test_option_tag<
             CurvedScalarWave::Worldtube::OptionTags::Charge>("1.") == 1.);
   CHECK(TestHelpers::test_option_tag<
             CurvedScalarWave::Worldtube::OptionTags::Spin>("[0., 0., 0.5]") ==
@@ -738,6 +775,9 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.CurvedScalarWave.Worldtube.Tags",
 
   TestHelpers::db::test_simple_tag<
       CurvedScalarWave::Worldtube::Tags::ExpansionOrder>("ExpansionOrder");
+  TestHelpers::db::test_simple_tag<
+      CurvedScalarWave::Worldtube::Tags::PunctureFieldConfig>(
+      "PunctureFieldConfig");
   TestHelpers::db::test_simple_tag<CurvedScalarWave::Worldtube::Tags::Charge>(
       "Charge");
   TestHelpers::db::test_simple_tag<CurvedScalarWave::Worldtube::Tags::Spin>(
@@ -778,7 +818,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.CurvedScalarWave.Worldtube.Tags",
       "ParticlePositionVelocity");
   TestHelpers::db::test_simple_tag<Tags::EvolvedPosition<3>>("EvolvedPosition");
   TestHelpers::db::test_simple_tag<Tags::EvolvedVelocity<3>>("EvolvedVelocity");
-  TestHelpers::db::test_simple_tag<Tags::PunctureField<3>>("PunctureField");
+  TestHelpers::db::test_simple_tag<Tags::GeodesicPunctureField<3>>(
+      "GeodesicPunctureField");
   TestHelpers::db::test_simple_tag<Tags::IteratedPunctureField<3>>(
       "IteratedPunctureField");
   TestHelpers::db::test_simple_tag<Tags::ObserveCoefficientsTrigger>(
@@ -794,6 +835,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.CurvedScalarWave.Worldtube.Tags",
   TestHelpers::db::test_simple_tag<Tags::Verbosity>("Verbosity");
   test_excision_sphere_tag();
   test_self_force_options();
+  test_puncture_field_options();
   test_radius_options();
   test_initial_position_velocity_tag();
   test_compute_face_coordinates_grid();


### PR DESCRIPTION
## Proposed changes
Creates a separate puncture field class that dispatches to the correct function. This will be needed to cleanly support a Kerr puncture field as it will be introduced in #7004.

Also, renames PunctureField tag to GeodesicPunctureField to avoid confusion with the IteratedPunctureField.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

When using the CurvedScalarWave worldtube executable, the PunctureField type now needs to be specified

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
