### PR TITLE
Add support for ZernikeB2 logical derivatives

### DIFF
--- a/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.cpp
+++ b/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.cpp
@@ -17,6 +17,9 @@
 #include "Domain/Tags.hpp"
 #include "NumericalAlgorithms/Spectral/DifferentiationMatrix.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/ModalToNodalMatrix.hpp"
+#include "NumericalAlgorithms/Spectral/NodalToModalMatrix.hpp"
+#include "NumericalAlgorithms/Spectral/Parity.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Spherepack.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/SpherepackCache.hpp"
 #include "Utilities/Blas.hpp"
@@ -125,6 +128,238 @@ void logical_partial_derivative(
       ERROR(
           "Support for complex numbers with spherical harmonics is not yet "
           "implemented for logical_partial_derivative.");
+    }
+  } else if (Dim == 2 and mesh.basis(0) == Spectral::Basis::ZernikeB2) {
+    if constexpr (std::is_same_v<typename DataType::value_type, double>) {
+      ASSERT(mesh.basis(0) == Spectral::Basis::ZernikeB2 and
+                 mesh.basis(1) == Spectral::Basis::ZernikeB2,
+             "Unexpected basis combination: " << mesh.basis());
+      const size_t n_r = mesh.extents(0);
+      const size_t n_phi = mesh.extents(1);
+      const size_t n_r_max = 2 * n_r - 2;
+      ASSERT(
+          n_phi % 2 == 1,
+          "Fourier with an even number of grid points can be unstable due to "
+          "the top derivative not being representable");
+      ASSERT(n_phi / 2 <= n_r_max,
+             "Zernike & Fourier on a disk have angular resolution limited by "
+             "extents in both dimensions. We choose to enforce the restriction "
+             "that the Fourier modal space is not larger than the Zernike "
+             "angular capabilities (which would waste space and be physically "
+             "ill-motivated).\nn_phi / 2 = "
+                 << n_phi / 2 << ", Maximum from Zernike = " << n_r_max);
+      const size_t M = n_phi / 2;
+
+      const Matrix& diff_matrix_r_even = Spectral::differentiation_matrix<
+          Spectral::Basis::ZernikeB2, Spectral::Quadrature::GaussRadauUpper>(
+          n_r, Spectral::Parity::Even);
+      const Matrix& diff_matrix_r_odd = Spectral::differentiation_matrix<
+          Spectral::Basis::ZernikeB2, Spectral::Quadrature::GaussRadauUpper>(
+          n_r, Spectral::Parity::Odd);
+      const Matrix& diff_matrix_phi = Spectral::differentiation_matrix<
+          Spectral::Basis::Fourier, Spectral::Quadrature::Equiangular>(n_phi);
+
+      const Matrix& nodal_to_modal_phi = Spectral::nodal_to_modal_matrix<
+          Spectral::Basis::Fourier, Spectral::Quadrature::Equiangular>(n_phi);
+      const Matrix& modal_to_nodal_phi = Spectral::modal_to_nodal_matrix<
+          Spectral::Basis::Fourier, Spectral::Quadrature::Equiangular>(n_phi);
+
+      for (size_t storage_index = 0; storage_index < u.size();
+           ++storage_index) {
+        const auto u_tensor_index = u.get_tensor_index(storage_index);
+        const auto r_deriv_tensor_index = prepend(u_tensor_index, 0_st);
+        const auto phi_deriv_tensor_index = prepend(u_tensor_index, 1_st);
+
+        // Do phi derivative
+        dgemm_<true>(
+            'N',
+            'T',  // transpose differentiation matrix to act on rows of data
+            n_r, n_phi, n_phi, 1.0, u[storage_index].data(), n_r,
+            diff_matrix_phi.data(), diff_matrix_phi.spacing(), 0.0,
+            // NOLINTNEXTLINE(readability-redundant-smartptr-get)
+            logical_derivative_of_u->get(phi_deriv_tensor_index).data(), n_r);
+
+        // Get u in terms of r and m index
+        dgemm_<true>('N', 'T', n_r, n_phi, n_phi, 1.0, u[storage_index].data(),
+                     n_r, nodal_to_modal_phi.data(),
+                     nodal_to_modal_phi.spacing(), 0.0,
+                     // NOLINTNEXTLINE(readability-redundant-smartptr-get)
+                     logical_derivative_of_u->get(r_deriv_tensor_index).data(),
+                     n_r);  // C and ldc
+
+        // Do radial derivative
+        // m = 0
+        dgemv_('N', n_r, n_r, 1.0, diff_matrix_r_even.data(),
+               diff_matrix_r_even.spacing(),
+               // NOLINTNEXTLINE(readability-redundant-smartptr-get)
+               logical_derivative_of_u->get(r_deriv_tensor_index).data(), 1,
+               0.0,  // beta = 0.0
+               (*buffer).data(), 1);
+        // j is index into Fourier modal vector
+        // {u_0, u_1, u_{-1}, u_2, u_{-2}, ... , u_M, u_{-M}}
+        size_t j = 1;
+        for (size_t m = 1; m <= M; ++m) {
+          const Matrix& diff_r =
+              m % 2 == 0 ? diff_matrix_r_even : diff_matrix_r_odd;
+          dgemm_<true>(
+              'N', 'N', n_r, 2, n_r, 1.0, diff_r.data(), diff_r.spacing(),
+              // NOLINTNEXTLINE(readability-redundant-smartptr-get)
+              logical_derivative_of_u->get(r_deriv_tensor_index).data() +
+                  j * n_r,
+              n_r,
+              0.0,  // beta = 0.0
+              // NOLINTNEXTLINE
+              (*buffer).data() + j * n_r, n_r);
+          j += 2;
+        }
+        // Transform from m back to phi
+        dgemm_<true>(
+            'N', 'T', n_r, n_phi, n_phi, 1.0, (*buffer).data(), n_r,
+            modal_to_nodal_phi.data(), modal_to_nodal_phi.spacing(), 0.0,
+            // NOLINTNEXTLINE(readability-redundant-smartptr-get)
+            logical_derivative_of_u->get(r_deriv_tensor_index).data(), n_r);
+      }
+    } else {
+      ERROR(
+          "Support for complex numbers with disk is not yet implemented for "
+          "logical_partial_derivative.");
+    }
+  } else if (Dim == 3 and mesh.basis(0) == Spectral::Basis::ZernikeB2) {
+    if constexpr (std::is_same_v<typename DataType::value_type, double>) {
+      ASSERT(mesh.basis(0) == Spectral::Basis::ZernikeB2 and
+                 mesh.basis(1) == Spectral::Basis::ZernikeB2,
+             "Unexpected basis combination: " << mesh.basis());
+      const size_t n_r = mesh.extents(0);
+      const size_t n_phi = mesh.extents(1);
+      const size_t n_z = mesh.extents(2);
+      const size_t n_r_max = 2 * n_r - 2;
+      ASSERT(
+          n_phi % 2 == 1,
+          "Fourier with an even number of grid points can be unstable due to "
+          "the top derivative not being representable");
+      ASSERT(n_phi / 2 <= n_r_max,
+             "Zernike & Fourier on a disk have angular resolution limited by "
+             "extents in both dimensions. We choose to enforce the restriction "
+             "that the Fourier modal space is not larger than the Zernike "
+             "angular capabilities (which would waste space and be physically "
+             "ill-motivated).\nn_phi / 2 = "
+                 << n_phi / 2 << ", Maximum from Zernike = " << n_r_max);
+
+      const Matrix& diff_matrix_r_even = Spectral::differentiation_matrix<
+          Spectral::Basis::ZernikeB2, Spectral::Quadrature::GaussRadauUpper>(
+          n_r, Spectral::Parity::Even);
+      const Matrix& diff_matrix_r_odd = Spectral::differentiation_matrix<
+          Spectral::Basis::ZernikeB2, Spectral::Quadrature::GaussRadauUpper>(
+          n_r, Spectral::Parity::Odd);
+      const Matrix& diff_matrix_phi = Spectral::differentiation_matrix<
+          Spectral::Basis::Fourier, Spectral::Quadrature::Equiangular>(n_phi);
+      const Matrix& diff_matrix_z =
+          Spectral::differentiation_matrix(mesh.slice_through(2));
+
+      const Matrix& nodal_to_modal_phi = Spectral::nodal_to_modal_matrix<
+          Spectral::Basis::Fourier, Spectral::Quadrature::Equiangular>(n_phi);
+      const Matrix& modal_to_nodal_phi = Spectral::modal_to_nodal_matrix<
+          Spectral::Basis::Fourier, Spectral::Quadrature::Equiangular>(n_phi);
+
+      for (size_t storage_index = 0; storage_index < u.size();
+           ++storage_index) {
+        const DataType& u_component = u[storage_index];
+        const auto u_tensor_index = u.get_tensor_index(storage_index);
+        const auto r_deriv_tensor_index = prepend(u_tensor_index, 0_st);
+        DataType& r_deriv_component =
+            logical_derivative_of_u->get(r_deriv_tensor_index);
+        const auto phi_deriv_tensor_index = prepend(u_tensor_index, 1_st);
+        DataType& phi_deriv_component =
+            logical_derivative_of_u->get(phi_deriv_tensor_index);
+        const auto z_deriv_tensor_index = prepend(u_tensor_index, 2_st);
+        DataType& z_deriv_component =
+            logical_derivative_of_u->get(z_deriv_tensor_index);
+
+        // phi derivative
+        raw_transpose(make_not_null(z_deriv_component.data()),
+                      u_component.data(), n_r, n_phi * n_z);
+        partial_derivatives_detail::apply_matrix_in_first_dim(
+            buffer->data(), z_deriv_component.data(), diff_matrix_phi,
+            num_grid_points);
+        raw_transpose(make_not_null(phi_deriv_component.data()), buffer->data(),
+                      n_phi * n_z, n_r);
+
+        // See comments in disk_apply() in the .tpp for considerations about
+        // the following code. For this function, we don't have enough buffer
+        // space to cleanly use the approach in the .tpp, so we use the
+        // masking approach instead. Note that timing shows this to only be a
+        // few percent slower
+
+        // reuse transposed data to go to angular spectral space
+        partial_derivatives_detail::apply_matrix_in_first_dim(
+            r_deriv_component.data(), z_deriv_component.data(),
+            nodal_to_modal_phi, num_grid_points);
+        // r_deriv_component holds transposed angular modal rep
+
+        raw_transpose(make_not_null(buffer->data()), r_deriv_component.data(),
+                      n_phi * n_z, n_r);
+        std::copy(buffer->data(), buffer->data() + num_grid_points,
+                  z_deriv_component.data());
+        // buffer and z_deriv_component hold angular modal rep
+
+        // buffer stores even components, z_deriv_component stores odd
+        for (size_t k = 0; k < n_z; ++k) {
+          size_t offset = k * n_phi * n_r;
+          for (size_t i = 0; i < n_phi; ++i) {
+            if (i == 0) {
+              // This is an even column -> zero odd vals
+              std::fill(z_deriv_component.data() + offset,
+                        z_deriv_component.data() + offset + n_r, 0.0);
+            } else {
+              if ((i - 1) / 2 % 2 == 1) {
+                // This is an even column with even next to it -> zero odd vals
+                std::fill(z_deriv_component.data() + offset,
+                          z_deriv_component.data() + offset + 2 * n_r, 0.0);
+              } else {
+                // This is an even column with odd next to it -> zero even vals
+                std::fill(buffer->data() + offset,
+                          buffer->data() + offset + 2 * n_r, 0.0);
+              }
+              ++i;
+              offset += n_r;
+            }
+            offset += n_r;
+          }
+        }
+        partial_derivatives_detail::apply_matrix_in_first_dim(
+            r_deriv_component.data(), buffer->data(), diff_matrix_r_even,
+            num_grid_points, false);
+        partial_derivatives_detail::apply_matrix_in_first_dim(
+            r_deriv_component.data(), z_deriv_component.data(),
+            diff_matrix_r_odd, num_grid_points, true);
+        // r_deriv_component holds the radial derivative in angular modal rep
+
+        raw_transpose(make_not_null(buffer->data()), r_deriv_component.data(),
+                      n_r, n_phi * n_z);
+        // buffer holds transposed radial derivative in angular modal rep
+
+        partial_derivatives_detail::apply_matrix_in_first_dim(
+            z_deriv_component.data(), buffer->data(), modal_to_nodal_phi,
+            num_grid_points);
+        // z_deriv_component holds transposed radial derivative in angular nodal
+        // rep
+
+        raw_transpose(make_not_null(r_deriv_component.data()),
+                      z_deriv_component.data(), n_phi * n_z, n_r);
+
+        // z derivative
+        raw_transpose(make_not_null(z_deriv_component.data()),
+                      u_component.data(), n_r * n_phi, n_z);
+        partial_derivatives_detail::apply_matrix_in_first_dim(
+            buffer->data(), z_deriv_component.data(), diff_matrix_z,
+            num_grid_points);
+        raw_transpose(make_not_null(z_deriv_component.data()), buffer->data(),
+                      n_z, n_r * n_phi);
+      }
+    } else {
+      ERROR(
+          "Support for complex numbers with cylinder is not yet implemented "
+          "for logical_partial_derivative.");
     }
   } else {
     const Matrix empty_matrix{};

--- a/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp
+++ b/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp
@@ -17,6 +17,9 @@
 #include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "NumericalAlgorithms/Spectral/DifferentiationMatrix.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/ModalToNodalMatrix.hpp"
+#include "NumericalAlgorithms/Spectral/NodalToModalMatrix.hpp"
+#include "NumericalAlgorithms/Spectral/Parity.hpp"
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Spherepack.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/SpherepackCache.hpp"
@@ -27,6 +30,7 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeArray.hpp"
 #include "Utilities/MemoryHelpers.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
 #include "Utilities/StdArrayHelpers.hpp"
 
 namespace partial_derivatives_detail {
@@ -824,25 +828,232 @@ struct LogicalImpl<2, VariableTags, DerivativeTags> {
         Variables<DerivativeTags>::number_of_independent_components <=
             Variables<T>::number_of_independent_components,
         "Temporary buffer in logical partial derivatives is too small");
-    auto& logical_partial_derivatives_of_u = *logical_du;
+    if (mesh.basis(0) == Spectral::Basis::ZernikeB2) {
+      if constexpr (std::is_same_v<ValueType, double>) {
+        disk_apply(logical_du, partial_u_wrt_eta, u_eta_fastest, u, mesh);
+      } else {
+        ERROR(
+            "Support for complex numbers with a disk is not yet "
+            "implemented for logical_partial_derivative.");
+      }
+    } else {
+      auto& logical_partial_derivatives_of_u = *logical_du;
+      const size_t deriv_size =
+          Variables<DerivativeTags>::number_of_independent_components *
+          u.number_of_grid_points();
+      const Matrix& differentiation_matrix_xi =
+          Spectral::differentiation_matrix(mesh.slice_through(0));
+      const size_t num_components_times_xi_slices =
+          deriv_size / mesh.extents(0);
+      apply_matrix_in_first_dim(logical_partial_derivatives_of_u[0], u.data(),
+                                differentiation_matrix_xi, deriv_size);
+      transpose<Variables<VariableTags>, Variables<DerivativeTags>>(
+          make_not_null(u_eta_fastest), u, mesh.extents(0),
+          num_components_times_xi_slices);
+      const Matrix& differentiation_matrix_eta =
+          Spectral::differentiation_matrix(mesh.slice_through(1));
+      apply_matrix_in_first_dim(partial_u_wrt_eta->data(),
+                                u_eta_fastest->data(),
+                                differentiation_matrix_eta, deriv_size);
+      raw_transpose(make_not_null(logical_partial_derivatives_of_u[1]),
+                    partial_u_wrt_eta->data(), num_components_times_xi_slices,
+                    mesh.extents(0));
+    }
+  }
+
+  template <typename T, typename ValueType = typename Variables<T>::value_type>
+  static void disk_apply(
+      const gsl::not_null<std::array<ValueType*, Dim>*> logical_du,
+      Variables<T>* const partial_u_wrt_eta,
+      Variables<DerivativeTags>* const u_eta_fastest,
+      const Variables<VariableTags>& u, const Mesh<2>& mesh) {
+    ASSERT(mesh.basis(0) == Spectral::Basis::ZernikeB2 and
+               mesh.basis(1) == Spectral::Basis::ZernikeB2,
+           "Unexpected basis combination: " << mesh.basis());
+    const auto [n_r, n_phi] = mesh.extents().indices();
+    const size_t n_r_max = 2 * n_r - 2;
+    ASSERT(n_phi % 2 == 1,
+           "Fourier with an even number of grid points can be unstable due to "
+           "the top derivative not being representable");
+    ASSERT(n_phi / 2 <= n_r_max,
+           "Zernike & Fourier on a disk have angular resolution limited by "
+           "extents in both dimensions. We choose to enforce the restriction "
+           "that the Fourier modal space is not larger than the Zernike "
+           "angular capabilities (which would waste space and be physically "
+           "ill-motivated).\nn_phi / 2 = "
+               << n_phi / 2 << ", Maximum from Zernike = " << n_r_max);
+
+    const Matrix& diff_matrix_r_even =
+        Spectral::differentiation_matrix<Spectral::Basis::ZernikeB2,
+                                         Spectral::Quadrature::GaussRadauUpper>(
+            n_r, Spectral::Parity::Even);
+    const Matrix& diff_matrix_r_odd =
+        Spectral::differentiation_matrix<Spectral::Basis::ZernikeB2,
+                                         Spectral::Quadrature::GaussRadauUpper>(
+            n_r, Spectral::Parity::Odd);
+    const Matrix& diff_matrix_phi = Spectral::differentiation_matrix<
+        Spectral::Basis::Fourier, Spectral::Quadrature::Equiangular>(n_phi);
+
+    const Matrix& nodal_to_modal_phi = Spectral::nodal_to_modal_matrix<
+        Spectral::Basis::Fourier, Spectral::Quadrature::Equiangular>(n_phi);
+    const Matrix& modal_to_nodal_phi = Spectral::modal_to_nodal_matrix<
+        Spectral::Basis::Fourier, Spectral::Quadrature::Equiangular>(n_phi);
+
+    const size_t local_buffer_size =
+        Variables<DerivativeTags>::number_of_independent_components *
+        u.number_of_grid_points();
+    // These just point to the passed buffers but it gets confusing to read when
+    // they are used for radial purposes that don't match their names
+    Variables<DerivativeTags> local_buffer1{};
+    Variables<DerivativeTags> local_buffer2{};
+    local_buffer1.set_data_ref(partial_u_wrt_eta->data(), local_buffer_size);
+    local_buffer2.set_data_ref(u_eta_fastest->data(), local_buffer_size);
+
     const size_t deriv_size =
         Variables<DerivativeTags>::number_of_independent_components *
         u.number_of_grid_points();
-    const Matrix& differentiation_matrix_xi =
-        Spectral::differentiation_matrix(mesh.slice_through(0));
     const size_t num_components_times_xi_slices = deriv_size / mesh.extents(0);
-    apply_matrix_in_first_dim(logical_partial_derivatives_of_u[0], u.data(),
-                              differentiation_matrix_xi, deriv_size);
+
+    // phi derivative
     transpose<Variables<VariableTags>, Variables<DerivativeTags>>(
         make_not_null(u_eta_fastest), u, mesh.extents(0),
         num_components_times_xi_slices);
-    const Matrix& differentiation_matrix_eta =
-        Spectral::differentiation_matrix(mesh.slice_through(1));
     apply_matrix_in_first_dim(partial_u_wrt_eta->data(), u_eta_fastest->data(),
-                              differentiation_matrix_eta, deriv_size);
-    raw_transpose(make_not_null(logical_partial_derivatives_of_u[1]),
-                  partial_u_wrt_eta->data(), num_components_times_xi_slices,
-                  mesh.extents(0));
+                              diff_matrix_phi, deriv_size);
+    raw_transpose(make_not_null((*logical_du)[1]), partial_u_wrt_eta->data(),
+                  num_components_times_xi_slices, mesh.extents(0));
+
+    // There are a few ways to achieve the task of applying the appropriate even
+    // or odd radial differentiation matrices.
+    // Testing showed that manual looping to apply the matrices on contiguous
+    // even/odd subsets was moderately slower than reworking the data to only
+    // apply 2 BLAS calls on the full even/odd subsets.
+    // One can rework the data two ways to get the subsets:
+    //  (1) copy the even and odd columns so the different components are split
+    // in two different buffers
+    //  (2) copy the entire data and then mask with zeros where appropriate.
+    // Option (1) uses less space for the BLAS calls as they act on truly dense
+    // matrices, whereas option (2) maintains the structure of the columns by
+    // adding zeros. Option (1) uses more copies but smaller BLAS operations,
+    // which testing showed to be slightly faster.
+
+    // reuse transposed data to go to angular spectral space
+    apply_matrix_in_first_dim((*logical_du)[0], u_eta_fastest->data(),
+                              nodal_to_modal_phi, deriv_size);
+    // (*logical_du)[0] holds transposed angular modal rep
+
+    raw_transpose(make_not_null(local_buffer1.data()), (*logical_du)[0],
+                  num_components_times_xi_slices, mesh.extents(0));
+    // local_buffer 1 holds angular modal rep
+
+    // Copy even/odd subsets to compact regions
+    const size_t n_even_cols =
+        (1 + 2 * ((n_phi - 1) / 4)) *
+        Variables<DerivativeTags>::number_of_independent_components;
+    const size_t n_odd_cols =
+        (2 * ((n_phi + 1) / 4)) *
+        Variables<DerivativeTags>::number_of_independent_components;
+
+    // Use local_buffer2 for initial compact storage
+    const size_t even_size = n_even_cols * n_r;
+    const size_t odd_size = n_odd_cols * n_r;
+    ValueType* even_data = local_buffer2.data();
+    ValueType* odd_data = local_buffer2.data() + even_size;
+
+    size_t even_col = 0;
+    size_t odd_col = 0;
+    for (size_t i = 0;
+         i <
+         Variables<DerivativeTags>::number_of_independent_components * n_phi;
+         ++i) {
+      if (i % n_phi == 0) {
+        // m = 0 (even) - copy single column
+        std::copy(local_buffer1.data() + i * n_r,
+                  local_buffer1.data() + (i + 1) * n_r,
+                  even_data + even_col * n_r);
+        ++even_col;
+      } else if ((i % n_phi - 1) / 2 % 2 == 1) {
+        // Even m with cos/sin pair - copy two columns
+        std::copy(local_buffer1.data() + i * n_r,
+                  local_buffer1.data() + (i + 2) * n_r,
+                  even_data + even_col * n_r);
+        even_col += 2;
+        ++i;
+      } else {
+        // Odd m with cos/sin pair - copy two columns
+        std::copy(local_buffer1.data() + i * n_r,
+                  local_buffer1.data() + (i + 2) * n_r,
+                  odd_data + odd_col * n_r);
+        odd_col += 2;
+        ++i;
+      }
+    }
+
+    // Use local_buffer1 for differentiated compact storage
+    ValueType* even_result = local_buffer1.data();
+    ValueType* odd_result = local_buffer1.data() + even_size;
+
+    apply_matrix_in_first_dim(even_result, even_data, diff_matrix_r_even,
+                              even_size, false);
+
+    // Copy even derivative components back to interleaved regions
+    even_col = 0;
+    for (size_t i = 0;
+         i <
+         Variables<DerivativeTags>::number_of_independent_components * n_phi;
+         ++i) {
+      if (i % n_phi == 0) {
+        // m = 0 (even) - copy single column back
+        std::copy(even_result + even_col * n_r,
+                  even_result + (even_col + 1) * n_r,
+                  (*logical_du)[0] + i * n_r);
+        ++even_col;
+      } else if ((i % n_phi - 1) / 2 % 2 == 1) {
+        // Even m with cos/sin pair - copy two columns back
+        std::copy(even_result + even_col * n_r,
+                  even_result + (even_col + 2) * n_r,
+                  (*logical_du)[0] + i * n_r);
+        even_col += 2;
+        ++i;
+      } else {
+        ++i;
+      }
+    }
+
+    apply_matrix_in_first_dim(odd_result, odd_data, diff_matrix_r_odd, odd_size,
+                              false);
+
+    // Copy odd derivative components back to interleaved regions
+    odd_col = 0;
+    for (size_t i = 0;
+         i <
+         Variables<DerivativeTags>::number_of_independent_components * n_phi;
+         ++i) {
+      if (i % n_phi == 0) {
+        // m = 0 (even) - skip
+      } else if ((i % n_phi - 1) / 2 % 2 == 1) {
+        // Even m - skip
+        ++i;
+      } else {
+        // Odd m with cos/sin pair - copy both columns
+        std::copy(odd_result + odd_col * n_r, odd_result + (odd_col + 2) * n_r,
+                  (*logical_du)[0] + i * n_r);
+        odd_col += 2;
+        ++i;
+      }
+    }
+    // (*logical_du)[0] holds the radial derivative in angular modal rep
+
+    raw_transpose(make_not_null(local_buffer1.data()), (*logical_du)[0],
+                  mesh.extents(0), num_components_times_xi_slices);
+    // local_buffer1 holds transposed radial derivative in angular modal rep
+
+    apply_matrix_in_first_dim(local_buffer2.data(), local_buffer1.data(),
+                              modal_to_nodal_phi, deriv_size);
+    // local_buffer2 holds transposed radial derivative in angular nodal rep
+
+    raw_transpose(make_not_null((*logical_du)[0]), local_buffer2.data(),
+                  num_components_times_xi_slices, mesh.extents(0));
   }
 };
 
