### PR TITLE
Add perturbative gravitational-wave GR analytic solution for testing wave extraction

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -2766,6 +2766,18 @@ archivePrefix = {arXiv},
   year          = {2016}
 }
 
+@article{Teukolsky1982nz,
+    author = "Teukolsky, S. A.",
+    title = "{Linearized quadrupole waves in general relativity and the motion
+              of test particles}",
+    doi = "10.1103/PhysRevD.26.745",
+    url = "https://doi.org/10.1103/PhysRevD.26.745",
+    journal = "Phys.~Rev.~D",
+    volume = "26",
+    pages = "745--750",
+    year = "1982"
+}
+
 @article{Teukolsky2015ega,
   author         = "Teukolsky, Saul A.",
   title          = "Formulation of discontinuous {Galerkin} methods for

--- a/src/DataStructures/Tensor/EagerMath/FrameTransform.cpp
+++ b/src/DataStructures/Tensor/EagerMath/FrameTransform.cpp
@@ -360,6 +360,10 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (Frame::Inertial),
                         (Frame::BlockLogical, Frame::ElementLogical,
                          Frame::Grid, Frame::Distorted),
                         (double, DataVector))
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (Frame::Inertial),
+                        (Frame::NoFrame), (double, DataVector))
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (Frame::NoFrame),
+                        (Frame::Inertial), (double, DataVector))
 #undef INSTANTIATE
 
 #define TENSOR(data) BOOST_PP_TUPLE_ELEM(4, data)
@@ -392,6 +396,12 @@ GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (Frame::Inertial),
                         (Frame::BlockLogical, Frame::ElementLogical,
                          Frame::Grid, Frame::Distorted),
                         (double, DataVector), (I, i, iJ, ii, II, ijj))
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (Frame::Inertial),
+                        (Frame::NoFrame), (double, DataVector),
+                        (I, i, iJ, ii, II, ijj))
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (Frame::NoFrame),
+                        (Frame::Inertial), (double, DataVector),
+                        (I, i, iJ, ii, II, ijj))
 
 #undef INSTANTIATE
 
@@ -417,8 +427,8 @@ using make_real_t = std::conditional_t<
       const tnsr::TENSOR(data) < DTYPE(data), DIM(data),                       \
       DESTFRAME(data) > &input,                                                \
       const InverseJacobian<make_real_t<DTYPE(data)>, DIM(data),               \
-                            SRCFRAME(data), DESTFRAME(data)>& inv_jacobian)    \
-      -> TensorMetafunctions::prepend_spatial_index<                           \
+                            SRCFRAME(data), DESTFRAME(data)>&inv_jacobian)     \
+      ->TensorMetafunctions::prepend_spatial_index<                            \
           TensorMetafunctions::remove_first_index<                             \
               tnsr::TENSOR(data) < DTYPE(data), DIM(data), DESTFRAME(data)>>,  \
       DIM(data), UpLo::Up, SRCFRAME(data) > ;

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/CMakeLists.txt
@@ -14,6 +14,7 @@ spectre_target_sources(
   KerrSchild.cpp
   Minkowski.cpp
   SphericalKerrSchild.cpp
+  TeukolskyWave.cpp
   TrumpetSchwarzschild.cpp
   WrappedGr.cpp
   )
