### PR TITLE
Allow injecting gravitational wave through outer boundary

### DIFF
--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -184,6 +184,8 @@
 #include "PointwiseFunctions/GeneralRelativity/WeylElectric.hpp"
 #include "PointwiseFunctions/GeneralRelativity/WeylTypeD1.hpp"
 #include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
+#include "PointwiseFunctions/MathFunctions/Factory.hpp"
+#include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
 #include "Time/Actions/SelfStartActions.hpp"
 #include "Time/AdvanceTime.hpp"
 #include "Time/ChangeSlabSize/Action.hpp"
@@ -530,6 +532,8 @@ struct EvolutionMetavars {
         tmpl::pair<
             gh::gauges::GaugeCondition,
             tmpl::list<gh::gauges::DampedHarmonic, gh::gauges::Harmonic>>,
+        tmpl::pair<MathFunction<1, Frame::Inertial>,
+                   MathFunctions::all_math_functions<1, Frame::Inertial>>,
         // Restrict to monotonic time steppers in LTS to avoid control
         // systems deadlocking.
         tmpl::pair<LtsTimeStepper, TimeSteppers::monotonic_lts_time_steppers>,

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -225,6 +225,8 @@
 #include "PointwiseFunctions/Hydro/Tags.hpp"
 #include "PointwiseFunctions/Hydro/TransportVelocity.hpp"
 #include "PointwiseFunctions/InitialDataUtilities/Tags/InitialData.hpp"
+#include "PointwiseFunctions/MathFunctions/Factory.hpp"
+#include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
 #include "Time/Actions/SelfStartActions.hpp"
 #include "Time/AdvanceTime.hpp"
 #include "Time/ChangeSlabSize/Action.hpp"
@@ -659,6 +661,8 @@ struct GhValenciaDivCleanTemplateBase<
             grmhd::AnalyticData::InitialMagneticFields::
                 initial_magnetic_fields>,
         tmpl::pair<gh::gauges::GaugeCondition, gh::gauges::all_gauges>,
+        tmpl::pair<MathFunction<1, Frame::Inertial>,
+                   MathFunctions::all_math_functions<1, Frame::Inertial>>,
         tmpl::pair<evolution::initial_data::InitialData, initial_data_list>,
         // Restrict to monotonic time steppers in LTS to avoid control
         // systems deadlocking.

--- a/src/Evolution/Executables/ScalarTensor/ScalarTensorBase.hpp
+++ b/src/Evolution/Executables/ScalarTensor/ScalarTensorBase.hpp
@@ -123,12 +123,13 @@
 #include "PointwiseFunctions/GeneralRelativity/WeylElectric.hpp"
 #include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
 #include "PointwiseFunctions/InitialDataUtilities/Tags/InitialData.hpp"
+#include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
 #include "PointwiseFunctions/ScalarTensor/ConstraintDampingTags.hpp"
 #include "PointwiseFunctions/ScalarTensor/ConstraintGammas.hpp"
 #include "PointwiseFunctions/ScalarTensor/ScalarCharge.hpp"
 #include "PointwiseFunctions/ScalarTensor/ScalarGaussBonnet/Tags.hpp"
-#include "PointwiseFunctions/ScalarTensor/SourceTags.hpp"
 #include "PointwiseFunctions/ScalarTensor/ScalarSource.hpp"
+#include "PointwiseFunctions/ScalarTensor/SourceTags.hpp"
 #include "PointwiseFunctions/ScalarTensor/StressEnergy.hpp"
 #include "Time/Actions/SelfStartActions.hpp"
 #include "Time/ChangeTimeStepperOrder.hpp"
@@ -367,6 +368,7 @@ struct FactoryCreation : tt::ConformsTo<Options::protocols::FactoryCreation> {
           ScalarTensor::BoundaryConditions::BoundaryCondition,
           ScalarTensor::BoundaryConditions::standard_boundary_conditions>,
       tmpl::pair<gh::gauges::GaugeCondition, gh::gauges::all_gauges>,
+      tmpl::pair<MathFunction<1, Frame::Inertial>, tmpl::list<>>,
       tmpl::pair<
           evolution::initial_data::InitialData,
           tmpl::push_back<initial_data_list, ScalarTensor::NumericInitialData>>,

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.cpp
@@ -66,8 +66,42 @@ convert_constraint_preserving_bjorhus_type_from_yaml(
 
 template <size_t Dim>
 ConstraintPreservingBjorhus<Dim>::ConstraintPreservingBjorhus(
-    const detail::ConstraintPreservingBjorhusType type)
-    : type_(type) {}
+    const detail::ConstraintPreservingBjorhusType type,
+    std::optional<std::unique_ptr<::MathFunction<1, Frame::Inertial>>>
+        incoming_wave_profile)
+    : type_(type),
+      incoming_wave_profile_(incoming_wave_profile.has_value()
+                                 ? std::move(incoming_wave_profile.value())
+                                 : nullptr) {
+  if constexpr (Dim < 3) {
+    if (incoming_wave_profile_ != nullptr) {
+      ERROR("IncomingWaveProfile can only be used for "
+            "ConstraintPreservingBjorhus in 3 spatial dimensions.");
+    }
+  }
+}
+
+template <size_t Dim>
+ConstraintPreservingBjorhus<Dim>::ConstraintPreservingBjorhus(
+    const ConstraintPreservingBjorhus& rhs)
+    : BoundaryCondition<Dim>{dynamic_cast<const BoundaryCondition<Dim>&>(rhs)},
+      type_(rhs.type_),
+      incoming_wave_profile_(rhs.incoming_wave_profile_ != nullptr
+                                 ? rhs.incoming_wave_profile_->get_clone()
+                                 : nullptr) {}
+
+template <size_t Dim>
+ConstraintPreservingBjorhus<Dim>& ConstraintPreservingBjorhus<Dim>::operator=(
+    const ConstraintPreservingBjorhus& rhs) {
+  if (&rhs == this) {
+    return *this;
+  }
+  type_ = rhs.type_;
+  incoming_wave_profile_ = rhs.incoming_wave_profile_ != nullptr
+                               ? rhs.incoming_wave_profile_->get_clone()
+                               : nullptr;
+  return *this;
+}
 
 template <size_t Dim>
 ConstraintPreservingBjorhus<Dim>::ConstraintPreservingBjorhus(
@@ -84,6 +118,7 @@ template <size_t Dim>
 void ConstraintPreservingBjorhus<Dim>::pup(PUP::er& p) {
   BoundaryCondition<Dim>::pup(p);
   p | type_;
+  p | incoming_wave_profile_;
 }
 
 template <size_t Dim>
@@ -122,7 +157,8 @@ std::optional<std::string> ConstraintPreservingBjorhus<Dim>::dg_time_derivative(
     // c.f. dg_interior_deriv_vars_tags
     const tnsr::iaa<DataVector, Dim, Frame::Inertial>& d_spacetime_metric,
     const tnsr::iaa<DataVector, Dim, Frame::Inertial>& d_pi,
-    const tnsr::ijaa<DataVector, Dim, Frame::Inertial>& d_phi) const {
+    const tnsr::ijaa<DataVector, Dim, Frame::Inertial>& d_phi,
+    const double time) const {
   TempBuffer<tmpl::list<::Tags::TempI<0, Dim, Frame::Inertial, DataVector>,
                         ::Tags::Tempiaa<1, Dim, Frame::Inertial, DataVector>,
                         ::Tags::TempII<0, Dim, Frame::Inertial, DataVector>,
@@ -317,7 +353,7 @@ std::optional<std::string> ConstraintPreservingBjorhus<Dim>::dg_time_derivative(
   } else if (type_ == detail::ConstraintPreservingBjorhusType::
                           ConstraintPreservingPhysical) {
     Bjorhus::constraint_preserving_gauge_physical_corrections_dt_v_minus(
-        make_not_null(&bc_dt_v_minus), gamma2, coords, normal_covector,
+        make_not_null(&bc_dt_v_minus), gamma2, coords, time, normal_covector,
         unit_interface_normal_vector, spacetime_unit_normal_vector,
         incoming_null_one_form, outgoing_null_one_form, incoming_null_vector,
         outgoing_null_vector, projection_ab, projection_Ab, projection_AB,
@@ -325,7 +361,7 @@ std::optional<std::string> ConstraintPreservingBjorhus<Dim>::dg_time_derivative(
         inverse_spacetime_metric, three_index_constraint,
         char_projected_rhs_dt_v_psi, char_projected_rhs_dt_v_minus,
         constraint_char_zero_plus, constraint_char_zero_minus, phi, d_phi, d_pi,
-        char_speeds);
+        char_speeds, incoming_wave_profile_.get());
   } else {
     ERROR(
         "Failed to set dtVMinus. Input option must be one of "

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.hpp
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <cstddef>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <pup.h>
@@ -18,12 +19,14 @@
 #include "Evolution/BoundaryConditions/Type.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BoundaryCondition.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "Options/Auto.hpp"
 #include "Options/Options.hpp"
 #include "Options/String.hpp"
 #include "PointwiseFunctions/AnalyticData/Tags.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/ConstraintDampingTags.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Serialization/CharmPupable.hpp"
 #include "Utilities/TMPL.hpp"
@@ -33,6 +36,9 @@ namespace domain::Tags {
 template <size_t Dim, typename Frame>
 struct Coordinates;
 }  // namespace domain::Tags
+namespace Tags {
+struct Time;
+}  // namespace Tags
 /// \endcond
 
 namespace gh::BoundaryConditions::detail {
@@ -82,6 +88,22 @@ namespace gh::BoundaryConditions {
  * all the above conditions are also imposed on characteristic modes with speeds
  * exactly zero.
  *
+ * An optional injected incoming-wave contribution can be specified through
+ * `IncomingWaveProfile`. The injected strain-rate tensor is
+ * \f[
+ *   \dot{h}_{ab} = \dot{f}(t)
+ *   \left(\hat{x}_a \hat{x}_b + \hat{y}_a \hat{y}_b - 2 \hat{z}_a
+ * \hat{z}_b\right),
+ * \f]
+ * where the configured profile is interpreted directly as \f$\dot{f}(t)\f$ and
+ * \f$\hat{x}_a\f$, \f$\hat{y}_a\f$ and \f$\hat{z}_a\f$ are the components of
+ * the coordinate basis vectors. This formula is taken from
+ * \cite Lindblom2005qh.  It should be considered an approximate perturbation
+ * rather than an exact gravitational wave which would have to be constructed at
+ * null-infinity. Note that the profile of the injected wave is specified at the
+ * outer boundary and its amplitude should be adjusted according to the usual
+ * 1/r scaling.
+ *
  * This class provides two choices of combinations of the above corrections:
  *  - `ConstraintPreserving` : this imposes the constraint-preserving and
  * gauge-controlling corrections;
@@ -95,9 +117,7 @@ namespace gh::BoundaryConditions {
  * `Bjorhus::constraint_preserving_gauge_physical_corrections_dt_v_minus()`
  * for the further details on implementation.
  *
- * \note These boundary conditions assume a spherical outer boundary. Also, we
- * do not yet have an option to inject incoming gravitational waves at the outer
- * boundary.
+ * \note These boundary conditions assume a spherical outer boundary.
  */
 template <size_t Dim>
 class ConstraintPreservingBjorhus final : public BoundaryCondition<Dim> {
@@ -110,7 +130,23 @@ class ConstraintPreservingBjorhus final : public BoundaryCondition<Dim> {
         "terms for VMinus."};
   };
 
-  using options = tmpl::list<TypeOptionTag>;
+  struct IncomingWaveProfileOptionTag {
+    using type =
+        Options::Auto<std::unique_ptr<::MathFunction<1, Frame::Inertial>>,
+                      Options::AutoLabel::None>;
+    static std::string name() { return "IncomingWaveProfile"; }
+    static constexpr Options::String help{
+        "Optional incoming-wave profile interpreted as the first time "
+        "derivative for the injected physical wave. See the "
+        "ConstraintPreservingBjorhus class documentation for the injected-wave "
+        "formula. Specify `None` to disable injection. This option is only "
+        "supported in 3D."};
+  };
+
+  using options = tmpl::flatten<tmpl::list<
+      TypeOptionTag,
+      tmpl::conditional_t<Dim == 3, tmpl::list<IncomingWaveProfileOptionTag>,
+                          tmpl::list<>>>>;
   static constexpr Options::String help{
       "ConstraintPreservingBjorhus boundary conditions setting the value of the"
       "time derivatives of the spacetime metric, Phi and Pi to expressions that"
@@ -118,16 +154,17 @@ class ConstraintPreservingBjorhus final : public BoundaryCondition<Dim> {
   static std::string name() { return "ConstraintPreservingBjorhus"; }
 
   explicit ConstraintPreservingBjorhus(
-      detail::ConstraintPreservingBjorhusType type);
+      detail::ConstraintPreservingBjorhusType type,
+      std::optional<std::unique_ptr<::MathFunction<1, Frame::Inertial>>>
+          incoming_wave_profile = std::nullopt);
 
   ConstraintPreservingBjorhus() = default;
   /// \cond
   ConstraintPreservingBjorhus(ConstraintPreservingBjorhus&&) = default;
   ConstraintPreservingBjorhus& operator=(ConstraintPreservingBjorhus&&) =
       default;
-  ConstraintPreservingBjorhus(const ConstraintPreservingBjorhus&) = default;
-  ConstraintPreservingBjorhus& operator=(const ConstraintPreservingBjorhus&) =
-      default;
+  ConstraintPreservingBjorhus(const ConstraintPreservingBjorhus&);
+  ConstraintPreservingBjorhus& operator=(const ConstraintPreservingBjorhus&);
   /// \endcond
   ~ConstraintPreservingBjorhus() override = default;
 
@@ -168,7 +205,7 @@ class ConstraintPreservingBjorhus final : public BoundaryCondition<Dim> {
                                Frame::Inertial>,
                  ::Tags::deriv<Tags::Phi<DataVector, Dim>, tmpl::size_t<Dim>,
                                Frame::Inertial>>;
-  using dg_gridless_tags = tmpl::list<>;
+  using dg_gridless_tags = tmpl::list<::Tags::Time>;
 
   std::optional<std::string> dg_time_derivative(
       gsl::not_null<tnsr::aa<DataVector, Dim, Frame::Inertial>*>
@@ -177,7 +214,6 @@ class ConstraintPreservingBjorhus final : public BoundaryCondition<Dim> {
           dt_pi_correction,
       gsl::not_null<tnsr::iaa<DataVector, Dim, Frame::Inertial>*>
           dt_phi_correction,
-
       const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
           face_mesh_velocity,
       const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_covector,
@@ -207,7 +243,8 @@ class ConstraintPreservingBjorhus final : public BoundaryCondition<Dim> {
       // c.f. dg_interior_deriv_vars_tags
       const tnsr::iaa<DataVector, Dim, Frame::Inertial>& d_spacetime_metric,
       const tnsr::iaa<DataVector, Dim, Frame::Inertial>& d_pi,
-      const tnsr::ijaa<DataVector, Dim, Frame::Inertial>& d_phi) const;
+      const tnsr::ijaa<DataVector, Dim, Frame::Inertial>& d_phi,
+      double time = std::numeric_limits<double>::signaling_NaN()) const;
 
  private:
   void compute_intermediate_vars(
@@ -274,6 +311,7 @@ class ConstraintPreservingBjorhus final : public BoundaryCondition<Dim> {
 
   detail::ConstraintPreservingBjorhusType type_{
       detail::ConstraintPreservingBjorhusType::ConstraintPreservingPhysical};
+  std::unique_ptr<::MathFunction<1, Frame::Inertial>> incoming_wave_profile_{};
 };
 }  // namespace gh::BoundaryConditions
 

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BjorhusImpl.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BjorhusImpl.cpp
@@ -17,10 +17,12 @@
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Ricci.hpp"
 #include "PointwiseFunctions/GeneralRelativity/ProjectionOperators.hpp"
 #include "PointwiseFunctions/GeneralRelativity/WeylPropagating.hpp"
+#include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
 #include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
 
 namespace gh::BoundaryConditions::Bjorhus {
 template <size_t VolumeDim, typename DataType>
@@ -247,7 +249,8 @@ void add_physical_terms_to_dt_v_minus(
     const tnsr::iaa<DataType, VolumeDim, Frame::Inertial>& phi,
     const tnsr::ijaa<DataType, VolumeDim, Frame::Inertial>& d_phi,
     const tnsr::iaa<DataType, VolumeDim, Frame::Inertial>& d_pi,
-    const std::array<DataType, 4>& char_speeds) {
+    const std::array<DataType, 4>& char_speeds, const double time,
+    const MathFunction<1, Frame::Inertial>* const incoming_wave_profile) {
   // hard-coded value from SpEC Bbh input file Mu = MuPhys = 0
   constexpr double mu_phys = 0.;
   constexpr bool adjust_phys_using_c4 = true;
@@ -257,12 +260,15 @@ void add_physical_terms_to_dt_v_minus(
   // https://arxiv.org/pdf/gr-qc/0105031.pdf.
   TempBuffer<tmpl::list<::Tags::Tempaa<0, VolumeDim, Frame::Inertial, DataType>,
                         ::Tags::Tempaa<1, VolumeDim, Frame::Inertial, DataType>,
+                        ::Tags::Tempaa<2, VolumeDim, Frame::Inertial, DataType>,
                         ::Tags::TempScalar<0, DataType>>>
       u3_buffer(get_size(get<0>(unit_interface_normal_vector)), 0.);
   auto& U3p =
       get<::Tags::Tempaa<0, VolumeDim, Frame::Inertial, DataType>>(u3_buffer);
   auto& U3m =
       get<::Tags::Tempaa<1, VolumeDim, Frame::Inertial, DataType>>(u3_buffer);
+  auto& injected_wave =
+      get<::Tags::Tempaa<2, VolumeDim, Frame::Inertial, DataType>>(u3_buffer);
 
   {
     TempBuffer<
@@ -428,11 +434,21 @@ void add_physical_terms_to_dt_v_minus(
     }
   }
 
+  if (incoming_wave_profile != nullptr) {
+    if constexpr (VolumeDim == 3) {
+      const double injected_wave_profile_value = (*incoming_wave_profile)(time);
+      injected_wave.get(1, 1) = injected_wave_profile_value;
+      injected_wave.get(2, 2) = injected_wave_profile_value;
+      injected_wave.get(3, 3) = -2. * injected_wave_profile_value;
+    } else {
+      ERROR("IncomingWaveProfile can only be used in 3 spatial dimensions.");
+    }
+  }
+
   // Add physical boundary corrections
   if (gamma2_in_phys) {
     auto& normal_dot_three_index_constraint_gamma2 =
         get(get<::Tags::TempScalar<0, DataType>>(u3_buffer));
-
     for (size_t a = 0; a <= VolumeDim; ++a) {
       for (size_t b = a; b <= VolumeDim; ++b) {
         for (size_t c = 0; c <= VolumeDim; ++c) {
@@ -452,7 +468,7 @@ void add_physical_terms_to_dt_v_minus(
                   (projection_Ab.get(c, a) * projection_Ab.get(d, b) -
                    0.5 * projection_ab.get(a, b) * projection_AB.get(c, d)) *
                   (char_projected_rhs_dt_v_minus.get(c, d) +
-                   char_speeds[3] * (U3m.get(c, d) -
+                   char_speeds[3] * (U3m.get(c, d) - injected_wave.get(c, d) -
                                      normal_dot_three_index_constraint_gamma2));
             } else {
               bc_dt_v_minus->get(a, b) +=
@@ -566,6 +582,7 @@ void constraint_preserving_gauge_physical_corrections_dt_v_minus(
         bc_dt_v_minus,
     const Scalar<DataType>& gamma2,
     const tnsr::I<DataType, VolumeDim, Frame::Inertial>& inertial_coords,
+    const double time,
     const tnsr::i<DataType, VolumeDim, Frame::Inertial>&
         unit_interface_normal_one_form,
     const tnsr::I<DataType, VolumeDim, Frame::Inertial>&
@@ -598,7 +615,8 @@ void constraint_preserving_gauge_physical_corrections_dt_v_minus(
     const tnsr::iaa<DataType, VolumeDim, Frame::Inertial>& phi,
     const tnsr::ijaa<DataType, VolumeDim, Frame::Inertial>& d_phi,
     const tnsr::iaa<DataType, VolumeDim, Frame::Inertial>& d_pi,
-    const std::array<DataType, 4>& char_speeds) {
+    const std::array<DataType, 4>& char_speeds,
+    const MathFunction<1, Frame::Inertial>* const incoming_wave_profile) {
   for (size_t a = 0; a <= VolumeDim; ++a) {
     for (size_t b = a; b <= VolumeDim; ++b) {
       bc_dt_v_minus->get(a, b) = -char_projected_rhs_dt_v_minus.get(a, b);
@@ -614,7 +632,8 @@ void constraint_preserving_gauge_physical_corrections_dt_v_minus(
       unit_interface_normal_vector, spacetime_unit_normal_vector, projection_ab,
       projection_Ab, projection_AB, inverse_spatial_metric, extrinsic_curvature,
       spacetime_metric, inverse_spacetime_metric, three_index_constraint,
-      char_projected_rhs_dt_v_minus, phi, d_phi, d_pi, char_speeds);
+      char_projected_rhs_dt_v_minus, phi, d_phi, d_pi, char_speeds, time,
+      incoming_wave_profile);
   detail::add_gauge_sommerfeld_terms_to_dt_v_minus(
       bc_dt_v_minus, gamma2, inertial_coords, incoming_null_one_form,
       outgoing_null_one_form, incoming_null_vector, outgoing_null_vector,
@@ -719,7 +738,8 @@ void constraint_preserving_gauge_physical_corrections_dt_v_minus(
       const tnsr::iaa<DTYPE(data), DIM(data), Frame::Inertial>& phi,           \
       const tnsr::ijaa<DTYPE(data), DIM(data), Frame::Inertial>& d_phi,        \
       const tnsr::iaa<DTYPE(data), DIM(data), Frame::Inertial>& d_pi,          \
-      const std::array<DTYPE(data), 4>& char_speeds);                          \
+      const std::array<DTYPE(data), 4>& char_speeds, const double time,        \
+      const MathFunction<1, Frame::Inertial>* incoming_wave_profile);          \
   template void gh::BoundaryConditions::Bjorhus::                              \
       constraint_preserving_corrections_dt_v_minus(                            \
           const gsl::not_null<                                                 \
@@ -783,6 +803,7 @@ void constraint_preserving_gauge_physical_corrections_dt_v_minus(
           const Scalar<DTYPE(data)>& gamma2,                                   \
           const tnsr::I<DTYPE(data), DIM(data), Frame::Inertial>&              \
               inertial_coords,                                                 \
+          const double time,                                                   \
           const tnsr::i<DTYPE(data), DIM(data), Frame::Inertial>&              \
               unit_interface_normal_one_form,                                  \
           const tnsr::I<DTYPE(data), DIM(data), Frame::Inertial>&              \
@@ -824,7 +845,8 @@ void constraint_preserving_gauge_physical_corrections_dt_v_minus(
           const tnsr::iaa<DTYPE(data), DIM(data), Frame::Inertial>& phi,       \
           const tnsr::ijaa<DTYPE(data), DIM(data), Frame::Inertial>& d_phi,    \
           const tnsr::iaa<DTYPE(data), DIM(data), Frame::Inertial>& d_pi,      \
-          const std::array<DTYPE(data), 4>& char_speeds);
+          const std::array<DTYPE(data), 4>& char_speeds,                       \
+          const MathFunction<1, Frame::Inertial>* incoming_wave_profile);
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (DataVector))
 

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BjorhusImpl.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BjorhusImpl.hpp
@@ -5,12 +5,15 @@
 
 #include <array>
 #include <cstddef>
+#include <limits>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Utilities/ContainerHelpers.hpp"
 
 /// \cond
 class DataVector;
+template <size_t VolumeDim, typename Fr>
+class MathFunction;
 namespace gsl {
 template <class T>
 class not_null;
@@ -215,6 +218,7 @@ void constraint_preserving_gauge_physical_corrections_dt_v_minus(
         bc_dt_v_minus,
     const Scalar<DataType>& gamma2,
     const tnsr::I<DataType, VolumeDim, Frame::Inertial>& inertial_coords,
+    double time,
     const tnsr::i<DataType, VolumeDim, Frame::Inertial>&
         unit_interface_normal_one_form,
     const tnsr::I<DataType, VolumeDim, Frame::Inertial>&
@@ -247,7 +251,8 @@ void constraint_preserving_gauge_physical_corrections_dt_v_minus(
     const tnsr::iaa<DataType, VolumeDim, Frame::Inertial>& phi,
     const tnsr::ijaa<DataType, VolumeDim, Frame::Inertial>& d_phi,
     const tnsr::iaa<DataType, VolumeDim, Frame::Inertial>& d_pi,
-    const std::array<DataType, 4>& char_speeds);
+    const std::array<DataType, 4>& char_speeds,
+    const MathFunction<1, Frame::Inertial>* incoming_wave_profile = nullptr);
 /// @}
 
 namespace detail {
@@ -310,7 +315,9 @@ void add_physical_terms_to_dt_v_minus(
     const tnsr::iaa<DataType, VolumeDim, Frame::Inertial>& phi,
     const tnsr::ijaa<DataType, VolumeDim, Frame::Inertial>& d_phi,
     const tnsr::iaa<DataType, VolumeDim, Frame::Inertial>& d_pi,
-    const std::array<DataType, 4>& char_speeds);
+    const std::array<DataType, 4>& char_speeds,
+    double time = std::numeric_limits<double>::signaling_NaN(),
+    const MathFunction<1, Frame::Inertial>* incoming_wave_profile = nullptr);
 }  // namespace detail
 }  // namespace Bjorhus
 }  // namespace gh::BoundaryConditions

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryConditions/ConstraintPreservingFreeOutflow.cpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryConditions/ConstraintPreservingFreeOutflow.cpp
@@ -6,11 +6,14 @@
 #include <cstddef>
 #include <memory>
 #include <pup.h>
+#include <utility>
 
 namespace grmhd::GhValenciaDivClean::BoundaryConditions {
 ConstraintPreservingFreeOutflow::ConstraintPreservingFreeOutflow(
-    gh::BoundaryConditions::detail::ConstraintPreservingBjorhusType type)
-    : constraint_preserving_(type) {}
+    gh::BoundaryConditions::detail::ConstraintPreservingBjorhusType type,
+    std::optional<std::unique_ptr<::MathFunction<1, Frame::Inertial>>>
+        incoming_wave_profile)
+    : constraint_preserving_(type, std::move(incoming_wave_profile)) {}
 
 // LCOV_EXCL_START
 ConstraintPreservingFreeOutflow::ConstraintPreservingFreeOutflow(

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryConditions/ConstraintPreservingFreeOutflow.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryConditions/ConstraintPreservingFreeOutflow.hpp
@@ -48,7 +48,9 @@ class ConstraintPreservingFreeOutflow final : public BoundaryCondition {
 
   ConstraintPreservingFreeOutflow() = default;
   explicit ConstraintPreservingFreeOutflow(
-      gh::BoundaryConditions::detail::ConstraintPreservingBjorhusType type);
+      gh::BoundaryConditions::detail::ConstraintPreservingBjorhusType type,
+      std::optional<std::unique_ptr<::MathFunction<1, Frame::Inertial>>>
+          incoming_wave_profile = std::nullopt);
 
   ConstraintPreservingFreeOutflow(ConstraintPreservingFreeOutflow&&) = default;
   ConstraintPreservingFreeOutflow& operator=(

--- a/src/Evolution/Systems/ScalarTensor/BoundaryConditions/ConstraintPreserving.cpp
+++ b/src/Evolution/Systems/ScalarTensor/BoundaryConditions/ConstraintPreserving.cpp
@@ -6,11 +6,14 @@
 #include <cstddef>
 #include <memory>
 #include <pup.h>
+#include <utility>
 
 namespace ScalarTensor::BoundaryConditions {
 ConstraintPreserving::ConstraintPreserving(
-    gh::BoundaryConditions::detail::ConstraintPreservingBjorhusType type)
-    : constraint_preserving_(type) {}
+    gh::BoundaryConditions::detail::ConstraintPreservingBjorhusType type,
+    std::optional<std::unique_ptr<::MathFunction<1, Frame::Inertial>>>
+        incoming_wave_profile)
+    : constraint_preserving_(type, std::move(incoming_wave_profile)) {}
 
 // LCOV_EXCL_START
 ConstraintPreserving::ConstraintPreserving(CkMigrateMessage* const msg)

--- a/src/Evolution/Systems/ScalarTensor/BoundaryConditions/ConstraintPreserving.hpp
+++ b/src/Evolution/Systems/ScalarTensor/BoundaryConditions/ConstraintPreserving.hpp
@@ -25,6 +25,7 @@
 #include "Evolution/Systems/ScalarTensor/Tags.hpp"
 #include "Options/String.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/ConstraintDampingTags.hpp"
+#include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Serialization/CharmPupable.hpp"
 #include "Utilities/TMPL.hpp"
@@ -52,7 +53,9 @@ class ConstraintPreserving final : public BoundaryCondition {
 
   ConstraintPreserving() = default;
   explicit ConstraintPreserving(
-      gh::BoundaryConditions::detail::ConstraintPreservingBjorhusType type);
+      gh::BoundaryConditions::detail::ConstraintPreservingBjorhusType type,
+      std::optional<std::unique_ptr<::MathFunction<1, Frame::Inertial>>>
+          incoming_wave_profile = std::nullopt);
 
   ConstraintPreserving(ConstraintPreserving&&) = default;
   ConstraintPreserving& operator=(ConstraintPreserving&&) = default;

--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -112,6 +112,7 @@ DomainCreator:
       BoundaryCondition:
         ConstraintPreservingBjorhus:
           Type: ConstraintPreservingPhysical
+          IncomingWaveProfile: None
     UseEquiangularMap: True
     # Found that a CubeScale of 1.2 worked well for equal mass non-spinning
     # inspirals and allowed for more common horizon finds.

--- a/support/Pipelines/Bbh/Ringdown.yaml
+++ b/support/Pipelines/Bbh/Ringdown.yaml
@@ -83,6 +83,7 @@ DomainCreator:
     OuterBoundaryCondition:
       ConstraintPreservingBjorhus:
         Type: ConstraintPreservingPhysical
+        IncomingWaveProfile: None
 
 Evolution:
   InitialTime: *InitialTime

--- a/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
@@ -58,6 +58,7 @@ DomainCreator:
       OuterBoundary:
         ConstraintPreservingBjorhus:
           Type: ConstraintPreservingPhysical
+          IncomingWaveProfile: None
     TimeDependentMaps:
       InitialTime: 0.0
       ExpansionMap:

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
@@ -75,6 +75,7 @@ DomainCreator:
       BoundaryCondition:
         ConstraintPreservingFreeOutflow:
           Type: ConstraintPreservingPhysical
+          IncomingWaveProfile: None
     UseEquiangularMap: True
     CubeScale: 1.0
     InitialRefinement:

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.py
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.py
@@ -695,6 +695,7 @@ def error(
     d_spacetime_metric,
     d_pi,
     d_phi,
+    time=0.0,
 ):
     if face_mesh_velocity is not None:
         (
@@ -1025,6 +1026,7 @@ def dt_spacetime_metric(
     d_spacetime_metric,
     d_pi,
     d_phi,
+    time=0.0,
 ):
     subtract_mesh_velocity(
         face_mesh_velocity,
@@ -1087,6 +1089,7 @@ def dt_spacetime_metric_static_mesh(
     d_spacetime_metric,
     d_pi,
     d_phi,
+    time=0.0,
 ):
     return dt_spacetime_metric(
         0.0 * normal_vector,
@@ -1137,6 +1140,7 @@ def dt_pi_ConstraintPreservingGauge(
     d_spacetime_metric,
     d_pi,
     d_phi,
+    time=0.0,
 ):
     subtract_mesh_velocity(
         face_mesh_velocity,
@@ -1201,6 +1205,7 @@ def dt_pi_ConstraintPreservingGauge_static_mesh(
     d_spacetime_metric,
     d_pi,
     d_phi,
+    time=0.0,
 ):
     return dt_pi_ConstraintPreservingGauge(
         0.0 * normal_vector,
@@ -1251,6 +1256,7 @@ def dt_pi_ConstraintPreservingGaugePhysical(
     d_spacetime_metric,
     d_pi,
     d_phi,
+    time=0.0,
 ):
     subtract_mesh_velocity(
         face_mesh_velocity,
@@ -1315,6 +1321,7 @@ def dt_pi_ConstraintPreservingGaugePhysical_static_mesh(
     d_spacetime_metric,
     d_pi,
     d_phi,
+    time=0.0,
 ):
     return dt_pi_ConstraintPreservingGaugePhysical(
         0.0 * normal_vector,
@@ -1365,6 +1372,7 @@ def dt_phi_ConstraintPreservingGauge(
     d_spacetime_metric,
     d_pi,
     d_phi,
+    time=0.0,
 ):
     subtract_mesh_velocity(
         face_mesh_velocity,
@@ -1429,6 +1437,7 @@ def dt_phi_ConstraintPreservingGauge_static_mesh(
     d_spacetime_metric,
     d_pi,
     d_phi,
+    time=0.0,
 ):
     return dt_phi_ConstraintPreservingGauge(
         0.0 * normal_vector,
@@ -1479,6 +1488,7 @@ def dt_phi_ConstraintPreservingGaugePhysical(
     d_spacetime_metric,
     d_pi,
     d_phi,
+    time=0.0,
 ):
     subtract_mesh_velocity(
         face_mesh_velocity,
@@ -1543,6 +1553,7 @@ def dt_phi_ConstraintPreservingGaugePhysical_static_mesh(
     d_spacetime_metric,
     d_pi,
     d_phi,
+    time=0.0,
 ):
     return dt_phi_ConstraintPreservingGaugePhysical(
         0.0 * normal_vector,

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Test_Bjorhus.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Test_Bjorhus.cpp
@@ -14,10 +14,15 @@
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
 #include "Framework/CheckWithRandomValues.hpp"
 #include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestCreation.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/Evolution/DiscontinuousGalerkin/BoundaryConditions.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
+#include "PointwiseFunctions/MathFunctions/Sinusoid.hpp"
+#include "Time/Tags/Time.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TaggedTuple.hpp"
@@ -28,6 +33,19 @@ namespace {
 using frame = Frame::Inertial;
 
 template <size_t Dim>
+struct Metavariables {
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes = tmpl::map<
+        tmpl::pair<MathFunction<1, Frame::Inertial>,
+                   tmpl::list<MathFunctions::Sinusoid<1, Frame::Inertial>>>,
+        tmpl::pair<gh::BoundaryConditions::BoundaryCondition<Dim>,
+                   tmpl::list<gh::BoundaryConditions::
+                                  ConstraintPreservingBjorhus<Dim>>>>;
+  };
+};
+
+template <size_t Dim>
 void test() {
   CAPTURE(Dim);
   MAKE_GENERATOR(gen);
@@ -36,11 +54,14 @@ void test() {
         std::pair{"ConstraintPreservingPhysical"s,
                   "ConstraintPreservingGaugePhysical"s}}) {
     CAPTURE(bc_string);
+    const auto box_of_gridless_data =
+        db::create<db::AddSimpleTags<::Tags::Time>>(0.0);
 
     helpers::test_boundary_condition_with_python<
         gh::BoundaryConditions::ConstraintPreservingBjorhus<Dim>,
         gh::BoundaryConditions::BoundaryCondition<Dim>, gh::System<Dim>,
-        tmpl::list<gh::BoundaryCorrections::UpwindPenalty<Dim>>>(
+        tmpl::list<gh::BoundaryCorrections::UpwindPenalty<Dim>>, tmpl::list<>,
+        tmpl::list<>, Metavariables<Dim>>(
         make_not_null(&gen),
         "Evolution.Systems.GeneralizedHarmonic.BoundaryConditions.Bjorhus",
         tuples::TaggedTuple<
@@ -55,8 +76,9 @@ void test() {
             "dt_phi_" + bc_type},
         "ConstraintPreservingBjorhus:\n"
         "  Type: " +
-            bc_string,
-        Index<Dim - 1>{Dim == 1 ? 1 : 5}, db::DataBox<tmpl::list<>>{},
+            bc_string +
+            (Dim == 3 ? "\n  IncomingWaveProfile: None" : ""),
+        Index<Dim - 1>{Dim == 1 ? 1 : 5}, box_of_gridless_data,
         tuples::TaggedTuple<
             helpers::Tags::Range<gr::Tags::Lapse<DataVector>>,
             helpers::Tags::Range<gr::Tags::Shift<DataVector, Dim, frame>>,
@@ -69,6 +91,62 @@ void test() {
             std::array<double, 2>{{-1000., 1000.}}},
         1.e-6);
   }
+}
+
+void test_incoming_wave_profile_option_parsing_and_dim_guard() {
+  {
+    const auto created = TestHelpers::test_creation<
+        std::unique_ptr<gh::BoundaryConditions::BoundaryCondition<3>>,
+        Metavariables<3>>(
+        "ConstraintPreservingBjorhus:\n"
+        "  Type: ConstraintPreservingPhysical\n"
+        "  IncomingWaveProfile: None");
+    CHECK(dynamic_cast<
+              const gh::BoundaryConditions::ConstraintPreservingBjorhus<3>*>(
+              created.get()) != nullptr);
+  }
+
+  {
+    const auto created = TestHelpers::test_creation<
+        std::unique_ptr<gh::BoundaryConditions::BoundaryCondition<3>>,
+        Metavariables<3>>(
+        "ConstraintPreservingBjorhus:\n"
+        "  Type: ConstraintPreservingPhysical\n"
+        "  IncomingWaveProfile:\n"
+        "    Sinusoid:\n"
+        "      Amplitude: 1.2\n"
+        "      Wavenumber: 0.7\n"
+        "      Phase: 0.4");
+    CHECK(dynamic_cast<
+              const gh::BoundaryConditions::ConstraintPreservingBjorhus<3>*>(
+              created.get()) != nullptr);
+  }
+
+  CHECK_THROWS_WITH(
+      (TestHelpers::test_creation<
+          std::unique_ptr<gh::BoundaryConditions::BoundaryCondition<1>>,
+          Metavariables<1>>("ConstraintPreservingBjorhus:\n"
+                            "  Type: ConstraintPreservingPhysical\n"
+                            "  IncomingWaveProfile:\n"
+                            "    Sinusoid:\n"
+                            "      Amplitude: 1.2\n"
+                            "      Wavenumber: 0.7\n"
+                            "      Phase: 0.4")),
+      Catch::Matchers::ContainsSubstring(
+          "Option 'IncomingWaveProfile' is not a valid option."));
+
+  CHECK_THROWS_WITH(
+      (TestHelpers::test_creation<
+          std::unique_ptr<gh::BoundaryConditions::BoundaryCondition<2>>,
+          Metavariables<2>>("ConstraintPreservingBjorhus:\n"
+                            "  Type: ConstraintPreservingPhysical\n"
+                            "  IncomingWaveProfile:\n"
+                            "    Sinusoid:\n"
+                            "      Amplitude: 1.2\n"
+                            "      Wavenumber: 0.7\n"
+                            "      Phase: 0.4")),
+      Catch::Matchers::ContainsSubstring(
+          "Option 'IncomingWaveProfile' is not a valid option."));
 }
 
 template <size_t Dim>
@@ -294,4 +372,5 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.GeneralizedHarmonic.BCBjorhus.Cls",
   test_with_random_values<1>(used_for_size);
   test_with_random_values<2>(used_for_size);
   test_with_random_values<3>(used_for_size);
+  test_incoming_wave_profile_option_parsing_and_dim_guard();
 }

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Test_BjorhusImpl.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Test_BjorhusImpl.cpp
@@ -7,8 +7,10 @@
 #include <cmath>
 #include <cstddef>
 #include <limits>
+#include <memory>
 
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/Side.hpp"
@@ -17,6 +19,7 @@
 #include "Framework/CheckWithRandomValues.hpp"
 #include "Framework/SetupLocalPythonEnvironment.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "PointwiseFunctions/MathFunctions/Sinusoid.hpp"
 #include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/Gsl.hpp"
@@ -907,7 +910,7 @@ void test_constraint_preserving_gauge_physical_bjorhus_v_minus_vs_spec_3d(
     gh::BoundaryConditions::Bjorhus::
         constraint_preserving_gauge_physical_corrections_dt_v_minus(
             make_not_null(&local_bc_dt_v_minus), local_constraint_gamma2,
-            local_inertial_coords, local_unit_interface_normal_one_form,
+            local_inertial_coords, 0., local_unit_interface_normal_one_form,
             local_unit_interface_normal_vector,
             local_spacetime_unit_normal_vector, local_incoming_null_one_form,
             local_outgoing_null_one_form, local_incoming_null_vector,
@@ -918,7 +921,7 @@ void test_constraint_preserving_gauge_physical_bjorhus_v_minus_vs_spec_3d(
             local_three_index_constraint, local_char_projected_rhs_dt_v_psi,
             local_char_projected_rhs_dt_v_minus,
             local_constraint_char_zero_plus, local_constraint_char_zero_minus,
-            local_phi, local_d_phi, local_d_pi, local_char_speeds);
+            local_phi, local_d_phi, local_d_pi, local_char_speeds, nullptr);
     // Add in the current boundary value to get corrected values for dt<vminus>
     for (size_t a = 0; a <= VolumeDim; ++a) {
       for (size_t b = a; b <= VolumeDim; ++b) {
@@ -1247,7 +1250,7 @@ tnsr::aa<DataVector, VolumeDim, Frame::Inertial> wrapper_func_cpgp_v_minus(
   gh::BoundaryConditions::Bjorhus::
       constraint_preserving_gauge_physical_corrections_dt_v_minus<VolumeDim,
                                                                   DataVector>(
-          make_not_null(&dt_v_minus), gamma2, inertial_coords,
+          make_not_null(&dt_v_minus), gamma2, inertial_coords, 0.,
           unit_interface_normal_one_form, unit_interface_normal_vector,
           spacetime_unit_normal_vector, incoming_null_one_form,
           outgoing_null_one_form, incoming_null_vector, outgoing_null_vector,
@@ -1255,8 +1258,300 @@ tnsr::aa<DataVector, VolumeDim, Frame::Inertial> wrapper_func_cpgp_v_minus(
           extrinsic_curvature, spacetime_metric, inverse_spacetime_metric,
           three_index_constraint, char_projected_rhs_dt_v_psi,
           char_projected_rhs_dt_v_minus, constraint_char_zero_plus,
-          constraint_char_zero_minus, phi, d_phi, d_pi, char_speed_array);
+          constraint_char_zero_minus, phi, d_phi, d_pi, char_speed_array,
+          nullptr);
   return dt_v_minus;
+}
+
+void test_incoming_wave_profile_uses_profile_value_in_3d() {
+  constexpr size_t local_volume_dim = 3;
+  const size_t num_points = 2;
+  const double time = 0.37;
+
+  auto gamma2 = make_with_value<Scalar<DataVector>>(num_points, 0.5);
+  auto inertial_coords =
+      make_with_value<tnsr::I<DataVector, local_volume_dim, frame>>(get(gamma2),
+                                                                    1.0);
+  inertial_coords.get(0) = DataVector{2.0, 2.5};
+  inertial_coords.get(1) = DataVector{1.0, 1.5};
+  inertial_coords.get(2) = DataVector{0.8, 1.2};
+
+  auto unit_interface_normal_one_form =
+      make_with_value<tnsr::i<DataVector, local_volume_dim, frame>>(get(gamma2),
+                                                                    0.0);
+  auto unit_interface_normal_vector =
+      make_with_value<tnsr::I<DataVector, local_volume_dim, frame>>(get(gamma2),
+                                                                    0.0);
+  unit_interface_normal_one_form.get(0) = 1.0;
+  unit_interface_normal_vector.get(0) = 1.0;
+
+  auto spacetime_unit_normal_vector =
+      make_with_value<tnsr::A<DataVector, local_volume_dim, frame>>(get(gamma2),
+                                                                    0.0);
+  spacetime_unit_normal_vector.get(0) = 1.0;
+
+  auto incoming_null_one_form =
+      make_with_value<tnsr::a<DataVector, local_volume_dim, frame>>(get(gamma2),
+                                                                    0.0);
+  auto outgoing_null_one_form =
+      make_with_value<tnsr::a<DataVector, local_volume_dim, frame>>(get(gamma2),
+                                                                    0.0);
+  auto incoming_null_vector =
+      make_with_value<tnsr::A<DataVector, local_volume_dim, frame>>(get(gamma2),
+                                                                    0.0);
+  auto outgoing_null_vector =
+      make_with_value<tnsr::A<DataVector, local_volume_dim, frame>>(get(gamma2),
+                                                                    0.0);
+  incoming_null_one_form.get(0) = 1.0;
+  outgoing_null_one_form.get(0) = 1.0;
+  incoming_null_vector.get(0) = 1.0;
+  outgoing_null_vector.get(0) = 1.0;
+
+  auto projection_ab =
+      make_with_value<tnsr::aa<DataVector, local_volume_dim, frame>>(
+          get(gamma2), 0.0);
+  auto projection_Ab =
+      make_with_value<tnsr::Ab<DataVector, local_volume_dim, frame>>(
+          get(gamma2), 0.0);
+  auto projection_AB =
+      make_with_value<tnsr::AA<DataVector, local_volume_dim, frame>>(
+          get(gamma2), 0.0);
+  for (size_t a = 0; a <= local_volume_dim; ++a) {
+    projection_ab.get(a, a) = 1.0;
+    projection_AB.get(a, a) = 1.0;
+    projection_Ab.get(a, a) = 1.0;
+  }
+
+  auto inverse_spatial_metric =
+      make_with_value<tnsr::II<DataVector, local_volume_dim, frame>>(
+          get(gamma2), 0.0);
+  auto extrinsic_curvature =
+      make_with_value<tnsr::ii<DataVector, local_volume_dim, frame>>(
+          get(gamma2), 0.0);
+  for (size_t i = 0; i < local_volume_dim; ++i) {
+    inverse_spatial_metric.get(i, i) = 1.0;
+  }
+
+  auto spacetime_metric =
+      make_with_value<tnsr::aa<DataVector, local_volume_dim, frame>>(
+          get(gamma2), 0.0);
+  auto inverse_spacetime_metric =
+      make_with_value<tnsr::AA<DataVector, local_volume_dim, frame>>(
+          get(gamma2), 0.0);
+  for (size_t a = 0; a <= local_volume_dim; ++a) {
+    spacetime_metric.get(a, a) = (a == 0 ? -1.0 : 1.0);
+    inverse_spacetime_metric.get(a, a) = (a == 0 ? -1.0 : 1.0);
+  }
+
+  auto three_index_constraint =
+      make_with_value<tnsr::iaa<DataVector, local_volume_dim, frame>>(
+          get(gamma2), 0.0);
+  auto char_projected_rhs_dt_v_psi =
+      make_with_value<tnsr::aa<DataVector, local_volume_dim, frame>>(
+          get(gamma2), 0.0);
+  auto char_projected_rhs_dt_v_minus =
+      make_with_value<tnsr::aa<DataVector, local_volume_dim, frame>>(
+          get(gamma2), 0.0);
+  auto constraint_char_zero_plus =
+      make_with_value<tnsr::a<DataVector, local_volume_dim, frame>>(get(gamma2),
+                                                                    0.0);
+  auto constraint_char_zero_minus =
+      make_with_value<tnsr::a<DataVector, local_volume_dim, frame>>(get(gamma2),
+                                                                    0.0);
+  auto phi = make_with_value<tnsr::iaa<DataVector, local_volume_dim, frame>>(
+      get(gamma2), 0.0);
+  auto d_phi = make_with_value<tnsr::ijaa<DataVector, local_volume_dim, frame>>(
+      get(gamma2), 0.0);
+  auto d_pi = make_with_value<tnsr::iaa<DataVector, local_volume_dim, frame>>(
+      get(gamma2), 0.0);
+  const std::array<DataVector, 4> char_speeds{
+      DataVector(num_points, 0.0), DataVector(num_points, 0.0),
+      DataVector(num_points, 0.0), DataVector{-0.7, -1.1}};
+
+  auto dt_v_minus_no_profile =
+      make_with_value<tnsr::aa<DataVector, local_volume_dim, frame>>(
+          get(gamma2), 0.0);
+  auto dt_v_minus_with_profile =
+      make_with_value<tnsr::aa<DataVector, local_volume_dim, frame>>(
+          get(gamma2), 0.0);
+
+  auto incoming_wave_profile =
+      std::make_unique<MathFunctions::Sinusoid<1, Frame::Inertial>>(1.4, 0.7,
+                                                                    0.2);
+  const double profile_value = incoming_wave_profile->operator()(time);
+  const double profile_derivative = incoming_wave_profile->first_deriv(time);
+  CHECK(std::abs(profile_value - profile_derivative) > 1.0e-3);
+
+  gh::BoundaryConditions::Bjorhus::
+      constraint_preserving_gauge_physical_corrections_dt_v_minus<
+          local_volume_dim, DataVector>(
+          make_not_null(&dt_v_minus_no_profile), gamma2, inertial_coords, time,
+          unit_interface_normal_one_form, unit_interface_normal_vector,
+          spacetime_unit_normal_vector, incoming_null_one_form,
+          outgoing_null_one_form, incoming_null_vector, outgoing_null_vector,
+          projection_ab, projection_Ab, projection_AB, inverse_spatial_metric,
+          extrinsic_curvature, spacetime_metric, inverse_spacetime_metric,
+          three_index_constraint, char_projected_rhs_dt_v_psi,
+          char_projected_rhs_dt_v_minus, constraint_char_zero_plus,
+          constraint_char_zero_minus, phi, d_phi, d_pi, char_speeds, nullptr);
+  gh::BoundaryConditions::Bjorhus::
+      constraint_preserving_gauge_physical_corrections_dt_v_minus<
+          local_volume_dim, DataVector>(
+          make_not_null(&dt_v_minus_with_profile), gamma2, inertial_coords,
+          time, unit_interface_normal_one_form, unit_interface_normal_vector,
+          spacetime_unit_normal_vector, incoming_null_one_form,
+          outgoing_null_one_form, incoming_null_vector, outgoing_null_vector,
+          projection_ab, projection_Ab, projection_AB, inverse_spatial_metric,
+          extrinsic_curvature, spacetime_metric, inverse_spacetime_metric,
+          three_index_constraint, char_projected_rhs_dt_v_psi,
+          char_projected_rhs_dt_v_minus, constraint_char_zero_plus,
+          constraint_char_zero_minus, phi, d_phi, d_pi, char_speeds,
+          incoming_wave_profile.get());
+
+  auto delta = dt_v_minus_with_profile;
+  for (size_t a = 0; a <= local_volume_dim; ++a) {
+    for (size_t b = a; b <= local_volume_dim; ++b) {
+      delta.get(a, b) -= dt_v_minus_no_profile.get(a, b);
+    }
+  }
+
+  auto expected_delta =
+      make_with_value<tnsr::aa<DataVector, local_volume_dim, frame>>(
+          get(gamma2), 0.0);
+  auto injected_wave =
+      make_with_value<tnsr::aa<DataVector, local_volume_dim, frame>>(
+          get(gamma2), 0.0);
+  auto char_speed_3 =
+      make_with_value<Scalar<DataVector>>(get(gamma2), 0.0);
+  get(char_speed_3) = char_speeds[3];
+  injected_wave.get(1, 1) = profile_value;
+  injected_wave.get(2, 2) = profile_value;
+  injected_wave.get(3, 3) = -2.0 * profile_value;
+  tenex::evaluate<ti::a, ti::b>(
+      make_not_null(&expected_delta),
+      (projection_Ab(ti::C, ti::a) * projection_Ab(ti::D, ti::b) -
+       0.5 * projection_ab(ti::a, ti::b) * projection_AB(ti::C, ti::D)) *
+          char_speed_3() * (-injected_wave(ti::c, ti::d)));
+
+  CHECK_ITERABLE_APPROX(delta, expected_delta);
+}
+
+template <size_t LocalVolumeDim>
+void test_incoming_wave_profile_throws_for_non_3d() {
+  static_assert(LocalVolumeDim < 3);
+  const size_t num_points = 1;
+
+  auto gamma2 =
+      make_with_value<Scalar<DataVector>>(DataVector(num_points), 0.5);
+  auto inertial_coords =
+      make_with_value<tnsr::I<DataVector, LocalVolumeDim, frame>>(get(gamma2),
+                                                                  1.0);
+  auto unit_interface_normal_one_form =
+      make_with_value<tnsr::i<DataVector, LocalVolumeDim, frame>>(get(gamma2),
+                                                                  0.0);
+  auto unit_interface_normal_vector =
+      make_with_value<tnsr::I<DataVector, LocalVolumeDim, frame>>(get(gamma2),
+                                                                  0.0);
+  unit_interface_normal_one_form.get(0) = 1.0;
+  unit_interface_normal_vector.get(0) = 1.0;
+
+  auto spacetime_unit_normal_vector =
+      make_with_value<tnsr::A<DataVector, LocalVolumeDim, frame>>(get(gamma2),
+                                                                  0.0);
+  spacetime_unit_normal_vector.get(0) = 1.0;
+  auto incoming_null_one_form =
+      make_with_value<tnsr::a<DataVector, LocalVolumeDim, frame>>(get(gamma2),
+                                                                  0.0);
+  auto outgoing_null_one_form =
+      make_with_value<tnsr::a<DataVector, LocalVolumeDim, frame>>(get(gamma2),
+                                                                  0.0);
+  auto incoming_null_vector =
+      make_with_value<tnsr::A<DataVector, LocalVolumeDim, frame>>(get(gamma2),
+                                                                  0.0);
+  auto outgoing_null_vector =
+      make_with_value<tnsr::A<DataVector, LocalVolumeDim, frame>>(get(gamma2),
+                                                                  0.0);
+  auto projection_ab =
+      make_with_value<tnsr::aa<DataVector, LocalVolumeDim, frame>>(get(gamma2),
+                                                                   0.0);
+  auto projection_Ab =
+      make_with_value<tnsr::Ab<DataVector, LocalVolumeDim, frame>>(get(gamma2),
+                                                                   0.0);
+  auto projection_AB =
+      make_with_value<tnsr::AA<DataVector, LocalVolumeDim, frame>>(get(gamma2),
+                                                                   0.0);
+  for (size_t a = 0; a <= LocalVolumeDim; ++a) {
+    projection_ab.get(a, a) = 1.0;
+    projection_AB.get(a, a) = 1.0;
+    projection_Ab.get(a, a) = 1.0;
+  }
+  auto inverse_spatial_metric =
+      make_with_value<tnsr::II<DataVector, LocalVolumeDim, frame>>(get(gamma2),
+                                                                   0.0);
+  auto extrinsic_curvature =
+      make_with_value<tnsr::ii<DataVector, LocalVolumeDim, frame>>(get(gamma2),
+                                                                   0.0);
+  auto spacetime_metric =
+      make_with_value<tnsr::aa<DataVector, LocalVolumeDim, frame>>(get(gamma2),
+                                                                   0.0);
+  auto inverse_spacetime_metric =
+      make_with_value<tnsr::AA<DataVector, LocalVolumeDim, frame>>(get(gamma2),
+                                                                   0.0);
+  for (size_t i = 0; i < LocalVolumeDim; ++i) {
+    inverse_spatial_metric.get(i, i) = 1.0;
+  }
+  for (size_t a = 0; a <= LocalVolumeDim; ++a) {
+    spacetime_metric.get(a, a) = (a == 0 ? -1.0 : 1.0);
+    inverse_spacetime_metric.get(a, a) = (a == 0 ? -1.0 : 1.0);
+  }
+  auto three_index_constraint =
+      make_with_value<tnsr::iaa<DataVector, LocalVolumeDim, frame>>(get(gamma2),
+                                                                    0.0);
+  auto char_projected_rhs_dt_v_psi =
+      make_with_value<tnsr::aa<DataVector, LocalVolumeDim, frame>>(get(gamma2),
+                                                                   0.0);
+  auto char_projected_rhs_dt_v_minus =
+      make_with_value<tnsr::aa<DataVector, LocalVolumeDim, frame>>(get(gamma2),
+                                                                   0.0);
+  auto constraint_char_zero_plus =
+      make_with_value<tnsr::a<DataVector, LocalVolumeDim, frame>>(get(gamma2),
+                                                                  0.0);
+  auto constraint_char_zero_minus =
+      make_with_value<tnsr::a<DataVector, LocalVolumeDim, frame>>(get(gamma2),
+                                                                  0.0);
+  auto phi = make_with_value<tnsr::iaa<DataVector, LocalVolumeDim, frame>>(
+      get(gamma2), 0.0);
+  auto d_phi = make_with_value<tnsr::ijaa<DataVector, LocalVolumeDim, frame>>(
+      get(gamma2), 0.0);
+  auto d_pi = make_with_value<tnsr::iaa<DataVector, LocalVolumeDim, frame>>(
+      get(gamma2), 0.0);
+  const std::array<DataVector, 4> char_speeds{
+      DataVector(num_points, 0.0), DataVector(num_points, 0.0),
+      DataVector(num_points, 0.0), DataVector(num_points, -1.0)};
+  auto bc_dt_v_minus =
+      make_with_value<tnsr::aa<DataVector, LocalVolumeDim, frame>>(get(gamma2),
+                                                                   0.0);
+
+  auto incoming_wave_profile =
+      std::make_unique<MathFunctions::Sinusoid<1, Frame::Inertial>>(1.0, 0.7,
+                                                                    0.2);
+  CHECK_THROWS_WITH(
+      (gh::BoundaryConditions::Bjorhus::
+           constraint_preserving_gauge_physical_corrections_dt_v_minus<
+               LocalVolumeDim, DataVector>(
+               make_not_null(&bc_dt_v_minus), gamma2, inertial_coords, 0.0,
+               unit_interface_normal_one_form, unit_interface_normal_vector,
+               spacetime_unit_normal_vector, incoming_null_one_form,
+               outgoing_null_one_form, incoming_null_vector,
+               outgoing_null_vector, projection_ab, projection_Ab,
+               projection_AB, inverse_spatial_metric, extrinsic_curvature,
+               spacetime_metric, inverse_spacetime_metric,
+               three_index_constraint, char_projected_rhs_dt_v_psi,
+               char_projected_rhs_dt_v_minus, constraint_char_zero_plus,
+               constraint_char_zero_minus, phi, d_phi, d_pi, char_speeds,
+               incoming_wave_profile.get())),
+      Catch::Matchers::ContainsSubstring(
+          "IncomingWaveProfile can only be used in 3 spatial dimensions."));
 }
 
 template <size_t VolumeDim>
@@ -1341,6 +1636,9 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.GeneralizedHarmonic.BCBjorhus.VMinus",
       grid_size);
   test_constraint_preserving_gauge_physical_corrections_dt_v_minus<3>(
       grid_size);
+  test_incoming_wave_profile_uses_profile_value_in_3d();
+  test_incoming_wave_profile_throws_for_non_3d<1>();
+  test_incoming_wave_profile_throws_for_non_3d<2>();
 
   // Piece-wise tests with SpEC output in 3D
   const std::array<double, 3> lower_bound{{299., -0.5, -0.5}};

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryConditions/Test_ConstraintPreservingFreeOutflow.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/BoundaryConditions/Test_ConstraintPreservingFreeOutflow.cpp
@@ -38,6 +38,7 @@
 #include "PointwiseFunctions/GeneralRelativity/SpacetimeNormalVector.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
 #include "Utilities/TMPL.hpp"
@@ -47,10 +48,12 @@ namespace {
 struct Metavariables {
   struct factory_creation
       : tt::ConformsTo<Options::protocols::FactoryCreation> {
-    using factory_classes = tmpl::map<tmpl::pair<
-        grmhd::GhValenciaDivClean::BoundaryConditions::BoundaryCondition,
-        tmpl::list<grmhd::GhValenciaDivClean::BoundaryConditions::
-                       ConstraintPreservingFreeOutflow>>>;
+    using factory_classes = tmpl::map<
+        tmpl::pair<MathFunction<1, Frame::Inertial>, tmpl::list<>>,
+        tmpl::pair<
+            grmhd::GhValenciaDivClean::BoundaryConditions::BoundaryCondition,
+            tmpl::list<grmhd::GhValenciaDivClean::BoundaryConditions::
+                           ConstraintPreservingFreeOutflow>>>;
   };
 };
 
@@ -497,7 +500,8 @@ SPECTRE_TEST_CASE(
               grmhd::GhValenciaDivClean::BoundaryConditions::BoundaryCondition>,
           Metavariables>(
           "ConstraintPreservingFreeOutflow:\n"
-          "  Type: ConstraintPreservingPhysical\n")
+          "  Type: ConstraintPreservingPhysical\n"
+          "  IncomingWaveProfile: None\n")
           ->get_clone();
 
   const auto serialized_and_deserialized_condition = serialize_and_deserialize(

--- a/tests/Unit/Evolution/Systems/ScalarTensor/BoundaryConditions/Test_ConstraintPreserving.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarTensor/BoundaryConditions/Test_ConstraintPreserving.cpp
@@ -34,6 +34,7 @@
 #include "PointwiseFunctions/GeneralRelativity/SpacetimeNormalOneForm.hpp"
 #include "PointwiseFunctions/GeneralRelativity/SpacetimeNormalVector.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
 #include "Utilities/TMPL.hpp"
@@ -44,9 +45,11 @@ namespace {
 struct Metavariables {
   struct factory_creation
       : tt::ConformsTo<Options::protocols::FactoryCreation> {
-    using factory_classes = tmpl::map<tmpl::pair<
-        ScalarTensor::BoundaryConditions::BoundaryCondition,
-        tmpl::list<ScalarTensor::BoundaryConditions::ConstraintPreserving>>>;
+    using factory_classes = tmpl::map<
+        tmpl::pair<MathFunction<1, Frame::Inertial>, tmpl::list<>>,
+        tmpl::pair<ScalarTensor::BoundaryConditions::BoundaryCondition,
+                   tmpl::list<ScalarTensor::BoundaryConditions::
+                                  ConstraintPreserving>>>;
   };
 };
 
@@ -381,9 +384,8 @@ void test_dg(const gsl::not_null<std::mt19937*> generator,
 
 }  // namespace
 
-SPECTRE_TEST_CASE(
-  "Unit.ScalarTensor.BoundaryConditions.ConstraintPreserving",
-  "[Unit][Evolution]") {
+SPECTRE_TEST_CASE("Unit.ScalarTensor.BoundaryConditions.ConstraintPreserving",
+                  "[Unit][Evolution]") {
   MAKE_GENERATOR(gen);
   register_factory_classes_with_charm<Metavariables>();
 
@@ -392,7 +394,8 @@ SPECTRE_TEST_CASE(
           std::unique_ptr<ScalarTensor::BoundaryConditions::BoundaryCondition>,
           Metavariables>(
           "ConstraintPreserving:\n"
-          "  Type: ConstraintPreservingPhysical\n")
+          "  Type: ConstraintPreservingPhysical\n"
+          "  IncomingWaveProfile: None\n")
           ->get_clone();
 
   const auto serialized_and_deserialized_condition = serialize_and_deserialize(


### PR DESCRIPTION
## Proposed changes

Adds the option to inject a gravitational wave through the outer boundary. The profile can be set as a MathFunction from the input file. The tensor components of the strain tensor are hard-coded to be (1,1,-2).

@geoffrey4444 I think you were interested in this for the spinning black hole simulations.
<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
For systems that use the ConstraintPreservingBjorhus boundary conditions, the wave profile has to be added to the intput file, e.g:

```
    OuterBoundaryCondition:
      ConstraintPreservingBjorhus:
        Type: ConstraintPreservingPhysical
        IncomingWaveProfile: None
```

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
