### PR TITLE
Update metavariables for subcell LTS wavezones

### DIFF
--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -228,10 +228,12 @@ struct EvolutionMetavars {
       evolution::dg::Actions::ComputeTimeDerivative<
           volume_dim, system, AllStepChoosers, local_time_stepping,
           use_dg_element_collection>,
+      evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
+          volume_dim, use_dg_element_collection>,
+      Actions::MutateApply<RecordTimeStepperData<system>>,
       tmpl::conditional_t<
           local_time_stepping,
-          tmpl::list<Actions::MutateApply<RecordTimeStepperData<system>>,
-                     evolution::Actions::RunEventsAndDenseTriggers<
+          tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<
                          tmpl::list<evolution::dg::ApplyBoundaryCorrections<
                              local_time_stepping, EvolutionMetavars, volume_dim,
                              true>>>,
@@ -240,9 +242,6 @@ struct EvolutionMetavars {
                          volume_dim, false, use_dg_element_collection>,
                      Actions::MutateApply<ChangeTimeStepperOrder<system>>>,
           tmpl::list<
-              evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
-                  volume_dim, use_dg_element_collection>,
-              Actions::MutateApply<RecordTimeStepperData<system>>,
               evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
               Actions::MutateApply<UpdateU<system, local_time_stepping>>>>,
       Actions::MutateApply<CleanHistory<system>>,

--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -20,6 +20,7 @@
 #include "Evolution/DgSubcell/Actions/TakeTimeStep.hpp"
 #include "Evolution/DgSubcell/Actions/TciAndRollback.hpp"
 #include "Evolution/DgSubcell/Actions/TciAndSwitchToDg.hpp"
+#include "Evolution/DgSubcell/DisableLts.hpp"
 #include "Evolution/DgSubcell/GetTciDecision.hpp"
 #include "Evolution/DgSubcell/NeighborReconstructedFaceSolution.hpp"
 #include "Evolution/DgSubcell/NeighborTciDecision.hpp"
@@ -92,10 +93,12 @@
 #include "Time/Actions/SelfStartActions.hpp"
 #include "Time/AdvanceTime.hpp"
 #include "Time/ChangeSlabSize/Action.hpp"
+#include "Time/ChangeStepSize.hpp"
 #include "Time/ChangeTimeStepperOrder.hpp"
 #include "Time/CleanHistory.hpp"
 #include "Time/RecordTimeStepperData.hpp"
 #include "Time/StepChoosers/Factory.hpp"
+#include "Time/StepChoosers/FixedLtsRatio.hpp"
 #include "Time/StepChoosers/StepChooser.hpp"
 #include "Time/Tags/Time.hpp"
 #include "Time/Tags/TimeStepId.hpp"
@@ -185,12 +188,17 @@ struct EvolutionMetavars {
         tmpl::pair<evolution::BoundaryCorrection,
                    Burgers::BoundaryCorrections::standard_boundary_corrections>,
         tmpl::pair<evolution::initial_data::InitialData, initial_data_list>,
+        tmpl::pair<LtsTimeStepper, TimeSteppers::lts_time_steppers>,
         tmpl::pair<PhaseChange, PhaseControl::factory_creatable_classes>,
         tmpl::pair<StepChooser<StepChooserUse::LtsStep>,
                    StepChoosers::standard_step_choosers<system>>,
-        tmpl::pair<
-            StepChooser<StepChooserUse::Slab>,
-            StepChoosers::standard_slab_choosers<system, local_time_stepping>>,
+        tmpl::pair<StepChooser<StepChooserUse::Slab>,
+                   tmpl::append<StepChoosers::standard_slab_choosers<
+                                    system, local_time_stepping>,
+                                tmpl::conditional_t<
+                                    use_dg_subcell and local_time_stepping,
+                                    tmpl::list<StepChoosers::FixedLtsRatio>,
+                                    tmpl::list<>>>>,
         tmpl::pair<TimeSequence<double>,
                    TimeSequences::all_time_sequences<double>>,
         tmpl::pair<TimeSequence<std::uint64_t>,
@@ -244,34 +252,31 @@ struct EvolutionMetavars {
           tmpl::list<
               evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
               Actions::MutateApply<UpdateU<system, local_time_stepping>>>>,
+      tmpl::conditional_t<use_dg_subcell,
+                          evolution::dg::subcell::Actions::TciAndRollback<
+                              Burgers::subcell::TciOnDgGrid>,
+                          tmpl::list<>>,
       Actions::MutateApply<CleanHistory<system>>,
       tmpl::conditional_t<
           local_time_stepping,
           Actions::MutateApply<evolution::dg::CleanMortarHistory<volume_dim>>,
           tmpl::list<>>,
-      Limiters::Actions::SendData<EvolutionMetavars>,
-      Limiters::Actions::Limit<EvolutionMetavars>>>;
+      tmpl::conditional_t<use_dg_subcell, tmpl::list<>,
+                          tmpl::list<
+                              Limiters::Actions::SendData<EvolutionMetavars>,
+                              Limiters::Actions::Limit<EvolutionMetavars>>>>>;
 
   using dg_subcell_step_actions = tmpl::flatten<tmpl::list<
       evolution::dg::subcell::Actions::SelectNumericalMethod,
       Actions::Label<evolution::dg::subcell::Actions::Labels::BeginDg>,
-      evolution::dg::Actions::ComputeTimeDerivative<
-          volume_dim, system, AllStepChoosers, local_time_stepping,
-          use_dg_element_collection>,
-      evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
-          volume_dim, use_dg_element_collection>,
-      Actions::MutateApply<RecordTimeStepperData<system>>,
-      evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
-      Actions::MutateApply<UpdateU<system, local_time_stepping>>,
-      evolution::dg::subcell::Actions::TciAndRollback<
-          Burgers::subcell::TciOnDgGrid>,
-      Actions::MutateApply<CleanHistory<system>>,
-      tmpl::conditional_t<
-          local_time_stepping,
-          Actions::MutateApply<evolution::dg::CleanMortarHistory<volume_dim>>,
-          tmpl::list<>>,
+      dg_step_actions,
       Actions::Goto<evolution::dg::subcell::Actions::Labels::EndOfSolvers>,
       Actions::Label<evolution::dg::subcell::Actions::Labels::BeginSubcell>,
+      tmpl::conditional_t<local_time_stepping,
+                          // This is just to adjust for FixedLtsRatio, so we
+                          // can pass an empty list of StepChoosers.
+                          Actions::MutateApply<ChangeStepSize<tmpl::list<>>>,
+                          tmpl::list<>>,
       evolution::dg::subcell::Actions::SendDataForReconstruction<
           volume_dim, Burgers::subcell::GhostVariables,
           use_dg_element_collection>,
@@ -330,7 +335,12 @@ struct EvolutionMetavars {
           StepChoosers::step_chooser_compute_tags<EvolutionMetavars,
                                                   local_time_stepping>>,
       ::evolution::dg::Initialization::Mortars<volume_dim>,
-      Initialization::Actions::Minmod<1>,
+      tmpl::conditional_t<use_dg_subcell and local_time_stepping,
+                          Initialization::Actions::InitializeItems<
+                              evolution::dg::subcell::DisableLts<1>>,
+                          tmpl::list<>>,
+      tmpl::conditional_t<use_dg_subcell, tmpl::list<>,
+                          Initialization::Actions::Minmod<1>>,
       evolution::Actions::InitializeRunEventsAndDenseTriggers,
       Parallel::Actions::TerminatePhase>;
 

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
@@ -257,10 +257,12 @@ struct EvolutionMetavars {
       evolution::dg::Actions::ComputeTimeDerivative<
           volume_dim, system, AllStepChoosers, local_time_stepping,
           use_dg_element_collection>,
+      evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
+          volume_dim, use_dg_element_collection>,
+      Actions::MutateApply<RecordTimeStepperData<system>>,
       tmpl::conditional_t<
           local_time_stepping,
-          tmpl::list<Actions::MutateApply<RecordTimeStepperData<system>>,
-                     evolution::Actions::RunEventsAndDenseTriggers<
+          tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<
                          tmpl::list<evolution::dg::ApplyBoundaryCorrections<
                              local_time_stepping, EvolutionMetavars, volume_dim,
                              true>>>,
@@ -269,9 +271,6 @@ struct EvolutionMetavars {
                          volume_dim, false, use_dg_element_collection>,
                      Actions::MutateApply<ChangeTimeStepperOrder<system>>>,
           tmpl::list<
-              evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
-                  volume_dim, use_dg_element_collection>,
-              Actions::MutateApply<RecordTimeStepperData<system>>,
               evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
               Actions::MutateApply<UpdateU<system, local_time_stepping>>>>,
       Actions::MutateApply<CleanHistory<system>>,

--- a/src/Evolution/Executables/ForceFree/EvolveForceFree.hpp
+++ b/src/Evolution/Executables/ForceFree/EvolveForceFree.hpp
@@ -191,10 +191,12 @@ struct EvolutionMetavars {
       evolution::dg::Actions::ComputeTimeDerivative<
           volume_dim, system, AllStepChoosers, local_time_stepping,
           use_dg_element_collection>,
+      evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
+          volume_dim, use_dg_element_collection>,
+      Actions::MutateApply<RecordTimeStepperData<system>>,
       tmpl::conditional_t<
           local_time_stepping,
-          tmpl::list<Actions::MutateApply<RecordTimeStepperData<system>>,
-                     evolution::Actions::RunEventsAndDenseTriggers<
+          tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<
                          tmpl::list<evolution::dg::ApplyBoundaryCorrections<
                              local_time_stepping, system, volume_dim, true>>>,
                      Actions::MutateApply<UpdateU<system, local_time_stepping>>,
@@ -202,9 +204,6 @@ struct EvolutionMetavars {
                          volume_dim, false, use_dg_element_collection>,
                      Actions::MutateApply<ChangeTimeStepperOrder<system>>>,
           tmpl::list<
-              evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
-                  volume_dim, use_dg_element_collection>,
-              Actions::MutateApply<RecordTimeStepperData<system>>,
               evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
               Actions::MutateApply<UpdateU<system, local_time_stepping>>>>,
       Actions::MutateApply<CleanHistory<system>>,

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -581,10 +581,12 @@ struct EvolutionMetavars {
       evolution::dg::Actions::ComputeTimeDerivative<
           volume_dim, system, AllStepChoosers, local_time_stepping,
           use_dg_element_collection>,
+      evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
+          volume_dim, use_dg_element_collection>,
+      Actions::MutateApply<RecordTimeStepperData<system>>,
       tmpl::conditional_t<
           local_time_stepping,
-          tmpl::list<Actions::MutateApply<RecordTimeStepperData<system>>,
-                     evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<
+          tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<
                          ::domain::CheckFunctionsOfTimeAreReadyPostprocessor<
                              volume_dim>,
                          evolution::dg::ApplyBoundaryCorrections<
@@ -595,9 +597,6 @@ struct EvolutionMetavars {
                          volume_dim, false, use_dg_element_collection>,
                      Actions::MutateApply<ChangeTimeStepperOrder<system>>>,
           tmpl::list<
-              evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
-                  volume_dim, use_dg_element_collection>,
-              Actions::MutateApply<RecordTimeStepperData<system>>,
               evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<
                   ::domain::CheckFunctionsOfTimeAreReadyPostprocessor<
                       volume_dim>>>,

--- a/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
@@ -393,10 +393,12 @@ struct GeneralizedHarmonicTemplateBase {
       evolution::dg::Actions::ComputeTimeDerivative<
           volume_dim, system, AllStepChoosers, local_time_stepping,
           use_dg_element_collection>,
+      evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
+          volume_dim, use_dg_element_collection>,
+      Actions::MutateApply<RecordTimeStepperData<system>>,
       tmpl::conditional_t<
           local_time_stepping,
           tmpl::list<
-              Actions::MutateApply<RecordTimeStepperData<system>>,
               evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<
                   ::domain::CheckFunctionsOfTimeAreReadyPostprocessor<
                       volume_dim>,
@@ -407,9 +409,6 @@ struct GeneralizedHarmonicTemplateBase {
                   volume_dim, false, use_dg_element_collection>,
               Actions::MutateApply<ChangeTimeStepperOrder<system>>>,
           tmpl::list<
-              evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
-                  volume_dim, use_dg_element_collection>,
-              Actions::MutateApply<RecordTimeStepperData<system>>,
               evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
               control_system::Actions::LimitTimeStep<ControlSystems>,
               Actions::MutateApply<UpdateU<system, local_time_stepping>>>>,

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -42,6 +42,7 @@
 #include "Evolution/DgSubcell/CellCenteredFlux.hpp"
 #include "Evolution/DgSubcell/ComputeBoundaryTerms.hpp"
 #include "Evolution/DgSubcell/CorrectPackagedData.hpp"
+#include "Evolution/DgSubcell/DisableLts.hpp"
 #include "Evolution/DgSubcell/GetActiveTag.hpp"
 #include "Evolution/DgSubcell/NeighborReconstructedFaceSolution.hpp"
 #include "Evolution/DgSubcell/PerssonTci.hpp"
@@ -228,10 +229,12 @@
 #include "Time/Actions/SelfStartActions.hpp"
 #include "Time/AdvanceTime.hpp"
 #include "Time/ChangeSlabSize/Action.hpp"
+#include "Time/ChangeStepSize.hpp"
 #include "Time/ChangeTimeStepperOrder.hpp"
 #include "Time/CleanHistory.hpp"
 #include "Time/RecordTimeStepperData.hpp"
 #include "Time/StepChoosers/Factory.hpp"
+#include "Time/StepChoosers/FixedLtsRatio.hpp"
 #include "Time/StepChoosers/StepChooser.hpp"
 #include "Time/Tags/Time.hpp"
 #include "Time/Tags/TimeStepId.hpp"
@@ -670,9 +673,13 @@ struct GhValenciaDivCleanTemplateBase<
         tmpl::pair<PhaseChange, PhaseControl::factory_creatable_classes>,
         tmpl::pair<StepChooser<StepChooserUse::LtsStep>,
                    StepChoosers::standard_step_choosers<system>>,
-        tmpl::pair<
-            StepChooser<StepChooserUse::Slab>,
-            StepChoosers::standard_slab_choosers<system, local_time_stepping>>,
+        tmpl::pair<StepChooser<StepChooserUse::Slab>,
+                   tmpl::append<StepChoosers::standard_slab_choosers<
+                                    system, local_time_stepping>,
+                                tmpl::conditional_t<
+                                    use_dg_subcell and local_time_stepping,
+                                    tmpl::list<StepChoosers::FixedLtsRatio>,
+                                    tmpl::list<>>>>,
         tmpl::pair<TimeSequence<double>,
                    TimeSequences::all_time_sequences<double>>,
         tmpl::pair<TimeSequence<std::uint64_t>,
@@ -750,6 +757,12 @@ struct GhValenciaDivCleanTemplateBase<
         grmhd::GhValenciaDivClean::subcell::PrimitiveGhostVariables;
   };
 
+  using events_and_dense_triggers_dg_postprocessors = tmpl::list<
+      ::domain::CheckFunctionsOfTimeAreReadyPostprocessor<volume_dim>,
+      AlwaysReadyPostprocessor<
+          typename system::template primitive_from_conservative<
+              ordered_list_of_primitive_recovery_schemes>>>;
+
   using events_and_dense_triggers_subcell_postprocessors = tmpl::list<
       ::domain::CheckFunctionsOfTimeAreReadyPostprocessor<volume_dim>,
       AlwaysReadyPostprocessor<
@@ -757,35 +770,6 @@ struct GhValenciaDivCleanTemplateBase<
               ordered_list_of_primitive_recovery_schemes, system>>>;
 
   using dg_step_actions = tmpl::flatten<tmpl::list<
-      evolution::dg::Actions::ComputeTimeDerivative<
-          volume_dim, system, AllStepChoosers, local_time_stepping,
-          use_dg_element_collection>,
-      evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
-          volume_dim, use_dg_element_collection>,
-      Actions::MutateApply<RecordTimeStepperData<system>>,
-      tmpl::conditional_t<
-          local_time_stepping,
-          tmpl::list<Actions::MutateApply<UpdateU<system, local_time_stepping>>,
-                     evolution::dg::Actions::ApplyLtsBoundaryCorrections<
-                         volume_dim, false, use_dg_element_collection>,
-                     Actions::MutateApply<ChangeTimeStepperOrder<system>>>,
-          tmpl::list<
-              Actions::MutateApply<UpdateU<system, local_time_stepping>>>>,
-      Actions::MutateApply<CleanHistory<system>>,
-      tmpl::conditional_t<
-          local_time_stepping,
-          Actions::MutateApply<evolution::dg::CleanMortarHistory<volume_dim>>,
-          tmpl::list<>>,
-      Limiters::Actions::SendData<derived_metavars>,
-      Limiters::Actions::Limit<derived_metavars>,
-      VariableFixing::Actions::FixVariables<
-          grmhd::ValenciaDivClean::FixConservatives>,
-      Actions::UpdatePrimitives>>;
-
-  using dg_subcell_step_actions = tmpl::flatten<tmpl::list<
-      evolution::dg::subcell::Actions::SelectNumericalMethod,
-
-      Actions::Label<evolution::dg::subcell::Actions::Labels::BeginDg>,
       dg::Actions::Filter<::Filters::Exponential<0>,
                           tmpl::list<gr::Tags::SpacetimeMetric<DataVector, 3>,
                                      gh::Tags::Pi<DataVector, 3>,
@@ -801,27 +785,63 @@ struct GhValenciaDivCleanTemplateBase<
                                    ZeroMhdTimeDerivatives<system>>,
           tmpl::list<>>,
       Actions::MutateApply<RecordTimeStepperData<system>>,
-      evolution::Actions::RunEventsAndDenseTriggers<
-          events_and_dense_triggers_subcell_postprocessors>,
-      control_system::Actions::LimitTimeStep<control_systems>,
-      Actions::MutateApply<UpdateU<system, local_time_stepping>>,
-      // Note: The primitive variables are computed as part of the TCI.
-      evolution::dg::subcell::Actions::TciAndRollback<
-          grmhd::GhValenciaDivClean::subcell::TciOnDgGrid<
-              tmpl::front<ordered_list_of_primitive_recovery_schemes>>>,
+      tmpl::conditional_t<
+          local_time_stepping,
+          tmpl::list<
+              evolution::Actions::RunEventsAndDenseTriggers<
+                  tmpl::push_front<events_and_dense_triggers_dg_postprocessors,
+                                   evolution::dg::ApplyBoundaryCorrections<
+                                       local_time_stepping, derived_metavars,
+                                       volume_dim, true>>>,
+              Actions::MutateApply<UpdateU<system, local_time_stepping>>,
+              evolution::dg::Actions::ApplyLtsBoundaryCorrections<
+                  volume_dim, false, use_dg_element_collection>,
+              Actions::MutateApply<ChangeTimeStepperOrder<system>>>,
+          tmpl::list<
+              evolution::Actions::RunEventsAndDenseTriggers<
+                  events_and_dense_triggers_dg_postprocessors>,
+              control_system::Actions::LimitTimeStep<control_systems>,
+              Actions::MutateApply<UpdateU<system, local_time_stepping>>>>,
+      tmpl::conditional_t<
+          use_dg_subcell,
+          // Note: The primitive variables are computed as part of the TCI.
+          evolution::dg::subcell::Actions::TciAndRollback<
+              grmhd::GhValenciaDivClean::subcell::TciOnDgGrid<
+                  tmpl::front<ordered_list_of_primitive_recovery_schemes>>>,
+          tmpl::list<>>,
       Actions::MutateApply<CleanHistory<system>>,
       tmpl::conditional_t<
           local_time_stepping,
           Actions::MutateApply<evolution::dg::CleanMortarHistory<volume_dim>>,
           tmpl::list<>>,
-      parameterized_deleptonization,
-      VariableFixing::Actions::FixVariables<
-          VariableFixing::FixToAtmosphere<volume_dim>>,
-      VariableFixing::Actions::FixVariables<VariableFixing::LimitLorentzFactor>,
-      Actions::UpdateConservatives,
+      tmpl::conditional_t<
+          use_dg_subcell,
+          tmpl::list<parameterized_deleptonization,
+                     VariableFixing::Actions::FixVariables<
+                         VariableFixing::FixToAtmosphere<volume_dim>>,
+                     VariableFixing::Actions::FixVariables<
+                         VariableFixing::LimitLorentzFactor>,
+                     Actions::UpdateConservatives>,
+          tmpl::list<Limiters::Actions::SendData<derived_metavars>,
+                     Limiters::Actions::Limit<derived_metavars>,
+                     parameterized_deleptonization,
+                     VariableFixing::Actions::FixVariables<
+                         grmhd::ValenciaDivClean::FixConservatives>,
+                     Actions::UpdatePrimitives>>>>;
+
+  using dg_subcell_step_actions = tmpl::flatten<tmpl::list<
+      evolution::dg::subcell::Actions::SelectNumericalMethod,
+
+      Actions::Label<evolution::dg::subcell::Actions::Labels::BeginDg>,
+      dg_step_actions,
       Actions::Goto<evolution::dg::subcell::Actions::Labels::EndOfSolvers>,
 
       Actions::Label<evolution::dg::subcell::Actions::Labels::BeginSubcell>,
+      tmpl::conditional_t<local_time_stepping,
+                          // This is just to adjust for FixedLtsRatio, so we
+                          // can pass an empty list of StepChoosers.
+                          Actions::MutateApply<ChangeStepSize<tmpl::list<>>>,
+                          tmpl::list<>>,
       Actions::MutateApply<evolution::dg::subcell::fd::CellCenteredFlux<
           system, grmhd::ValenciaDivClean::ComputeFluxes, volume_dim, false>>,
       evolution::dg::subcell::Actions::SendDataForReconstruction<
@@ -841,7 +861,9 @@ struct GhValenciaDivCleanTemplateBase<
       Actions::MutateApply<RecordTimeStepperData<system>>,
       evolution::Actions::RunEventsAndDenseTriggers<
           events_and_dense_triggers_subcell_postprocessors>,
-      control_system::Actions::LimitTimeStep<control_systems>,
+      tmpl::conditional_t<
+          local_time_stepping, tmpl::list<>,
+          control_system::Actions::LimitTimeStep<control_systems>>,
       Actions::MutateApply<UpdateU<system, local_time_stepping>>,
       Actions::MutateApply<CleanHistory<system>>,
       tmpl::conditional_t<
@@ -891,7 +913,12 @@ struct GhValenciaDivCleanTemplateBase<
           StepChoosers::step_chooser_compute_tags<
               GhValenciaDivCleanTemplateBase, local_time_stepping>>,
       ::evolution::dg::Initialization::Mortars<volume_dim>,
-      Initialization::Actions::Minmod<3>,
+      tmpl::conditional_t<use_dg_subcell and local_time_stepping,
+                          Initialization::Actions::InitializeItems<
+                              evolution::dg::subcell::DisableLts<3>>,
+                          tmpl::list<>>,
+      tmpl::conditional_t<use_dg_subcell, tmpl::list<>,
+                          Initialization::Actions::Minmod<3>>,
       evolution::Actions::InitializeRunEventsAndDenseTriggers,
       intrp::Actions::ElementInitInterpPoints<volume_dim,
                                               interpolation_target_tags>,

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -760,17 +760,16 @@ struct GhValenciaDivCleanTemplateBase<
       evolution::dg::Actions::ComputeTimeDerivative<
           volume_dim, system, AllStepChoosers, local_time_stepping,
           use_dg_element_collection>,
+      evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
+          volume_dim, use_dg_element_collection>,
+      Actions::MutateApply<RecordTimeStepperData<system>>,
       tmpl::conditional_t<
           local_time_stepping,
-          tmpl::list<Actions::MutateApply<RecordTimeStepperData<system>>,
-                     Actions::MutateApply<UpdateU<system, local_time_stepping>>,
+          tmpl::list<Actions::MutateApply<UpdateU<system, local_time_stepping>>,
                      evolution::dg::Actions::ApplyLtsBoundaryCorrections<
                          volume_dim, false, use_dg_element_collection>,
                      Actions::MutateApply<ChangeTimeStepperOrder<system>>>,
           tmpl::list<
-              evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
-                  volume_dim, use_dg_element_collection>,
-              Actions::MutateApply<RecordTimeStepperData<system>>,
               Actions::MutateApply<UpdateU<system, local_time_stepping>>>>,
       Actions::MutateApply<CleanHistory<system>>,
       tmpl::conditional_t<

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -412,10 +412,12 @@ struct EvolutionMetavars<tmpl::list<InterpolationTargetTags...>,
       evolution::dg::Actions::ComputeTimeDerivative<
           volume_dim, system, AllStepChoosers, local_time_stepping,
           use_dg_element_collection>,
+      evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
+          volume_dim, use_dg_element_collection>,
+      Actions::MutateApply<RecordTimeStepperData<system>>,
       tmpl::conditional_t<
           local_time_stepping,
           tmpl::list<
-              Actions::MutateApply<RecordTimeStepperData<system>>,
               evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<
                   evolution::dg::ApplyBoundaryCorrections<
                       local_time_stepping, EvolutionMetavars, volume_dim, true>,
@@ -426,9 +428,6 @@ struct EvolutionMetavars<tmpl::list<InterpolationTargetTags...>,
                   volume_dim, false, use_dg_element_collection>,
               Actions::MutateApply<ChangeTimeStepperOrder<system>>>,
           tmpl::list<
-              evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
-                  volume_dim, use_dg_element_collection>,
-              Actions::MutateApply<RecordTimeStepperData<system>>,
               evolution::Actions::RunEventsAndDenseTriggers<
                   tmpl::list<system::primitive_from_conservative<
                       ordered_list_of_primitive_recovery_schemes>>>,

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -660,9 +660,9 @@ struct EvolutionMetavars<tmpl::list<InterpolationTargetTags...>,
           tmpl::list<
               grmhd::ValenciaDivClean::fd::Tags::Reconstructor,
               ::Tags::VariableFixer<grmhd::ValenciaDivClean::FixConservatives>,
-              grmhd::ValenciaDivClean::Tags::PrimitiveFromConservativeOptions,
               grmhd::ValenciaDivClean::subcell::Tags::TciOptions>,
           tmpl::list<>>,
+      grmhd::ValenciaDivClean::Tags::PrimitiveFromConservativeOptions,
       equation_of_state_tag, initial_data_tag,
       grmhd::ValenciaDivClean::Tags::ConstraintDampingParameter>;
 

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -26,6 +26,7 @@
 #include "Evolution/DgSubcell/CellCenteredFlux.hpp"
 #include "Evolution/DgSubcell/ComputeBoundaryTerms.hpp"
 #include "Evolution/DgSubcell/CorrectPackagedData.hpp"
+#include "Evolution/DgSubcell/DisableLts.hpp"
 #include "Evolution/DgSubcell/GetTciDecision.hpp"
 #include "Evolution/DgSubcell/NeighborReconstructedFaceSolution.hpp"
 #include "Evolution/DgSubcell/NeighborTciDecision.hpp"
@@ -163,10 +164,12 @@
 #include "Time/Actions/SelfStartActions.hpp"
 #include "Time/AdvanceTime.hpp"
 #include "Time/ChangeSlabSize/Action.hpp"
+#include "Time/ChangeStepSize.hpp"
 #include "Time/ChangeTimeStepperOrder.hpp"
 #include "Time/CleanHistory.hpp"
 #include "Time/RecordTimeStepperData.hpp"
 #include "Time/StepChoosers/Factory.hpp"
+#include "Time/StepChoosers/FixedLtsRatio.hpp"
 #include "Time/StepChoosers/StepChooser.hpp"
 #include "Time/Tags/Time.hpp"
 #include "Time/Tags/TimeStepId.hpp"
@@ -355,9 +358,13 @@ struct EvolutionMetavars<tmpl::list<InterpolationTargetTags...>,
         tmpl::pair<PhaseChange, PhaseControl::factory_creatable_classes>,
         tmpl::pair<StepChooser<StepChooserUse::LtsStep>,
                    StepChoosers::standard_step_choosers<system>>,
-        tmpl::pair<
-            StepChooser<StepChooserUse::Slab>,
-            StepChoosers::standard_slab_choosers<system, local_time_stepping>>,
+        tmpl::pair<StepChooser<StepChooserUse::Slab>,
+                   tmpl::append<StepChoosers::standard_slab_choosers<
+                                    system, local_time_stepping>,
+                                tmpl::conditional_t<
+                                    use_dg_subcell and local_time_stepping,
+                                    tmpl::list<StepChoosers::FixedLtsRatio>,
+                                    tmpl::list<>>>>,
         tmpl::pair<TimeSequence<double>,
                    TimeSequences::all_time_sequences<double>>,
         tmpl::pair<TimeSequence<std::uint64_t>,
@@ -401,6 +408,10 @@ struct EvolutionMetavars<tmpl::list<InterpolationTargetTags...>,
         grmhd::ValenciaDivClean::subcell::PrimitiveGhostVariables;
   };
 
+  using events_and_dense_triggers_dg_postprocessors =
+      tmpl::list<AlwaysReadyPostprocessor<system::primitive_from_conservative<
+          ordered_list_of_primitive_recovery_schemes>>>;
+
   using events_and_dense_triggers_subcell_postprocessors =
       tmpl::list<AlwaysReadyPostprocessor<
           grmhd::ValenciaDivClean::subcell::FixConservativesAndComputePrims<
@@ -418,29 +429,39 @@ struct EvolutionMetavars<tmpl::list<InterpolationTargetTags...>,
       tmpl::conditional_t<
           local_time_stepping,
           tmpl::list<
-              evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<
-                  evolution::dg::ApplyBoundaryCorrections<
-                      local_time_stepping, EvolutionMetavars, volume_dim, true>,
-                  system::primitive_from_conservative<
-                      ordered_list_of_primitive_recovery_schemes>>>,
+              evolution::Actions::RunEventsAndDenseTriggers<
+                  tmpl::push_front<events_and_dense_triggers_dg_postprocessors,
+                                   evolution::dg::ApplyBoundaryCorrections<
+                                       local_time_stepping, EvolutionMetavars,
+                                       volume_dim, true>>>,
               Actions::MutateApply<UpdateU<system, local_time_stepping>>,
               evolution::dg::Actions::ApplyLtsBoundaryCorrections<
                   volume_dim, false, use_dg_element_collection>,
               Actions::MutateApply<ChangeTimeStepperOrder<system>>>,
           tmpl::list<
               evolution::Actions::RunEventsAndDenseTriggers<
-                  tmpl::list<system::primitive_from_conservative<
-                      ordered_list_of_primitive_recovery_schemes>>>,
+                  events_and_dense_triggers_dg_postprocessors>,
               Actions::MutateApply<UpdateU<system, local_time_stepping>>>>,
+      tmpl::conditional_t<
+          use_dg_subcell,
+          // Note: The primitive variables are computed as part of the TCI.
+          evolution::dg::subcell::Actions::TciAndRollback<
+              grmhd::ValenciaDivClean::subcell::TciOnDgGrid<
+                  tmpl::front<ordered_list_of_primitive_recovery_schemes>>>,
+          tmpl::list<>>,
       Actions::MutateApply<CleanHistory<system>>,
       tmpl::conditional_t<
           local_time_stepping,
           Actions::MutateApply<evolution::dg::CleanMortarHistory<volume_dim>>,
           tmpl::list<>>,
-      Limiters::Actions::SendData<EvolutionMetavars>,
-      Limiters::Actions::Limit<EvolutionMetavars>,
-      VariableFixing::Actions::FixVariables<grmhd::ValenciaDivClean::Flattener<
-          ordered_list_of_primitive_recovery_schemes>>,
+      tmpl::conditional_t<
+          use_dg_subcell,
+          tmpl::list<>,
+          tmpl::list<Limiters::Actions::SendData<EvolutionMetavars>,
+                     Limiters::Actions::Limit<EvolutionMetavars>,
+                     VariableFixing::Actions::FixVariables<
+                         grmhd::ValenciaDivClean::Flattener<
+                             ordered_list_of_primitive_recovery_schemes>>>>,
       parameterized_deleptonization,
       VariableFixing::Actions::FixVariables<
           VariableFixing::FixToAtmosphere<volume_dim>>,
@@ -450,33 +471,15 @@ struct EvolutionMetavars<tmpl::list<InterpolationTargetTags...>,
       evolution::dg::subcell::Actions::SelectNumericalMethod,
 
       Actions::Label<evolution::dg::subcell::Actions::Labels::BeginDg>,
-      Actions::MutateApply<
-          evolution::dg::BackgroundGrVars<system, EvolutionMetavars>>,
-      evolution::dg::Actions::ComputeTimeDerivative<
-          volume_dim, system, AllStepChoosers, local_time_stepping,
-          use_dg_element_collection>,
-      evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
-          volume_dim, use_dg_element_collection>,
-      Actions::MutateApply<RecordTimeStepperData<system>>,
-      evolution::Actions::RunEventsAndDenseTriggers<
-          events_and_dense_triggers_subcell_postprocessors>,
-      Actions::MutateApply<UpdateU<system, local_time_stepping>>,
-      // Note: The primitive variables are computed as part of the TCI.
-      evolution::dg::subcell::Actions::TciAndRollback<
-          grmhd::ValenciaDivClean::subcell::TciOnDgGrid<
-              tmpl::front<ordered_list_of_primitive_recovery_schemes>>>,
-      Actions::MutateApply<CleanHistory<system>>,
-      tmpl::conditional_t<
-          local_time_stepping,
-          Actions::MutateApply<evolution::dg::CleanMortarHistory<volume_dim>>,
-          tmpl::list<>>,
-      parameterized_deleptonization,
-      VariableFixing::Actions::FixVariables<
-          VariableFixing::FixToAtmosphere<volume_dim>>,
-      Actions::UpdateConservatives,
+      dg_step_actions,
       Actions::Goto<evolution::dg::subcell::Actions::Labels::EndOfSolvers>,
 
       Actions::Label<evolution::dg::subcell::Actions::Labels::BeginSubcell>,
+      tmpl::conditional_t<local_time_stepping,
+                          // This is just to adjust for FixedLtsRatio, so we
+                          // can pass an empty list of StepChoosers.
+                          Actions::MutateApply<ChangeStepSize<tmpl::list<>>>,
+                          tmpl::list<>>,
       Actions::MutateApply<evolution::dg::subcell::BackgroundGrVars<
           system, EvolutionMetavars, false>>,
       Actions::MutateApply<evolution::dg::subcell::fd::CellCenteredFlux<
@@ -586,7 +589,12 @@ struct EvolutionMetavars<tmpl::list<InterpolationTargetTags...>,
           StepChoosers::step_chooser_compute_tags<EvolutionMetavars,
                                                   local_time_stepping>>,
       ::evolution::dg::Initialization::Mortars<volume_dim>,
-      Initialization::Actions::Minmod<3>,
+      tmpl::conditional_t<use_dg_subcell and local_time_stepping,
+                          Initialization::Actions::InitializeItems<
+                              evolution::dg::subcell::DisableLts<3>>,
+                          tmpl::list<>>,
+      tmpl::conditional_t<use_dg_subcell, tmpl::list<>,
+                          Initialization::Actions::Minmod<3>>,
       evolution::Actions::InitializeRunEventsAndDenseTriggers,
       intrp::Actions::ElementInitInterpPoints<volume_dim,
                                               interpolation_target_tags>,

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -290,10 +290,12 @@ struct EvolutionMetavars {
       evolution::dg::Actions::ComputeTimeDerivative<
           volume_dim, system, AllStepChoosers, local_time_stepping,
           use_dg_element_collection>,
+      evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
+          volume_dim, use_dg_element_collection>,
+      Actions::MutateApply<RecordTimeStepperData<system>>,
       tmpl::conditional_t<
           local_time_stepping,
-          tmpl::list<Actions::MutateApply<RecordTimeStepperData<system>>,
-                     evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<
+          tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<
                          evolution::dg::ApplyBoundaryCorrections<
                              local_time_stepping, system, volume_dim, true>,
                          typename system::primitive_from_conservative>>,
@@ -302,9 +304,6 @@ struct EvolutionMetavars {
                          volume_dim, false, use_dg_element_collection>,
                      Actions::MutateApply<ChangeTimeStepperOrder<system>>>,
           tmpl::list<
-              evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
-                  volume_dim, use_dg_element_collection>,
-              Actions::MutateApply<RecordTimeStepperData<system>>,
               evolution::Actions::RunEventsAndDenseTriggers<
                   tmpl::list<typename system::primitive_from_conservative>>,
               Actions::MutateApply<UpdateU<system, local_time_stepping>>>>,

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -23,6 +23,7 @@
 #include "Evolution/DgSubcell/Actions/TakeTimeStep.hpp"
 #include "Evolution/DgSubcell/Actions/TciAndRollback.hpp"
 #include "Evolution/DgSubcell/Actions/TciAndSwitchToDg.hpp"
+#include "Evolution/DgSubcell/DisableLts.hpp"
 #include "Evolution/DgSubcell/GetTciDecision.hpp"
 #include "Evolution/DgSubcell/NeighborReconstructedFaceSolution.hpp"
 #include "Evolution/DgSubcell/NeighborTciDecision.hpp"
@@ -103,10 +104,12 @@
 #include "Time/Actions/SelfStartActions.hpp"
 #include "Time/AdvanceTime.hpp"
 #include "Time/ChangeSlabSize/Action.hpp"
+#include "Time/ChangeStepSize.hpp"
 #include "Time/ChangeTimeStepperOrder.hpp"
 #include "Time/CleanHistory.hpp"
 #include "Time/RecordTimeStepperData.hpp"
 #include "Time/StepChoosers/Factory.hpp"
+#include "Time/StepChoosers/FixedLtsRatio.hpp"
 #include "Time/StepChoosers/StepChooser.hpp"
 #include "Time/Tags/Time.hpp"
 #include "Time/Tags/TimeStepId.hpp"
@@ -229,9 +232,13 @@ struct EvolutionMetavars {
         tmpl::pair<PhaseChange, PhaseControl::factory_creatable_classes>,
         tmpl::pair<StepChooser<StepChooserUse::LtsStep>,
                    StepChoosers::standard_step_choosers<system>>,
-        tmpl::pair<
-            StepChooser<StepChooserUse::Slab>,
-            StepChoosers::standard_slab_choosers<system, local_time_stepping>>,
+        tmpl::pair<StepChooser<StepChooserUse::Slab>,
+                   tmpl::append<StepChoosers::standard_slab_choosers<
+                                    system, local_time_stepping>,
+                                tmpl::conditional_t<
+                                    use_dg_subcell and local_time_stepping,
+                                    tmpl::list<StepChoosers::FixedLtsRatio>,
+                                    tmpl::list<>>>>,
         tmpl::pair<TimeSequence<double>,
                    TimeSequences::all_time_sequences<double>>,
         tmpl::pair<TimeSequence<std::uint64_t>,
@@ -282,9 +289,17 @@ struct EvolutionMetavars {
           StepChoosers::step_chooser_compute_tags<EvolutionMetavars,
                                                   local_time_stepping>>,
       ::evolution::dg::Initialization::Mortars<volume_dim>,
-      Initialization::Actions::Minmod<Dim>,
+      tmpl::conditional_t<use_dg_subcell and local_time_stepping,
+                          Initialization::Actions::InitializeItems<
+                              evolution::dg::subcell::DisableLts<Dim>>,
+                          tmpl::list<>>,
+      tmpl::conditional_t<use_dg_subcell, tmpl::list<>,
+                          Initialization::Actions::Minmod<Dim>>,
       evolution::Actions::InitializeRunEventsAndDenseTriggers,
       Parallel::Actions::TerminatePhase>>;
+
+  using events_and_dense_triggers_postprocessors = tmpl::list<
+      AlwaysReadyPostprocessor<typename system::primitive_from_conservative>>;
 
   using dg_step_actions = tmpl::flatten<tmpl::list<
       evolution::dg::Actions::ComputeTimeDerivative<
@@ -295,28 +310,41 @@ struct EvolutionMetavars {
       Actions::MutateApply<RecordTimeStepperData<system>>,
       tmpl::conditional_t<
           local_time_stepping,
-          tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<
-                         evolution::dg::ApplyBoundaryCorrections<
-                             local_time_stepping, system, volume_dim, true>,
-                         typename system::primitive_from_conservative>>,
-                     Actions::MutateApply<UpdateU<system, local_time_stepping>>,
-                     evolution::dg::Actions::ApplyLtsBoundaryCorrections<
-                         volume_dim, false, use_dg_element_collection>,
-                     Actions::MutateApply<ChangeTimeStepperOrder<system>>>,
           tmpl::list<
               evolution::Actions::RunEventsAndDenseTriggers<
-                  tmpl::list<typename system::primitive_from_conservative>>,
+                  tmpl::push_front<events_and_dense_triggers_postprocessors,
+                                   evolution::dg::ApplyBoundaryCorrections<
+                                       local_time_stepping, EvolutionMetavars,
+                                       volume_dim, true>>>,
+              Actions::MutateApply<UpdateU<system, local_time_stepping>>,
+              evolution::dg::Actions::ApplyLtsBoundaryCorrections<
+                  volume_dim, false, use_dg_element_collection>,
+              Actions::MutateApply<ChangeTimeStepperOrder<system>>>,
+          tmpl::list<
+              evolution::Actions::RunEventsAndDenseTriggers<
+                  events_and_dense_triggers_postprocessors>,
               Actions::MutateApply<UpdateU<system, local_time_stepping>>>>,
+      tmpl::conditional_t<use_dg_subcell,
+                          // Note: The primitive variables are computed as part
+                          // of the TCI.
+                          evolution::dg::subcell::Actions::TciAndRollback<
+                              NewtonianEuler::subcell::TciOnDgGrid<volume_dim>>,
+                          tmpl::list<>>,
       Actions::MutateApply<CleanHistory<system>>,
       tmpl::conditional_t<
           local_time_stepping,
           Actions::MutateApply<evolution::dg::CleanMortarHistory<volume_dim>>,
           tmpl::list<>>,
-      Limiters::Actions::SendData<EvolutionMetavars>,
-      Limiters::Actions::Limit<EvolutionMetavars>,
-      // Conservative `UpdatePrimitives` expects system to possess
-      // list of recovery schemes so we use `MutateApply` instead.
-      Actions::MutateApply<typename system::primitive_from_conservative>>>;
+      tmpl::conditional_t<
+          use_dg_subcell,
+          tmpl::list<>,
+          tmpl::list<Limiters::Actions::SendData<EvolutionMetavars>,
+                     Limiters::Actions::Limit<EvolutionMetavars>,
+                     // Conservative `UpdatePrimitives` expects system to
+                     // possess list of recovery schemes so we use
+                     // `MutateApply` instead.
+                     Actions::MutateApply<
+                         typename system::primitive_from_conservative>>>>>;
 
   struct SubcellOptions {
     static constexpr bool subcell_enabled = use_dg_subcell;
@@ -344,25 +372,15 @@ struct EvolutionMetavars {
       evolution::dg::subcell::Actions::SelectNumericalMethod,
 
       Actions::Label<evolution::dg::subcell::Actions::Labels::BeginDg>,
-      evolution::dg::Actions::ComputeTimeDerivative<
-          volume_dim, system, AllStepChoosers, local_time_stepping,
-          use_dg_element_collection>,
-      evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
-          volume_dim, use_dg_element_collection>,
-      Actions::MutateApply<RecordTimeStepperData<system>>,
-      Actions::MutateApply<UpdateU<system, local_time_stepping>>,
-      Actions::MutateApply<typename system::primitive_from_conservative>,
-      // Note: The primitive variables are computed as part of the TCI.
-      evolution::dg::subcell::Actions::TciAndRollback<
-          NewtonianEuler::subcell::TciOnDgGrid<volume_dim>>,
-      Actions::MutateApply<CleanHistory<system>>,
-      tmpl::conditional_t<
-          local_time_stepping,
-          Actions::MutateApply<evolution::dg::CleanMortarHistory<volume_dim>>,
-          tmpl::list<>>,
+      dg_step_actions,
       Actions::Goto<evolution::dg::subcell::Actions::Labels::EndOfSolvers>,
 
       Actions::Label<evolution::dg::subcell::Actions::Labels::BeginSubcell>,
+      tmpl::conditional_t<local_time_stepping,
+                          // This is just to adjust for FixedLtsRatio, so we
+                          // can pass an empty list of StepChoosers.
+                          Actions::MutateApply<ChangeStepSize<tmpl::list<>>>,
+                          tmpl::list<>>,
       evolution::dg::subcell::Actions::SendDataForReconstruction<
           volume_dim,
           NewtonianEuler::subcell::PrimitiveGhostVariables<volume_dim>,
@@ -375,6 +393,8 @@ struct EvolutionMetavars {
       evolution::dg::subcell::fd::Actions::TakeTimeStep<
           NewtonianEuler::subcell::TimeDerivative<volume_dim>>,
       Actions::MutateApply<RecordTimeStepperData<system>>,
+      evolution::Actions::RunEventsAndDenseTriggers<
+          events_and_dense_triggers_postprocessors>,
       Actions::MutateApply<UpdateU<system, local_time_stepping>>,
       Actions::MutateApply<CleanHistory<system>>,
       tmpl::conditional_t<

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
@@ -197,10 +197,13 @@ struct EvolutionMetavars {
       evolution::dg::Actions::ComputeTimeDerivative<
           volume_dim, system, AllStepChoosers, local_time_stepping,
           use_dg_element_collection>,
+      evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
+          volume_dim, use_dg_element_collection>,
+      Actions::MutateApply<RecordTimeStepperData<system>>,
+      imex::Actions::RecordTimeStepperData<system>,
       tmpl::conditional_t<
           local_time_stepping,
-          tmpl::list<Actions::MutateApply<RecordTimeStepperData<system>>,
-                     evolution::Actions::RunEventsAndDenseTriggers<
+          tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<
                          tmpl::list<evolution::dg::ApplyBoundaryCorrections<
                              local_time_stepping, EvolutionMetavars, volume_dim,
                              true>>>,
@@ -209,10 +212,6 @@ struct EvolutionMetavars {
                          volume_dim, false, use_dg_element_collection>,
                      Actions::MutateApply<ChangeTimeStepperOrder<system>>>,
           tmpl::list<
-              evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
-                  volume_dim, use_dg_element_collection>,
-              Actions::MutateApply<RecordTimeStepperData<system>>,
-              imex::Actions::RecordTimeStepperData<system>,
               evolution::Actions::RunEventsAndDenseTriggers<
                   tmpl::list<imex::ImplicitDenseOutput<system>>>,
               Actions::MutateApply<UpdateU<system, local_time_stepping>>>>,

--- a/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
+++ b/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
@@ -21,6 +21,7 @@
 #include "Evolution/DgSubcell/Actions/TakeTimeStep.hpp"
 #include "Evolution/DgSubcell/Actions/TciAndRollback.hpp"
 #include "Evolution/DgSubcell/Actions/TciAndSwitchToDg.hpp"
+#include "Evolution/DgSubcell/DisableLts.hpp"
 #include "Evolution/DgSubcell/GetTciDecision.hpp"
 #include "Evolution/DgSubcell/NeighborReconstructedFaceSolution.hpp"
 #include "Evolution/DgSubcell/NeighborTciDecision.hpp"
@@ -93,9 +94,12 @@
 #include "Time/Actions/SelfStartActions.hpp"
 #include "Time/AdvanceTime.hpp"
 #include "Time/ChangeSlabSize/Action.hpp"
+#include "Time/ChangeStepSize.hpp"
+#include "Time/ChangeTimeStepperOrder.hpp"
 #include "Time/CleanHistory.hpp"
 #include "Time/RecordTimeStepperData.hpp"
 #include "Time/StepChoosers/Factory.hpp"
+#include "Time/StepChoosers/FixedLtsRatio.hpp"
 #include "Time/StepChoosers/StepChooser.hpp"
 #include "Time/Tags/Time.hpp"
 #include "Time/Tags/TimeStepId.hpp"
@@ -211,9 +215,13 @@ struct EvolutionMetavars {
                        standard_boundary_conditions<Dim>>,
         tmpl::pair<StepChooser<StepChooserUse::LtsStep>,
                    StepChoosers::standard_step_choosers<system>>,
-        tmpl::pair<
-            StepChooser<StepChooserUse::Slab>,
-            StepChoosers::standard_slab_choosers<system, local_time_stepping>>,
+        tmpl::pair<StepChooser<StepChooserUse::Slab>,
+                   tmpl::append<StepChoosers::standard_slab_choosers<
+                                    system, local_time_stepping>,
+                                tmpl::conditional_t<
+                                    use_dg_subcell and local_time_stepping,
+                                    tmpl::list<StepChoosers::FixedLtsRatio>,
+                                    tmpl::list<>>>>,
         tmpl::pair<TimeSequence<double>,
                    TimeSequences::all_time_sequences<double>>,
         tmpl::pair<TimeSequence<std::uint64_t>,
@@ -255,37 +263,44 @@ struct EvolutionMetavars {
       evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
           volume_dim, use_dg_element_collection>,
       Actions::MutateApply<RecordTimeStepperData<system>>,
-      evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
-      Actions::MutateApply<UpdateU<system, local_time_stepping>>,
+      tmpl::conditional_t<
+          local_time_stepping,
+          tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<
+                         tmpl::list<evolution::dg::ApplyBoundaryCorrections<
+                             local_time_stepping, EvolutionMetavars, volume_dim,
+                             true>>>,
+                     Actions::MutateApply<UpdateU<system, local_time_stepping>>,
+                     evolution::dg::Actions::ApplyLtsBoundaryCorrections<
+                         volume_dim, false, use_dg_element_collection>,
+                     Actions::MutateApply<ChangeTimeStepperOrder<system>>>,
+          tmpl::list<
+              evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
+              Actions::MutateApply<UpdateU<system, local_time_stepping>>>>,
+      tmpl::conditional_t<use_dg_subcell,
+                          evolution::dg::subcell::Actions::TciAndRollback<
+                              ScalarAdvection::subcell::TciOnDgGrid<Dim>>,
+                          tmpl::list<>>,
       Actions::MutateApply<CleanHistory<system>>,
       tmpl::conditional_t<
           local_time_stepping,
           Actions::MutateApply<evolution::dg::CleanMortarHistory<volume_dim>>,
           tmpl::list<>>,
-      Limiters::Actions::SendData<EvolutionMetavars>,
-      Limiters::Actions::Limit<EvolutionMetavars>>>;
+      tmpl::conditional_t<use_dg_subcell, tmpl::list<>,
+                          tmpl::list<
+                              Limiters::Actions::SendData<EvolutionMetavars>,
+                              Limiters::Actions::Limit<EvolutionMetavars>>>>>;
 
   using dg_subcell_step_actions = tmpl::flatten<tmpl::list<
       evolution::dg::subcell::Actions::SelectNumericalMethod,
       Actions::Label<evolution::dg::subcell::Actions::Labels::BeginDg>,
-
-      evolution::dg::Actions::ComputeTimeDerivative<
-          volume_dim, system, AllStepChoosers, local_time_stepping,
-          use_dg_element_collection>,
-      evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
-          volume_dim, use_dg_element_collection>,
-      Actions::MutateApply<RecordTimeStepperData<system>>,
-      evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
-      Actions::MutateApply<UpdateU<system, local_time_stepping>>,
-      evolution::dg::subcell::Actions::TciAndRollback<
-          ScalarAdvection::subcell::TciOnDgGrid<Dim>>,
-      Actions::MutateApply<CleanHistory<system>>,
-      tmpl::conditional_t<
-          local_time_stepping,
-          Actions::MutateApply<evolution::dg::CleanMortarHistory<volume_dim>>,
-          tmpl::list<>>,
+      dg_step_actions,
       Actions::Goto<evolution::dg::subcell::Actions::Labels::EndOfSolvers>,
       Actions::Label<evolution::dg::subcell::Actions::Labels::BeginSubcell>,
+      tmpl::conditional_t<local_time_stepping,
+                          // This is just to adjust for FixedLtsRatio, so we
+                          // can pass an empty list of StepChoosers.
+                          Actions::MutateApply<ChangeStepSize<tmpl::list<>>>,
+                          tmpl::list<>>,
       evolution::dg::subcell::Actions::SendDataForReconstruction<
           volume_dim, ScalarAdvection::subcell::GhostVariables,
           use_dg_element_collection>,
@@ -351,7 +366,12 @@ struct EvolutionMetavars {
           StepChoosers::step_chooser_compute_tags<EvolutionMetavars,
                                                   local_time_stepping>>,
       ::evolution::dg::Initialization::Mortars<volume_dim>,
-      Initialization::Actions::Minmod<Dim>,
+      tmpl::conditional_t<use_dg_subcell and local_time_stepping,
+                          Initialization::Actions::InitializeItems<
+                              evolution::dg::subcell::DisableLts<Dim>>,
+                          tmpl::list<>>,
+      tmpl::conditional_t<use_dg_subcell, tmpl::list<>,
+                          Initialization::Actions::Minmod<Dim>>,
       evolution::Actions::InitializeRunEventsAndDenseTriggers,
       Parallel::Actions::TerminatePhase>;
 

--- a/src/Evolution/Executables/ScalarTensor/ScalarTensorBase.hpp
+++ b/src/Evolution/Executables/ScalarTensor/ScalarTensorBase.hpp
@@ -439,10 +439,12 @@ struct ScalarTensorTemplateBase {
       evolution::dg::Actions::ComputeTimeDerivative<
           volume_dim, system, AllStepChoosers, local_time_stepping,
           use_dg_element_collection>,
+      evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
+          volume_dim, use_dg_element_collection>,
+      Actions::MutateApply<RecordTimeStepperData<system>>,
       tmpl::conditional_t<
           local_time_stepping,
-          tmpl::list<Actions::MutateApply<RecordTimeStepperData<system>>,
-                     evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<
+          tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<
                          ::domain::CheckFunctionsOfTimeAreReadyPostprocessor<
                              volume_dim>,
                          evolution::dg::ApplyBoundaryCorrections<
@@ -453,9 +455,6 @@ struct ScalarTensorTemplateBase {
                          volume_dim, false, use_dg_element_collection>,
                      Actions::MutateApply<ChangeTimeStepperOrder<system>>>,
           tmpl::list<
-              evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
-                  volume_dim, use_dg_element_collection>,
-              Actions::MutateApply<RecordTimeStepperData<system>>,
               evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
               control_system::Actions::LimitTimeStep<ControlSystems>,
               Actions::MutateApply<UpdateU<system, local_time_stepping>>>>,

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -235,10 +235,12 @@ struct EvolutionMetavars {
       evolution::dg::Actions::ComputeTimeDerivative<
           volume_dim, system, AllStepChoosers, local_time_stepping,
           use_dg_element_collection>,
+      evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
+          volume_dim, use_dg_element_collection>,
+      Actions::MutateApply<RecordTimeStepperData<system>>,
       tmpl::conditional_t<
           local_time_stepping,
-          tmpl::list<Actions::MutateApply<RecordTimeStepperData<system>>,
-                     evolution::Actions::RunEventsAndDenseTriggers<
+          tmpl::list<evolution::Actions::RunEventsAndDenseTriggers<
                          tmpl::list<evolution::dg::ApplyBoundaryCorrections<
                              local_time_stepping, EvolutionMetavars, volume_dim,
                              true>>>,
@@ -247,9 +249,6 @@ struct EvolutionMetavars {
                          volume_dim, false, use_dg_element_collection>,
                      Actions::MutateApply<ChangeTimeStepperOrder<system>>>,
           tmpl::list<
-              evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
-                  volume_dim, use_dg_element_collection>,
-              Actions::MutateApply<RecordTimeStepperData<system>>,
               evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
               Actions::MutateApply<UpdateU<system, local_time_stepping>>>>,
       Actions::MutateApply<CleanHistory<system>>,

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
@@ -146,6 +146,13 @@ SpatialDiscretization:
       AveragedUpwindPenalty:
       Rusanov:
 
+Filtering:
+  ExpFilter0:
+    Enable: false
+    Alpha: 64
+    HalfPower: 420
+    BlocksToFilter: All
+
 EventsAndTriggersAtCheckpoints:
 
 EventsAndTriggersAtSlabs:


### PR DESCRIPTION
This does not enable the option, but sets things up so that changing `TimeStepperBase` to `LtsTimeStepper` should work.  I've tested this with the BNS executable, and verified that the other subcell executables compile but haven't done runtime testing.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