@@ -30,6 +31,7 @@ spectre_target_headers(
   Minkowski.hpp
   Solutions.hpp
   SphericalKerrSchild.hpp
+  TeukolskyWave.hpp
   TrumpetSchwarzschild.hpp
   WrappedGr.hpp
   WrappedGr.tpp

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/TeukolskyWave.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/TeukolskyWave.cpp
@@ -1,0 +1,692 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/TeukolskyWave.hpp"
+
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <pup.h>
+#include <string>
+#include <utility>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "DataStructures/Tensor/EagerMath/FrameTransform.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Options/ParseError.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/Math.hpp"
+
+namespace {
+
+// The spherical-coordinate implementation is not valid near the origin.
+// Evaluations at or below this radius from the wave center trigger an error.
+constexpr double origin_exclusion_radius = 0.1;
+
+// Points within this distance of the z axis (cylindrical_radius == 0) are
+// treated as being exactly on the axis. In this case, the value on the
+// axis is found by averaging the values at two small offsets from the
+// axis in orthogonal directions.
+constexpr double axis_coordinate_tolerance = 1.0e-14;
+
+// When evaluating the axis limit (cylindrical_radius == 0), approach the
+// axis from a transverse offset of this size from two orthogonal directions
+// and then average the result to get the value on the limit.
+constexpr double axis_limit_offset = 1.0e-8;
+
+template <typename DataType>
+std::pair<tnsr::ii<DataType, 3, Frame::Inertial>,
+          tnsr::ii<DataType, 3, Frame::Inertial>>
+perturbation_and_dt_perturbation(const DataType& centered_x,
+                                 const DataType& centered_y,
+                                 const DataType& centered_z, const double t,
+                                 const double amplitude, const int mode,
+                                 const bool even_parity, const bool ingoing,
+                                 const double radius, const double width) {
+  const DataType radius_from_center =
+      sqrt(square(centered_x) + square(centered_y) + square(centered_z));
+  const DataType cylindrical_radius =
+      sqrt(square(centered_x) + square(centered_y));
+
+  const DataType axis_mask =
+      step_function(cylindrical_radius - axis_coordinate_tolerance);
+  const DataType safe_cylindrical_radius =
+      cylindrical_radius + (1.0 - axis_mask);
+
+  const DataType cos_theta = centered_z / radius_from_center;
+  const DataType sin_theta = cylindrical_radius / radius_from_center;
+  const DataType cos_phi =
+      axis_mask * centered_x / safe_cylindrical_radius + (1.0 - axis_mask);
+  const DataType sin_phi = axis_mask * centered_y / safe_cylindrical_radius;
+  const DataType sin_2phi = 2.0 * sin_phi * cos_phi;
+  const DataType cos_2phi = square(cos_phi) - square(sin_phi);
+
+  const DataType y_profile = radius_from_center - radius + (ingoing ? t : -t);
+  const double minus_two_over_width_squared = -2.0 / square(width);
+  const DataType profile = amplitude * exp(-square(y_profile) / square(width));
+  const DataType profile_1 = minus_two_over_width_squared * y_profile * profile;
+  const DataType profile_2 =
+      minus_two_over_width_squared * (profile + y_profile * profile_1);
+  const DataType profile_3 =
+      minus_two_over_width_squared * (2.0 * profile_1 + y_profile * profile_2);
+  const DataType profile_4 =
+      minus_two_over_width_squared * (3.0 * profile_2 + y_profile * profile_3);
+  const DataType profile_5 =
+      minus_two_over_width_squared * (4.0 * profile_3 + y_profile * profile_4);
+
+  auto spherical_metric =
+      make_with_value<tnsr::ii<DataType, 3, Frame::NoFrame>>(centered_x, 0.0);
+  auto dt_spherical_metric =
+      make_with_value<tnsr::ii<DataType, 3, Frame::NoFrame>>(centered_x, 0.0);
+
+  if (even_parity) {
+    auto angular_rr = make_with_value<DataType>(centered_x, 0.0);
+    auto angular_rtheta = make_with_value<DataType>(centered_x, 0.0);
+    auto angular_rphi = make_with_value<DataType>(centered_x, 0.0);
+    auto angular_thetaphi = make_with_value<DataType>(centered_x, 0.0);
+    auto angular_theta_theta_1 = make_with_value<DataType>(centered_x, 0.0);
+    auto angular_theta_theta_2 = make_with_value<DataType>(centered_x, 0.0);
+    auto angular_phi_phi_1 = make_with_value<DataType>(centered_x, 0.0);
+    auto angular_phi_phi_2 = make_with_value<DataType>(centered_x, 0.0);
+    switch (mode) {
+      case -2:
+        angular_rr = square(sin_theta) * sin_2phi;
+        angular_rtheta = sin_theta * cos_theta * sin_2phi;
+        angular_rphi = sin_theta * cos_2phi;
+        angular_theta_theta_1 = (1.0 + square(cos_theta)) * sin_2phi;
+        angular_theta_theta_2 = -sin_2phi;
+        angular_thetaphi = -cos_theta * cos_2phi;
+        angular_phi_phi_1 = -angular_theta_theta_1;
+        angular_phi_phi_2 = square(cos_theta) * sin_2phi;
+        break;
+      case -1:
+        angular_rr = 2.0 * sin_theta * cos_theta * sin_phi;
+        angular_rtheta = (square(cos_theta) - square(sin_theta)) * sin_phi;
+        angular_rphi = cos_theta * cos_phi;
+        angular_theta_theta_1 = -2.0 * sin_theta * cos_theta * sin_phi;
+        angular_thetaphi = sin_theta * cos_phi;
+        angular_phi_phi_1 = -angular_theta_theta_1;
+        angular_phi_phi_2 = -2.0 * sin_theta * cos_theta * sin_phi;
+        break;
+      case 0:
+        angular_rr = 2.0 - 3.0 * square(sin_theta);
+        angular_rtheta = -3.0 * sin_theta * cos_theta;
+        angular_theta_theta_1 = 3.0 * square(sin_theta);
+        angular_theta_theta_2 = -1.0;
+        angular_phi_phi_1 = -angular_theta_theta_1;
+        angular_phi_phi_2 = 3.0 * square(sin_theta) - 1.0;
+        break;
+      case 1:
+        angular_rr = 2.0 * sin_theta * cos_theta * cos_phi;
+        angular_rtheta = (square(cos_theta) - square(sin_theta)) * cos_phi;
+        angular_rphi = -cos_theta * sin_phi;
+        angular_theta_theta_1 = -2.0 * sin_theta * cos_theta * cos_phi;
+        angular_thetaphi = -sin_theta * sin_phi;
+        angular_phi_phi_1 = -angular_theta_theta_1;
+        angular_phi_phi_2 = -2.0 * sin_theta * cos_theta * cos_phi;
+        break;
+      case 2:
+        angular_rr = square(sin_theta) * cos_2phi;
+        angular_rtheta = sin_theta * cos_theta * cos_2phi;
+        angular_rphi = -sin_theta * sin_2phi;
+        angular_theta_theta_1 = (1.0 + square(cos_theta)) * cos_2phi;
+        angular_theta_theta_2 = -cos_2phi;
+        angular_thetaphi = cos_theta * sin_2phi;
+        angular_phi_phi_1 = -angular_theta_theta_1;
+        angular_phi_phi_2 = square(cos_theta) * cos_2phi;
+        break;
+      default:
+        ERROR("Unsupported Teukolsky mode");
+    }
+
+    const DataType radial_a =
+        3.0 *
+        (profile_2 + (-3.0 * profile_1 + 3.0 * profile / radius_from_center) /
+                         radius_from_center) /
+        cube(radius_from_center);
+    const DataType radial_b =
+        -(-profile_3 + (3.0 * profile_2 + (-6.0 * profile_1 +
+                                           6.0 * profile / radius_from_center) /
+                                              radius_from_center) /
+                           radius_from_center) /
+        square(radius_from_center);
+    const DataType radial_c =
+        0.25 *
+        (profile_4 + (-2.0 * profile_3 +
+                      (9.0 * profile_2 + (-21.0 * profile_1 +
+                                          21.0 * profile / radius_from_center) /
+                                             radius_from_center) /
+                          radius_from_center) /
+                         radius_from_center) /
+        radius_from_center;
+
+    get<0, 0>(spherical_metric) = radial_a * angular_rr;
+    get<0, 1>(spherical_metric) =
+        radius_from_center * radial_b * angular_rtheta;
+    get<0, 2>(spherical_metric) =
+        radius_from_center * radial_b * angular_rphi * sin_theta;
+    get<1, 1>(spherical_metric) =
+        square(radius_from_center) *
+        (radial_c * angular_theta_theta_1 + radial_a * angular_theta_theta_2);
+    get<1, 2>(spherical_metric) = square(radius_from_center) *
+                                  (radial_a - 2.0 * radial_c) *
+                                  angular_thetaphi * sin_theta;
+    get<2, 2>(spherical_metric) =
+        square(radius_from_center) *
+        (radial_c * angular_phi_phi_1 + radial_a * angular_phi_phi_2) *
+        square(sin_theta);
+
+    const double propagation_sign = ingoing ? 1.0 : -1.0;
+    const DataType dt_radial_a =
+        propagation_sign * 3.0 *
+        (profile_3 + (-3.0 * profile_2 + 3.0 * profile_1 / radius_from_center) /
+                         radius_from_center) /
+        cube(radius_from_center);
+    const DataType dt_radial_b =
+        -propagation_sign *
+        (-profile_4 +
+         (3.0 * profile_3 +
+          (-6.0 * profile_2 + 6.0 * profile_1 / radius_from_center) /
+              radius_from_center) /
+             radius_from_center) /
+        square(radius_from_center);
+    const DataType dt_radial_c =
+        propagation_sign * 0.25 *
+        (profile_5 +
+         (-2.0 * profile_4 +
+          (9.0 * profile_3 +
+           (-21.0 * profile_2 + 21.0 * profile_1 / radius_from_center) /
+               radius_from_center) /
+              radius_from_center) /
+             radius_from_center) /
+        radius_from_center;
+
+    get<0, 0>(dt_spherical_metric) = dt_radial_a * angular_rr;
+    get<0, 1>(dt_spherical_metric) =
+        radius_from_center * dt_radial_b * angular_rtheta;
+    get<0, 2>(dt_spherical_metric) =
+        radius_from_center * dt_radial_b * angular_rphi * sin_theta;
+    get<1, 1>(dt_spherical_metric) =
+        square(radius_from_center) * (dt_radial_c * angular_theta_theta_1 +
+                                      dt_radial_a * angular_theta_theta_2);
+    get<1, 2>(dt_spherical_metric) = square(radius_from_center) *
+                                     (dt_radial_a - 2.0 * dt_radial_c) *
+                                     angular_thetaphi * sin_theta;
+    get<2, 2>(dt_spherical_metric) =
+        square(radius_from_center) *
+        (dt_radial_c * angular_phi_phi_1 + dt_radial_a * angular_phi_phi_2) *
+        square(sin_theta);
+  } else {
+    auto angular_rtheta = make_with_value<DataType>(centered_x, 0.0);
+    auto angular_rphi = make_with_value<DataType>(centered_x, 0.0);
+    auto angular_theta_theta = make_with_value<DataType>(centered_x, 0.0);
+    auto angular_thetaphi = make_with_value<DataType>(centered_x, 0.0);
+    auto angular_phi_phi = make_with_value<DataType>(centered_x, 0.0);
+    switch (mode) {
+      case -2:
+        angular_rtheta = 4.0 * sin_theta * sin_2phi;
+        angular_rphi = 4.0 * sin_theta * cos_theta * cos_2phi;
+        angular_theta_theta = -2.0 * cos_theta * sin_2phi;
+        angular_thetaphi = -(2.0 - square(sin_theta)) * cos_2phi;
+        angular_phi_phi = 2.0 * cos_theta * sin_2phi;
+        break;
+      case -1:
+        angular_rtheta = -2.0 * cos_theta * sin_phi;
+        angular_rphi = -2.0 * (square(cos_theta) - square(sin_theta)) * cos_phi;
+        angular_theta_theta = -sin_theta * sin_phi;
+        angular_thetaphi = -cos_theta * sin_theta * cos_phi;
+        angular_phi_phi = sin_theta * sin_phi;
+        break;
+      case 0:
+        angular_rphi = -4.0 * cos_theta * sin_theta;
+        angular_thetaphi = -square(sin_theta);
+        break;
+      case 1:
+        angular_rtheta = -2.0 * cos_theta * cos_phi;
+        angular_rphi = 2.0 * (square(cos_theta) - square(sin_theta)) * sin_phi;
+        angular_theta_theta = -sin_theta * cos_phi;
+        angular_thetaphi = cos_theta * sin_theta * sin_phi;
+        angular_phi_phi = sin_theta * cos_phi;
+        break;
+      case 2:
+        angular_rtheta = 4.0 * sin_theta * cos_2phi;
+        angular_rphi = -4.0 * sin_theta * cos_theta * sin_2phi;
+        angular_theta_theta = -2.0 * cos_theta * cos_2phi;
+        angular_thetaphi = (2.0 - square(sin_theta)) * sin_2phi;
+        angular_phi_phi = 2.0 * cos_theta * cos_2phi;
+        break;
+      default:
+        ERROR("Unsupported Teukolsky mode");
+    }
+
+    const DataType radial_k =
+        (profile_2 + (-3.0 * profile_1 + 3.0 * profile / radius_from_center) /
+                         radius_from_center) /
+        square(radius_from_center);
+    const DataType radial_l =
+        (-profile_3 + (2.0 * profile_2 +
+                       (-3.0 * profile_1 + 3.0 * profile / radius_from_center) /
+                           radius_from_center) /
+                          radius_from_center) /
+        radius_from_center;
+
+    get<0, 1>(spherical_metric) =
+        radius_from_center * radial_k * angular_rtheta;
+    get<0, 2>(spherical_metric) =
+        radius_from_center * radial_k * angular_rphi * sin_theta;
+    get<1, 1>(spherical_metric) =
+        square(radius_from_center) * radial_l * angular_theta_theta;
+    get<1, 2>(spherical_metric) =
+        square(radius_from_center) * radial_l * angular_thetaphi * sin_theta;
+    get<2, 2>(spherical_metric) = square(radius_from_center) * radial_l *
+                                  angular_phi_phi * square(sin_theta);
+
+    const double propagation_sign = ingoing ? 1.0 : -1.0;
+    const DataType dt_radial_k =
+        propagation_sign *
+        (profile_3 + (-3.0 * profile_2 + 3.0 * profile_1 / radius_from_center) /
+                         radius_from_center) /
+        square(radius_from_center);
+    const DataType dt_radial_l =
+        propagation_sign *
+        (-profile_4 +
+         (2.0 * profile_3 +
+          (-3.0 * profile_2 + 3.0 * profile_1 / radius_from_center) /
+              radius_from_center) /
+             radius_from_center) /
+        radius_from_center;
+
+    get<0, 1>(dt_spherical_metric) =
+        radius_from_center * dt_radial_k * angular_rtheta;
+    get<0, 2>(dt_spherical_metric) =
+        radius_from_center * dt_radial_k * angular_rphi * sin_theta;
+    get<1, 1>(dt_spherical_metric) =
+        square(radius_from_center) * dt_radial_l * angular_theta_theta;
+    get<1, 2>(dt_spherical_metric) =
+        square(radius_from_center) * dt_radial_l * angular_thetaphi * sin_theta;
+    get<2, 2>(dt_spherical_metric) = square(radius_from_center) * dt_radial_l *
+                                     angular_phi_phi * square(sin_theta);
+  }
+
+  // Jacobian dx^{spherical}/dx^{Cartesian} used by to_different_frame.
+  Jacobian<DataType, 3, Frame::Inertial, Frame::NoFrame> jacobian =
+      make_with_value<Jacobian<DataType, 3, Frame::Inertial, Frame::NoFrame>>(
+          centered_x, 0.0);
+  get<0, 0>(jacobian) = sin_theta * cos_phi;
+  get<0, 1>(jacobian) = sin_theta * sin_phi;
+  get<0, 2>(jacobian) = cos_theta;
+  get<1, 0>(jacobian) = cos_theta * cos_phi / radius_from_center;
+  get<1, 1>(jacobian) = cos_theta * sin_phi / radius_from_center;
+  get<1, 2>(jacobian) = -sin_theta / radius_from_center;
+  const DataType sin_theta_for_phi = sin_theta + (1.0 - axis_mask);
+  get<2, 0>(jacobian) = -sin_phi / (radius_from_center * sin_theta_for_phi);
+  get<2, 1>(jacobian) = cos_phi / (radius_from_center * sin_theta_for_phi);
+
+  auto perturbation = transform::to_different_frame(spherical_metric, jacobian);
+  auto dt_perturbation =
+      transform::to_different_frame(dt_spherical_metric, jacobian);
+  return {std::move(perturbation), std::move(dt_perturbation)};
+}
+
+template <typename DataType>
+std::pair<tnsr::ii<DataType, 3, Frame::Inertial>,
+          tnsr::ii<DataType, 3, Frame::Inertial>>
+metric_and_dt_spatial_metric(const DataType& x, const DataType& y,
+                             const DataType& z, const double t,
+                             const double amplitude, const int mode,
+                             const bool even_parity, const bool ingoing,
+                             const std::array<double, 3>& center,
+                             const double radius, const double width,
+                             const bool include_minkowski_background) {
+  auto spatial_metric =
+      make_with_value<tnsr::ii<DataType, 3, Frame::Inertial>>(x, 0.0);
+  auto dt_spatial_metric =
+      make_with_value<tnsr::ii<DataType, 3, Frame::Inertial>>(x, 0.0);
+  if (include_minkowski_background) {
+    get<0, 0>(spatial_metric) = 1.0;
+    get<1, 1>(spatial_metric) = 1.0;
+    get<2, 2>(spatial_metric) = 1.0;
+  }
+
+  const DataType centered_x = x - center[0];
+  const DataType centered_y = y - center[1];
+  const DataType centered_z = z - center[2];
+  const DataType radius_from_center =
+      sqrt(square(centered_x) + square(centered_y) + square(centered_z));
+  const double minimum_radius_from_center = min(radius_from_center);
+  if (minimum_radius_from_center <= origin_exclusion_radius) {
+    ERROR(
+        "TeukolskyWave cannot be evaluated at points with radius <= "
+        << origin_exclusion_radius
+        << " from its center because the implementation uses spherical "
+           "coordinates, which are singular at the origin. Minimum radius was "
+        << minimum_radius_from_center << ".");
+  }
+  const DataType cylindrical_radius =
+      sqrt(square(centered_x) + square(centered_y));
+  const DataType axis_mask =
+      step_function(cylindrical_radius - axis_coordinate_tolerance);
+  const DataType centered_x_axis_limit =
+      centered_x + (1.0 - axis_mask) * axis_limit_offset;
+  const DataType centered_y_axis_limit =
+      centered_y + (1.0 - axis_mask) * axis_limit_offset;
+
+  const auto perturbation_and_dt = perturbation_and_dt_perturbation(
+      centered_x, centered_y, centered_z, t, amplitude, mode, even_parity,
+      ingoing, radius, width);
+  // On the axis, evaluate the smooth Cartesian limit by approaching from two
+  // orthogonal transverse directions instead of fixing an arbitrary azimuth.
+  const auto axis_limit_perturbation_and_dt_x =
+      perturbation_and_dt_perturbation(centered_x_axis_limit, centered_y,
+                                       centered_z, t, amplitude, mode,
+                                       even_parity, ingoing, radius, width);
+  const auto axis_limit_perturbation_and_dt_y =
+      perturbation_and_dt_perturbation(centered_x, centered_y_axis_limit,
+                                       centered_z, t, amplitude, mode,
+                                       even_parity, ingoing, radius, width);
+
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = i; j < 3; ++j) {
+      const DataType axis_limit_perturbation =
+          0.5 * (axis_limit_perturbation_and_dt_x.first.get(i, j) +
+                 axis_limit_perturbation_and_dt_y.first.get(i, j));
+      const DataType axis_limit_dt_perturbation =
+          0.5 * (axis_limit_perturbation_and_dt_x.second.get(i, j) +
+                 axis_limit_perturbation_and_dt_y.second.get(i, j));
+      spatial_metric.get(i, j) +=
+          axis_mask * perturbation_and_dt.first.get(i, j) +
+          (1.0 - axis_mask) * axis_limit_perturbation;
+      dt_spatial_metric.get(i, j) =
+          axis_mask * perturbation_and_dt.second.get(i, j) +
+          (1.0 - axis_mask) * axis_limit_dt_perturbation;
+    }
+  }
+
+  return {std::move(spatial_metric), std::move(dt_spatial_metric)};
+}
+
+}  // namespace
+
+namespace gr::Solutions {
+
+TeukolskyWave::TeukolskyWave(CkMigrateMessage* /*msg*/) {}
+
+TeukolskyWave::TeukolskyWave(double amplitude, const int mode,
+                             std::string parity, std::string direction,
+                             std::array<double, 3> center, const double radius,
+                             const double width,
+                             const Options::Context& context)
+    : TeukolskyWave(amplitude, mode, std::move(parity), std::move(direction),
+                    center, radius, width, true, context) {}
+
+TeukolskyWave::TeukolskyWave(double amplitude, const int mode,
+                             std::string parity, std::string direction,
+                             std::array<double, 3> center, const double radius,
+                             const double width,
+                             const bool include_minkowski_background,
+                             const Options::Context& context)
+    : amplitude_(amplitude),
+      mode_(mode),
+      parity_(std::move(parity)),
+      direction_(std::move(direction)),
+      center_(center),
+      radius_(radius),
+      width_(width),
+      include_minkowski_background_(include_minkowski_background) {
+  if (mode_ < -2 or mode_ > 2) {
+    PARSE_ERROR(context, "Mode must lie between -2 and 2, inclusive.");
+  }
+  if (parity_ != "even" and parity_ != "odd") {
+    PARSE_ERROR(context, "Parity must be either 'even' or 'odd'.");
+  }
+  if (direction_ != "outgoing" and direction_ != "ingoing") {
+    PARSE_ERROR(context, "Direction must be either 'outgoing' or 'ingoing'.");
+  }
+  if (width_ <= 0.0) {
+    PARSE_ERROR(context, "Width must be greater than 0.");
+  }
+}
+
+void TeukolskyWave::pup(PUP::er& p) {
+  p | amplitude_;
+  p | mode_;
+  p | parity_;
+  p | direction_;
+  p | center_;
+  p | radius_;
+  p | width_;
+  p | include_minkowski_background_;
+}
+
+template <typename DataType>
+auto TeukolskyWave::variables(
+    const tnsr::I<DataType, volume_dim, Frame::Inertial>& x, const double /*t*/,
+    tmpl::list<gr::Tags::Lapse<DataType>> /*meta*/) const
+    -> tuples::TaggedTuple<gr::Tags::Lapse<DataType>> {
+  return {Scalar<DataType>{
+      make_with_value<DataType>(x, include_minkowski_background_ ? 1.0 : 0.0)}};
+}
+
+template <typename DataType>
+auto TeukolskyWave::variables(
+    const tnsr::I<DataType, volume_dim, Frame::Inertial>& x, const double /*t*/,
+    tmpl::list<::Tags::dt<gr::Tags::Lapse<DataType>>> /*meta*/) const
+    -> tuples::TaggedTuple<::Tags::dt<gr::Tags::Lapse<DataType>>> {
+  return {Scalar<DataType>{make_with_value<DataType>(x, 0.0)}};
+}
+
+template <typename DataType>
+auto TeukolskyWave::variables(
+    const tnsr::I<DataType, volume_dim, Frame::Inertial>& x, const double /*t*/,
+    tmpl::list<gr::Tags::Shift<DataType, volume_dim, Frame::Inertial>>
+    /*meta*/) const
+    -> tuples::TaggedTuple<
+        gr::Tags::Shift<DataType, volume_dim, Frame::Inertial>> {
+  return {
+      make_with_value<tnsr::I<DataType, volume_dim, Frame::Inertial>>(x, 0.0)};
+}
+
+template <typename DataType>
+auto TeukolskyWave::variables(
+    const tnsr::I<DataType, volume_dim, Frame::Inertial>& x, const double /*t*/,
+    tmpl::list<
+        ::Tags::dt<gr::Tags::Shift<DataType, volume_dim, Frame::Inertial>>>
+    /*meta*/) const
+    -> tuples::TaggedTuple<
+        ::Tags::dt<gr::Tags::Shift<DataType, volume_dim, Frame::Inertial>>> {
+  return {
+      make_with_value<tnsr::I<DataType, volume_dim, Frame::Inertial>>(x, 0.0)};
+}
+
+template <typename DataType>
+auto TeukolskyWave::variables(
+    const tnsr::I<DataType, volume_dim, Frame::Inertial>& x, const double t,
+    tmpl::list<gr::Tags::SpatialMetric<DataType, volume_dim, Frame::Inertial>>
+    /*meta*/) const
+    -> tuples::TaggedTuple<
+        gr::Tags::SpatialMetric<DataType, volume_dim, Frame::Inertial>> {
+  return metric_and_dt_spatial_metric(get<0>(x), get<1>(x), get<2>(x), t,
+                                      amplitude_, mode_, parity_ == "even",
+                                      direction_ == "ingoing", center_, radius_,
+                                      width_, include_minkowski_background_)
+      .first;
+}
+
+template <typename DataType>
+auto TeukolskyWave::variables(
+    const tnsr::I<DataType, volume_dim, Frame::Inertial>& x, const double t,
+    tmpl::list<::Tags::dt<gr::Tags::SpatialMetric<
+        DataType, volume_dim, Frame::Inertial>>> /*meta*/) const
+    -> tuples::TaggedTuple<::Tags::dt<
+        gr::Tags::SpatialMetric<DataType, volume_dim, Frame::Inertial>>> {
+  return metric_and_dt_spatial_metric(get<0>(x), get<1>(x), get<2>(x), t,
+                                      amplitude_, mode_, parity_ == "even",
+                                      direction_ == "ingoing", center_, radius_,
+                                      width_, include_minkowski_background_)
+      .second;
+}
+
+template <typename DataType>
+auto TeukolskyWave::variables(
+    const tnsr::I<DataType, volume_dim, Frame::Inertial>& x, const double t,
+    tmpl::list<gr::Tags::SqrtDetSpatialMetric<DataType>> /*meta*/) const
+    -> tuples::TaggedTuple<gr::Tags::SqrtDetSpatialMetric<DataType>> {
+  if (not include_minkowski_background_) {
+    ERROR(
+        "IncludeMinkowskiBackground must be true to compute "
+        "sqrt(det(gamma)).");
+  }
+  const auto spatial_metric =
+      get<gr::Tags::SpatialMetric<DataType, volume_dim>>(variables(
+          x, t, tmpl::list<gr::Tags::SpatialMetric<DataType, volume_dim>>{}));
+  const auto det_and_inverse = determinant_and_inverse(spatial_metric);
+  auto sqrt_det_spatial_metric = make_with_value<Scalar<DataType>>(x, 0.0);
+  get(sqrt_det_spatial_metric) = sqrt(get(det_and_inverse.first));
+  return sqrt_det_spatial_metric;
+}
+
+template <typename DataType>
+auto TeukolskyWave::variables(
+    const tnsr::I<DataType, volume_dim, Frame::Inertial>& x, const double t,
+    tmpl::list<
+        gr::Tags::ExtrinsicCurvature<DataType, volume_dim, Frame::Inertial>>
+    /*meta*/) const
+    -> tuples::TaggedTuple<
+        gr::Tags::ExtrinsicCurvature<DataType, volume_dim, Frame::Inertial>> {
+  if (not include_minkowski_background_) {
+    ERROR(
+        "IncludeMinkowskiBackground must be true to compute extrinsic "
+        "curvature.");
+  }
+  auto extrinsic_curvature =
+      make_with_value<tnsr::ii<DataType, volume_dim, Frame::Inertial>>(x, 0.0);
+  const auto dt_spatial_metric = get<
+      ::Tags::dt<gr::Tags::SpatialMetric<DataType, volume_dim>>>(variables(
+      x, t,
+      tmpl::list<::Tags::dt<gr::Tags::SpatialMetric<DataType, volume_dim>>>{}));
+  for (size_t i = 0; i < volume_dim; ++i) {
+    for (size_t j = i; j < volume_dim; ++j) {
+      extrinsic_curvature.get(i, j) = -0.5 * dt_spatial_metric.get(i, j);
+    }
+  }
+  return extrinsic_curvature;
+}
+
+template <typename DataType>
+auto TeukolskyWave::variables(
+    const tnsr::I<DataType, volume_dim, Frame::Inertial>& x, const double t,
+    tmpl::list<gr::Tags::InverseSpatialMetric<DataType, volume_dim,
+                                              Frame::Inertial>> /*meta*/) const
+    -> tuples::TaggedTuple<
+        gr::Tags::InverseSpatialMetric<DataType, volume_dim, Frame::Inertial>> {
+  if (not include_minkowski_background_) {
+    ERROR(
+        "IncludeMinkowskiBackground must be true to compute inverse spatial "
+        "metric.");
+  }
+  const auto spatial_metric =
+      get<gr::Tags::SpatialMetric<DataType, volume_dim>>(variables(
+          x, t, tmpl::list<gr::Tags::SpatialMetric<DataType, volume_dim>>{}));
+  return determinant_and_inverse(spatial_metric).second;
+}
+
+bool operator==(const TeukolskyWave& lhs, const TeukolskyWave& rhs) {
+  return lhs.amplitude() == rhs.amplitude() and lhs.mode() == rhs.mode() and
+         lhs.parity() == rhs.parity() and lhs.direction() == rhs.direction() and
+         lhs.center() == rhs.center() and lhs.radius() == rhs.radius() and
+         lhs.width() == rhs.width() and
+         lhs.include_minkowski_background() ==
+             rhs.include_minkowski_background();
+}
+
+bool operator!=(const TeukolskyWave& lhs, const TeukolskyWave& rhs) {
+  return not(lhs == rhs);
+}
+
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                                   \
+  template tuples::TaggedTuple<gr::Tags::Lapse<DTYPE(data)>>                   \
+  gr::Solutions::TeukolskyWave::variables(                                     \
+      const tnsr::I<DTYPE(data), TeukolskyWave::volume_dim, Frame::Inertial>&  \
+          x,                                                                   \
+      double t, tmpl::list<gr::Tags::Lapse<DTYPE(data)>> /*meta*/) const;      \
+  template tuples::TaggedTuple<::Tags::dt<gr::Tags::Lapse<DTYPE(data)>>>       \
+  gr::Solutions::TeukolskyWave::variables(                                     \
+      const tnsr::I<DTYPE(data), TeukolskyWave::volume_dim, Frame::Inertial>&  \
+          x,                                                                   \
+      double t, tmpl::list<::Tags::dt<gr::Tags::Lapse<DTYPE(data)>>> /*meta*/) \
+      const;                                                                   \
+  template tuples::TaggedTuple<gr::Tags::Shift<                                \
+      DTYPE(data), TeukolskyWave::volume_dim, Frame::Inertial>>                \
+  gr::Solutions::TeukolskyWave::variables(                                     \
+      const tnsr::I<DTYPE(data), TeukolskyWave::volume_dim, Frame::Inertial>&  \
+          x,                                                                   \
+      double t,                                                                \
+      tmpl::list<gr::Tags::Shift<DTYPE(data), TeukolskyWave::volume_dim,       \
+                                 Frame::Inertial>> /*meta*/) const;            \
+  template tuples::TaggedTuple<::Tags::dt<gr::Tags::Shift<                     \
+      DTYPE(data), TeukolskyWave::volume_dim, Frame::Inertial>>>               \
+  gr::Solutions::TeukolskyWave::variables(                                     \
+      const tnsr::I<DTYPE(data), TeukolskyWave::volume_dim, Frame::Inertial>&  \
+          x,                                                                   \
+      double t,                                                                \
+      tmpl::list<::Tags::dt<gr::Tags::Shift<                                   \
+          DTYPE(data), TeukolskyWave::volume_dim, Frame::Inertial>>> /*meta*/) \
+      const;                                                                   \
+  template tuples::TaggedTuple<gr::Tags::SpatialMetric<                        \
+      DTYPE(data), TeukolskyWave::volume_dim, Frame::Inertial>>                \
+  gr::Solutions::TeukolskyWave::variables(                                     \
+      const tnsr::I<DTYPE(data), TeukolskyWave::volume_dim, Frame::Inertial>&  \
+          x,                                                                   \
+      double t,                                                                \
+      tmpl::list<gr::Tags::SpatialMetric<                                      \
+          DTYPE(data), TeukolskyWave::volume_dim, Frame::Inertial>> /*meta*/)  \
+      const;                                                                   \
+  template tuples::TaggedTuple<::Tags::dt<gr::Tags::SpatialMetric<             \
+      DTYPE(data), TeukolskyWave::volume_dim, Frame::Inertial>>>               \
+  gr::Solutions::TeukolskyWave::variables(                                     \
+      const tnsr::I<DTYPE(data), TeukolskyWave::volume_dim, Frame::Inertial>&  \
+          x,                                                                   \
+      double t,                                                                \
+      tmpl::list<::Tags::dt<gr::Tags::SpatialMetric<                           \
+          DTYPE(data), TeukolskyWave::volume_dim, Frame::Inertial>>> /*meta*/) \
+      const;                                                                   \
+  template tuples::TaggedTuple<gr::Tags::SqrtDetSpatialMetric<DTYPE(data)>>    \
+  gr::Solutions::TeukolskyWave::variables(                                     \
+      const tnsr::I<DTYPE(data), TeukolskyWave::volume_dim, Frame::Inertial>&  \
+          x,                                                                   \
+      double t,                                                                \
+      tmpl::list<gr::Tags::SqrtDetSpatialMetric<DTYPE(data)>> /*meta*/) const; \
+  template tuples::TaggedTuple<gr::Tags::ExtrinsicCurvature<                   \
+      DTYPE(data), TeukolskyWave::volume_dim, Frame::Inertial>>                \
+  gr::Solutions::TeukolskyWave::variables(                                     \
+      const tnsr::I<DTYPE(data), TeukolskyWave::volume_dim, Frame::Inertial>&  \
+          x,                                                                   \
+      double t,                                                                \
+      tmpl::list<gr::Tags::ExtrinsicCurvature<                                 \
+          DTYPE(data), TeukolskyWave::volume_dim, Frame::Inertial>> /*meta*/)  \
+      const;                                                                   \
+  template tuples::TaggedTuple<gr::Tags::InverseSpatialMetric<                 \
+      DTYPE(data), TeukolskyWave::volume_dim, Frame::Inertial>>                \
+  gr::Solutions::TeukolskyWave::variables(                                     \
+      const tnsr::I<DTYPE(data), TeukolskyWave::volume_dim, Frame::Inertial>&  \
+          x,                                                                   \
+      double t,                                                                \
+      tmpl::list<gr::Tags::InverseSpatialMetric<                               \
+          DTYPE(data), TeukolskyWave::volume_dim, Frame::Inertial>> /*meta*/)  \
+      const;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector))
+
+#undef DTYPE
+#undef INSTANTIATE
+
+}  // namespace gr::Solutions

