### PR TITLE
Update DG actions for GaussRadauUpper

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/Actions/ApplyBoundaryCorrections.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/ApplyBoundaryCorrections.hpp
@@ -525,13 +525,18 @@ struct ApplyBoundaryCorrections {
                 make_array<volume_dim>(volume_mesh.quadrature(0)) or
             element.topologies() != domain::topologies::hypercube<volume_dim>,
         "Must have isotropic quadrature, but got volume mesh: " << volume_mesh);
-    const bool using_gauss_lobatto_points =
-        volume_mesh.quadrature(0) == Spectral::Quadrature::GaussLobatto;
-
     Scalar<DataVector> volume_det_inv_jacobian{};
     Scalar<DataVector> volume_det_jacobian{};
     if constexpr (not local_time_stepping) {
-      if (not using_gauss_lobatto_points) {
+      // Need volume Jacobian for any face whose normal direction uses Gauss
+      // points (i.e. not GaussLobatto or GaussRadauUpper). This means
+      // mixed-quadrature non-hypercube elements (e.g. full_cylinder) where
+      // some directions have collocated face points and others do not.
+      const bool any_direction_uses_gauss = alg::any_of(
+          volume_mesh.quadrature(), [](const Spectral::Quadrature q) {
+            return q == Spectral::Quadrature::Gauss;
+          });
+      if (any_direction_uses_gauss) {
         get(volume_det_inv_jacobian)
             .set_data_ref(make_not_null(
                 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
@@ -546,11 +551,11 @@ struct ApplyBoundaryCorrections {
         "final.");
     call_with_dynamic_type<void, derived_boundary_corrections>(
         &boundary_correction,
-        [&dense_output_time, &dg_formulation,
+        [&dense_output_time, &dg_formulation, &element,
          &face_normal_covector_and_magnitude, &mortar_data, &mortar_meshes,
          &mortar_infos, &mortars_to_act_on, &time_step, &time_stepper,
-         using_gauss_lobatto_points, &vars_to_update, &volume_args_tuple,
-         &volume_det_jacobian, &volume_det_inv_jacobian,
+         &vars_to_update, &volume_args_tuple, &volume_det_jacobian,
+         &volume_det_inv_jacobian,
          &volume_mesh](auto* typed_boundary_correction) {
           using BcType = std::decay_t<decltype(*typed_boundary_correction)>;
           // Compute internal boundary quantities on the mortar for sides of
@@ -588,23 +593,44 @@ struct ApplyBoundaryCorrections {
                      "instead. You may have unintentionally added external "
                      "mortars in one of the initialization actions.");
             }
+            if (volume_mesh.basis(direction.dimension()) ==
+                    Spectral::Basis::ZernikeB2 and
+                volume_mesh.quadrature(direction.dimension()) ==
+                    Spectral::Quadrature::GaussRadauUpper and
+                direction.side() != Side::Upper) {
+              ERROR(
+                  "Trying to use ZernikeB2 basis with GaussRadauUpper "
+                  "quadrature on the lower side: there is not a boundary here. "
+                  "volume mesh: "
+                  << volume_mesh << ", element ID " << element.id());
+            }
 
             const Mesh<volume_dim - 1> face_mesh =
                 volume_mesh.slice_away(direction.dimension());
+
+            // Whether the mesh has a collocation point on this face. True for
+            // GaussLobatto (points on both faces) and GaussRadauUpper (point
+            // on the upper face only). When true, lifting is done via
+            // lift_flux on the slice; otherwise the full Gauss-point lifting
+            // path is used.
+            const bool using_points_on_face =
+                volume_mesh.quadrature(direction.dimension()) ==
+                    Spectral::Quadrature::GaussLobatto or
+                volume_mesh.quadrature(direction.dimension()) ==
+                    Spectral::Quadrature::GaussRadauUpper;
 
             const auto compute_correction_coupling =
                 [&typed_boundary_correction, &direction, dg_formulation,
                  &dt_boundary_correction_on_mortar, &face_det_jacobian,
                  &face_mesh, &face_normal_covector_and_magnitude,
                  &local_data_on_mortar, &mortar_id, &mortar_meshes,
-                 &mortar_infos, &neighbor_data_on_mortar,
-                 using_gauss_lobatto_points, &volume_args_tuple,
-                 &volume_det_jacobian, &volume_det_inv_jacobian,
-                 &volume_dt_correction, &volume_mesh](
+                 &mortar_infos, &neighbor_data_on_mortar, using_points_on_face,
+                 &volume_args_tuple, &volume_det_jacobian,
+                 &volume_det_inv_jacobian, &volume_dt_correction, &volume_mesh](
                     const MortarData<volume_dim>& local_mortar_data,
                     const MortarData<volume_dim>& neighbor_mortar_data)
                 -> DtVariables {
-              if (local_time_stepping and not using_gauss_lobatto_points) {
+              if (local_time_stepping and not using_points_on_face) {
                 // This needs to be updated every call because the Jacobian
                 // may be time-dependent. In the case of time-independent maps
                 // and local time stepping we could first perform the integral
@@ -707,12 +733,13 @@ struct ApplyBoundaryCorrections {
                                 direction))))));
               }
 
-              if (using_gauss_lobatto_points) {
+              if (using_points_on_face) {
                 // The lift_flux function lifts only on the slice, it does not
                 // add the contribution to the volume.
                 ::dg::lift_flux(make_not_null(&dt_boundary_correction),
                                 volume_mesh.extents(direction.dimension()),
-                                magnitude_of_face_normal);
+                                magnitude_of_face_normal,
+                                volume_mesh.basis(direction.dimension()));
                 return std::move(dt_boundary_correction);
               } else {
                 // We are using Gauss points.
@@ -767,10 +794,10 @@ struct ApplyBoundaryCorrections {
             };
 
             if constexpr (local_time_stepping) {
-              typename variables_tag::type lgl_lifted_data{};
-              auto& lifted_data = using_gauss_lobatto_points ? lgl_lifted_data
-                                                             : *vars_to_update;
-              if (using_gauss_lobatto_points) {
+              typename variables_tag::type boundary_lifted_data{};
+              auto& lifted_data =
+                  using_points_on_face ? boundary_lifted_data : *vars_to_update;
+              if (using_points_on_face) {
                 lifted_data.initialize(face_mesh.number_of_grid_points(), 0.0);
               }
 
@@ -787,7 +814,7 @@ struct ApplyBoundaryCorrections {
                                                 compute_correction_coupling);
               }
 
-              if (using_gauss_lobatto_points) {
+              if (using_points_on_face) {
                 // Add the flux contribution to the volume data
                 add_slice_to_data(
                     vars_to_update, lifted_data, volume_mesh.extents(),
@@ -807,14 +834,14 @@ struct ApplyBoundaryCorrections {
               // similar because the LTS code always stores the result
               // in the history and so sometimes benefits from moving
               // into the return value of compute_correction_coupling.
-              auto& lifted_data = using_gauss_lobatto_points
+              auto& lifted_data = using_points_on_face
                                       ? dt_boundary_correction_on_mortar
                                       : volume_dt_correction;
               lifted_data = compute_correction_coupling(
                   mortar_id_and_data.second.local(),
                   mortar_id_and_data.second.neighbor());
 
-              if (using_gauss_lobatto_points) {
+              if (using_points_on_face) {
                 // Add the flux contribution to the volume data
                 add_slice_to_data(
                     vars_to_update, lifted_data, volume_mesh.extents(),

--- a/src/Evolution/DiscontinuousGalerkin/Actions/BoundaryConditionsImpl.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/BoundaryConditionsImpl.hpp
@@ -424,6 +424,13 @@ void apply_boundary_condition_on_face(
   Variables<tags_on_exterior_face> exterior_face_fields{
       number_of_points_on_face};
 
+  const bool has_collocation_points_on_side =
+      volume_mesh.quadrature(direction.dimension()) ==
+          Spectral::Quadrature::GaussLobatto or
+      (volume_mesh.quadrature(direction.dimension()) ==
+           Spectral::Quadrature::GaussRadauUpper and
+       direction.side() == Side::Upper);
+
   if constexpr (uses_ghost_condition) {
     using mortar_tags_list = tmpl::list<PackageFieldTags...>;
     using dg_package_data_projected_tags =
@@ -584,12 +591,13 @@ void apply_boundary_condition_on_face(
         get<evolution::dg::Tags::MagnitudeOfNormal>(
             *db::get<evolution::dg::Tags::NormalCovectorAndMagnitude<Dim>>(*box)
                  .at(direction));
-    if (volume_mesh.quadrature(0) == Spectral::Quadrature::GaussLobatto) {
+    if (has_collocation_points_on_side) {
       // The lift_flux function lifts only on the slice, it does not add
       // the contribution to the volume.
       ::dg::lift_flux(make_not_null(&boundary_corrections_on_face),
                       volume_mesh.extents(direction.dimension()),
-                      magnitude_of_interior_face_normal);
+                      magnitude_of_interior_face_normal,
+                      volume_mesh.basis(direction.dimension()));
 
       // Add the flux contribution to the volume data
       db::mutate<dt_variables_tag>(
@@ -637,7 +645,7 @@ void apply_boundary_condition_on_face(
   }
   // Add TimeDerivative correction to volume time derivatives.
   if constexpr (uses_time_derivative_condition) {
-    if (volume_mesh.quadrature(0) == Spectral::Quadrature::GaussLobatto) {
+    if (has_collocation_points_on_side) {
       db::mutate<dt_variables_tag>(
           [&direction, &dt_time_derivative_correction,
            &volume_mesh](const auto dt_variables_ptr) {

--- a/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp
@@ -793,14 +793,17 @@ void ComputeTimeDerivative<Dim, EvolutionSystem, DgStepChoosers,
   }
 
   if (not mortar_history_directions.empty()) {
-    // We assume isotropic quadrature, i.e. the quadrature is the same in
-    // all directions.
-    const bool using_gauss_points =
-        db::get<domain::Tags::Mesh<Dim>>(*box).quadrature() ==
-        make_array<Dim>(Spectral::Quadrature::Gauss);
+    // Need volume Jacobian for any face whose normal direction uses Gauss
+    // points. This means mixed-quadrature non-hypercube elements (e.g.
+    // full_cylinder) where some directions have collocated face points and
+    // others do not.
+    const bool any_direction_uses_gauss =
+        alg::any_of(volume_mesh.quadrature(), [](const Spectral::Quadrature q) {
+          return q == Spectral::Quadrature::Gauss;
+        });
 
     const Scalar<DataVector> volume_det_inv_jacobian{};
-    if (using_gauss_points) {
+    if (any_direction_uses_gauss) {
       // NOLINTNEXTLINE
       const_cast<DataVector&>(get(volume_det_inv_jacobian))
           .set_data_ref(make_not_null(&const_cast<DataVector&>(  // NOLINT
@@ -809,8 +812,8 @@ void ComputeTimeDerivative<Dim, EvolutionSystem, DgStepChoosers,
     }
 
     // Add face normal and Jacobian determinants to the local mortar data. We
-    // only need the Jacobians if we are using Gauss points. Then copy over
-    // into the boundary history, since that's what the LTS steppers use.
+    // only need the Jacobians for directions using Gauss points. Then copy
+    // over into the boundary history, since that's what the LTS steppers use.
     //
     // The boundary history coupling computation (which computes the _lifted_
     // boundary correction) returns a Variables<dt<EvolvedVars>> instead of
@@ -820,7 +823,7 @@ void ComputeTimeDerivative<Dim, EvolutionSystem, DgStepChoosers,
     db::mutate<evolution::dg::Tags::MortarData<Dim>,
                evolution::dg::Tags::MortarDataHistory<Dim>>(
         [&element, integration_order, &mortar_history_directions, &mortar_info,
-         &time_step_id, using_gauss_points, &volume_det_inv_jacobian,
+         &time_step_id, any_direction_uses_gauss, &volume_det_inv_jacobian,
          &volume_mesh](
             const gsl::not_null<
                 DirectionalIdMap<Dim, evolution::dg::MortarDataHolder<Dim>>*>
@@ -837,7 +840,7 @@ void ComputeTimeDerivative<Dim, EvolutionSystem, DgStepChoosers,
                 normal_covector_and_magnitude) {
           Scalar<DataVector> volume_det_jacobian{};
           Scalar<DataVector> face_det_jacobian{};
-          if (using_gauss_points) {
+          if (any_direction_uses_gauss) {
             get(volume_det_jacobian) = 1.0 / get(volume_det_inv_jacobian);
           }
           for (const auto& [direction, neighbors_in_direction] :
@@ -853,7 +856,8 @@ void ComputeTimeDerivative<Dim, EvolutionSystem, DgStepChoosers,
             const Scalar<DataVector>& face_normal_magnitude =
                 get<evolution::dg::Tags::MagnitudeOfNormal>(
                     *normal_covector_and_magnitude.at(direction));
-            if (using_gauss_points) {
+            if (volume_mesh.quadrature(direction.dimension()) ==
+                Spectral::Quadrature::Gauss) {
               const Matrix identity{};
               auto interpolation_matrices =
                   make_array<Dim>(std::cref(identity));
@@ -881,7 +885,8 @@ void ComputeTimeDerivative<Dim, EvolutionSystem, DgStepChoosers,
               }
               auto& local_mortar_data = mortar_data->at(mortar_id).local();
               local_mortar_data.face_normal_magnitude = face_normal_magnitude;
-              if (using_gauss_points) {
+              if (volume_mesh.quadrature(direction.dimension()) ==
+                  Spectral::Quadrature::Gauss) {
                 local_mortar_data.volume_mesh = volume_mesh;
                 local_mortar_data.volume_det_inv_jacobian =
                     volume_det_inv_jacobian;

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/LiftFromBoundary.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/LiftFromBoundary.hpp
@@ -15,7 +15,6 @@
 #include "NumericalAlgorithms/Spectral/BoundaryLiftingTerm.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
-#include "Utilities/Algorithm.hpp"
 #include "Utilities/Gsl.hpp"
 
 namespace dg {
@@ -100,12 +99,10 @@ void lift_boundary_terms_gauss_points(
     const Variables<BoundaryCorrectionTagsList>& boundary_corrections,
     const Scalar<DataVector>& magnitude_of_face_normal,
     const Scalar<DataVector>& face_det_jacobian) {
-  ASSERT(alg::all_of(volume_mesh.quadrature(),
-                     [](const Spectral::Quadrature quadrature) {
-                       return quadrature == Spectral::Quadrature::Gauss;
-                     }),
-         "Must use Gauss points in all directions but got the mesh: "
-             << volume_mesh);
+  ASSERT(volume_mesh.quadrature(direction.dimension()) ==
+             Spectral::Quadrature::Gauss,
+         "Must use Gauss points in the face-normal direction "
+             << direction.dimension() << " but got mesh: " << volume_mesh);
   const Mesh<Dim - 1> boundary_mesh =
       volume_mesh.slice_away(direction.dimension());
   const Mesh<1> volume_stripe_mesh =
@@ -173,12 +170,9 @@ void lift_boundary_terms_gauss_points(
     const Variables<BoundaryCorrectionTagsList>& lower_boundary_corrections,
     const Scalar<DataVector>& lower_magnitude_of_face_normal,
     const Scalar<DataVector>& lower_face_det_jacobian) {
-  ASSERT(alg::all_of(volume_mesh.quadrature(),
-                     [](const Spectral::Quadrature quadrature) {
-                       return quadrature == Spectral::Quadrature::Gauss;
-                     }),
-         "Must use Gauss points in all directions but got the mesh: "
-             << volume_mesh);
+  ASSERT(volume_mesh.quadrature(dimension) == Spectral::Quadrature::Gauss,
+         "Must use Gauss points in the face-normal dimension "
+             << dimension << " but got mesh: " << volume_mesh);
   const Mesh<Dim - 1> boundary_mesh = volume_mesh.slice_away(dimension);
   const Mesh<1> volume_stripe_mesh = volume_mesh.slice_through(dimension);
   const size_t num_boundary_grid_points = boundary_mesh.number_of_grid_points();

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.cpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.cpp
@@ -26,11 +26,19 @@ Mesh<Dim> mortar_mesh(const Mesh<Dim>& face_mesh1,
   } else {
     Index<Dim> mortar_extents{};
     for (size_t i = 0; i < Dim; ++i) {
-      ASSERT(face_mesh1.basis(i) == face_mesh2.basis(i),
-             "The quadrature on face_mesh1 and face_mesh2 must be equal in "
-             "direction "
-                 << i << " but face_mesh1 is " << face_mesh1.quadrature(i)
-                 << " while face_mesh2 is " << face_mesh2.quadrature(i));
+      // From the point of view of mortars, ZernikeB2 with Equiangular
+      // quadrature are identical to Fourier with Equiangular quadrature
+      ASSERT(
+          face_mesh1.basis(i) == face_mesh2.basis(i) or
+              (face_mesh1.quadrature(i) == Spectral::Quadrature::Equiangular and
+               ((face_mesh1.basis(i) == Spectral::Basis::ZernikeB2 and
+                 face_mesh2.basis(0) == Spectral::Basis::Fourier) or
+                (face_mesh1.basis(i) == Spectral::Basis::Fourier and
+                 face_mesh2.basis(0) == Spectral::Basis::ZernikeB2))),
+          "The quadrature on face_mesh1 and face_mesh2 must be equal in "
+          "direction "
+              << i << " but face_mesh1 is " << face_mesh1.basis(i)
+              << " while face_mesh2 is " << face_mesh2.basis(i));
       ASSERT(face_mesh1.quadrature(i) == face_mesh2.quadrature(i),
              "The quadrature on face_mesh1 and face_mesh2 must be equal in "
              "direction "

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/ProjectToBoundary.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/ProjectToBoundary.hpp
@@ -112,6 +112,13 @@ void project_contiguous_data_to_boundary(
             first_volume_field[0].size() * number_of_independent_components},
         volume_mesh.extents());
   } else {
+    ASSERT(volume_mesh.quadrature(sliced_dim) ==
+                   Spectral::Quadrature::GaussLobatto or
+               (volume_mesh.quadrature(sliced_dim) ==
+                    Spectral::Quadrature::GaussRadauUpper and
+                direction.side() == Side::Upper),
+           "Got quadrature without boundary collocation point at "
+               << direction << " with " << volume_mesh.quadrature(sliced_dim));
     const size_t fixed_index = direction.side() == Side::Upper
                                    ? volume_mesh.extents(sliced_dim) - 1
                                    : 0;
@@ -194,6 +201,13 @@ void project_tensors_to_boundary(
                      volume_mesh.extents());
     });
   } else {
+    ASSERT(volume_mesh.quadrature(sliced_dim) ==
+                   Spectral::Quadrature::GaussLobatto or
+               (volume_mesh.quadrature(sliced_dim) ==
+                    Spectral::Quadrature::GaussRadauUpper and
+                direction.side() == Side::Upper),
+           "Got quadrature without boundary collocation point at "
+               << direction << " with " << volume_mesh.quadrature(sliced_dim));
     const size_t fixed_index = direction.side() == Side::Upper
                                    ? volume_mesh.extents(sliced_dim) - 1
                                    : 0;
@@ -255,6 +269,13 @@ void project_tensor_to_boundary(
                      volume_mesh.extents());
     }
   } else {
+    ASSERT(volume_mesh.quadrature(sliced_dim) ==
+                   Spectral::Quadrature::GaussLobatto or
+               (volume_mesh.quadrature(sliced_dim) ==
+                    Spectral::Quadrature::GaussRadauUpper and
+                direction.side() == Side::Upper),
+           "Got quadrature without boundary collocation point at "
+               << direction << " with " << volume_mesh.quadrature(sliced_dim));
     const size_t fixed_index = direction.side() == Side::Upper
                                    ? volume_mesh.extents(sliced_dim) - 1
                                    : 0;

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryCorrections.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryCorrections.cpp
@@ -289,7 +289,8 @@ struct SetLocalMortarData {
                         10 * static_cast<unsigned long>(direction.side()) +
                         100 * count + 100000);
           past_mortar_data.face_normal_magnitude = local_face_normal_magnitude;
-          if (volume_mesh.quadrature(0) == Spectral::Quadrature::Gauss) {
+          if (volume_mesh.quadrature(direction.dimension()) ==
+              Spectral::Quadrature::Gauss) {
             Scalar<DataVector> local_face_det_jacobian{
                 face_mesh.number_of_grid_points()};
             alg::iota(get(local_face_det_jacobian),
@@ -333,11 +334,9 @@ struct SetLocalMortarData {
                         *normal_covector_and_magnitude.at(
                             mortar_id.direction()));
 
-                const bool using_gauss_points =
-                    mesh.quadrature() == make_array<Metavariables::volume_dim>(
-                                             Spectral::Quadrature::Gauss);
                 local_mortar_data.face_normal_magnitude = face_normal_magnitude;
-                if (using_gauss_points) {
+                if (mesh.quadrature(mortar_id.direction().dimension()) ==
+                    Spectral::Quadrature::Gauss) {
                   const Scalar<DataVector> det_jacobian{
                       DataVector{1.0 / get(det_inv_jacobian)}};
                   Scalar<DataVector> face_det_jacobian{
@@ -806,7 +805,7 @@ void test_impl(const Spectral::Quadrature quadrature,
       [&det_inv_jacobian, &dg_formulation, &dt_boundary_correction_on_mortar,
        &dt_boundary_correction_projected_onto_face,
        &expected_dt_variables_volume, &mesh, &mortar_id_ptr, &mortar_meshes,
-       &mortar_infos, &quadrature, &runner,
+       &mortar_infos, &runner,
        &self_id](const evolution::dg::MortarData<Dim>& local_mortar_data,
                  const evolution::dg::MortarData<Dim>& neighbor_mortar_data)
       -> Variables<db::wrap_tags_in<::Tags::dt, variables_tags>> {
@@ -815,7 +814,10 @@ void test_impl(const Spectral::Quadrature quadrature,
     const auto& mortar_mesh = mortar_meshes.at(mortar_id);
     const size_t dimension = direction.dimension();
 
-    if (UseLocalTimeStepping and quadrature == Spectral::Quadrature::Gauss) {
+    const bool using_points_on_face =
+        mesh.quadrature(dimension) == Spectral::Quadrature::GaussLobatto or
+        mesh.quadrature(dimension) == Spectral::Quadrature::GaussRadauUpper;
+    if (UseLocalTimeStepping and not using_points_on_face) {
       // This needs to be updated every call because the Jacobian may be
       // time-dependent. In the case of time-independent maps and local
       // time stepping we could first perform the integral on the
@@ -888,11 +890,12 @@ void test_impl(const Spectral::Quadrature quadrature,
                .at(direction));
     }
 
-    if (quadrature == Spectral::Quadrature::GaussLobatto) {
+    if (using_points_on_face) {
       // The lift_flux function lifts only on the slice, it does not add
       // the contribution to the volume.
       ::dg::lift_flux(make_not_null(&dt_boundary_correction),
-                      mesh.extents(dimension), magnitude_of_face_normal);
+                      mesh.extents(dimension), magnitude_of_face_normal,
+                      mesh.basis(dimension));
       if (UseLocalTimeStepping) {
         return dt_boundary_correction;
       } else {
@@ -961,14 +964,19 @@ void test_impl(const Spectral::Quadrature quadrature,
             return p_project_mortar_data(data, mortar_mesh);
           });
       mortar_id_ptr = &mortar_id;
+      const bool direction_uses_points_on_face =
+          mesh.quadrature(direction.dimension()) ==
+              Spectral::Quadrature::GaussLobatto or
+          mesh.quadrature(direction.dimension()) ==
+              Spectral::Quadrature::GaussRadauUpper;
       Variables<variables_tags> lifted_volume_data{
-          quadrature == Spectral::Quadrature::GaussLobatto
+          direction_uses_points_on_face
               ? mesh.slice_away(direction.dimension()).number_of_grid_points()
               : mesh.number_of_grid_points(),
           0.0};
       time_stepper.add_boundary_delta(&lifted_volume_data, mortar_data_hist,
                                       time_step, compute_correction_coupling);
-      if (quadrature == Spectral::Quadrature::GaussLobatto) {
+      if (direction_uses_points_on_face) {
         // Add the flux contribution to the volume data
         add_slice_to_data(make_not_null(&expected_evolved_variables),
                           lifted_volume_data, mesh.extents(),

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_BoundaryConditions.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_BoundaryConditions.cpp
@@ -2287,8 +2287,7 @@ void test_1d(const bool moving_mesh, const dg::Formulation formulation,
     }
   }
 
-  const auto expected_ghost_dt_correction = [&box, &formulation, &mesh,
-                                             &quadrature](
+  const auto expected_ghost_dt_correction = [&box, &formulation, &mesh](
                                                 const auto& ghost_direction) {
     Variables<tmpl::list<::Tags::dt<Tags::Var1>, ::Tags::dt<Tags::Var2<Dim>>>>
         expected_on_boundary{mesh.slice_away(ghost_direction.dimension())
@@ -2310,7 +2309,8 @@ void test_1d(const bool moving_mesh, const dg::Formulation formulation,
         get<evolution::dg::Tags::MagnitudeOfNormal>(
             *db::get<evolution::dg::Tags::NormalCovectorAndMagnitude<Dim>>(box)
                  .at(ghost_direction));
-    if (quadrature == Spectral::Quadrature::Gauss) {
+    if (mesh.quadrature(ghost_direction.dimension()) ==
+        Spectral::Quadrature::Gauss) {
       Scalar<DataVector> face_det_inv_jacobian{
           mesh.slice_away(ghost_direction.dimension()).number_of_grid_points()};
       const Matrix identity{};
@@ -2333,7 +2333,8 @@ void test_1d(const bool moving_mesh, const dg::Formulation formulation,
     } else {
       ::dg::lift_flux(make_not_null(&expected_on_boundary),
                       mesh.extents(ghost_direction.dimension()),
-                      magnitude_of_interior_face_normal);
+                      magnitude_of_interior_face_normal,
+                      mesh.basis(ghost_direction.dimension()));
       add_slice_to_data(make_not_null(&expected_dt_volume_correction),
                         expected_on_boundary, mesh.extents(),
                         ghost_direction.dimension(),
@@ -2389,7 +2390,7 @@ void test_1d(const bool moving_mesh, const dg::Formulation formulation,
   // Ghost +xi, DemandOutgoingCharSpeeds -xi
   check_outgoing_and_ghost(Direction<Dim>::lower_xi());
 
-  const auto expected_time_derivative_dt_correction = [&mesh, &quadrature](
+  const auto expected_time_derivative_dt_correction = [&mesh](
                                                           const auto&
                                                               dt_direction) {
     Variables<tmpl::list<::Tags::dt<Tags::Var1>, ::Tags::dt<Tags::Var2<Dim>>>>
@@ -2409,7 +2410,8 @@ void test_1d(const bool moving_mesh, const dg::Formulation formulation,
       get<::Tags::dt<Tags::Var2<Dim>>>(dt_correction_gl)
           .get(i)[boundary_index] += offset_boundary_condition + 1.0 + i;
     }
-    if (quadrature == Spectral::Quadrature::GaussLobatto) {
+    if (mesh.quadrature(dt_direction.dimension()) ==
+        Spectral::Quadrature::GaussLobatto) {
       expected_dt_volume_correction += dt_correction_gl;
     } else {
       // Interpolate to Gauss mesh

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
@@ -1743,15 +1743,17 @@ void test_impl(const Spectral::Quadrature quadrature,
       };
 
   const auto check_mortar_data = [&compute_expected_mortar_data,
-                                  &det_inv_jacobian, &get_tag, &mesh,
-                                  &quadrature](const auto& mortar_data,
-                                               const auto& mortar_id) {
+                                  &det_inv_jacobian, &get_tag,
+                                  &mesh](const auto& mortar_data,
+                                         const auto& mortar_id) {
     CHECK_ITERABLE_APPROX(mortar_data.mortar_data.value(),
                           compute_expected_mortar_data(mortar_id.direction(),
                                                        mortar_id.id(), true));
 
     // Check face normal and/or Jacobians
-    const bool using_gauss_points = quadrature == Spectral::Quadrature::Gauss;
+    const bool using_gauss_points =
+        mesh.quadrature(mortar_id.direction().dimension()) ==
+        Spectral::Quadrature::Gauss;
     REQUIRE(mortar_data.face_normal_magnitude.has_value());
     const Scalar<DataVector>& local_face_normal_magnitude =
         mortar_data.face_normal_magnitude.value();

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_ProjectToBoundary.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_ProjectToBoundary.cpp
@@ -17,8 +17,10 @@
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/ProjectToBoundary.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -56,7 +58,13 @@ void test(const Spectral::Quadrature quadrature) {
   MAKE_GENERATOR(gen);
   UniformCustomDistribution<size_t> sdist{5, 10};
 
-  Mesh<Dim> volume_mesh{sdist(gen), Spectral::Basis::Legendre, quadrature};
+  const bool using_zernike =
+      quadrature == Spectral::Quadrature::GaussRadauUpper;
+
+  const Mesh<Dim> volume_mesh{
+      sdist(gen),
+      using_zernike ? Spectral::Basis::ZernikeB2 : Spectral::Basis::Legendre,
+      quadrature};
   Index<Dim> powers{};
   for (size_t i = 0; i < Dim; ++i) {
     powers[i] = volume_mesh.extents(i) - 2 - i;
@@ -72,6 +80,9 @@ void test(const Spectral::Quadrature quadrature) {
       get<Var2>(volume_data);
 
   for (const auto& direction : Direction<Dim>::all_directions()) {
+    if (using_zernike and direction.side() != Side::Upper) {
+      continue;
+    }
     const size_t sliced_dim = direction.dimension();
     const size_t fixed_index = direction.side() == Side::Upper
                                    ? volume_mesh.extents(sliced_dim) - 1
@@ -140,6 +151,21 @@ void test(const Spectral::Quadrature quadrature) {
     CHECK_ITERABLE_APPROX(var2_face, get<Var2>(expected_face_values));
   }
 }
+
+void test_asserts() {
+#ifdef SPECTRE_DEBUG
+  const Mesh<1> mesh(5, Spectral::Basis::ZernikeB2,
+                     Spectral::Quadrature::GaussRadauUpper);
+  Variables<tmpl::list<Var1>> face{mesh.number_of_grid_points(), 0.0};
+  const Variables<tmpl::list<Var1>> volume{mesh.number_of_grid_points(), 0.0};
+
+  CHECK_THROWS_WITH(
+      ::dg::project_tensors_to_boundary<tmpl::list<Var1>>(
+          make_not_null(&face), volume, mesh, Direction<1>::lower_xi()),
+      Catch::Matchers::ContainsSubstring(
+          "Got quadrature without boundary collocation point at"));
+#endif  // SPECTRE_DEBUG
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.ProjectToBoundary",
@@ -150,4 +176,6 @@ SPECTRE_TEST_CASE("Unit.DiscontinuousGalerkin.ProjectToBoundary",
     test<2>(quadrature);
     test<3>(quadrature);
   }
+  test<1>(Spectral::Quadrature::GaussRadauUpper);
+  test_asserts();
 }


### PR DESCRIPTION
## Proposed changes

These are the minimal changes to use `GaussRadauUpper` quadrature.

Currently, my test updates are just changing the logic to match the source code: the new paths are not tested. That is primarily because these are complex tests that would potentially require moderate changes to properly test. I know Larry has in mind to refactor the test of ComputeTimeDerivative, so I wanted to get input about what is the right place to put effort into tests.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
