### PR TITLE
Add ZernikeB2 support to DefiniteIntegral

### DIFF
--- a/src/NumericalAlgorithms/LinearOperators/DefiniteIntegral.cpp
+++ b/src/NumericalAlgorithms/LinearOperators/DefiniteIntegral.cpp
@@ -4,9 +4,13 @@
 #include "NumericalAlgorithms/LinearOperators/DefiniteIntegral.hpp"
 
 #include <array>  // Used for mesh.slices
+#include <numbers>
 #include <ostream>
 
 #include "DataStructures/DataVector.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/CollocationPoints.hpp"
+#include "NumericalAlgorithms/Spectral/CollocationPointsAndWeights.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
 #include "NumericalAlgorithms/Spectral/QuadratureWeights.hpp"
@@ -56,22 +60,42 @@ double definite_integral<2>(const DataVector& integrand, const Mesh<2>& mesh) {
   const size_t x_size = sliced_meshes[0].number_of_grid_points();
   const size_t x_last_unrolled = x_size - x_size % 2;
   const size_t y_size = sliced_meshes[1].number_of_grid_points();
-  const double* const w_x =
-      Spectral::quadrature_weights(sliced_meshes[0]).data();
-  const double* const w_y =
-      Spectral::quadrature_weights(sliced_meshes[1]).data();
-
   double result = 0.0;
-  for (size_t j = 0; j < y_size; ++j) {
-    const size_t offset = j * x_size;
-    for (size_t i = 0; i < x_last_unrolled; i += 2) {
-      // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-      result += w_y[j] * w_x[i] * integrand[i + offset] +
-                w_y[j] * w_x[i + 1] * integrand[i + 1 + offset];  // NOLINT
+  if (mesh.basis(0) == Spectral::Basis::ZernikeB2) {
+    const DataVector w_radial =
+        Spectral::quadrature_weights(sliced_meshes[0]) * 2.0 /
+        (Spectral::collocation_points(sliced_meshes[0]) + 1.0);
+    const double* const w_r = w_radial.data();
+    // Fourier weights are constant 2 \pi / n_\phi, no need to fetch
+    for (size_t j = 0; j < y_size; ++j) {
+      const size_t offset = j * x_size;
+      for (size_t i = 0; i < x_last_unrolled; i += 2) {
+        result += (w_r[i] * integrand[i + offset] +          // NOLINT
+                   w_r[i + 1] * integrand[i + 1 + offset]);  // NOLINT
+      }
+      for (size_t i = x_last_unrolled; i < x_size; ++i) {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        result += w_r[i] * integrand[i + offset];
+      }
     }
-    for (size_t i = x_last_unrolled; i < x_size; ++i) {
-      // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-      result += w_y[j] * w_x[i] * integrand[i + offset];
+    result *= (2 * std::numbers::pi / static_cast<double>(y_size));
+  } else {
+    const double* const w_x =
+        Spectral::quadrature_weights(sliced_meshes[0]).data();
+    const double* const w_y =
+        Spectral::quadrature_weights(sliced_meshes[1]).data();
+
+    for (size_t j = 0; j < y_size; ++j) {
+      const size_t offset = j * x_size;
+      for (size_t i = 0; i < x_last_unrolled; i += 2) {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        result += w_y[j] * w_x[i] * integrand[i + offset] +
+                  w_y[j] * w_x[i + 1] * integrand[i + 1 + offset];  // NOLINT
+      }
+      for (size_t i = x_last_unrolled; i < x_size; ++i) {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        result += w_y[j] * w_x[i] * integrand[i + offset];
+      }
     }
   }
   return result;
@@ -126,6 +150,34 @@ double definite_integral<3>(const DataVector& integrand, const Mesh<3>& mesh) {
         result += w_ylm[j] * w_x[i] * integrand[i + offset];
       }
     }
+  } else if (mesh.basis(0) == Spectral::Basis::ZernikeB2) {
+    const size_t y_size = sliced_meshes[1].number_of_grid_points();
+    const size_t z_size = sliced_meshes[2].number_of_grid_points();
+    const DataVector w_radial =
+        Spectral::quadrature_weights(sliced_meshes[0]) * 2.0 /
+        (Spectral::collocation_points(sliced_meshes[0]) + 1.0);
+    const double* const w_r = w_radial.data();
+    // Fourier weights are constant 2 \pi / n_\phi, no need to fetch
+    const double* const w_z =
+        Spectral::quadrature_weights(sliced_meshes[2]).data();
+
+    for (size_t k = 0; k < z_size; ++k) {
+      for (size_t j = 0; j < y_size; ++j) {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        const double z_contribution = w_z[k];
+        const size_t offset = x_size * (j + y_size * k);
+        for (size_t i = 0; i < x_last_unrolled; i += 2) {
+          result += z_contribution * w_r[i] * integrand[i + offset] +  // NOLINT
+                    z_contribution * w_r[i + 1] *                      // NOLINT
+                        integrand[i + 1 + offset];                     // NOLINT
+        }
+        for (size_t i = x_last_unrolled; i < x_size; ++i) {
+          // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+          result += z_contribution * w_r[i] * integrand[i + offset];
+        }
+      }
+    }
+    result *= 2 * std::numbers::pi / static_cast<double>(y_size);
   } else {
     const size_t y_size = sliced_meshes[1].number_of_grid_points();
     const size_t z_size = sliced_meshes[2].number_of_grid_points();

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_DefiniteIntegral.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_DefiniteIntegral.cpp
@@ -9,6 +9,7 @@
 #include "DataStructures/Index.hpp"
 #include "DataStructures/IndexIterator.hpp"
 #include "Framework/TestHelpers.hpp"
+#include "Helpers/NumericalAlgorithms/Spectral/DiskTestFunctions.hpp"
 #include "Helpers/NumericalAlgorithms/Spectral/FourierTestFunctions.hpp"
 #include "Helpers/NumericalAlgorithms/SphericalHarmonics/YlmTestFunctions.hpp"
 #include "NumericalAlgorithms/LinearOperators/DefiniteIntegral.hpp"
@@ -133,6 +134,63 @@ void test_definite_integral_spherical_shell(const size_t n_r, const size_t L) {
         const DataVector integrand =
             r * f(get<1>(xi_vector), get<2>(xi_vector));
         CHECK(4.0 * f.definite_integral() ==
+              approx(definite_integral(integrand, mesh)));
+      }
+    }
+  }
+}
+
+void test_definite_integral_disk(const size_t n_r, const size_t n_ph) {
+  CAPTURE(n_r);
+  CAPTURE(n_ph);
+  const Mesh<2> mesh{{n_r, n_ph},
+                     {Spectral::Basis::ZernikeB2, Spectral::Basis::ZernikeB2},
+                     {Spectral::Quadrature::GaussRadauUpper,
+                      Spectral::Quadrature::Equiangular}};
+  const size_t M = n_ph / 2;
+  const auto xi_vector = logical_coordinates(mesh);
+  const DataVector r = 0.5 * (get<0>(xi_vector) + 1.0);
+  const DataVector& phi = get<1>(xi_vector);
+  for (size_t pow_nx = 0; pow_nx <= M; ++pow_nx) {
+    CAPTURE(pow_nx);
+    for (size_t pow_ny = 0; pow_ny <= M - pow_nx; ++pow_ny) {
+      CAPTURE(pow_ny);
+      const DiskTestFunctions::ProductOfPolynomials f{pow_nx, pow_ny};
+      const DataVector integrand = r * f(r, phi);
+      CHECK(f.definite_integral() ==
+            approx(definite_integral(integrand, mesh)));
+    }
+  }
+}
+
+void test_definite_integral_cylinder(const size_t n_r, const size_t n_ph,
+                                     const size_t n_z) {
+  CAPTURE(n_r);
+  CAPTURE(n_ph);
+  CAPTURE(n_z);
+  const Mesh<3> mesh{
+      {n_r, n_ph, n_z},
+      {Spectral::Basis::ZernikeB2, Spectral::Basis::ZernikeB2,
+       Spectral::Basis::Legendre},
+      {Spectral::Quadrature::GaussRadauUpper, Spectral::Quadrature::Equiangular,
+       Spectral::Quadrature::GaussLobatto}};
+  const size_t M = n_ph / 2;
+  const auto xi_vector = logical_coordinates(mesh);
+  const DataVector r = 0.5 * (get<0>(xi_vector) + 1.0);
+  const DataVector& phi = get<1>(xi_vector);
+  const DataVector& z = get<2>(xi_vector);
+  for (size_t pow_nx = 0; pow_nx <= M; ++pow_nx) {
+    CAPTURE(pow_nx);
+    for (size_t pow_ny = 0; pow_ny <= M - pow_nx; ++pow_ny) {
+      CAPTURE(pow_ny);
+      const DiskTestFunctions::ProductOfPolynomials f{pow_nx, pow_ny};
+      const double disk_integral = f.definite_integral();
+      for (size_t pow_nz = 0; pow_nz < n_z; ++pow_nz) {
+        CAPTURE(pow_nz);
+        const DataVector integrand = r * f(r, phi) * pow(z, pow_nz);
+        const double z_integral =
+            (0 == pow_nz % 2) ? 2.0 / (static_cast<double>(pow_nz) + 1.0) : 0.0;
+        CHECK(disk_integral * z_integral ==
               approx(definite_integral(integrand, mesh)));
       }
     }
@@ -294,6 +352,18 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.DefiniteIntegral",
   for (size_t n_r = 2; n_r < 5; ++n_r) {
     for (size_t L = 2; L < 9; ++L) {
       test_definite_integral_spherical_shell(n_r, L);
+    }
+  }
+
+  for (size_t n_r = 1; n_r < 9; ++n_r) {
+    for (size_t n_ph = 3; n_ph < 15; n_ph += 2) {
+      // We enforce these restrictions for the disk
+      if (n_ph / 2 <= 2 * n_r - 2) {
+        test_definite_integral_disk(n_r, n_ph);
+        for (size_t n_z = 2; n_z < 5; ++n_z) {
+          test_definite_integral_cylinder(n_r, n_ph, n_z);
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## Proposed changes

Adding support for definite integrals of disks and cylinders.

(Indefinite integrals are not feasible for Zernike bases)

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