--- a/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/TeukolskyWave.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/TeukolskyWave.hpp
@@ -1,0 +1,266 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <limits>
+#include <string>
+
+#include "DataStructures/TaggedTuple.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Options/Context.hpp"
+#include "Options/String.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
+#include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+namespace Tags {
+template <typename Tag>
+struct dt;
+}  // namespace Tags
+/// \endcond
+
+namespace gr::Solutions {
+
+/*!
+ * \brief A perturbative Teukolsky wave (optionally plus Minkowski).
+ *
+ * \details This class provides a linearized \f$l=2\f$ Teukolsky wave in
+ * Cartesian inertial coordinates. The implementation evaluates the spherical
+ * formulas point-by-point and then transforms to Cartesian coordinates.
+ *
+ * This solution does not provide spatial derivatives of the metric, so it
+ * does not support the full tag list of a typical GR analytic solution.
+ *
+ * See Eqs. (5) -- (10) of \cite Teukolsky1982nz for the equations in
+ * spherical coordinates of the perturbed metric implemented here. Those
+ * equations contain a freely specifiable radial profile; this implementation
+ * chooses a Gaussian in \f$r - R_0 \pm t\f$, where \f$R_0\f$ is the
+ * `Radius` parameter, with `Width` setting the pulse width.
+ *
+ * \note The implementation evaluates spherical-coordinate expressions, so it
+ * must not be used too close to the origin about `Center`, where those
+ * coordinates are singular. Specifically, evaluating the solution at points
+ * with \f$r \le 0.1\f$, where \f$r\f$ is the distance from `Center`,
+ * triggers an error. This cutoff is unrelated to the option `Radius`,
+ * which sets the location of the Gaussian pulse.
+ *
+ * On the \f$z\f$-axis, the spherical coordinate \f$\phi\f$ is not well
+ * defined. The implementation here is based on an implementation in SpEC that
+ * just assumed the solution is never evaluated on the axis. Here, the
+ * z-axis singularity is handled explicitly: on the \f$z\f$-axis
+ * (cylindrical radius \f$\rho = 0\f$), the Cartesian result is obtained by
+ * averaging the smooth limit approached from two orthogonal transverse
+ * directions, so the solution is regular there.
+ *
+ * Optionally, the solution can include a flat Minkowski background as well as
+ * the metric perturbation. Note that the tags for the inverse spatial metric,
+ * square root of the spatial metric determinant, and extrinsic curvature
+ * require the flat background to be included. The background can be excluded
+ * when one wants only the perturbation itself (e.g., to add it on top of a
+ * different background, such as the metric of a Kerr-Schild black hole).
+ */
+class TeukolskyWave : public MarkAsAnalyticSolution {
+ public:
+  static constexpr size_t volume_dim = 3;
+
+  struct Amplitude {
+    using type = double;
+    static constexpr Options::String help{"Amplitude of the perturbation"};
+  };
+
+  struct Mode {
+    using type = int;
+    static constexpr Options::String help{
+        "Azimuthal mode m of the l=2 Teukolsky wave"};
+    static type lower_bound() { return -2; }
+    static type upper_bound() { return 2; }
+  };
+
+  struct Parity {
+    using type = std::string;
+    static constexpr Options::String help{
+        "Parity of the perturbation: 'even' or 'odd'"};
+  };
+
+  struct Direction {
+    using type = std::string;
+    static constexpr Options::String help{
+        "Propagation direction: 'outgoing' or 'ingoing'"};
+  };
+
+  struct Center {
+    using type = std::array<double, 3>;
+    static constexpr Options::String help{
+        "Center of the Teukolsky wave in inertial coordinates"};
+  };
+
+  struct Radius {
+    using type = double;
+    static constexpr Options::String help{
+        "Radius of the center of the Gaussian pulse at t=0"};
+  };
+
+  struct Width {
+    using type = double;
+    static constexpr Options::String help{
+        "Width of the Gaussian pulse profile"};
+    static type lower_bound() { return 0.0; }
+  };
+
+  using options =
+      tmpl::list<Amplitude, Mode, Parity, Direction, Center, Radius, Width>;
+  static constexpr Options::String help{
+      "A perturbative Teukolsky wave in Cartesian inertial coordinates"};
+
+  template <typename DataType>
+  using tags = tmpl::list<
+      gr::Tags::Lapse<DataType>, ::Tags::dt<gr::Tags::Lapse<DataType>>,
+      gr::Tags::Shift<DataType, volume_dim, Frame::Inertial>,
+      ::Tags::dt<gr::Tags::Shift<DataType, volume_dim, Frame::Inertial>>,
+      gr::Tags::SpatialMetric<DataType, volume_dim, Frame::Inertial>,
+      ::Tags::dt<
+          gr::Tags::SpatialMetric<DataType, volume_dim, Frame::Inertial>>,
+      gr::Tags::SqrtDetSpatialMetric<DataType>,
+      gr::Tags::ExtrinsicCurvature<DataType, volume_dim, Frame::Inertial>,
+      gr::Tags::InverseSpatialMetric<DataType, volume_dim, Frame::Inertial>>;
+
+  TeukolskyWave(double amplitude, int mode, std::string parity,
+                std::string direction, std::array<double, 3> center,
+                double radius, double width,
+                const Options::Context& context = {});
+
+  TeukolskyWave(double amplitude, int mode, std::string parity,
+                std::string direction, std::array<double, 3> center,
+                double radius, double width, bool include_minkowski_background,
+                const Options::Context& context = {});
+
+  TeukolskyWave() = default;
+  TeukolskyWave(const TeukolskyWave& /*rhs*/) = default;
+  TeukolskyWave& operator=(const TeukolskyWave& /*rhs*/) = default;
+  TeukolskyWave(TeukolskyWave&& /*rhs*/) = default;
+  TeukolskyWave& operator=(TeukolskyWave&& /*rhs*/) = default;
+  ~TeukolskyWave() = default;
+
+  explicit TeukolskyWave(CkMigrateMessage* /*msg*/);
+
+  template <typename DataType, typename... RequestedTags>
+  tuples::TaggedTuple<RequestedTags...> variables(
+      const tnsr::I<DataType, volume_dim, Frame::Inertial>& x, double t,
+      tmpl::list<RequestedTags...> /*meta*/) const {
+    static_assert(tmpl2::flat_all_v<
+                      tmpl::list_contains_v<tags<DataType>, RequestedTags>...>,
+                  "At least one of the requested tags is not supported.");
+    return {
+        get<RequestedTags>(variables(x, t, tmpl::list<RequestedTags>{}))...};
+  }
+
+  template <typename RequestedTag, typename DataType>
+  tuples::TaggedTuple<RequestedTag> variable(
+      const tnsr::I<DataType, volume_dim, Frame::Inertial>& x,
+      const double t) const {
+    return variables(x, t, tmpl::list<RequestedTag>{});
+  }
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p);
+
+  double amplitude() const { return amplitude_; }
+  int mode() const { return mode_; }
+  const std::string& parity() const { return parity_; }
+  const std::string& direction() const { return direction_; }
+  const std::array<double, 3>& center() const { return center_; }
+  double radius() const { return radius_; }
+  double width() const { return width_; }
+  bool include_minkowski_background() const {
+    return include_minkowski_background_;
+  }
+
+ private:
+  template <typename DataType>
+  auto variables(const tnsr::I<DataType, volume_dim, Frame::Inertial>& x,
+                 double t, tmpl::list<gr::Tags::Lapse<DataType>> /*meta*/) const
+      -> tuples::TaggedTuple<gr::Tags::Lapse<DataType>>;
+
+  template <typename DataType>
+  auto variables(
+      const tnsr::I<DataType, volume_dim, Frame::Inertial>& x, double t,
+      tmpl::list<::Tags::dt<gr::Tags::Lapse<DataType>>> /*meta*/) const
+      -> tuples::TaggedTuple<::Tags::dt<gr::Tags::Lapse<DataType>>>;
+
+  template <typename DataType>
+  auto variables(
+      const tnsr::I<DataType, volume_dim, Frame::Inertial>& x, double t,
+      tmpl::list<gr::Tags::Shift<DataType, volume_dim, Frame::Inertial>>
+      /*meta*/) const
+      -> tuples::TaggedTuple<
+          gr::Tags::Shift<DataType, volume_dim, Frame::Inertial>>;
+
+  template <typename DataType>
+  auto variables(const tnsr::I<DataType, volume_dim, Frame::Inertial>& x,
+                 double t,
+                 tmpl::list<::Tags::dt<gr::Tags::Shift<
+                     DataType, volume_dim, Frame::Inertial>>> /*meta*/) const
+      -> tuples::TaggedTuple<
+          ::Tags::dt<gr::Tags::Shift<DataType, volume_dim, Frame::Inertial>>>;
+
+  template <typename DataType>
+  auto variables(const tnsr::I<DataType, volume_dim, Frame::Inertial>& x,
+                 double t,
+                 tmpl::list<gr::Tags::SpatialMetric<
+                     DataType, volume_dim, Frame::Inertial>> /*meta*/) const
+      -> tuples::TaggedTuple<
+          gr::Tags::SpatialMetric<DataType, volume_dim, Frame::Inertial>>;
+
+  template <typename DataType>
+  auto variables(
+      const tnsr::I<DataType, volume_dim, Frame::Inertial>& x, double t,
+      tmpl::list<::Tags::dt<
+          gr::Tags::SpatialMetric<DataType, volume_dim, Frame::Inertial>>>
+      /*meta*/) const
+      -> tuples::TaggedTuple<::Tags::dt<
+          gr::Tags::SpatialMetric<DataType, volume_dim, Frame::Inertial>>>;
+
+  template <typename DataType>
+  auto variables(
+      const tnsr::I<DataType, volume_dim, Frame::Inertial>& x, double t,
+      tmpl::list<gr::Tags::SqrtDetSpatialMetric<DataType>> /*meta*/) const
+      -> tuples::TaggedTuple<gr::Tags::SqrtDetSpatialMetric<DataType>>;
+
+  template <typename DataType>
+  auto variables(
+      const tnsr::I<DataType, volume_dim, Frame::Inertial>& x, double t,
+      tmpl::list<
+          gr::Tags::ExtrinsicCurvature<DataType, volume_dim, Frame::Inertial>>
+      /*meta*/) const
+      -> tuples::TaggedTuple<
+          gr::Tags::ExtrinsicCurvature<DataType, volume_dim, Frame::Inertial>>;
+
+  template <typename DataType>
+  auto variables(const tnsr::I<DataType, volume_dim, Frame::Inertial>& x,
+                 double t,
+                 tmpl::list<gr::Tags::InverseSpatialMetric<
+                     DataType, volume_dim, Frame::Inertial>> /*meta*/) const
+      -> tuples::TaggedTuple<gr::Tags::InverseSpatialMetric<
+          DataType, volume_dim, Frame::Inertial>>;
+
+  double amplitude_{std::numeric_limits<double>::signaling_NaN()};
+  int mode_{0};
+  std::string parity_{};
+  std::string direction_{};
+  std::array<double, 3> center_{};
+  double radius_{std::numeric_limits<double>::signaling_NaN()};
+  double width_{std::numeric_limits<double>::signaling_NaN()};
+  bool include_minkowski_background_{false};
+};
+
+bool operator==(const TeukolskyWave& lhs, const TeukolskyWave& rhs);
+bool operator!=(const TeukolskyWave& lhs, const TeukolskyWave& rhs);
+
+}  // namespace gr::Solutions