@@ -861,6 +1072,15 @@ struct LogicalImpl<3, VariableTags, DerivativeTags> {
       } else {
         ERROR(
             "Support for complex numbers with spherical harmonics is not yet "
+            "implemented for logical_partial_derivative.");
+      }
+    } else if (mesh.basis(0) == Spectral::Basis::ZernikeB2) {
+      if constexpr (std::is_same_v<ValueType, double>) {
+        cylinder_apply(logical_du, partial_u_wrt_eta_or_zeta,
+                       u_eta_or_zeta_fastest, u, mesh);
+      } else {
+        ERROR(
+            "Support for complex numbers with the cylinder is not yet "
             "implemented for logical_partial_derivative.");
       }
     } else {
@@ -925,6 +1145,209 @@ struct LogicalImpl<3, VariableTags, DerivativeTags> {
       ylm.gradient_all_offsets(du, make_not_null(u.data() + offset),
                                mesh.extents(0));
     }
+  }
+
+  template <typename T, typename ValueType = typename Variables<T>::value_type>
+  static void cylinder_apply(
+      const gsl::not_null<std::array<ValueType*, Dim>*> logical_du,
+      Variables<T>* const partial_u_wrt_eta_or_zeta,
+      Variables<DerivativeTags>* const u_eta_or_zeta_fastest,
+      const Variables<VariableTags>& u, const Mesh<3>& mesh) {
+    ASSERT(mesh.basis(0) == Spectral::Basis::ZernikeB2 and
+               mesh.basis(1) == Spectral::Basis::ZernikeB2,
+           "Unexpected basis combination: " << mesh.basis());
+    const auto [n_r, n_phi, n_zeta] = mesh.extents().indices();
+    ASSERT(n_phi % 2 == 1,
+           "Fourier with an even number of grid points can be unstable due to "
+           "the top derivative not being representable");
+    ASSERT(n_phi / 2 <= 2 * n_r - 2,
+           "Zernike & Fourier on a disk have angular resolution limited by "
+           "extents in both dimensions. We choose to enforce the restriction "
+           "that the Fourier modal space is not larger than the Zernike "
+           "angular capabilities (which would waste space and be physically "
+           "ill-motivated).\nn_phi / 2 = "
+               << n_phi / 2 << ", Maximum from Zernike = " << 2 * n_r - 2);
+
+    const Matrix& diff_matrix_r_even =
+        Spectral::differentiation_matrix<Spectral::Basis::ZernikeB2,
+                                         Spectral::Quadrature::GaussRadauUpper>(
+            n_r, Spectral::Parity::Even);
+    const Matrix& diff_matrix_r_odd =
+        Spectral::differentiation_matrix<Spectral::Basis::ZernikeB2,
+                                         Spectral::Quadrature::GaussRadauUpper>(
+            n_r, Spectral::Parity::Odd);
+    const Matrix& diff_matrix_phi = Spectral::differentiation_matrix<
+        Spectral::Basis::Fourier, Spectral::Quadrature::Equiangular>(n_phi);
+    const Matrix& differentiation_matrix_zeta =
+        Spectral::differentiation_matrix(mesh.slice_through(2));
+
+    const Matrix& nodal_to_modal_phi = Spectral::nodal_to_modal_matrix<
+        Spectral::Basis::Fourier, Spectral::Quadrature::Equiangular>(n_phi);
+    const Matrix& modal_to_nodal_phi = Spectral::modal_to_nodal_matrix<
+        Spectral::Basis::Fourier, Spectral::Quadrature::Equiangular>(n_phi);
+
+    const size_t local_buffer_size =
+        Variables<DerivativeTags>::number_of_independent_components *
+        u.number_of_grid_points();
+    // These just point to the passed buffers but it gets confusing to read when
+    // they are used for radial purposes that don't match their names
+    Variables<DerivativeTags> local_buffer1{};
+    Variables<DerivativeTags> local_buffer2{};
+    local_buffer1.set_data_ref(partial_u_wrt_eta_or_zeta->data(),
+                               local_buffer_size);
+    local_buffer2.set_data_ref(u_eta_or_zeta_fastest->data(),
+                               local_buffer_size);
+
+    const size_t deriv_size =
+        Variables<DerivativeTags>::number_of_independent_components *
+        u.number_of_grid_points();
+    const size_t num_components_times_xi_slices = deriv_size / mesh.extents(0);
+
+    // phi derivative
+    transpose<Variables<VariableTags>, Variables<DerivativeTags>>(
+        make_not_null(u_eta_or_zeta_fastest), u, mesh.extents(0),
+        num_components_times_xi_slices);
+    apply_matrix_in_first_dim(partial_u_wrt_eta_or_zeta->data(),
+                              u_eta_or_zeta_fastest->data(), diff_matrix_phi,
+                              deriv_size);
+    raw_transpose(make_not_null((*logical_du)[1]),
+                  partial_u_wrt_eta_or_zeta->data(),
+                  num_components_times_xi_slices, mesh.extents(0));
+
+    // See comments in disk_apply() for why the following choices were made
+
+    // reuse transposed data to go to angular spectral space
+    apply_matrix_in_first_dim((*logical_du)[0], u_eta_or_zeta_fastest->data(),
+                              nodal_to_modal_phi, deriv_size);
+    // (*logical_du)[0] holds transposed angular modal rep
+
+    raw_transpose(make_not_null(local_buffer1.data()), (*logical_du)[0],
+                  num_components_times_xi_slices, mesh.extents(0));
+    std::copy(local_buffer1.data(), local_buffer1.data() + local_buffer_size,
+              local_buffer2.data());
+    // local_buffer 1 and local_buffer2 hold angular modal rep
+
+    // Copy even/odd subsets to compact regions for 3D cylinder
+    const size_t n_even_cols =
+        (1 + 2 * ((n_phi - 1) / 4)) *
+        Variables<DerivativeTags>::number_of_independent_components;
+    const size_t n_odd_cols =
+        (2 * ((n_phi + 1) / 4)) *
+        Variables<DerivativeTags>::number_of_independent_components;
+
+    // Use local_buffer2 for compact storage
+    const size_t total_even_size = n_even_cols * n_r * n_zeta;
+    const size_t total_odd_size = n_odd_cols * n_r * n_zeta;
+
+    ValueType* even_data = local_buffer2.data();
+    ValueType* odd_data = local_buffer2.data() + total_even_size;
+
+    size_t even_col = 0;
+    size_t odd_col = 0;
+    for (size_t i = 0;
+         i < Variables<DerivativeTags>::number_of_independent_components *
+                 n_phi * n_zeta;
+         ++i) {
+      if (i % n_phi == 0) {
+        // m = 0 (even) - copy single column
+        std::copy(local_buffer1.data() + i * n_r,
+                  local_buffer1.data() + (i + 1) * n_r,
+                  even_data + even_col * n_r);
+        ++even_col;
+      } else if ((i % n_phi - 1) / 2 % 2 == 1) {
+        // Even m with cos/sin pair - copy two columns
+        std::copy(local_buffer1.data() + i * n_r,
+                  local_buffer1.data() + (i + 2) * n_r,
+                  even_data + even_col * n_r);
+        even_col += 2;
+        ++i;
+      } else {
+        // Odd m with cos/sin pair - copy two columns
+        std::copy(local_buffer1.data() + i * n_r,
+                  local_buffer1.data() + (i + 2) * n_r,
+                  odd_data + odd_col * n_r);
+        odd_col += 2;
+        ++i;
+      }
+    }
+
+    // Use local_buffer1 for temporary storage since it's no longer needed
+    ValueType* even_result = local_buffer1.data();
+    ValueType* odd_result = local_buffer1.data() + total_even_size;
+
+    apply_matrix_in_first_dim(even_result, even_data, diff_matrix_r_even,
+                              total_even_size, false);
+
+    // Copy even derivative components back to interleaved regions
+    even_col = 0;
+    for (size_t i = 0;
+         i < Variables<DerivativeTags>::number_of_independent_components *
+                 n_phi * n_zeta;
+         ++i) {
+      if (i % n_phi == 0) {
+        // m = 0 (even) - copy single column back
+        std::copy(even_result + even_col * n_r,
+                  even_result + (even_col + 1) * n_r,
+                  (*logical_du)[0] + i * n_r);
+        ++even_col;
+      } else if ((i % n_phi - 1) / 2 % 2 == 1) {
+        // Even m with cos/sin pair - copy two columns back
+        std::copy(even_result + even_col * n_r,
+                  even_result + (even_col + 2) * n_r,
+                  (*logical_du)[0] + i * n_r);
+        even_col += 2;
+        ++i;
+      } else {
+        ++i;
+      }
+    }
+
+    apply_matrix_in_first_dim(odd_result, odd_data, diff_matrix_r_odd,
+                              total_odd_size, false);
+
+    // Copy odd derivative components back to interleaved regions
+    odd_col = 0;
+    for (size_t i = 0;
+         i < Variables<DerivativeTags>::number_of_independent_components *
+                 n_phi * n_zeta;
+         ++i) {
+      if (i % n_phi == 0) {
+        // m = 0 (even) - skip
+      } else if ((i % n_phi - 1) / 2 % 2 == 1) {
+        // Even m - skip
+        ++i;
+      } else {
+        // Odd m with cos/sin pair - copy both columns
+        std::copy(odd_result + odd_col * n_r, odd_result + (odd_col + 2) * n_r,
+                  (*logical_du)[0] + i * n_r);
+        odd_col += 2;
+        ++i;
+      }
+    }
+    // (*logical_du)[0] holds the radial derivative in angular modal rep
+
+    raw_transpose(make_not_null(local_buffer1.data()), (*logical_du)[0],
+                  mesh.extents(0), num_components_times_xi_slices);
+    // local_buffer1 holds transposed radial derivative in angular modal rep
+
+    apply_matrix_in_first_dim(local_buffer2.data(), local_buffer1.data(),
+                              modal_to_nodal_phi, deriv_size);
+    // local_buffer2 holds transposed radial derivative in angular nodal rep
+
+    raw_transpose(make_not_null((*logical_du)[0]), local_buffer2.data(),
+                  num_components_times_xi_slices, mesh.extents(0));
+
+    // zeta derivative
+    const size_t chunk_size = mesh.extents(0) * mesh.extents(1);
+    const size_t number_of_chunks = deriv_size / chunk_size;
+    transpose(make_not_null(u_eta_or_zeta_fastest), u, chunk_size,
+              number_of_chunks);
+    apply_matrix_in_first_dim(partial_u_wrt_eta_or_zeta->data(),
+                              u_eta_or_zeta_fastest->data(),
+                              differentiation_matrix_zeta, deriv_size);
+    raw_transpose(make_not_null((*logical_du)[2]),
+                  partial_u_wrt_eta_or_zeta->data(), number_of_chunks,
+                  chunk_size);
   }
 };
 }  // namespace partial_derivatives_detail

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
@@ -37,11 +37,13 @@
 #include "Domain/Tags.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "Helpers/NumericalAlgorithms/Spectral/DiskTestFunctions.hpp"
 #include "Helpers/NumericalAlgorithms/SphericalHarmonics/YlmTestFunctions.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp"
 #include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "NumericalAlgorithms/Spectral/BasisFunctions/Fourier.hpp"
