### PR TITLE
Support clang-21+libstdc++-12+old Boost

### DIFF
--- a/cmake/SetupBoost.cmake
+++ b/cmake/SetupBoost.cmake
@@ -98,7 +98,17 @@ set_property(
 set_property(TARGET Boost::boost
   APPEND PROPERTY
   INTERFACE_COMPILE_DEFINITIONS
-  $<$<COMPILE_LANGUAGE:CXX>:BOOST_SP_DISABLE_THREADS>)
+  $<$<COMPILE_LANGUAGE:CXX>:BOOST_SP_DISABLE_THREADS>
+)
+
+# Some older versions of boost don't play nice with new versions of Clang and
+# GCC-12. We can just blanket enable the BOOST_NO_CXX98_FUNCTION_BASE macro,
+# which is what boost does anyway with newer versions.
+set_property(TARGET Boost::boost
+  APPEND PROPERTY
+  INTERFACE_COMPILE_DEFINITIONS
+  $<$<COMPILE_LANGUAGE:CXX>:BOOST_NO_CXX98_FUNCTION_BASE>
+)
 
 # With newer versions of boost, sometimes there are internal boost warnings
 # about deprecated headers. This disables those as we have no control over what


### PR DESCRIPTION
## Proposed changes

There were deprecation warnings in Boost when using an older Boost version (the one in our container) with clang-21 and libstdc++-12.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