--- a/tests/Unit/DataStructures/Tensor/EagerMath/Test_FrameTransform.cpp
+++ b/tests/Unit/DataStructures/Tensor/EagerMath/Test_FrameTransform.cpp
@@ -218,6 +218,15 @@ SPECTRE_TEST_CASE("Unit.Tensor.EagerMath.FrameTransform",
   test_transform_to_different_frame<1, Frame::Inertial, Frame::Distorted>(dv);
   test_transform_to_different_frame<2, Frame::Inertial, Frame::Distorted>(dv);
   test_transform_to_different_frame<3, Frame::Inertial, Frame::Distorted>(dv);
+  test_transform_to_different_frame<1, Frame::NoFrame, Frame::Inertial>(
+      double{});
+  test_transform_to_different_frame<2, Frame::NoFrame, Frame::Inertial>(
+      double{});
+  test_transform_to_different_frame<3, Frame::NoFrame, Frame::Inertial>(
+      double{});
+  test_transform_to_different_frame<1, Frame::NoFrame, Frame::Inertial>(dv);
+  test_transform_to_different_frame<2, Frame::NoFrame, Frame::Inertial>(dv);
+  test_transform_to_different_frame<3, Frame::NoFrame, Frame::Inertial>(dv);
   test_transform_first_index_to_different_frame();
 }
 

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/CMakeLists.txt
@@ -10,6 +10,7 @@ set(LIBRARY_SOURCES
   Test_KerrSchild.cpp
   Test_Minkowski.cpp
   Test_SphericalKerrSchild.cpp
+  Test_TeukolskyWave.cpp
   Test_TrumpetSchwarzschild.cpp
   Test_WrappedGr.cpp
   )

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_TeukolskyWave.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Test_TeukolskyWave.cpp
@@ -1,0 +1,615 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <limits>
+#include <random>
+#include <string>
+#include <vector>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/TeukolskyWave.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+
+using TeukolskyWave = gr::Solutions::TeukolskyWave;
+
+template <typename DataType>
+using WithoutBackgroundTags = tmpl::list<
+    gr::Tags::Lapse<DataType>, ::Tags::dt<gr::Tags::Lapse<DataType>>,
+    gr::Tags::Shift<DataType, 3, Frame::Inertial>,
+    ::Tags::dt<gr::Tags::Shift<DataType, 3, Frame::Inertial>>,
+    gr::Tags::SpatialMetric<DataType, 3, Frame::Inertial>,
+    ::Tags::dt<gr::Tags::SpatialMetric<DataType, 3, Frame::Inertial>>>;
+
+template <typename DataType>
+using WithBackgroundTags = tmpl::flatten<tmpl::list<
+    WithoutBackgroundTags<DataType>,
+    tmpl::list<gr::Tags::SqrtDetSpatialMetric<DataType>,
+               gr::Tags::ExtrinsicCurvature<DataType, 3, Frame::Inertial>,
+               gr::Tags::InverseSpatialMetric<DataType, 3, Frame::Inertial>>>>;
+
+template <typename DataType>
+using WithoutBackgroundResultType =
+    tuples::tagged_tuple_from_typelist<WithoutBackgroundTags<DataType>>;
+
+template <typename DataType>
+using WithBackgroundResultType =
+    tuples::tagged_tuple_from_typelist<WithBackgroundTags<DataType>>;
+
+struct SolutionParameters {
+  double amplitude{};
+  int mode{};
+  std::string parity{};
+  std::string direction{};
+  std::array<double, 3> center{};
+  double radius{};
+  double width{};
+  bool include_minkowski_background{};
+  double time{};
+};
+
+struct TeukolskyWaveProxy : TeukolskyWave {
+  using TeukolskyWave::TeukolskyWave;
+
+  template <typename DataType>
+  WithBackgroundResultType<DataType> test_variables_with_background(
+      const tnsr::I<DataType, 3, Frame::Inertial>& x, const double t) const {
+    return this->variables(x, t, WithBackgroundTags<DataType>{});
+  }
+
+  template <typename DataType>
+  WithoutBackgroundResultType<DataType> test_variables_without_background(
+      const tnsr::I<DataType, 3, Frame::Inertial>& x, const double t) const {
+    return this->variables(x, t, WithoutBackgroundTags<DataType>{});
+  }
+};
+
+std::vector<std::string> with_background_python_functions() {
+  return {"teukolsky_wave_lapse",
+          "teukolsky_wave_dt_lapse",
+          "teukolsky_wave_shift",
+          "teukolsky_wave_dt_shift",
+          "teukolsky_wave_spatial_metric",
+          "teukolsky_wave_dt_spatial_metric",
+          "teukolsky_wave_sqrt_det_spatial_metric",
+          "teukolsky_wave_extrinsic_curvature",
+          "teukolsky_wave_inverse_spatial_metric"};
+}
+
+std::vector<std::string> without_background_python_functions() {
+  return {"teukolsky_wave_no_background_lapse",
+          "teukolsky_wave_no_background_dt_lapse",
+          "teukolsky_wave_no_background_shift",
+          "teukolsky_wave_no_background_dt_shift",
+          "teukolsky_wave_no_background_spatial_metric",
+          "teukolsky_wave_no_background_dt_spatial_metric"};
+}
+
+SolutionParameters random_solution_parameters(
+    gsl::not_null<std::mt19937*> generator,
+    const bool include_minkowski_background) {
+  std::uniform_real_distribution<double> amplitude_magnitude(1.0e-5, 1.0e-3);
+  std::uniform_int_distribution<int> sign_distribution(0, 1);
+  std::uniform_int_distribution<int> mode_distribution(-2, 2);
+  std::uniform_int_distribution<int> bool_distribution(0, 1);
+  std::uniform_real_distribution<double> center_distribution(-2.0, 2.0);
+  std::uniform_real_distribution<double> radius_distribution(4.0, 9.0);
+  std::uniform_real_distribution<double> width_distribution(0.7, 2.2);
+  std::uniform_real_distribution<double> time_distribution(-1.5, 1.5);
+
+  const double sign = sign_distribution(*generator) == 0 ? -1.0 : 1.0;
+  return SolutionParameters{
+      sign * amplitude_magnitude(*generator),
+      mode_distribution(*generator),
+      bool_distribution(*generator) == 0 ? "even" : "odd",
+      bool_distribution(*generator) == 0 ? "outgoing" : "ingoing",
+      {center_distribution(*generator), center_distribution(*generator),
+       center_distribution(*generator)},
+      radius_distribution(*generator),
+      width_distribution(*generator),
+      include_minkowski_background,
+      time_distribution(*generator)};
+}
+
+TeukolskyWaveProxy make_solution(const SolutionParameters& parameters) {
+  return {parameters.amplitude, parameters.mode,
+          parameters.parity,    parameters.direction,
+          parameters.center,    parameters.radius,
+          parameters.width,     parameters.include_minkowski_background};
+}
+
+template <typename DataType>
+tnsr::I<DataType, 3, Frame::Inertial> random_coords(
+    gsl::not_null<std::mt19937*> generator, const DataType& used_for_size,
+    const double lower = -9.0, const double upper = 9.0) {
+  const std::uniform_real_distribution<double> distribution(lower, upper);
+  return make_with_random_values<tnsr::I<DataType, 3, Frame::Inertial>>(
+      generator, distribution, used_for_size);
+}
+
+template <typename DataType>
+tnsr::I<DataType, 3, Frame::Inertial> safe_random_coords(
+    gsl::not_null<std::mt19937*> generator, const DataType& used_for_size,
+    const std::array<double, 3>& center) {
+  auto x = random_coords(generator, used_for_size, -3.0, 3.0);
+  get<0>(x) += center[0] + 4.0;
+  get<1>(x) += center[1];
+  get<2>(x) += center[2];
+  return x;
+}
+
+template <typename DataType>
+void test_background_true_basics(const TeukolskyWave& solution,
+                                 const double time,
+                                 const DataType& used_for_size,
+                                 gsl::not_null<std::mt19937*> generator) {
+  const auto x =
+      safe_random_coords(generator, used_for_size, solution.center());
+  const auto vars = solution.variables(x, time, WithBackgroundTags<DataType>{});
+
+  CHECK(solution.include_minkowski_background());
+  CHECK_ITERABLE_APPROX(get(get<gr::Tags::Lapse<DataType>>(vars)),
+                        make_with_value<DataType>(used_for_size, 1.0));
+  CHECK_ITERABLE_APPROX(get(get<Tags::dt<gr::Tags::Lapse<DataType>>>(vars)),
+                        make_with_value<DataType>(used_for_size, 0.0));
+
+  const auto zero_shift =
+      make_with_value<tnsr::I<DataType, 3, Frame::Inertial>>(x, 0.0);
+  const auto& shift = get<gr::Tags::Shift<DataType, 3>>(vars);
+  const auto& dt_shift = get<Tags::dt<gr::Tags::Shift<DataType, 3>>>(vars);
+  CHECK_ITERABLE_APPROX(shift, zero_shift);
+  CHECK_ITERABLE_APPROX(dt_shift, zero_shift);
+
+  const auto& gamma = get<gr::Tags::SpatialMetric<DataType, 3>>(vars);
+  const auto& dt_gamma =
+      get<Tags::dt<gr::Tags::SpatialMetric<DataType, 3>>>(vars);
+  const auto det_and_inverse = determinant_and_inverse(gamma);
+  const auto& inverse_spatial_metric =
+      get<gr::Tags::InverseSpatialMetric<DataType, 3>>(vars);
+  CHECK_ITERABLE_APPROX(inverse_spatial_metric, det_and_inverse.second);
+  CHECK_ITERABLE_APPROX(
+      get(get<gr::Tags::SqrtDetSpatialMetric<DataType>>(vars)),
+      sqrt(get(det_and_inverse.first)));
+
+  const auto& extrinsic_curvature =
+      get<gr::Tags::ExtrinsicCurvature<DataType, 3>>(vars);
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = i; j < 3; ++j) {
+      CHECK_ITERABLE_APPROX(extrinsic_curvature.get(i, j),
+                            -0.5 * dt_gamma.get(i, j));
+    }
+  }
+}
+
+template <typename DataType>
+void test_background_false_basics(const TeukolskyWave& solution,
+                                  const double time,
+                                  const DataType& used_for_size,
+                                  gsl::not_null<std::mt19937*> generator) {
+  const auto x =
+      safe_random_coords(generator, used_for_size, solution.center());
+  const auto vars =
+      solution.variables(x, time, WithoutBackgroundTags<DataType>{});
+
+  CHECK_FALSE(solution.include_minkowski_background());
+  CHECK_ITERABLE_APPROX(get(get<gr::Tags::Lapse<DataType>>(vars)),
+                        make_with_value<DataType>(used_for_size, 0.0));
+  CHECK_ITERABLE_APPROX(get(get<Tags::dt<gr::Tags::Lapse<DataType>>>(vars)),
+                        make_with_value<DataType>(used_for_size, 0.0));
+
+  const auto zero_shift =
+      make_with_value<tnsr::I<DataType, 3, Frame::Inertial>>(x, 0.0);
+  const auto& shift = get<gr::Tags::Shift<DataType, 3>>(vars);
+  const auto& dt_shift = get<Tags::dt<gr::Tags::Shift<DataType, 3>>>(vars);
+  CHECK_ITERABLE_APPROX(shift, zero_shift);
+  CHECK_ITERABLE_APPROX(dt_shift, zero_shift);
+}
+
+void test_origin_errors(gsl::not_null<std::mt19937*> generator) {
+  const auto parameters = random_solution_parameters(generator, true);
+  const double time = parameters.time;
+  const TeukolskyWave with_background = make_solution(parameters);
+  const TeukolskyWave without_background(
+      parameters.amplitude, parameters.mode, parameters.parity,
+      parameters.direction, parameters.center, parameters.radius,
+      parameters.width, false);
+
+  auto check_origin_error = [&time](const TeukolskyWave& solution,
+                                    const auto& x) {
+    CHECK_THROWS_WITH(
+        (get<gr::Tags::SpatialMetric<typename std::decay_t<decltype(get<0>(x))>,
+                                     3>>(
+            solution.template variable<gr::Tags::SpatialMetric<
+                typename std::decay_t<decltype(get<0>(x))>, 3>>(x, time))),
+        Catch::Matchers::ContainsSubstring("radius <=") and
+            Catch::Matchers::ContainsSubstring("Minimum radius was"));
+  };
+
+  tnsr::I<double, 3, Frame::Inertial> x_at_center{};
+  get<0>(x_at_center) = parameters.center[0];
+  get<1>(x_at_center) = parameters.center[1];
+  get<2>(x_at_center) = parameters.center[2];
+  check_origin_error(with_background, x_at_center);
+  check_origin_error(without_background, x_at_center);
+
+  tnsr::I<double, 3, Frame::Inertial> x_inside_cutoff{};
+  get<0>(x_inside_cutoff) = parameters.center[0] + 0.05;
+  get<1>(x_inside_cutoff) = parameters.center[1];
+  get<2>(x_inside_cutoff) = parameters.center[2];
+  check_origin_error(with_background, x_inside_cutoff);
+
+  tnsr::I<double, 3, Frame::Inertial> x_near_cutoff{};
+  get<0>(x_near_cutoff) = parameters.center[0] + 0.09;
+  get<1>(x_near_cutoff) = parameters.center[1];
+  get<2>(x_near_cutoff) = parameters.center[2];
+  check_origin_error(with_background, x_near_cutoff);
+  check_origin_error(without_background, x_near_cutoff);
+
+  tnsr::I<DataVector, 3, Frame::Inertial> x_datavector{DataVector(3)};
+  get<0>(x_datavector) =
+      DataVector{parameters.center[0], parameters.center[0] + 0.2,
+                 parameters.center[0] + 1.0};
+  get<1>(x_datavector) = DataVector{parameters.center[1], parameters.center[1],
+                                    parameters.center[1]};
+  get<2>(x_datavector) = DataVector{parameters.center[2], parameters.center[2],
+                                    parameters.center[2]};
+  check_origin_error(with_background, x_datavector);
+}
+
+void test_far_field_background_recovery(
+    gsl::not_null<std::mt19937*> generator) {
+  // This checks Gaussian localization: far from the pulse center, the
+  // perturbation should be negligible and the metric should reduce to the
+  // requested background state.
+  std::uniform_real_distribution<double> direction_distribution(-1.0, 1.0);
+  for (const bool include_background : {true, false}) {
+    const auto parameters =
+        random_solution_parameters(generator, include_background);
+    const TeukolskyWave solution = make_solution(parameters);
+
+    const double propagation_shift =
+        parameters.direction == "ingoing" ? parameters.time : -parameters.time;
+    const double far_radius =
+        parameters.radius - propagation_shift + 12.0 * parameters.width;
+
+    tnsr::I<double, 3, Frame::Inertial> x{};
+    get<0>(x) = parameters.center[0] + far_radius;
+    get<1>(x) = parameters.center[1] + 0.2 * direction_distribution(*generator);
+    get<2>(x) = parameters.center[2] - 0.2 * direction_distribution(*generator);
+
+    const auto vars =
+        solution.variables(x, parameters.time, WithoutBackgroundTags<double>{});
+    const auto& gamma = get<gr::Tags::SpatialMetric<double, 3>>(vars);
+    const auto& dt_gamma =
+        get<Tags::dt<gr::Tags::SpatialMetric<double, 3>>>(vars);
+    const auto local_approx = approx.custom().margin(1.0e-12);
+
+    CHECK(get<0, 0>(gamma) == local_approx(include_background ? 1.0 : 0.0));
+    CHECK(get<1, 1>(gamma) == local_approx(include_background ? 1.0 : 0.0));
+    CHECK(get<2, 2>(gamma) == local_approx(include_background ? 1.0 : 0.0));
+    CHECK(get<0, 1>(gamma) == local_approx(0.0));
+    CHECK(get<0, 2>(gamma) == local_approx(0.0));
+    CHECK(get<1, 2>(gamma) == local_approx(0.0));
+    CHECK(get<0, 0>(dt_gamma) == local_approx(0.0));
+    CHECK(get<1, 1>(dt_gamma) == local_approx(0.0));
+    CHECK(get<2, 2>(dt_gamma) == local_approx(0.0));
+    CHECK(get<0, 1>(dt_gamma) == local_approx(0.0));
+    CHECK(get<0, 2>(dt_gamma) == local_approx(0.0));
+    CHECK(get<1, 2>(dt_gamma) == local_approx(0.0));
+  }
+}
+
+void test_axis_regularization(gsl::not_null<std::mt19937*> generator) {
+  const auto parameters = random_solution_parameters(generator, true);
+  std::uniform_real_distribution<double> offset_distribution(0.5, 2.0);
+  const std::array<double, 2> axis_signs{{-1.0, 1.0}};
+  // Use a different offset than the implementation's internal axis-limit
+  // stencil so this remains an independent limit check.
+  const double rho = 3.0e-8;
+
+  for (const std::string parity : {"even", "odd"}) {
+    for (int mode = -2; mode <= 2; ++mode) {
+      const TeukolskyWave solution(parameters.amplitude, mode, parity,
+                                   parameters.direction, parameters.center,
+                                   parameters.radius, parameters.width, true);
+      for (const double axis_sign : axis_signs) {
+        tnsr::I<double, 3, Frame::Inertial> axis_x{};
+        get<0>(axis_x) = parameters.center[0];
+        get<1>(axis_x) = parameters.center[1];
+        get<2>(axis_x) =
+            parameters.center[2] +
+            axis_sign * (parameters.radius + offset_distribution(*generator));
+
+        const auto axis_vars = solution.variables(axis_x, parameters.time,
+                                                  WithBackgroundTags<double>{});
+        const auto& axis_gamma =
+            get<gr::Tags::SpatialMetric<double, 3>>(axis_vars);
+        const auto& axis_dt_gamma =
+            get<Tags::dt<gr::Tags::SpatialMetric<double, 3>>>(axis_vars);
+        const auto det_and_inverse = determinant_and_inverse(axis_gamma);
+        const auto& inverse_spatial_metric =
+            get<gr::Tags::InverseSpatialMetric<double, 3>>(axis_vars);
+        CHECK_ITERABLE_APPROX(inverse_spatial_metric, det_and_inverse.second);
+        CHECK(get(get<gr::Tags::SqrtDetSpatialMetric<double>>(axis_vars)) >
+              0.0);
+
+        const auto near_axis_limit_approx =
+            approx.custom().epsilon(1.0e-10).scale(1.0);
+        CAPTURE(mode);
+        CAPTURE(parity);
+        CAPTURE(axis_sign);
+
+        tnsr::I<double, 3, Frame::Inertial> near_axis_x{};
+        get<0>(near_axis_x) = parameters.center[0] + rho;
+        get<1>(near_axis_x) = parameters.center[1];
+        get<2>(near_axis_x) = get<2>(axis_x);
+        tnsr::I<double, 3, Frame::Inertial> near_axis_y{};
+        get<0>(near_axis_y) = parameters.center[0];
+        get<1>(near_axis_y) = parameters.center[1] + rho;
+        get<2>(near_axis_y) = get<2>(axis_x);
+
+        const auto near_axis_x_vars = solution.variables(
+            near_axis_x, parameters.time, WithBackgroundTags<double>{});
+        const auto near_axis_y_vars = solution.variables(
+            near_axis_y, parameters.time, WithBackgroundTags<double>{});
+        const auto& near_axis_x_gamma =
+            get<gr::Tags::SpatialMetric<double, 3>>(near_axis_x_vars);
+        const auto& near_axis_x_dt_gamma =
+            get<Tags::dt<gr::Tags::SpatialMetric<double, 3>>>(near_axis_x_vars);
+        const auto& near_axis_y_gamma =
+            get<gr::Tags::SpatialMetric<double, 3>>(near_axis_y_vars);
+        const auto& near_axis_y_dt_gamma =
+            get<Tags::dt<gr::Tags::SpatialMetric<double, 3>>>(near_axis_y_vars);
+
+        for (size_t i = 0; i < 3; ++i) {
+          for (size_t j = i; j < 3; ++j) {
+            CHECK(std::isfinite(axis_gamma.get(i, j)));
+            CHECK(std::isfinite(axis_dt_gamma.get(i, j)));
+            const double near_axis_gamma_limit =
+                0.5 *
+                (near_axis_x_gamma.get(i, j) + near_axis_y_gamma.get(i, j));
+            const double near_axis_dt_gamma_limit =
+                0.5 * (near_axis_x_dt_gamma.get(i, j) +
+                       near_axis_y_dt_gamma.get(i, j));
+            CHECK(near_axis_x_gamma.get(i, j) ==
+                  near_axis_limit_approx(near_axis_y_gamma.get(i, j)));
+            CHECK(near_axis_x_dt_gamma.get(i, j) ==
+                  near_axis_limit_approx(near_axis_y_dt_gamma.get(i, j)));
+            CHECK(axis_gamma.get(i, j) ==
+                  near_axis_limit_approx(near_axis_gamma_limit));
+            CHECK(axis_dt_gamma.get(i, j) ==
+                  near_axis_limit_approx(near_axis_dt_gamma_limit));
+          }
+        }
+      }
+    }
+  }
+}
+
+void test_spec_pointwise_agreement() {
+  // This regression test checks agreement with SpEC's
+  // PointwiseFunctions/AnalyticSolutions/LinearizedGravity/TeukolskyWave.cpp
+  // at one representative point for the double-valued no-background case.
+  const TeukolskyWave solution{0.01, 2,   "even", "outgoing", {{0.0, 0.0, 0.0}},
+                               18.5, 1.2, false};
+  tnsr::I<double, 3, Frame::Inertial> x{};
+  get<0>(x) = 17.1;
+  get<1>(x) = -0.2;
+  get<2>(x) = 0.3;
+
+  const auto vars = solution.variables(x, 0.0, WithoutBackgroundTags<double>{});
+  const auto& gamma = get<gr::Tags::SpatialMetric<double, 3>>(vars);
+  const auto& dt_gamma =
+      get<Tags::dt<gr::Tags::SpatialMetric<double, 3>>>(vars);
+
+  const auto spec_approx = approx.custom().epsilon(1.0e-13).scale(1.0);
+  CHECK(get<0, 0>(gamma) == spec_approx(3.0726477174852849e-06));
+  CHECK(get<0, 1>(gamma) == spec_approx(4.6856056129806923e-06));
+  CHECK(get<0, 2>(gamma) == spec_approx(7.7441285036194232e-06));
+  CHECK(get<1, 1>(gamma) == spec_approx(4.2473114121358127e-04));
+  CHECK(get<1, 2>(gamma) == spec_approx(2.5498181687206425e-07));
+  CHECK(get<2, 2>(gamma) == spec_approx(-4.2780378893106667e-04));
+
+  CHECK(get<0, 0>(dt_gamma) == spec_approx(2.0523780729181779e-06));
+  CHECK(get<0, 1>(dt_gamma) == spec_approx(-4.9599082769854031e-06));
+  CHECK(get<0, 2>(dt_gamma) == spec_approx(-1.2565408165979533e-05));
+  CHECK(get<1, 1>(dt_gamma) == spec_approx(-6.2085896232436382e-04));
+  CHECK(get<1, 2>(dt_gamma) == spec_approx(-3.2099570756649984e-07));
+  CHECK(get<2, 2>(dt_gamma) == spec_approx(6.1880658425144612e-04));
+}
+
+template <typename DataType>
+void test_python_comparison_with_background(const TeukolskyWaveProxy& solution,
+                                            const DataType& used_for_size) {
+  for (const std::string parity : {"even", "odd"}) {
+    for (int mode = -2; mode <= 2; ++mode) {
+      const TeukolskyWaveProxy branch_solution(
+          solution.amplitude(), mode, parity, solution.direction(),
+          {{20.0, 0.0, 0.0}}, solution.radius(), solution.width(), true);
+      CAPTURE(parity);
+      CAPTURE(mode);
+      pypp::check_with_random_values<2>(
+          &TeukolskyWaveProxy::template test_variables_with_background<
+              DataType>,
+          branch_solution, "TeukolskyWave", with_background_python_functions(),
+          {{{-9.0, 9.0}, {-2.0, 2.0}}},
+          std::make_tuple(branch_solution.amplitude(), branch_solution.mode(),
+                          branch_solution.parity(), branch_solution.direction(),
+                          branch_solution.center(), branch_solution.radius(),
+                          branch_solution.width()),
+          used_for_size);
+    }
+  }
+}
+
+template <typename DataType>
+void test_python_comparison_without_background(
+    const TeukolskyWaveProxy& solution, const DataType& used_for_size) {
+  for (const std::string parity : {"even", "odd"}) {
+    for (int mode = -2; mode <= 2; ++mode) {
+      const TeukolskyWaveProxy branch_solution(
+          solution.amplitude(), mode, parity, solution.direction(),
+          {{20.0, 0.0, 0.0}}, solution.radius(), solution.width(), false);
+      CAPTURE(parity);
+      CAPTURE(mode);
+      pypp::check_with_random_values<2>(
+          &TeukolskyWaveProxy::template test_variables_without_background<
+              DataType>,
+          branch_solution, "TeukolskyWave",
+          without_background_python_functions(), {{{-9.0, 9.0}, {-2.0, 2.0}}},
+          std::make_tuple(branch_solution.amplitude(), branch_solution.mode(),
+                          branch_solution.parity(), branch_solution.direction(),
+                          branch_solution.center(), branch_solution.radius(),
+                          branch_solution.width()),
+          used_for_size);
+    }
+  }
+}
+
+void test_construct_from_options() {
+  const auto created_solution = TestHelpers::test_creation<TeukolskyWave>(
+      "Amplitude: 1e-4\n"
+      "Mode: 2\n"
+      "Parity: even\n"
+      "Direction: outgoing\n"
+      "Center: [0.0, 0.0, 0.0]\n"
+      "Radius: 8.0\n"
+      "Width: 1.5");
+  CHECK(created_solution == TeukolskyWave(1.0e-4, 2, "even", "outgoing",
+                                          {{0.0, 0.0, 0.0}}, 8.0, 1.5, true));
+}
+
+void test_background_false_errors() {
+  const TeukolskyWave solution{
+      1.0e-4, 2, "even", "outgoing", {{0.0, 0.0, 0.0}}, 8.0, 1.5, false};
+  tnsr::I<double, 3, Frame::Inertial> x{};
+  get<0>(x) = 6.2;
+  get<1>(x) = -1.4;
+  get<2>(x) = 3.6;
+  const double t = 1.3;
+  CHECK_THROWS_WITH(
+      (get<gr::Tags::InverseSpatialMetric<double, 3>>(
+          solution.template variable<gr::Tags::InverseSpatialMetric<double, 3>>(
+              x, t))),
+      Catch::Matchers::ContainsSubstring(
+          "IncludeMinkowskiBackground must be true to compute inverse spatial "
+          "metric"));
+  CHECK_THROWS_WITH(
+      (get<gr::Tags::SqrtDetSpatialMetric<double>>(
+          solution.template variable<gr::Tags::SqrtDetSpatialMetric<double>>(
+              x, t))),
+      Catch::Matchers::ContainsSubstring("IncludeMinkowskiBackground must be "
+                                         "true to compute sqrt(det(gamma))"));
+  CHECK_THROWS_WITH(
+      (get<gr::Tags::ExtrinsicCurvature<double, 3>>(
+          solution.template variable<gr::Tags::ExtrinsicCurvature<double, 3>>(
+              x, t))),
+      Catch::Matchers::ContainsSubstring(
+          "IncludeMinkowskiBackground must be true to compute extrinsic "
+          "curvature"));
+}
+
+void test_invalid_construction_throws() {
+  CHECK_THROWS_WITH(
+      []() {
+        const TeukolskyWave bad_solution(1.0e-4, 3, "even", "outgoing",
+                                         {{0.0, 0.0, 0.0}}, 8.0, 1.5, true);
+      }(),
+      Catch::Matchers::ContainsSubstring("Mode must lie between -2 and 2"));
+  CHECK_THROWS_WITH(
+      []() {
+        const TeukolskyWave bad_solution(1.0e-4, 2, "even", "outgoing",
+                                         {{0.0, 0.0, 0.0}}, 8.0, 0.0, true);
+      }(),
+      Catch::Matchers::ContainsSubstring("Width must be greater than 0"));
+  CHECK_THROWS_WITH(
+      []() {
+        const TeukolskyWave bad_solution(1.0e-4, 2, "even", "outgoing",
+                                         {{0.0, 0.0, 0.0}}, 8.0, -1.0, true);
+      }(),
+      Catch::Matchers::ContainsSubstring("Width must be greater than 0"));
+  CHECK_THROWS_WITH(
+      []() {
+        const TeukolskyWave bad_solution(1.0e-4, 2, "bad", "outgoing",
+                                         {{0.0, 0.0, 0.0}}, 8.0, 1.5, true);
+      }(),
+      Catch::Matchers::ContainsSubstring(
+          "Parity must be either 'even' or 'odd'"));
+  CHECK_THROWS_WITH(
+      []() {
+        const TeukolskyWave bad_solution(1.0e-4, 2, "even", "bad",
+                                         {{0.0, 0.0, 0.0}}, 8.0, 1.5, true);
+      }(),
+      Catch::Matchers::ContainsSubstring(
+          "Direction must be either 'outgoing' or 'ingoing'"));
+}
+
+void test_serialize_and_copy(gsl::not_null<std::mt19937*> generator) {
+  const auto parameters = random_solution_parameters(generator, true);
+  const TeukolskyWave solution = make_solution(parameters);
+  test_serialization(solution);
+  test_copy_semantics(solution);
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.AnalyticSolutions.Gr.TeukolskyWave",
+                  "[PointwiseFunctions][Unit]") {
+  const pypp::SetupLocalPythonEnvironment local_python_env{
+      "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/"};
+
+  MAKE_GENERATOR(generator);
+  const auto with_background_parameters =
+      random_solution_parameters(make_not_null(&generator), true);
+  const TeukolskyWaveProxy with_background_solution =
+      make_solution(with_background_parameters);
+  test_background_true_basics(
+      with_background_solution, with_background_parameters.time,
+      DataVector(5, std::numeric_limits<double>::signaling_NaN()),
+      make_not_null(&generator));
+  test_background_true_basics(
+      with_background_solution, with_background_parameters.time,
+      std::numeric_limits<double>::signaling_NaN(), make_not_null(&generator));
+  test_python_comparison_with_background(
+      with_background_solution, std::numeric_limits<double>::signaling_NaN());
+
+  const auto without_background_parameters =
+      random_solution_parameters(make_not_null(&generator), false);
+  const TeukolskyWaveProxy without_background_solution =
+      make_solution(without_background_parameters);
+  test_background_false_basics(
+      without_background_solution, without_background_parameters.time,
+      DataVector(5, std::numeric_limits<double>::signaling_NaN()),
+      make_not_null(&generator));
+  test_background_false_basics(
+      without_background_solution, without_background_parameters.time,
+      std::numeric_limits<double>::signaling_NaN(), make_not_null(&generator));
+  test_python_comparison_without_background(
+      without_background_solution,
+      std::numeric_limits<double>::signaling_NaN());
+
+  test_origin_errors(make_not_null(&generator));
+  test_far_field_background_recovery(make_not_null(&generator));
+  test_axis_regularization(make_not_null(&generator));
+  test_spec_pointwise_agreement();
+  test_construct_from_options();
+  test_background_false_errors();
+  test_invalid_construction_throws();
+  test_serialize_and_copy(make_not_null(&generator));
+}

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/TeukolskyWave.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/TeukolskyWave.py
@@ -1,0 +1,653 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+ORIGIN_EXCLUSION_RADIUS = 0.1
+AXIS_COORDINATE_TOLERANCE = 1.0e-14
+AXIS_LIMIT_OFFSET = 1.0e-8
+
+
+def _perturbation_and_dt_perturbation(
+    centered_coords,
+    t,
+    amplitude,
+    mode,
+    parity,
+    direction,
+    radius,
+    width,
+):
+    radius_from_center = np.sqrt(np.sum(centered_coords**2))
+    if radius_from_center <= ORIGIN_EXCLUSION_RADIUS:
+        raise RuntimeError(
+            "TeukolskyWave cannot be evaluated at points with radius <= 0.1 "
+            "from its center because the implementation uses spherical "
+            "coordinates, which are singular at the origin."
+        )
+
+    cylindrical_radius = np.sqrt(
+        centered_coords[0] ** 2 + centered_coords[1] ** 2
+    )
+    cos_theta = centered_coords[2] / radius_from_center
+    sin_theta = cylindrical_radius / radius_from_center
+    if cylindrical_radius > AXIS_COORDINATE_TOLERANCE:
+        cos_phi = centered_coords[0] / cylindrical_radius
+        sin_phi = centered_coords[1] / cylindrical_radius
+    else:
+        cos_phi = 1.0
+        sin_phi = 0.0
+    sin_2phi = 2.0 * sin_phi * cos_phi
+    cos_2phi = cos_phi**2 - sin_phi**2
+
+    y_profile = (
+        radius_from_center - radius + (t if direction == "ingoing" else -t)
+    )
+    minus_two_over_width_squared = -2.0 / width**2
+    profile = amplitude * np.exp(-(y_profile**2) / width**2)
+    profile_1 = minus_two_over_width_squared * y_profile * profile
+    profile_2 = minus_two_over_width_squared * (profile + y_profile * profile_1)
+    profile_3 = minus_two_over_width_squared * (
+        2.0 * profile_1 + y_profile * profile_2
+    )
+    profile_4 = minus_two_over_width_squared * (
+        3.0 * profile_2 + y_profile * profile_3
+    )
+    profile_5 = minus_two_over_width_squared * (
+        4.0 * profile_3 + y_profile * profile_4
+    )
+
+    spherical_metric = np.zeros((3, 3))
+    dt_spherical_metric = np.zeros((3, 3))
+
+    if parity == "even":
+        if mode == -2:
+            angular_rr = sin_theta**2 * sin_2phi
+            angular_rtheta = sin_theta * cos_theta * sin_2phi
+            angular_rphi = sin_theta * cos_2phi
+            angular_theta_theta_1 = (1.0 + cos_theta**2) * sin_2phi
+            angular_theta_theta_2 = -sin_2phi
+            angular_thetaphi = -cos_theta * cos_2phi
+            angular_phi_phi_1 = -angular_theta_theta_1
+            angular_phi_phi_2 = cos_theta**2 * sin_2phi
+        elif mode == -1:
+            angular_rr = 2.0 * sin_theta * cos_theta * sin_phi
+            angular_rtheta = (cos_theta**2 - sin_theta**2) * sin_phi
+            angular_rphi = cos_theta * cos_phi
+            angular_theta_theta_1 = -2.0 * sin_theta * cos_theta * sin_phi
+            angular_theta_theta_2 = 0.0
+            angular_thetaphi = sin_theta * cos_phi
+            angular_phi_phi_1 = -angular_theta_theta_1
+            angular_phi_phi_2 = -2.0 * sin_theta * cos_theta * sin_phi
+        elif mode == 0:
+            angular_rr = 2.0 - 3.0 * sin_theta**2
+            angular_rtheta = -3.0 * sin_theta * cos_theta
+            angular_rphi = 0.0
+            angular_theta_theta_1 = 3.0 * sin_theta**2
+            angular_theta_theta_2 = -1.0
+            angular_thetaphi = 0.0
+            angular_phi_phi_1 = -angular_theta_theta_1
+            angular_phi_phi_2 = 3.0 * sin_theta**2 - 1.0
+        elif mode == 1:
+            angular_rr = 2.0 * sin_theta * cos_theta * cos_phi
+            angular_rtheta = (cos_theta**2 - sin_theta**2) * cos_phi
+            angular_rphi = -cos_theta * sin_phi
+            angular_theta_theta_1 = -2.0 * sin_theta * cos_theta * cos_phi
+            angular_theta_theta_2 = 0.0
+            angular_thetaphi = -sin_theta * sin_phi
+            angular_phi_phi_1 = -angular_theta_theta_1
+            angular_phi_phi_2 = -2.0 * sin_theta * cos_theta * cos_phi
+        elif mode == 2:
+            angular_rr = sin_theta**2 * cos_2phi
+            angular_rtheta = sin_theta * cos_theta * cos_2phi
+            angular_rphi = -sin_theta * sin_2phi
+            angular_theta_theta_1 = (1.0 + cos_theta**2) * cos_2phi
+            angular_theta_theta_2 = -cos_2phi
+            angular_thetaphi = cos_theta * sin_2phi
+            angular_phi_phi_1 = -angular_theta_theta_1
+            angular_phi_phi_2 = cos_theta**2 * cos_2phi
+        else:
+            raise RuntimeError("Unsupported Teukolsky mode")
+
+        radial_a = (
+            3.0
+            * (
+                profile_2
+                + (-3.0 * profile_1 + 3.0 * profile / radius_from_center)
+                / radius_from_center
+            )
+            / radius_from_center**3
+        )
+        radial_b = (
+            -(
+                -profile_3
+                + (
+                    3.0 * profile_2
+                    + (-6.0 * profile_1 + 6.0 * profile / radius_from_center)
+                    / radius_from_center
+                )
+                / radius_from_center
+            )
+            / radius_from_center**2
+        )
+        radial_c = (
+            0.25
+            * (
+                profile_4
+                + (
+                    -2.0 * profile_3
+                    + (
+                        9.0 * profile_2
+                        + (
+                            -21.0 * profile_1
+                            + 21.0 * profile / radius_from_center
+                        )
+                        / radius_from_center
+                    )
+                    / radius_from_center
+                )
+                / radius_from_center
+            )
+            / radius_from_center
+        )
+
+        spherical_metric[0, 0] += radial_a * angular_rr
+        spherical_metric[0, 1] += radius_from_center * radial_b * angular_rtheta
+        spherical_metric[0, 2] += (
+            radius_from_center * radial_b * angular_rphi * sin_theta
+        )
+        spherical_metric[1, 1] += radius_from_center**2 * (
+            radial_c * angular_theta_theta_1 + radial_a * angular_theta_theta_2
+        )
+        spherical_metric[1, 2] += (
+            radius_from_center**2
+            * (radial_a - 2.0 * radial_c)
+            * angular_thetaphi
+            * sin_theta
+        )
+        spherical_metric[2, 2] += (
+            radius_from_center**2
+            * (radial_c * angular_phi_phi_1 + radial_a * angular_phi_phi_2)
+            * sin_theta**2
+        )
+
+        propagation_sign = 1.0 if direction == "ingoing" else -1.0
+        dt_radial_a = (
+            propagation_sign
+            * 3.0
+            * (
+                profile_3
+                + (-3.0 * profile_2 + 3.0 * profile_1 / radius_from_center)
+                / radius_from_center
+            )
+            / radius_from_center**3
+        )
+        dt_radial_b = (
+            -propagation_sign
+            * (
+                -profile_4
+                + (
+                    3.0 * profile_3
+                    + (-6.0 * profile_2 + 6.0 * profile_1 / radius_from_center)
+                    / radius_from_center
+                )
+                / radius_from_center
+            )
+            / radius_from_center**2
+        )
+        dt_radial_c = (
+            propagation_sign
+            * 0.25
+            * (
+                profile_5
+                + (
+                    -2.0 * profile_4
+                    + (
+                        9.0 * profile_3
+                        + (
+                            -21.0 * profile_2
+                            + 21.0 * profile_1 / radius_from_center
+                        )
+                        / radius_from_center
+                    )
+                    / radius_from_center
+                )
+                / radius_from_center
+            )
+            / radius_from_center
+        )
+
+        dt_spherical_metric[0, 0] += dt_radial_a * angular_rr
+        dt_spherical_metric[0, 1] += (
+            radius_from_center * dt_radial_b * angular_rtheta
+        )
+        dt_spherical_metric[0, 2] += (
+            radius_from_center * dt_radial_b * angular_rphi * sin_theta
+        )
+        dt_spherical_metric[1, 1] += radius_from_center**2 * (
+            dt_radial_c * angular_theta_theta_1
+            + dt_radial_a * angular_theta_theta_2
+        )
+        dt_spherical_metric[1, 2] += (
+            radius_from_center**2
+            * (dt_radial_a - 2.0 * dt_radial_c)
+            * angular_thetaphi
+            * sin_theta
+        )
+        dt_spherical_metric[2, 2] += (
+            radius_from_center**2
+            * (
+                dt_radial_c * angular_phi_phi_1
+                + dt_radial_a * angular_phi_phi_2
+            )
+            * sin_theta**2
+        )
+    else:
+        if mode == -2:
+            angular_rtheta = 4.0 * sin_theta * sin_2phi
+            angular_rphi = 4.0 * sin_theta * cos_theta * cos_2phi
+            angular_theta_theta = -2.0 * cos_theta * sin_2phi
+            angular_thetaphi = -(2.0 - sin_theta**2) * cos_2phi
+            angular_phi_phi = 2.0 * cos_theta * sin_2phi
+        elif mode == -1:
+            angular_rtheta = -2.0 * cos_theta * sin_phi
+            angular_rphi = -2.0 * (cos_theta**2 - sin_theta**2) * cos_phi
+            angular_theta_theta = -sin_theta * sin_phi
+            angular_thetaphi = -cos_theta * sin_theta * cos_phi
+            angular_phi_phi = sin_theta * sin_phi
+        elif mode == 0:
+            angular_rtheta = 0.0
+            angular_rphi = -4.0 * cos_theta * sin_theta
+            angular_theta_theta = 0.0
+            angular_thetaphi = -(sin_theta**2)
+            angular_phi_phi = 0.0
+        elif mode == 1:
+            angular_rtheta = -2.0 * cos_theta * cos_phi
+            angular_rphi = 2.0 * (cos_theta**2 - sin_theta**2) * sin_phi
+            angular_theta_theta = -sin_theta * cos_phi
+            angular_thetaphi = cos_theta * sin_theta * sin_phi
+            angular_phi_phi = sin_theta * cos_phi
+        elif mode == 2:
+            angular_rtheta = 4.0 * sin_theta * cos_2phi
+            angular_rphi = -4.0 * sin_theta * cos_theta * sin_2phi
+            angular_theta_theta = -2.0 * cos_theta * cos_2phi
+            angular_thetaphi = (2.0 - sin_theta**2) * sin_2phi
+            angular_phi_phi = 2.0 * cos_theta * cos_2phi
+        else:
+            raise RuntimeError("Unsupported Teukolsky mode")
+
+        radial_k = (
+            profile_2
+            + (-3.0 * profile_1 + 3.0 * profile / radius_from_center)
+            / radius_from_center
+        ) / radius_from_center**2
+        radial_l = (
+            -profile_3
+            + (
+                2.0 * profile_2
+                + (-3.0 * profile_1 + 3.0 * profile / radius_from_center)
+                / radius_from_center
+            )
+            / radius_from_center
+        ) / radius_from_center
+
+        spherical_metric[0, 1] += radius_from_center * radial_k * angular_rtheta
+        spherical_metric[0, 2] += (
+            radius_from_center * radial_k * angular_rphi * sin_theta
+        )
+        spherical_metric[1, 1] += (
+            radius_from_center**2 * radial_l * angular_theta_theta
+        )
+        spherical_metric[1, 2] += (
+            radius_from_center**2 * radial_l * angular_thetaphi * sin_theta
+        )
+        spherical_metric[2, 2] += (
+            radius_from_center**2
+            * radial_l
+            * angular_phi_phi
+            * sin_theta**2
+        )
+
+        propagation_sign = 1.0 if direction == "ingoing" else -1.0
+        dt_radial_k = (
+            propagation_sign
+            * (
+                profile_3
+                + (-3.0 * profile_2 + 3.0 * profile_1 / radius_from_center)
+                / radius_from_center
+            )
+            / radius_from_center**2
+        )
+        dt_radial_l = (
+            propagation_sign
+            * (
+                -profile_4
+                + (
+                    2.0 * profile_3
+                    + (-3.0 * profile_2 + 3.0 * profile_1 / radius_from_center)
+                    / radius_from_center
+                )
+                / radius_from_center
+            )
+            / radius_from_center
+        )
+
+        dt_spherical_metric[0, 1] += (
+            radius_from_center * dt_radial_k * angular_rtheta
+        )
+        dt_spherical_metric[0, 2] += (
+            radius_from_center * dt_radial_k * angular_rphi * sin_theta
+        )
+        dt_spherical_metric[1, 1] += (
+            radius_from_center**2 * dt_radial_l * angular_theta_theta
+        )
+        dt_spherical_metric[1, 2] += (
+            radius_from_center**2 * dt_radial_l * angular_thetaphi * sin_theta
+        )
+        dt_spherical_metric[2, 2] += (
+            radius_from_center**2
+            * dt_radial_l
+            * angular_phi_phi
+            * sin_theta**2
+        )
+
+    spherical_metric = spherical_metric + np.triu(spherical_metric, 1).T
+    dt_spherical_metric = (
+        dt_spherical_metric + np.triu(dt_spherical_metric, 1).T
+    )
+
+    sin_theta_for_phi = max(sin_theta, AXIS_COORDINATE_TOLERANCE)
+    inverse_jacobian = np.array(
+        [
+            [
+                sin_theta * cos_phi,
+                sin_theta * sin_phi,
+                cos_theta,
+            ],
+            [
+                cos_theta * cos_phi / radius_from_center,
+                cos_theta * sin_phi / radius_from_center,
+                -sin_theta / radius_from_center,
+            ],
+            [
+                -sin_phi / (radius_from_center * sin_theta_for_phi),
+                cos_phi / (radius_from_center * sin_theta_for_phi),
+                0.0,
+            ],
+        ]
+    )
+    perturbation = np.einsum(
+        "ai,bj,ab->ij", inverse_jacobian, inverse_jacobian, spherical_metric
+    )
+    dt_perturbation = np.einsum(
+        "ai,bj,ab->ij", inverse_jacobian, inverse_jacobian, dt_spherical_metric
+    )
+    return perturbation, dt_perturbation
+
+
+def _pointwise_metric(
+    x,
+    t,
+    amplitude,
+    mode,
+    parity,
+    direction,
+    center,
+    radius,
+    width,
+    include_minkowski_background,
+):
+    spatial_metric = np.zeros((3, 3))
+    if include_minkowski_background:
+        spatial_metric += np.eye(3)
+    dt_spatial_metric = np.zeros((3, 3))
+
+    centered_coords = np.asarray(x) - np.asarray(center)
+    radius_from_center = np.sqrt(np.sum(centered_coords**2))
+    if radius_from_center <= ORIGIN_EXCLUSION_RADIUS:
+        raise RuntimeError(
+            "TeukolskyWave cannot be evaluated at points with radius <= 0.1 "
+            "from its center because the implementation uses spherical "
+            "coordinates, which are singular at the origin."
+        )
+
+    cylindrical_radius = np.sqrt(
+        centered_coords[0] ** 2 + centered_coords[1] ** 2
+    )
+    if cylindrical_radius > AXIS_COORDINATE_TOLERANCE:
+        perturbation, dt_perturbation = _perturbation_and_dt_perturbation(
+            centered_coords,
+            t,
+            amplitude,
+            mode,
+            parity,
+            direction,
+            radius,
+            width,
+        )
+    else:
+        perturbation_x, dt_perturbation_x = _perturbation_and_dt_perturbation(
+            centered_coords + np.array([AXIS_LIMIT_OFFSET, 0.0, 0.0]),
+            t,
+            amplitude,
+            mode,
+            parity,
+            direction,
+            radius,
+            width,
+        )
+        perturbation_y, dt_perturbation_y = _perturbation_and_dt_perturbation(
+            centered_coords + np.array([0.0, AXIS_LIMIT_OFFSET, 0.0]),
+            t,
+            amplitude,
+            mode,
+            parity,
+            direction,
+            radius,
+            width,
+        )
+        perturbation = 0.5 * (perturbation_x + perturbation_y)
+        dt_perturbation = 0.5 * (dt_perturbation_x + dt_perturbation_y)
+
+    return spatial_metric + perturbation, dt_spatial_metric + dt_perturbation
+
+
+def _variables(
+    x,
+    t,
+    amplitude,
+    mode,
+    parity,
+    direction,
+    center,
+    radius,
+    width,
+    include_minkowski_background,
+):
+    spatial_metric, dt_spatial_metric = _pointwise_metric(
+        np.asarray(x, dtype=float),
+        t,
+        amplitude,
+        mode,
+        parity,
+        direction,
+        center,
+        radius,
+        width,
+        include_minkowski_background,
+    )
+    lapse = 1.0 if include_minkowski_background else 0.0
+    dt_lapse = 0.0
+    shift = np.zeros(3)
+    dt_shift = np.zeros(3)
+
+    result = {
+        "Lapse": lapse,
+        "dt(Lapse)": dt_lapse,
+        "Shift": shift,
+        "dt(Shift)": dt_shift,
+        "SpatialMetric": spatial_metric,
+        "dt(SpatialMetric)": dt_spatial_metric,
+    }
+
+    if include_minkowski_background:
+        extrinsic_curvature = -0.5 * dt_spatial_metric
+        result["SqrtDetSpatialMetric"] = np.sqrt(np.linalg.det(spatial_metric))
+        result["ExtrinsicCurvature"] = extrinsic_curvature
+        result["InverseSpatialMetric"] = np.linalg.inv(spatial_metric)
+
+    return result
+
+
+def teukolsky_wave_variables(
+    x, t, amplitude, mode, parity, direction, center, radius, width
+):
+    return _variables(
+        x,
+        t,
+        amplitude,
+        mode,
+        parity,
+        direction,
+        center,
+        radius,
+        width,
+        True,
+    )
+
+
+def teukolsky_wave_variables_no_background(
+    x, t, amplitude, mode, parity, direction, center, radius, width
+):
+    return _variables(
+        x,
+        t,
+        amplitude,
+        mode,
+        parity,
+        direction,
+        center,
+        radius,
+        width,
+        False,
+    )
+
+
+def teukolsky_wave_lapse(
+    x, t, amplitude, mode, parity, direction, center, radius, width
+):
+    return teukolsky_wave_variables(
+        x, t, amplitude, mode, parity, direction, center, radius, width
+    )["Lapse"]
+
+
+def teukolsky_wave_dt_lapse(
+    x, t, amplitude, mode, parity, direction, center, radius, width
+):
+    return teukolsky_wave_variables(
+        x, t, amplitude, mode, parity, direction, center, radius, width
+    )["dt(Lapse)"]
+
+
+def teukolsky_wave_shift(
+    x, t, amplitude, mode, parity, direction, center, radius, width
+):
+    return teukolsky_wave_variables(
+        x, t, amplitude, mode, parity, direction, center, radius, width
+    )["Shift"]
+
+
+def teukolsky_wave_dt_shift(
+    x, t, amplitude, mode, parity, direction, center, radius, width
+):
+    return teukolsky_wave_variables(
+        x, t, amplitude, mode, parity, direction, center, radius, width
+    )["dt(Shift)"]
+
+
+def teukolsky_wave_spatial_metric(
+    x, t, amplitude, mode, parity, direction, center, radius, width
+):
+    return teukolsky_wave_variables(
+        x, t, amplitude, mode, parity, direction, center, radius, width
+    )["SpatialMetric"]
+
+
+def teukolsky_wave_dt_spatial_metric(
+    x, t, amplitude, mode, parity, direction, center, radius, width
+):
+    return teukolsky_wave_variables(
+        x, t, amplitude, mode, parity, direction, center, radius, width
+    )["dt(SpatialMetric)"]
+
+
+def teukolsky_wave_sqrt_det_spatial_metric(
+    x, t, amplitude, mode, parity, direction, center, radius, width
+):
+    return teukolsky_wave_variables(
+        x, t, amplitude, mode, parity, direction, center, radius, width
+    )["SqrtDetSpatialMetric"]
+
+
+def teukolsky_wave_extrinsic_curvature(
+    x, t, amplitude, mode, parity, direction, center, radius, width
+):
+    return teukolsky_wave_variables(
+        x, t, amplitude, mode, parity, direction, center, radius, width
+    )["ExtrinsicCurvature"]
+
+
+def teukolsky_wave_inverse_spatial_metric(
+    x, t, amplitude, mode, parity, direction, center, radius, width
+):
+    return teukolsky_wave_variables(
+        x, t, amplitude, mode, parity, direction, center, radius, width
+    )["InverseSpatialMetric"]
+
+
+def teukolsky_wave_no_background_lapse(
+    x, t, amplitude, mode, parity, direction, center, radius, width
+):
+    return teukolsky_wave_variables_no_background(
+        x, t, amplitude, mode, parity, direction, center, radius, width
+    )["Lapse"]
+
+
+def teukolsky_wave_no_background_dt_lapse(
+    x, t, amplitude, mode, parity, direction, center, radius, width
+):
+    return teukolsky_wave_variables_no_background(
+        x, t, amplitude, mode, parity, direction, center, radius, width
+    )["dt(Lapse)"]
+
+
+def teukolsky_wave_no_background_shift(
+    x, t, amplitude, mode, parity, direction, center, radius, width
+):
+    return teukolsky_wave_variables_no_background(
+        x, t, amplitude, mode, parity, direction, center, radius, width
+    )["Shift"]
+
+
+def teukolsky_wave_no_background_dt_shift(
+    x, t, amplitude, mode, parity, direction, center, radius, width
+):
+    return teukolsky_wave_variables_no_background(
+        x, t, amplitude, mode, parity, direction, center, radius, width
+    )["dt(Shift)"]
+
+
+def teukolsky_wave_no_background_spatial_metric(
+    x, t, amplitude, mode, parity, direction, center, radius, width
+):
+    return teukolsky_wave_variables_no_background(
+        x, t, amplitude, mode, parity, direction, center, radius, width
+    )["SpatialMetric"]
+
+
+def teukolsky_wave_no_background_dt_spatial_metric(
+    x, t, amplitude, mode, parity, direction, center, radius, width
+):
+    return teukolsky_wave_variables_no_background(
+        x, t, amplitude, mode, parity, direction, center, radius, width
+    )["dt(SpatialMetric)"]


### PR DESCRIPTION
## Proposed changes

This is the first in a series of PRs to add finite-radius wave extraction to SpECTRE, by porting the relevant finite-radius wave extraction code from SpEC. This PR ports SpEC's "TeukolskyWave" perturbative pointwise analytic GR solution from SpEC to SpECTRE; this solution will be one important way to test the wave extraction code in future PRs.

### Note on AI usage and implementation
I used codex CLI to prepare the code in this PR. I manually revised the documentation. Codex generated the C++, python, and cmake code. I did two rounds of code review, checking every line of code in this PR for correctness and spectre style. I did not find any apparently unlicensed code in the PR.

The spectre implementation of the metric perturbation and its time derivative very closely tracks the spec implementation.

The unit tests include comparing with a python implementation using random numbers and a comparison with SpEC, where I check that I get the same outputs in both spec and spectre for the same inputs. To make the SpEC test, codex first output results from spec for inputs I chose, then used those outputs to write the test in spectre, and only then ran the test in spectre (it passed).

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