+#include "NumericalAlgorithms/Spectral/BasisFunctions/Zernike.hpp"
 #include "NumericalAlgorithms/Spectral/CollocationPoints.hpp"
 #include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
 #include "NumericalAlgorithms/Spectral/MaximumNumberOfPoints.hpp"
@@ -433,6 +435,151 @@ void test_logical_partial_derivatives_spherical_shell(const size_t n_r,
 }
 
 template <typename VariableTags, typename GradientTags = VariableTags>
+void test_logical_partial_derivatives_disk(const size_t n_r,
+                                           const size_t n_phi) {
+  CAPTURE(n_r);
+  CAPTURE(n_phi);
+  const Mesh<2> mesh{{n_r, n_phi},
+                     {Spectral::Basis::ZernikeB2, Spectral::Basis::ZernikeB2},
+                     {Spectral::Quadrature::GaussRadauUpper,
+                      Spectral::Quadrature::Equiangular}};
+  const auto x = logical_coordinates(mesh);
+  const DataVector r = 0.5 * (x[0] + 1.0);
+  const DataVector& phi = x[1];
+  const size_t number_of_grid_points = mesh.number_of_grid_points();
+  const size_t k_max = n_phi / 2;
+  const size_t pow_nx = k_max / 2;
+  const size_t pow_ny = k_max - pow_nx;
+  const DiskTestFunctions::ProductOfPolynomials f1{pow_nx, pow_ny};
+  const DiskTestFunctions::ProductOfPolynomials f2{
+      pow_nx > 0 ? pow_nx - 1 : pow_nx, pow_ny};
+  const DiskTestFunctions::ProductOfPolynomials f3{
+      pow_nx, pow_ny > 0 ? pow_ny - 1 : pow_ny};
+  Variables<VariableTags> u{number_of_grid_points};
+  for (size_t n = 0; n < u.number_of_independent_components; ++n) {
+    DataVector component_ref(u.data() + n * number_of_grid_points,
+                             number_of_grid_points);
+    switch (n % 3) {
+      case 0:
+        component_ref = f1(r, phi);
+        break;
+      case 1:
+        component_ref = f2(r, phi);
+        break;
+      case 2:
+        component_ref = f3(r, phi);
+        break;
+      default:
+        ERROR("Cannot get here");
+    }
+  }
+  std::array<Variables<GradientTags>, 2> du_expected{};
+  du_expected[0].initialize(number_of_grid_points);
+  du_expected[1].initialize(number_of_grid_points);
+  for (size_t n = 0;
+       n < Variables<GradientTags>::number_of_independent_components; ++n) {
+    DataVector du_dr_ref(du_expected[0].data() + n * number_of_grid_points,
+                         number_of_grid_points);
+    DataVector du_dph_ref(du_expected[1].data() + n * number_of_grid_points,
+                          number_of_grid_points);
+    // radial derivative factor of 1/2 from the fact that we provided an
+    // affine map to get from logical [-1,1] to actual logical [0,1]
+    // coordinates. This is correctly handled by the jacobian factor when
+    // one calls partial_derivatives()
+    switch (n % 3) {
+      case 0:
+        du_dr_ref = 0.5 * f1.df_dr(r, phi);
+        du_dph_ref = f1.df_dph(r, phi);
+        break;
+      case 1:
+        du_dr_ref = 0.5 * f2.df_dr(r, phi);
+        du_dph_ref = f2.df_dph(r, phi);
+        break;
+      case 2:
+        du_dr_ref = 0.5 * f3.df_dr(r, phi);
+        du_dph_ref = f3.df_dph(r, phi);
+        break;
+      default:
+        ERROR("Cannot get here");
+    }
+  }
+  const auto du = logical_partial_derivatives<GradientTags>(u, mesh);
+  const Approx local_approx = Approx::custom().epsilon(1.0e-13).scale(1.0);
+  CHECK_VARIABLES_CUSTOM_APPROX(du[0], du_expected[0], local_approx);
+  CHECK_VARIABLES_CUSTOM_APPROX(du[1], du_expected[1], local_approx);
+  // We've checked that du is correct, now test that taking derivatives of
+  // individual tensors gets the matching result.
+  test_logical_partial_derivative_per_tensor(du, u, mesh);
+}
+
+template <typename VariableTags, typename GradientTags = VariableTags>
+void test_logical_partial_derivatives_cylinder(const size_t n_r,
+                                               const size_t n_phi,
+                                               const size_t n_z) {
+  CAPTURE(n_r);
+  CAPTURE(n_phi);
+  CAPTURE(n_z);
+  const Mesh<3> mesh{
+      {n_r, n_phi, n_z},
+      {Spectral::Basis::ZernikeB2, Spectral::Basis::ZernikeB2,
+       Spectral::Basis::Legendre},
+      {Spectral::Quadrature::GaussRadauUpper, Spectral::Quadrature::Equiangular,
+       Spectral::Quadrature::GaussLobatto}};
+  const auto x = logical_coordinates(mesh);
+  const DataVector r = 0.5 * (x[0] + 1.0);
+  const DataVector& phi = x[1];
+  const DataVector& z = x[2];
+  const size_t number_of_grid_points = mesh.number_of_grid_points();
+  const size_t k_max = n_phi / 2;
+  const size_t pow_nx = k_max / 2;
+  const size_t pow_ny = k_max - pow_nx;
+  const DiskTestFunctions::ProductOfPolynomials f{pow_nx, pow_ny};
+  Variables<VariableTags> u{number_of_grid_points};
+  for (size_t n = 0; n < u.number_of_independent_components; ++n) {
+    DataVector component_ref(u.data() + n * number_of_grid_points,
+                             number_of_grid_points);
+    component_ref = (1.0 + static_cast<double>(n)) *
+                    pow(z, -1.0 + static_cast<double>(n_z)) * f(r, phi);
+  }
+  std::array<Variables<GradientTags>, 3> du_expected{};
+  du_expected[0].initialize(number_of_grid_points);
+  du_expected[1].initialize(number_of_grid_points);
+  du_expected[2].initialize(number_of_grid_points);
+  for (size_t n = 0;
+       n < Variables<GradientTags>::number_of_independent_components; ++n) {
+    DataVector du_dr_ref(du_expected[0].data() + n * number_of_grid_points,
+                         number_of_grid_points);
+    // radial derivative factor of 1/2 from the fact that we provided an
+    // affine map to get from logical [-1,1] to actual logical [0,1]
+    // coordinates. This is correctly handled by the jacobian factor when
+    // one calls partial_derivatives()
+    du_dr_ref = 0.5 * (1.0 + static_cast<double>(n)) *
+                pow(z, -1.0 + static_cast<double>(n_z)) * f.df_dr(r, phi);
+    DataVector du_dph_ref(du_expected[1].data() + n * number_of_grid_points,
+                          number_of_grid_points);
+    du_dph_ref = (1.0 + static_cast<double>(n)) *
+                 pow(z, -1.0 + static_cast<double>(n_z)) * f.df_dph(r, phi);
+    DataVector du_dzeta_ref(du_expected[2].data() + n * number_of_grid_points,
+                            number_of_grid_points);
+    if (n_z == 1) {
+      du_dzeta_ref = 0.0;
+    } else {
+      du_dzeta_ref = (-1.0 + static_cast<double>(n_z)) *
+                     (1.0 + static_cast<double>(n)) *
+                     pow(z, -2.0 + static_cast<double>(n_z)) * f(r, phi);
+    }
+  }
+  const auto du = logical_partial_derivatives<GradientTags>(u, mesh);
+  const Approx local_approx = Approx::custom().epsilon(1.0e-13).scale(1.0);
+  CHECK_VARIABLES_CUSTOM_APPROX(du[0], du_expected[0], local_approx);
+  CHECK_VARIABLES_CUSTOM_APPROX(du[1], du_expected[1], local_approx);
+  CHECK_VARIABLES_CUSTOM_APPROX(du[2], du_expected[2], local_approx);
+  // We've checked that du is correct, now test that taking derivatives of
+  // individual tensors gets the matching result.
+  test_logical_partial_derivative_per_tensor(du, u, mesh);
+}
+
+template <typename VariableTags, typename GradientTags = VariableTags>
 void test_partial_derivatives_1d(const Mesh<1>& mesh) {
   const size_t number_of_grid_points = mesh.number_of_grid_points();
   const Affine x_map{-1.0, 1.0, -0.3, 0.7};
@@ -654,6 +801,148 @@ void test_partial_derivatives_spherical_shell() {
 }
 
 template <typename VariableTags, typename GradientTags = VariableTags>
+void test_partial_derivatives_disk() {
+  const size_t n_r = 3;
+  const size_t n_phi = 9;
+  const size_t M = n_phi / 2;
+  const Mesh<2> mesh{{n_r, n_phi},
+                     {Spectral::Basis::ZernikeB2, Spectral::Basis::ZernikeB2},
+                     {Spectral::Quadrature::GaussRadauUpper,
+                      Spectral::Quadrature::Equiangular}};
+
+  const size_t number_of_grid_points = mesh.number_of_grid_points();
+  const auto prod_map2d =
+      domain::make_coordinate_map<Frame::ElementLogical, Frame::Grid>(
+          domain::CoordinateMaps::ProductOf2Maps<
+              Affine, domain::CoordinateMaps::Identity<1>>{
+              Affine{-1.0, 1.0, 0.0, 1.5},
+              domain::CoordinateMaps::Identity<1>{}},
+          domain::CoordinateMaps::PolarToCartesian{});
+  const auto xi = logical_coordinates(mesh);
+  auto x = prod_map2d(xi);
+  const InverseJacobian<DataVector, 2, Frame::ElementLogical, Frame::Grid>
+      inverse_jacobian = prod_map2d.inv_jacobian(xi);
+
+  Variables<VariableTags> u(number_of_grid_points);
+  Variables<
+      db::wrap_tags_in<Tags::deriv, GradientTags, tmpl::size_t<2>, Frame::Grid>>
+      expected_du(number_of_grid_points);
+  const Approx local_approx = Approx::custom().epsilon(1e-13).scale(1.0);
+  for (size_t a = 0; a <= M; ++a) {
+    CAPTURE(a);
+    for (size_t b = 0; b <= M - a; ++b) {
+      CAPTURE(b);
+      tmpl::for_each<VariableTags>(
+          [&a, &b, &x, &u]<typename Tag>(tmpl::type_<Tag> /*meta*/) {
+            get<Tag>(u) = Tag::f({{a, b}}, x);
+          });
+      tmpl::for_each<GradientTags>([&a, &b, &x, &expected_du]<typename Tag>(
+                                       tmpl::type_<Tag> /*meta*/) {
+        using DerivativeTag = Tags::deriv<Tag, tmpl::size_t<2>, Frame::Grid>;
+        get<DerivativeTag>(expected_du) = Tag::df({{a, b}}, x);
+      });
+
+      CHECK_VARIABLES_CUSTOM_APPROX(
+          (partial_derivatives<GradientTags>(u, mesh, inverse_jacobian)),
+          expected_du, local_approx);
+
+      using vars_type = decltype(partial_derivatives<GradientTags>(
+          u, mesh, inverse_jacobian));
+      vars_type du{};
+      partial_derivatives(make_not_null(&du), u, mesh, inverse_jacobian);
+      CHECK_VARIABLES_CUSTOM_APPROX(du, expected_du, local_approx);
+
+      vars_type du_with_logical{};
+      partial_derivatives(make_not_null(&du_with_logical),
+                          logical_partial_derivatives<GradientTags>(u, mesh),
+                          inverse_jacobian);
+      CHECK_VARIABLES_CUSTOM_APPROX(du_with_logical, expected_du, local_approx);
+
+      // We've checked that du is correct, now test that taking derivatives of
+      // individual tensors gets the matching result.
+      test_partial_derivative_per_tensor(du, u, mesh, inverse_jacobian);
+    }
+  }
+}
+
+template <typename VariableTags, typename GradientTags = VariableTags>
+void test_partial_derivatives_cylinder() {
+  const size_t n_r = 3;
+  const size_t n_phi = 9;
+  const size_t n_z = 4;
+  const size_t M = n_phi / 2;
+  const Mesh<3> mesh{
+      {n_r, n_phi, n_z},
+      {Spectral::Basis::ZernikeB2, Spectral::Basis::ZernikeB2,
+       Spectral::Basis::Legendre},
+      {Spectral::Quadrature::GaussRadauUpper, Spectral::Quadrature::Equiangular,
+       Spectral::Quadrature::GaussLobatto}};
+  const size_t number_of_grid_points = mesh.number_of_grid_points();
+  const auto prod_map3d =
+      domain::make_coordinate_map<Frame::ElementLogical, Frame::Grid>(
+          domain::CoordinateMaps::ProductOf3Maps<
+              Affine, domain::CoordinateMaps::Identity<1>, Affine>{
+              Affine{-1.0, 1.0, 0.0, 2.5},
+              domain::CoordinateMaps::Identity<1>{},
+              Affine{-1.0, 1.0, -2.0, 2.0}},
+          domain::CoordinateMaps::ProductOf2Maps<
+              domain::CoordinateMaps::PolarToCartesian,
+              domain::CoordinateMaps::Identity<1>>{
+              domain::CoordinateMaps::PolarToCartesian{},
+              domain::CoordinateMaps::Identity<1>{}});
+  const auto xi = logical_coordinates(mesh);
+  auto x = prod_map3d(xi);
+  const InverseJacobian<DataVector, 3, Frame::ElementLogical, Frame::Grid>
+      inverse_jacobian = prod_map3d.inv_jacobian(xi);
+
+  Variables<VariableTags> u(number_of_grid_points);
+  Variables<
+      db::wrap_tags_in<Tags::deriv, GradientTags, tmpl::size_t<3>, Frame::Grid>>
+      expected_du(number_of_grid_points);
+  const Approx local_approx = Approx::custom().epsilon(5e-13).scale(1.0);
+  for (size_t a = 0; a <= M; ++a) {
+    CAPTURE(a);
+    for (size_t b = 0; b < M - a; ++b) {
+      CAPTURE(b);
+      for (size_t c = 0; c < n_z; ++c) {
+        CAPTURE(c);
+        tmpl::for_each<VariableTags>(
+            [&a, &b, &c, &x, &u]<typename Tag>(tmpl::type_<Tag> /*meta*/) {
+              get<Tag>(u) = Tag::f({{a, b, c}}, x);
+            });
+        tmpl::for_each<GradientTags>([&a, &b, &c, &x,
+                                      &expected_du]<typename Tag>(
+                                         tmpl::type_<Tag> /*meta*/) {
+          using DerivativeTag = Tags::deriv<Tag, tmpl::size_t<3>, Frame::Grid>;
+          get<DerivativeTag>(expected_du) = Tag::df({{a, b, c}}, x);
+        });
+
+        CHECK_VARIABLES_CUSTOM_APPROX(
+            (partial_derivatives<GradientTags>(u, mesh, inverse_jacobian)),
+            expected_du, local_approx);
+
+        using vars_type = decltype(partial_derivatives<GradientTags>(
+            u, mesh, inverse_jacobian));
+        vars_type du{};
+        partial_derivatives(make_not_null(&du), u, mesh, inverse_jacobian);
+        CHECK_VARIABLES_CUSTOM_APPROX(du, expected_du, local_approx);
+
+        vars_type du_with_logical{};
+        partial_derivatives(make_not_null(&du_with_logical),
+                            logical_partial_derivatives<GradientTags>(u, mesh),
+                            inverse_jacobian);
+        CHECK_VARIABLES_CUSTOM_APPROX(du_with_logical, expected_du,
+                                      local_approx);
+
+        // We've checked that du is correct, now test that taking derivatives of
+        // individual tensors gets the matching result.
+        test_partial_derivative_per_tensor(du, u, mesh, inverse_jacobian);
+      }
+    }
+  }
+}
+
+template <typename VariableTags, typename GradientTags = VariableTags>
 void test_partial_derivatives_hollow_cylinder() {
   const size_t n_r = 4;
   const size_t n_ph = 9;
@@ -689,7 +978,7 @@ void test_partial_derivatives_hollow_cylinder() {
       db::wrap_tags_in<Tags::deriv, GradientTags, tmpl::size_t<3>, Frame::Grid>>
       expected_du(number_of_grid_points);
   const Approx local_approx = Approx::custom().epsilon(5e-12).scale(1.0);
-  for (size_t a = 0; a < M; ++a) {
+  for (size_t a = 0; a <= M; ++a) {
     CAPTURE(a);
     for (size_t b = 0; b < M - a; ++b) {
       CAPTURE(b);
@@ -1305,6 +1594,39 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.LogicalDerivs",
       }
     }
   }
+  for (size_t n_r = 2; n_r < 9; ++n_r) {
+    for (size_t n_phi = 3; n_phi < 15; n_phi += 2) {
+      // Restrictions enforced in the logical derivative
+      if (n_phi / 2 <= 2 * n_r - 2) {
+        test_logical_partial_derivatives_disk<two_vars<DataVector, 2>>(n_r,
+                                                                       n_phi);
+        for (size_t n_zeta = 2; n_zeta < 8; ++n_zeta) {
+          test_logical_partial_derivatives_cylinder<two_vars<DataVector, 3>>(
+              n_r, n_phi, n_zeta);
+        }
+      }
+    }
+  }
+#ifdef SPECTRE_DEBUG
+  CHECK_THROWS_WITH(
+      (test_logical_partial_derivatives_disk<two_vars<DataVector, 2>>(2, 7)),
+      Catch::Matchers::ContainsSubstring(
+          "Zernike & Fourier on a disk have angular resolution limited by "));
+  CHECK_THROWS_WITH(
+      (test_logical_partial_derivatives_disk<two_vars<DataVector, 2>>(2, 4)),
+      Catch::Matchers::ContainsSubstring(
+          "Fourier with an even number of grid points can be unstable due "));
+  CHECK_THROWS_WITH(
+      (test_logical_partial_derivatives_cylinder<two_vars<DataVector, 3>>(2, 7,
+                                                                          3)),
+      Catch::Matchers::ContainsSubstring(
+          "Zernike & Fourier on a disk have angular resolution limited by "));
+  CHECK_THROWS_WITH(
+      (test_logical_partial_derivatives_cylinder<two_vars<DataVector, 3>>(2, 4,
+                                                                          3)),
+      Catch::Matchers::ContainsSubstring(
+          "Fourier with an even number of grid points can be unstable due "));
+#endif  // SPECTRE_DEBUG
 }
 
 // [[Timeout, 120]]
@@ -1313,6 +1635,12 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.PartialDerivs",
   test_partial_derivatives_spherical_shell<two_vars<DataVector, 3>>();
   test_partial_derivatives_spherical_shell<two_vars<DataVector, 3>,
                                            one_var<DataVector, 3>>();
+  test_partial_derivatives_disk<two_vars<DataVector, 2>>();
+  test_partial_derivatives_disk<two_vars<DataVector, 2>,
+                                one_var<DataVector, 2>>();
+  test_partial_derivatives_cylinder<two_vars<DataVector, 3>>();
+  test_partial_derivatives_cylinder<two_vars<DataVector, 3>,
+                                    one_var<DataVector, 3>>();
   test_partial_derivatives_hollow_cylinder<two_vars<DataVector, 3>>();
   test_partial_derivatives_hollow_cylinder<two_vars<DataVector, 3>,
                                            one_var<DataVector, 3>>();


### PR DESCRIPTION
## Proposed changes

Representing functions on a filled disk (with ZernikeB2) couples the bases. We found that you need to "extend" the derivatives to negative $r$ to get stable runs, which means we need to act on the functions in the angular modal basis.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
