### PR TITLE
Fix FunctionsOfTimeFromVolume test directory

### DIFF
--- a/tests/Unit/IO/H5/Python/Test_FunctionsOfTimeFromVolume.py
+++ b/tests/Unit/IO/H5/Python/Test_FunctionsOfTimeFromVolume.py
@@ -30,7 +30,7 @@ from spectre.support.Logging import configure_logging
 class TestFunctionsOfTimeFromVolume(unittest.TestCase):
     def setUp(self):
         self.test_dir = Path(
-            unit_test_build_path(), "support/Pipelines/Bbh/Ringdown"
+            unit_test_build_path(), "IO/H5/Python/FunctionsOfTimeFromVolume"
         )
         shutil.rmtree(self.test_dir, ignore_errors=True)
         self.test_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Fixes an issue where tests could delete each other's files when run in parallel.

Fixes #7089.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
