### PR TITLE
Update GH documentation notation to modern conventions

### DIFF
--- a/src/DataStructures/Variables.hpp
+++ b/src/DataStructures/Variables.hpp
@@ -134,11 +134,11 @@ class Variables<tmpl::list<Tags...>> {
       "reference.");
 
   /// The number of variables of the Variables object is holding. E.g.
-  /// \f$\psi_{ab}\f$ would be counted as one variable.
+  /// \f$g_{ab}\f$ would be counted as one variable.
   static constexpr auto number_of_variables = sizeof...(Tags);
 
   /// The total number of independent components of all the variables. E.g.
-  /// a rank-2 symmetric spacetime Tensor \f$\psi_{ab}\f$ in 3 spatial
+  /// a rank-2 symmetric spacetime Tensor \f$g_{ab}\f$ in 3 spatial
   /// dimensions would have 10 independent components.
   static constexpr size_t number_of_independent_components =
       (... + Tags::type::size());

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BjorhusImpl.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BjorhusImpl.hpp
@@ -22,20 +22,20 @@ namespace gh::BoundaryConditions {
 namespace Bjorhus {
 /*!
  * \brief Computes the expression needed to set boundary conditions on the time
- * derivative of the characteristic field \f$v^{\psi}_{ab}\f$
+ * derivative of the characteristic field \f$v^{g}_{ab}\f$
  *
  * \details In the Bjorhus scheme, the time derivatives of evolved variables are
  * characteristic projected. A constraint-preserving correction term is added
  * here to the resulting characteristic (time-derivative) field:
  *
  * \f{align}
- * \Delta \partial_t v^{\psi}_{ab} = \lambda_{\psi} n^i C_{iab}
+ * \Delta \partial_t v^{g}_{ab} = \lambda_{g} n^i C_{iab}
  * \f}
  *
  * where \f$n^i\f$ is the local unit normal to the external boundary,
- * \f$C_{iab} = \partial_i \psi_{ab} - \Phi_{iab}\f$ is the three-index
- * constraint, and \f$\lambda_{\psi}\f$ is the characteristic speed of the field
- * \f$v^{\psi}_{ab}\f$.
+ * \f$C_{iab} = \partial_i g_{ab} - \Phi_{iab}\f$ is the three-index
+ * constraint, and \f$\lambda_{g}\f$ is the characteristic speed of the field
+ * \f$v^{g}_{ab}\f$.
  */
 template <size_t VolumeDim, typename DataType>
 void constraint_preserving_corrections_dt_v_psi(
@@ -128,13 +128,13 @@ void constraint_preserving_corrections_dt_v_zero(
  *     \left(k_a P^c_b l^d + k_b P^c_a l^d -
  *          \left(k_a l_b k^c l^d + k_b l_a k_c l^d + k_a k_b l^c l^d
  *          \right) \right) \left(\gamma_2 - \frac{1}{r}
- *                          \right) \partial_t v^{\psi}_{cd}
+ *                          \right) \partial_t v^{g}_{cd}
  * \f}
  *
  * where \f$r\f$ is the radial coordinate at the outer boundary, which is
  * assumed to be spherical, \f$\gamma_2\f$ is a GH constraint damping parameter,
- * and \f$\partial_t v^{\psi}_{ab}\f$ is the characteristic projected time
- * derivative of evolved variables (corresponding to the \f$v^{\psi}\f$ field).
+ * and \f$\partial_t v^{g}_{ab}\f$ is the characteristic projected time
+ * derivative of evolved variables (corresponding to the \f$v^{g}\f$ field).
  * Finally, we constrain physical degrees of freedom using corrections from
  * Eq. (68) of \cite Lindblom2005qh :
  *

--- a/src/Evolution/Systems/GeneralizedHarmonic/Characteristics.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Characteristics.hpp
@@ -40,7 +40,7 @@ namespace gh {
  *
  * It computes
  * \f[
- * v_\psi^{\hat{\imath}} = -(1 + \gamma_1) \beta^{\hat{\imath}}
+ * v_g^{\hat{\imath}} = -(1 + \gamma_1) \beta^{\hat{\imath}}
  *                           -(1 + \gamma_1) v^{\hat{\imath}},
  * \f]
  * where \f$\hat{\imath}\f$ is in `SourceFrame`.
@@ -297,7 +297,7 @@ struct VMinusSpeedCompute : VMinusSpeed<DataVector, Dim, SourceFrame>,
  *
  * \f{align*}
  * \mathrm{SpECTRE} && \mathrm{Lindblom} \\
- * u^{\psi}_{ab} && u^\hat{0}_{ab} \\
+ * u^{g}_{ab} && u^\hat{0}_{ab} \\
  * u^0_{iab} && u^\hat{2}_{iab} \\
  * u^{\pm}_{ab} && u^{\hat{1}\pm}_{ab}
  * \f}
@@ -307,7 +307,7 @@ struct VMinusSpeedCompute : VMinusSpeed<DataVector, Dim, SourceFrame>,
  * term used in SpEC and SpECTRE but not published anywhere:
  *
  * \f{align*}
- * v_{\psi} =& -(1 + \gamma_1) n_k \beta^k - (1 + \gamma_1) n_k v^k_g \\
+ * v_{g} =& -(1 + \gamma_1) n_k \beta^k - (1 + \gamma_1) n_k v^k_g \\
  * v_{0} =& -n_k \beta^k - n_k v^k_g\\
  * v_{\pm} =& -n_k \beta^k \pm \alpha - n_k v^k_g
  * \f}
@@ -413,7 +413,7 @@ struct CharacteristicSpeedsOnStrahlkorperCompute
  *
  * \f{align*}
  * \mathrm{SpECTRE} && \mathrm{Lindblom} \\
- * u^{\psi}_{ab} && u^\hat{0}_{ab} \\
+ * u^{g}_{ab} && u^\hat{0}_{ab} \\
  * u^0_{iab} && u^\hat{2}_{iab} \\
  * u^{\pm}_{ab} && u^{\hat{1}\pm}_{ab}
  * \f}
@@ -421,14 +421,14 @@ struct CharacteristicSpeedsOnStrahlkorperCompute
  * The characteristic fields \f$u\f$ are given in terms of the evolved fields by
  * Eq.(32) - (34) of \cite Lindblom2005qh, respectively:
  * \f{align*}
- * u^{\psi}_{ab} =& \psi_{ab} \\
+ * u^{g}_{ab} =& g_{ab} \\
  * u^0_{iab} =& (\delta^k_i - n_i n^k) \Phi_{kab} := P^k_i \Phi_{kab} \\
- * u^{\pm}_{ab} =& \Pi_{ab} \pm n^i \Phi_{iab} - \gamma_2\psi_{ab}
+ * u^{\pm}_{ab} =& \Pi_{ab} \pm n^i \Phi_{iab} - \gamma_2 g_{ab}
  * \f}
  *
- * where \f$\psi_{ab}\f$ is the spacetime metric, \f$\Pi_{ab}\f$ and
+ * where \f$g_{ab}\f$ is the spacetime metric, \f$\Pi_{ab}\f$ and
  * \f$\Phi_{iab}\f$ are evolved generalized harmonic fields introduced by first
- * derivatives of \f$\psi_{ab}\f$, \f$\gamma_2\f$ is a constraint damping
+ * derivatives of \f$g_{ab}\f$, \f$\gamma_2\f$ is a constraint damping
  * parameter, and \f$n_k\f$ is the unit normal to the surface.
  *
  * \ref EvolvedFieldsFromCharacteristicFieldsCompute computes evolved fields
@@ -436,8 +436,8 @@ struct CharacteristicSpeedsOnStrahlkorperCompute
  * above relations:
  *
  * \f{align*}
- * \psi_{ab} =& u^{\psi}_{ab}, \\
- * \Pi_{ab} =& \frac{1}{2}(u^{+}_{ab} + u^{-}_{ab}) + \gamma_2 u^{\psi}_{ab}, \\
+ * g_{ab} =& u^{g}_{ab}, \\
+ * \Pi_{ab} =& \frac{1}{2}(u^{+}_{ab} + u^{-}_{ab}) + \gamma_2 u^{g}_{ab}, \\
  * \Phi_{iab} =& \frac{1}{2}(u^{+}_{ab} - u^{-}_{ab}) n_i + u^0_{iab}.
  * \f}
  *

--- a/src/Evolution/Systems/GeneralizedHarmonic/Constraints.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Constraints.hpp
@@ -31,7 +31,7 @@ namespace gh {
  * \brief Computes the generalized-harmonic 3-index constraint.
  *
  * \details Computes the generalized-harmonic 3-index constraint,
- * \f$C_{iab} = \partial_i\psi_{ab} - \Phi_{iab},\f$ which is
+ * \f$C_{iab} = \partial_i g_{ab} - \Phi_{iab},\f$ which is
  * given by Eq. (26) of \cite Lindblom2005qh
  */
 template <typename DataType, size_t SpatialDim, typename Frame>
@@ -53,16 +53,16 @@ void three_index_constraint(
  * \details Computes the generalized-harmonic gauge constraint
  * [Eq. (40) of \cite Lindblom2005qh],
  * \f[
- * C_a = H_a + g^{ij} \Phi_{ija} + t^b \Pi_{ba}
- * - \frac{1}{2} g^i_a \psi^{bc} \Phi_{ibc}
- * - \frac{1}{2} t_a \psi^{bc} \Pi_{bc},
+ * C_a = H_a + \gamma^{ij} \Phi_{ija} + n^b \Pi_{ba}
+ * - \frac{1}{2} \gamma^i_a g^{bc} \Phi_{ibc}
+ * - \frac{1}{2} n_a g^{bc} \Pi_{bc},
  * \f]
  * where \f$H_a\f$ is the gauge function,
- * \f$\psi_{ab}\f$ is the spacetime metric,
- * \f$\Pi_{ab}=-t^c\partial_c \psi_{ab}\f$, and
- * \f$\Phi_{iab} = \partial_i\psi_{ab}\f$; \f$t^a\f$ is the timelike unit
- * normal vector to the spatial slice, \f$g^{ij}\f$ is the inverse spatial
- * metric, and \f$g^b_c = \delta^b_c + t^b t_c\f$.
+ * \f$g_{ab}\f$ is the spacetime metric,
+ * \f$\Pi_{ab}=-n^c\partial_c g_{ab}\f$, and
+ * \f$\Phi_{iab} = \partial_i g_{ab}\f$; \f$n^a\f$ is the timelike unit
+ * normal vector to the spatial slice, \f$\gamma^{ij}\f$ is the inverse spatial
+ * metric, and \f$\gamma^b_c = \delta^b_c + n^b n_c\f$.
  */
 template <typename DataType, size_t SpatialDim, typename Frame>
 tnsr::a<DataType, SpatialDim, Frame> gauge_constraint(
@@ -93,33 +93,33 @@ void gauge_constraint(
  * \details Computes the generalized-harmonic 2-index constraint
  * [Eq. (44) of \cite Lindblom2005qh],
  * \f{eqnarray}{
- * C_{ia} &\equiv& g^{jk}\partial_j \Phi_{ika}
- * - \frac{1}{2} g_a^j\psi^{cd}\partial_j \Phi_{icd}
- * + t^b \partial_i \Pi_{ba}
- * - \frac{1}{2} t_a \psi^{cd}\partial_i\Pi_{cd}
+ * C_{ia} &\equiv& \gamma^{jk}\partial_j \Phi_{ika}
+ * - \frac{1}{2} \gamma_a^j g^{cd}\partial_j \Phi_{icd}
+ * + n^b \partial_i \Pi_{ba}
+ * - \frac{1}{2} n_a g^{cd}\partial_i\Pi_{cd}
  * \nonumber\\&&
  * + \partial_i H_a
- * + \frac{1}{2} g_a^j \Phi_{jcd} \Phi_{ief}
- * \psi^{ce}\psi^{df}
- * + \frac{1}{2} g^{jk} \Phi_{jcd} \Phi_{ike}
- * \psi^{cd}t^e t_a
+ * + \frac{1}{2} \gamma_a^j \Phi_{jcd} \Phi_{ief}
+ * g^{ce}g^{df}
+ * + \frac{1}{2} \gamma^{jk} \Phi_{jcd} \Phi_{ike}
+ * g^{cd}n^e n_a
  * \nonumber\\&&
- * - g^{jk}g^{mn}\Phi_{jma}\Phi_{ikn}
- * + \frac{1}{2} \Phi_{icd} \Pi_{be} t_a
- *                             \left(\psi^{cb}\psi^{de}
- *                       +\frac{1}{2}\psi^{be} t^c t^d\right)
+ * - \gamma^{jk}\gamma^{mn}\Phi_{jma}\Phi_{ikn}
+ * + \frac{1}{2} \Phi_{icd} \Pi_{be} n_a
+ *                             \left(g^{cb}g^{de}
+ *                       +\frac{1}{2}g^{be} n^c n^d\right)
  * \nonumber\\&&
- * - \Phi_{icd} \Pi_{ba} t^c \left(\psi^{bd}
- *                             +\frac{1}{2} t^b t^d\right)
- * + \frac{1}{2} \gamma_2 \left(t_a \psi^{cd}
- * - 2 \delta^c_a t^d\right) C_{icd}.
+ * - \Phi_{icd} \Pi_{ba} n^c \left(g^{bd}
+ *                             +\frac{1}{2} n^b n^d\right)
+ * + \frac{1}{2} \gamma_2 \left(n_a g^{cd}
+ * - 2 \delta^c_a n^d\right) C_{icd}.
  * \f}
  * where \f$H_a\f$ is the gauge function,
- * \f$\psi_{ab}\f$ is the spacetime metric,
- * \f$\Pi_{ab}=-t^c\partial_c \psi_{ab}\f$, and
- * \f$\Phi_{iab} = \partial_i\psi_{ab}\f$; \f$t^a\f$ is the timelike unit
- * normal vector to the spatial slice, \f$g^{ij}\f$ is the inverse spatial
- * metric, and \f$g^b_c = \delta^b_c + t^b t_c\f$.
+ * \f$g_{ab}\f$ is the spacetime metric,
+ * \f$\Pi_{ab}=-n^c\partial_c g_{ab}\f$, and
+ * \f$\Phi_{iab} = \partial_i g_{ab}\f$; \f$n^a\f$ is the timelike unit
+ * normal vector to the spatial slice, \f$\gamma^{ij}\f$ is the inverse spatial
+ * metric, and \f$\gamma^b_c = \delta^b_c + n^b n_c\f$.
  */
 template <typename DataType, size_t SpatialDim, typename Frame>
 tnsr::ia<DataType, SpatialDim, Frame> two_index_constraint(
@@ -161,7 +161,7 @@ void two_index_constraint(
  * \f{eqnarray}{
  * C_{ijab} = 2 \partial_{[i}\Phi_{j]ab},
  * \f}
- * where \f$\Phi_{iab} = \partial_i\psi_{ab}\f$. Because the constraint is
+ * where \f$\Phi_{iab} = \partial_i g_{ab}\f$. Because the constraint is
  * antisymmetric on the two spatial indices, here we compute and store
  * only the independent components of \f$C_{ijab}\f$. Specifically, we
  * compute
@@ -195,53 +195,53 @@ void four_index_constraint(
  * [Eq. (43) of \cite Lindblom2005qh],
  * \f{eqnarray}{
  * {\cal F}_a &\equiv&
- * \frac{1}{2} g_a^i \psi^{bc}\partial_i \Pi_{bc}
- * - g^{ij} \partial_i \Pi_{ja}
- * - g^{ij} t^b \partial_i \Phi_{jba}
- * + \frac{1}{2} t_a \psi^{bc} g^{ij} \partial_i \Phi_{jbc}
+ * \frac{1}{2} \gamma_a^i g^{bc}\partial_i \Pi_{bc}
+ * - \gamma^{ij} \partial_i \Pi_{ja}
+ * - \gamma^{ij} n^b \partial_i \Phi_{jba}
+ * + \frac{1}{2} n_a g^{bc} \gamma^{ij} \partial_i \Phi_{jbc}
  * \nonumber \\ &&
- * + t_a g^{ij} \partial_i H_j
- * + g_a^i \Phi_{ijb} g^{jk}\Phi_{kcd} \psi^{bd} t^c
- * - \frac{1}{2} g_a^i \Phi_{ijb} g^{jk}
- *   \Phi_{kcd} \psi^{cd} t^b
+ * + n_a \gamma^{ij} \partial_i H_j
+ * + \gamma_a^i \Phi_{ijb} \gamma^{jk}\Phi_{kcd} g^{bd} n^c
+ * - \frac{1}{2} \gamma_a^i \Phi_{ijb} \gamma^{jk}
+ *   \Phi_{kcd} g^{cd} n^b
  * \nonumber \\ &&
- * - g_a^i t^b \partial_i H_b
- * + g^{ij} \Phi_{icd} \Phi_{jba} \psi^{bc} t^d
- * - \frac{1}{2} t_a g^{ij} g^{mn} \Phi_{imc} \Phi_{njd}\psi^{cd}
+ * - \gamma_a^i n^b \partial_i H_b
+ * + \gamma^{ij} \Phi_{icd} \Phi_{jba} g^{bc} n^d
+ * - \frac{1}{2} n_a \gamma^{ij} \gamma^{mn} \Phi_{imc} \Phi_{njd}g^{cd}
  * \nonumber \\ &&
- * - \frac{1}{4}  t_a g^{ij}\Phi_{icd}\Phi_{jbe}
- *    \psi^{cb}\psi^{de}
- * + \frac{1}{4}  t_a \Pi_{cd} \Pi_{be}
- *    \psi^{cb}\psi^{de}
- * - g^{ij} H_i \Pi_{ja}
+ * - \frac{1}{4}  n_a \gamma^{ij}\Phi_{icd}\Phi_{jbe}
+ *    g^{cb}g^{de}
+ * + \frac{1}{4}  n_a \Pi_{cd} \Pi_{be}
+ *    g^{cb}g^{de}
+ * - \gamma^{ij} H_i \Pi_{ja}
  * \nonumber \\ &&
- * - t^b g^{ij} \Pi_{b i} \Pi_{ja}
- * - \frac{1}{4}  g_a^i \Phi_{icd} t^c t^d \Pi_{be}
- *   \psi^{be}
- * + \frac{1}{2} t_a \Pi_{cd} \Pi_{be}\psi^{ce}
- *   t^d t^b
+ * - n^b \gamma^{ij} \Pi_{b i} \Pi_{ja}
+ * - \frac{1}{4}  \gamma_a^i \Phi_{icd} n^c n^d \Pi_{be}
+ *   g^{be}
+ * + \frac{1}{2} n_a \Pi_{cd} \Pi_{be}g^{ce}
+ *   n^d n^b
  * \nonumber \\ &&
- * + g_a^i \Phi_{icd} \Pi_{be} t^c t^b \psi^{de}
- * - g^{ij}\Phi_{iba} t^b \Pi_{je} t^e
- * - \frac{1}{2} g^{ij}\Phi_{icd} t^c t^d \Pi_{ja}
+ * + \gamma_a^i \Phi_{icd} \Pi_{be} n^c n^b g^{de}
+ * - \gamma^{ij}\Phi_{iba} n^b \Pi_{je} n^e
+ * - \frac{1}{2} \gamma^{ij}\Phi_{icd} n^c n^d \Pi_{ja}
  * \nonumber \\ &&
- * - g^{ij} H_i \Phi_{jba} t^b
- * + g_{a}^i \Phi_{icd} H_b \psi^{bc} t^d
- * +\gamma_2\bigl(g^{id}{\cal C}_{ida}
- * -\frac{1}{2}  g_a^i\psi^{cd}{\cal C}_{icd}\bigr)
+ * - \gamma^{ij} H_i \Phi_{jba} n^b
+ * + \gamma_{a}^i \Phi_{icd} H_b g^{bc} n^d
+ * +\gamma_2\bigl(\gamma^{id}{\cal C}_{ida}
+ * -\frac{1}{2}  \gamma_a^i g^{cd}{\cal C}_{icd}\bigr)
  * \nonumber \\ &&
- * + \frac{1}{2} t_a \Pi_{cd}\psi^{cd} H_b t^b
- * - t_a g^{ij} \Phi_{ijc} H_d \psi^{cd}
- * +\frac{1}{2}  t_a g^{ij} H_i \Phi_{jcd}\psi^{cd}
+ * + \frac{1}{2} n_a \Pi_{cd}g^{cd} H_b n^b
+ * - n_a \gamma^{ij} \Phi_{ijc} H_d g^{cd}
+ * +\frac{1}{2}  n_a \gamma^{ij} H_i \Phi_{jcd}g^{cd}
  * \nonumber \\ &&
- * - 16 \pi t^a T_{a b}
+ * - 16 \pi n^a T_{a b}
  * \f}
  * where \f$H_a\f$ is the gauge function,
- * \f$\psi_{ab}\f$ is the spacetime metric,
- * \f$\Pi_{ab}=-t^c\partial_c \psi_{ab}\f$, and
- * \f$\Phi_{iab} = \partial_i\psi_{ab}\f$; \f$t^a\f$ is the timelike unit
- * normal vector to the spatial slice, \f$g^{ij}\f$ is the inverse spatial
- * metric, \f$g^b_c = \delta^b_c + t^b t_c\f$, and \f$T_{a b}\f$ is the
+ * \f$g_{ab}\f$ is the spacetime metric,
+ * \f$\Pi_{ab}=-n^c\partial_c g_{ab}\f$, and
+ * \f$\Phi_{iab} = \partial_i g_{ab}\f$; \f$n^a\f$ is the timelike unit
+ * normal vector to the spatial slice, \f$\gamma^{ij}\f$ is the inverse spatial
+ * metric, \f$\gamma^b_c = \delta^b_c + n^b n_c\f$, and \f$T_{a b}\f$ is the
  * stress-energy tensor if nonzero (if using the overload with no stress-energy
  * tensor provided, the stress energy term is omitted).
  *
@@ -258,9 +258,9 @@ void four_index_constraint(
  * where
  *
  * \f[
- * {\cal C}_a = H_a + g^{i j} \Phi_{ij a} + t^b \Pi_{ba}
- * - \frac{1}{2} g_a{}^i \psi^{bc} \Phi_{i b c}
- * - \frac{1}{2} t_a \psi^{bc} \Pi_{b c}.
+ * {\cal C}_a = H_a + \gamma^{i j} \Phi_{ij a} + n^b \Pi_{ba}
+ * - \frac{1}{2} \gamma_a{}^i g^{bc} \Phi_{i b c}
+ * - \frac{1}{2} n_a g^{bc} \Pi_{b c}.
  * \f].
  *
  * Therefore, the Stress-energy contribution can be calculated from the
@@ -343,13 +343,14 @@ void f_constraint(
  * term in the sum scaled by an arbitrary coefficient],
  * \f{eqnarray}{
  * E & = & K_1 C_a C_a + K_2\left(F_a F_a
-     + C_{ia} C_{ja} g^{ij}\right)\nonumber\\
-     & + & K_3 C_{iab} C_{jab} g^{ij} + K_4 C_{ikab} C_{jlab}g^{ij} g^{kl}.
+     + C_{ia} C_{ja} \gamma^{ij}\right)\nonumber\\
+     & + & K_3 C_{iab} C_{jab} \gamma^{ij} + K_4 C_{ikab} C_{jlab}\gamma^{ij}
+ \gamma^{kl}.
  * \f}
  * Here \f$C_a\f$ is the gauge constraint, \f$F_a\f$ is the f constraint,
  * \f$C_{ia}\f$ is the two-index constraint, \f$C_{iab}\f$ is the
  * three-index constraint, \f$C_{ikab}\f$ is the four-index constraint,
- * \f$g^{ij}\f$ is the inverse spatial metric, and
+ * \f$\gamma^{ij}\f$ is the inverse spatial metric, and
  * \f$K_1\f$, \f$K_2\f$, \f$K_3\f$, and \f$K_4\f$ are constant multipliers
  * for each term that each default to a value of 1.0. Note that in this
  * equation, spacetime indices \f$a,b\f$ are raised and lowered with
@@ -367,67 +368,68 @@ void f_constraint(
  * The result is
  * \f{eqnarray}{
  * E & = & K_1 C_a C_a + K_2\left(F_a F_a
- *       + C_{ia} C_{ja} g^{ij}\right)\nonumber\\
- *   & + & K_3 C_{iab} C_{jab} g^{ij}\nonumber\\
-     & + & 2 K_4 g D_{iab} D_{jab} g^{ij},
- * \f} where \f$g\f$ is the determinant of the spatial metric.
+ *       + C_{ia} C_{ja} \gamma^{ij}\right)\nonumber\\
+ *   & + & K_3 C_{iab} C_{jab} \gamma^{ij}\nonumber\\
+     & + & 2 K_4 \gamma D_{iab} D_{jab} \gamma^{ij},
+ * \f} where \f$\gamma\f$ is the determinant of the spatial metric.
  *
  * To derive this expression for the constraint energy implemented here,
  * Eq.~(53) of \cite Lindblom2005qh is
  * \f{eqnarray}{
  * S_{AB} dc^A dc^B &=&
  *      m^{ab}\Bigl[d F_ad F_b
- *      +g^{ij}\bigl(d C_{ia}d C_{jb}
- *      +g^{kl}m^{cd}d C_{ikac}d C_{jlbd}\bigr)
+ *      +\gamma^{ij}\bigl(d C_{ia}d C_{jb}
+ *      +\gamma^{kl}m^{cd}d C_{ikac}d C_{jlbd}\bigr)
  * \nonumber\\
  *      & + & \Lambda^2\bigl(d C_ad C_b
- *      +g^{ij}m^{cd}d C_{iac}d C_{jbd}\bigr)
+ *      +\gamma^{ij}m^{cd}d C_{iac}d C_{jbd}\bigr)
  * \Bigr].
  * \f} Replace \f$dc^A\rightarrow c^A\f$ to get
  * \f{eqnarray}{
  * E&=&
  *      m^{ab}\Bigl[ F_a F_b
- *      +g^{ij}\bigl( C_{ia} C_{jb}
- *      +g^{kl}m^{cd} C_{ikac} C_{jlbd}\bigr)
+ *      +\gamma^{ij}\bigl( C_{ia} C_{jb}
+ *      +\gamma^{kl}m^{cd} C_{ikac} C_{jlbd}\bigr)
  * \nonumber\\
  *      & + & \Lambda^2\bigl( C_a C_b
- *      +g^{ij}m^{cd} C_{iac} C_{jbd}\bigr)
+ *      +\gamma^{ij}m^{cd} C_{iac} C_{jbd}\bigr)
  * \Bigr]\nonumber\\
  * &=&
  *      m^{ab} F_a F_b
- *      +m^{ab}g^{ij} C_{ia} C_{jb}
- *      +m^{ab}g^{ij} g^{kl}m^{cd} C_{ikac} C_{jlbd}
+ *      +m^{ab}\gamma^{ij} C_{ia} C_{jb}
+ *      +m^{ab}\gamma^{ij} \gamma^{kl}m^{cd} C_{ikac} C_{jlbd}
  * \nonumber\\
  *      & + & m^{ab}\Lambda^2 C_a C_b
- *      +m^{ab}\Lambda^2 g^{ij}m^{cd} C_{iac} C_{jbd}.
+ *      +m^{ab}\Lambda^2 \gamma^{ij}m^{cd} C_{iac} C_{jbd}.
  * \f} Here \f$m^{ab}\f$ is an arbitrary positive-definite matrix, and
  * \f$\Lambda\f$ is an arbitrary real scalar.
  * Choose \f$m^{ab} = \delta^{ab}\f$ but allow an arbitrary coefficient to be
  * placed in front of each term. Then, absorb \f$\Lambda^2\f$ into one of
  * these coefficients, to get
  * \f{eqnarray}{ E &=& K_
- * F\delta^{ab} F_a F_b +K_2\delta^{ab}g^{ij} C_{ia} C_{jb}
- +K_4\delta^{ab}g^{ij}
- * g^{kl}\delta^{cd} C_{ikac} C_{jlbd}
+ * F\delta^{ab} F_a F_b +K_2\delta^{ab}\gamma^{ij} C_{ia} C_{jb}
+ +K_4\delta^{ab}\gamma^{ij}
+ * \gamma^{kl}\delta^{cd} C_{ikac} C_{jlbd}
  * \nonumber\\
  *      & + & K_1\delta^{ab} C_a C_b
- *      +K_3\delta^{ab} g^{ij}\delta^{cd} C_{iac} C_{jbd}.
+ *      +K_3\delta^{ab} \gamma^{ij}\delta^{cd} C_{iac} C_{jbd}.
  * \f}
  * Adopting a Euclidean norm for the constraint space (i.e., choosing to raise
  and
  * lower spacetime indices with Kronecker deltas) gives
  * \f{eqnarray}{ E &=& K_ F
- * F_a F_a +K_2g^{ij} C_{ia} C_{ja} +K_4 g^{ij} g^{kl} C_{ikac} C_{jlac}
+ * F_a F_a +K_2\gamma^{ij} C_{ia} C_{ja} +K_4 \gamma^{ij} \gamma^{kl} C_{ikac}
+ C_{jlac}
  * \nonumber\\
  *      & + & K_1 C_a C_a
- *      +K_3g^{ij} C_{iac} C_{jac}.
+ *      +K_3\gamma^{ij} C_{iac} C_{jac}.
  * \f} The two-index constraint and f constraint can be viewed as the
  * time and space components of a combined spacetime constraint. So next
  * choose
  * \f$K_ F=K_2\f$, giving \f{eqnarray}{ E&=& K_1 C_a C_a + K_2\left(F_a F_a
- *      + C_{ia} C_{ja} g^{ij}\right)\nonumber\\
- *      & + & K_3 C_{iab} C_{jab} g^{ij}
- *      + K_4 C_{ikab} C_{jlab}g^{ij} g^{kl}.
+ *      + C_{ia} C_{ja} \gamma^{ij}\right)\nonumber\\
+ *      & + & K_3 C_{iab} C_{jab} \gamma^{ij}
+ *      + K_4 C_{ikab} C_{jlab}\gamma^{ij} \gamma^{kl}.
  * \f}
  *
  * Note that \f$C_{ikab}\f$ is antisymmetric on the first two indices. Next,
@@ -444,81 +446,87 @@ void f_constraint(
  * to replace \f$C_{jkab}\f$ with \f$D_{iab}\f$ gives \f{eqnarray}{ E &=& K_1
  C_a
  * C_a + K_2\left(F_a F_a
- *      + C_{ia} C_{ja} g^{ij}\right)\nonumber\\
- *      & + & K_3 C_{iab} C_{jab} g^{ij}\nonumber\\
+ *      + C_{ia} C_{ja} \gamma^{ij}\right)\nonumber\\
+ *      & + & K_3 C_{iab} C_{jab} \gamma^{ij}\nonumber\\
  *      & + & K_4 D_{mab} D_{nab} \epsilon^{m}{}_{ik}
- *      \epsilon^{n}{}_{jl} g^{ij} g^{kl}. \f}
+ *      \epsilon^{n}{}_{jl} \gamma^{ij} \gamma^{kl}. \f}
  *
- * There's a subtle point here: \f$g^{ij}\f$ is the inverse spatial metric,
+ * There's a subtle point here: \f$\gamma^{ij}\f$ is the inverse spatial metric,
  which
  * is not necessarily flat. But \f$\epsilon^{i}{}_{jk}\f$ is the flat space
  * Levi-Civita tensor. In order to raise and lower indices of the Levi-Civita
  * tensor with the inverse spatial metrics, put in the appropriate factors of
- * \f$\sqrt{g}\f$, where \f$g\f$ is the metric determinant, to make the
- * curved-space Levi-Civita tensor compatible with \f$g^{ij}\f$. Let
+ * \f$\sqrt{\gamma}\f$, where \f$\gamma\f$ is the metric determinant, to make
+ the
+ * curved-space Levi-Civita tensor compatible with \f$\gamma^{ij}\f$. Let
  * \f$\varepsilon^{ijk}\f$ represent the curved space Levi-Civita tensor
  compatible
- * with \f$g^{ij}\f$: \f{eqnarray}{
- * \varepsilon^{mik} = g^{-1/2} \epsilon^{mik}\\
- * \varepsilon_{mik} = g^{1/2} \epsilon_{mik}.
+ * with \f$\gamma^{ij}\f$: \f{eqnarray}{
+ * \varepsilon^{mik} = \gamma^{-1/2} \epsilon^{mik}\\
+ * \varepsilon_{mik} = \gamma^{1/2} \epsilon_{mik}.
  * \f} Then we can write the constraint energy as
  * \f{eqnarray}{
  * E &=& K_1 C_a C_a + K_2\left(F_a F_a
- *      + C_{ia} C_{ja} g^{ij}\right)\nonumber\\
- *      & + & K_3 C_{iab} C_{jab} g^{ij}\nonumber\\
- *      & + & K_4 D_{mab} D_{nab} g g^{-1/2}\epsilon^{m}{}_{ik}
- * g^{-1/2}\epsilon^{n}{}_{jl} g^{ij} g^{kl}. \f} The factors of
- * \f$g^{-1/2}\f$ make the Levi-Civita tensor compatible with \f$g^{ij}\f$.
+ *      + C_{ia} C_{ja} \gamma^{ij}\right)\nonumber\\
+ *      & + & K_3 C_{iab} C_{jab} \gamma^{ij}\nonumber\\
+ *      & + & K_4 D_{mab} D_{nab} \gamma \gamma^{-1/2}\epsilon^{m}{}_{ik}
+ * \gamma^{-1/2}\epsilon^{n}{}_{jl} \gamma^{ij} \gamma^{kl}. \f} The factors of
+ * \f$\gamma^{-1/2}\f$ make the Levi-Civita tensor compatible with
+ \f$\gamma^{ij}\f$.
  * Swapping which summed indices are raised and which are lowered gives
  * \f{eqnarray}{ E &=& K_1 C_a
  C_a +
  * K_2\left(F_a F_a
- *      + C_{ia} C_{ja} g^{ij}\right)\nonumber\\
- *      & + & K_3 C_{iab} C_{jab} g^{ij}\nonumber\\
- *      & + & K_4 D_{mab} D_{nab} g g^{-1/2}\epsilon^{mik}
- g^{-1/2}\epsilon^{njl}
- * g_{ij} g_{kl}, \f} or \f{eqnarray}{ E &=& K_1 C_a C_a + K_2\left(F_a F_a
- *      + C_{ia} C_{ja} g^{ij}\right)\nonumber\\
- *      & + & K_3 C_{iab} C_{jab} g^{ij}\nonumber\\
- *      & + & K_4 D_{mab} D_{nab} g \varepsilon^{mik} \varepsilon^{njl} g_{ij}
- * g_{kl}, \f} or, reversing up and down repeated indices again,
+ *      + C_{ia} C_{ja} \gamma^{ij}\right)\nonumber\\
+ *      & + & K_3 C_{iab} C_{jab} \gamma^{ij}\nonumber\\
+ *      & + & K_4 D_{mab} D_{nab} \gamma \gamma^{-1/2}\epsilon^{mik}
+ \gamma^{-1/2}\epsilon^{njl}
+ * \gamma_{ij} \gamma_{kl}, \f} or \f{eqnarray}{ E &=& K_1 C_a C_a +
+ K_2\left(F_a F_a
+ *      + C_{ia} C_{ja} \gamma^{ij}\right)\nonumber\\
+ *      & + & K_3 C_{iab} C_{jab} \gamma^{ij}\nonumber\\
+ *      & + & K_4 D_{mab} D_{nab} \gamma \varepsilon^{mik} \varepsilon^{njl}
+ \gamma_{ij}
+ * \gamma_{kl}, \f} or, reversing up and down repeated indices again,
  * \f{eqnarray}{ E
  * &=& K_1 C_a C_a + K_2\left(F_a F_a
- *      + C_{ia} C_{ja} g^{ij}\right)\nonumber\\
- *      & + & K_3 C_{iab} C_{jab} g^{ij}\nonumber\\
- *      & + & K_4 D_{mab} D_{nab} g \varepsilon^{m}{}_{ik}
+ *      + C_{ia} C_{ja} \gamma^{ij}\right)\nonumber\\
+ *      & + & K_3 C_{iab} C_{jab} \gamma^{ij}\nonumber\\
+ *      & + & K_4 D_{mab} D_{nab} \gamma \varepsilon^{m}{}_{ik}
  \varepsilon^{n}{}_{jl}
- * g^{ij} g^{kl}. \f}
+ * \gamma^{ij} \gamma^{kl}. \f}
  *
  * The metric raises and lowers the indices of \f$\varepsilon^{ijk}\f$,
  * so this can
  * be written as \f{eqnarray}{ E &=& K_1 C_a C_a + K_2\left(F_a F_a
- *      + C_{ia} C_{ja} g^{ij}\right)\nonumber\\
- *      & + & K_3 C_{iab} C_{jab} g^{ij}\nonumber\\
- *      & + & K_4 g D_{mab} D^{n}{}_{ab} \varepsilon^{mjl} \varepsilon_{njl}.
+ *      + C_{ia} C_{ja} \gamma^{ij}\right)\nonumber\\
+ *      & + & K_3 C_{iab} C_{jab} \gamma^{ij}\nonumber\\
+ *      & + & K_4 \gamma D_{mab} D^{n}{}_{ab} \varepsilon^{mjl}
+ \varepsilon_{njl}.
  * \f}
  *
  * Now, in flat space (Eq. (1.23) of \cite ThorneBlandford2017),
  * \f{eqnarray}{
  * \epsilon^{mjl} \epsilon_{njl} = \delta^{mj}_{nj} = \delta^m_n \delta^j_j -
  * \delta^m_j \delta^j_n = 2 \delta^m_n. \f} But this holds for curved space
- * as well: multiply the left hand side by \f$1 = g^{1/2} g^{-1/2}\f$ to get
+ * as well: multiply the left hand side by \f$1 = \gamma^{1/2} \gamma^{-1/2}\f$
+ to get
  * \f{eqnarray}{
- * g^{-1/2}\epsilon^{mjl} g^{1/2}\epsilon_{njl} = \varepsilon^{mjl}
+ * \gamma^{-1/2}\epsilon^{mjl} \gamma^{1/2}\epsilon_{njl} = \varepsilon^{mjl}
  * \varepsilon_{njl} = \delta^{mj}_{nj} = \delta^m_n \delta^j_j - \delta^m_j
  * \delta^j_n = 2 \delta^m_n. \f} So the constraint energy is \f{eqnarray}{ E
  &=&
  * K_1 C_a C_a + K_2\left(F_a F_a
- *      + C_{ia} C_{ja} g^{ij}\right)\nonumber\\
- *      & + & K_3 C_{iab} C_{jab} g^{ij}\nonumber\\
+ *      + C_{ia} C_{ja} \gamma^{ij}\right)\nonumber\\
+ *      & + & K_3 C_{iab} C_{jab} \gamma^{ij}\nonumber\\
  *      & + & 2 K_4 D_{mab} D^{n}{}_{ab} \delta^m_n.
  * \f}
  * Simplifying gives the formula implemented here:
  * \f{eqnarray}{
  * E &=& K_1 C_a C_a + K_2\left(F_a F_a
- *      + C_{ia} C_{ja} g^{ij}\right)\nonumber\\
- *      & + & K_3 C_{iab} C_{jab} g^{ij}\nonumber\\
- *      & + & 2 K_4 g D_{iab} D_{jab} g^{ij}.
+ *      + C_{ia} C_{ja} \gamma^{ij}\right)\nonumber\\
+ *      & + & K_3 C_{iab} C_{jab} \gamma^{ij}\nonumber\\
+ *      & + & 2 K_4 \gamma D_{iab} D_{jab} \gamma^{ij}.
  * \f}
  */
 template <typename DataType, size_t SpatialDim, typename Frame>

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.cpp
@@ -183,9 +183,9 @@ void damped_harmonic_impl(
                       spacetime_metric.get(i + 1, j + 1), 0, num_points);
     }
   }
-  // We need \f$ \partial_a g_{bi} = \partial_a \psi_{bi} \f$. Here we
+  // We need \f$ \partial_a \gamma_{bi} = \partial_a g_{bi} \f$. Here we
   // use `derivatives_of_spacetime_metric` to get \f$ \partial_a g_{bc}\f$
-  // instead, and use only the derivatives of \f$ g_{bi}\f$.
+  // instead, and use only the derivatives of \f$ \gamma_{bi}\f$.
   const tnsr::ii<DataVector, SpatialDim, Frame> d0_spatial_metric{};
   for (size_t i = 0; i < SpatialDim; ++i) {
     for (size_t j = i; j < SpatialDim; ++j) {
@@ -222,15 +222,16 @@ void damped_harmonic_impl(
   get(mu_L2) = amp_coef_L2 * roll_on * get(weight) * get(pow3);
   get(mu_S_over_lapse) = get(mu_S) * get(one_over_lapse);
 
-  // Calc \f$ \mu_1 = \mu_{L1} log(rootg/N) = R W log(rootg/N)^5\f$
+  // Calc \f$ \mu_1 = \mu_{L1} \log(\sqrt{\gamma}/\alpha) = R W
+  // \log(\sqrt{\gamma}/\alpha)^5\f$
   get(mu1) = get(mu_L1) * get(log_fac_1);
 
-  // Calc \f$ \mu_2 = \mu_{L2} log(1/N) = R W log(1/N)^5\f$
+  // Calc \f$ \mu_2 = \mu_{L2} \log(1/\alpha) = R W \log(1/\alpha)^5\f$
   get(mu2) = get(mu_L2) * get(log_fac_2);
 
   get(prefac) = get(mu_L1) * get(log_fac_1) + get(mu_L2) * get(log_fac_2);
 
-  // Compute g_ai shift^i
+  // Compute g_{ai} shift^i
   for (size_t a = 0; a < SpatialDim + 1; ++a) {
     spacetime_metric_dot_shift.get(a) =
         spacetime_metric.get(a, 1) * shift.get(0);
@@ -304,11 +305,11 @@ void damped_harmonic_impl(
     }
   };
   // \partial_a \mu_{S} = \partial_a(A_S R_S W
-  //                               \log(\sqrt{g}/N)^{c_{S}})
+  //                               \log(\sqrt{\gamma}/\alpha)^{c_{S}})
   // \partial_a \mu_1 = \partial_a(A_L1 R_L1 W
-  //                               \log(\sqrt{g}/N)^{1+c_{L1}})
+  //                               \log(\sqrt{\gamma}/\alpha)^{1+c_{L1}})
   // \partial_a \mu_2 = \partial_a(A_L2 R_L2 W
-  //                               \log(1/N)^{1+c_{L2}})
+  //                               \log(1/\alpha)^{1+c_{L2}})
   spacetime_deriv_of_power_log_factor_metric_lapse(
       make_not_null(&d4_log_fac_mu1), exp_fac_1, exp_L1 + 1);
   spacetime_deriv_of_power_log_factor_metric_lapse(
@@ -376,8 +377,8 @@ void damped_harmonic_impl(
         + (get(mu1) + get(mu2)) * get(lapse) * half_phi_two_normals.get(i);
   }
 
-  // \f[ \partial_a (\mu_S/N) = (1/N) \partial_a \mu_{S}
-  //         - (\mu_{S}/N^2) \partial_a N
+  // \f[ \partial_a (\mu_S/\alpha) = (1/\alpha) \partial_a \mu_{S}
+  //         - (\mu_{S}/\alpha^2) \partial_a \alpha
   // \f]
   //
   // Note that the d4_lapse terms are actually

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.hpp
@@ -39,19 +39,21 @@ namespace gauges {
  *
  * \f{align*}
  * H_a :=  [1 - R(t)] H_a^\mathrm{init} +
- *  [\mu_{L1} \mathrm{log}(\sqrt{g}/N) + \mu_{L2} \mathrm{log}(1/N)] t_a
- *   - \mu_S g_{ai} N^i / N
+ *  [\mu_{L1} \mathrm{log}(\sqrt{\gamma}/\alpha) + \mu_{L2}
+ * \mathrm{log}(1/\alpha)] n_a
+ *   - \mu_S \gamma_{ai} \beta^i / \alpha
  * \f}
  *
- * where \f$N, N^k\f$ are the lapse and shift respectively, \f$t_a\f$ is the
- * unit normal one-form to the spatial slice, and \f$g_{ab}\f$ is
+ * where \f$\alpha, \beta^k\f$ are the lapse and shift respectively, \f$n_a\f$
+ * is the unit normal one-form to the spatial slice, and \f$\gamma_{ab}\f$ is
  * the spatial metric (obtained by projecting the spacetime metric onto the
- * 3-slice, i.e. \f$g_{ab} = \psi_{ab} + t_a t_b\f$). The prefactors are:
+ * 3-slice, i.e. \f$\gamma_{ab} = g_{ab} + n_a n_b\f$). The prefactors are:
  *
  * \f{align*}
- *  \mu_{L1} &= A_{L1} R(t) W(x^i) \mathrm{log}(\sqrt{g}/N)^{e_{L1}}, \\
- *  \mu_{L2} &= A_{L2} R(t) W(x^i) \mathrm{log}(1/N)^{e_{L2}}, \\
- *  \mu_{S} &= A_{S} R(t) W(x^i) \mathrm{log}(\sqrt{g}/N)^{e_{S}},
+ *  \mu_{L1} &= A_{L1} R(t) W(x^i) \mathrm{log}(\sqrt{\gamma}/\alpha)^{e_{L1}},
+ * \\
+ *  \mu_{L2} &= A_{L2} R(t) W(x^i) \mathrm{log}(1/\alpha)^{e_{L2}}, \\
+ *  \mu_{S} &= A_{S} R(t) W(x^i) \mathrm{log}(\sqrt{\gamma}/\alpha)^{e_{S}},
  * \f}
  *
  * temporal roll-on function \f$ R(t)\f$ is:
@@ -94,9 +96,10 @@ namespace gauges {
  *
  * \f{align*}
  * T_1 =& [1 - R(t)] H_a^\mathrm{init}, \\
- * T_2 =& [\mu_{L1} \mathrm{log}(\sqrt{g}/N) + \mu_{L2} \mathrm{log}(1/N)] t_a,
+ * T_2 =& [\mu_{L1} \mathrm{log}(\sqrt{\gamma}/\alpha) + \mu_{L2}
+ * \mathrm{log}(1/\alpha)] n_a,
  * \\
- * T_3 =& - \mu_S g_{ai} N^i / N.
+ * T_3 =& - \mu_S \gamma_{ai} \beta^i / \alpha.
  * \f}
  *
  * Derivation:
@@ -108,30 +111,32 @@ namespace gauges {
  *                - H_b^\mathrm{init} \partial_a R.
  * \f}
  *
- * \f$\blacksquare\f$ Write \f$ T_2 \equiv (\mu_1 + \mu_2) t_b \f$. Then:
+ * \f$\blacksquare\f$ Write \f$ T_2 \equiv (\mu_1 + \mu_2) n_b \f$. Then:
  *
  * \f{align*}
- * \partial_a T_2 =& (\partial_a \mu_1 + \partial_a \mu_2) t_b \\
- *               +& (\mu_1 + \mu_2) \partial_a t_b,
+ * \partial_a T_2 =& (\partial_a \mu_1 + \partial_a \mu_2) n_b \\
+ *               +& (\mu_1 + \mu_2) \partial_a n_b,
  * \f}
  *
  * where
  *
  * \f{align*}
- * \partial_a t_b =& \left(-\partial_a N, 0, 0, 0\right) \\
+ * \partial_a n_b =& \left(-\partial_a \alpha, 0, 0, 0\right) \\
  *
  * \partial_a \mu_1
- *  =& \partial_a [A_{L1} R(t) W(x^i) \mathrm{log}(\sqrt{g}/N)^{e_{L1} +
+ *  =& \partial_a [A_{L1} R(t) W(x^i) \mathrm{log}(\sqrt{\gamma}/\alpha)^{e_{L1}
+ * +
  * 1}], \\
- *  =& A_{L1} R(t) W(x^i) \partial_a [\mathrm{log}(\sqrt{g}/N)^{e_{L1} +
+ *  =& A_{L1} R(t) W(x^i) \partial_a [\mathrm{log}(\sqrt{\gamma}/\alpha)^{e_{L1}
+ * +
  * 1}] \\
- *   +& A_{L1} \mathrm{log}(\sqrt{g}/N)^{e_{L1} + 1} \partial_a [R(t)
+ *   +& A_{L1} \mathrm{log}(\sqrt{\gamma}/\alpha)^{e_{L1} + 1} \partial_a [R(t)
  * W(x^i)],\\
  *
  * \partial_a \mu_2
- *  =& \partial_a [A_{L2} R(t) W(x^i) \mathrm{log}(1/N)^{e_{L2} + 1}], \\
- *  =& A_{L2} R(t) W(x^i) \partial_a [\mathrm{log}(1/N)^{e_{L2} + 1}] \\
- *     +& A_{L2} \mathrm{log}(1/N)^{e_{L2} + 1} \partial_a [R(t) W(x^i)],
+ *  =& \partial_a [A_{L2} R(t) W(x^i) \mathrm{log}(1/\alpha)^{e_{L2} + 1}], \\
+ *  =& A_{L2} R(t) W(x^i) \partial_a [\mathrm{log}(1/\alpha)^{e_{L2} + 1}] \\
+ *     +& A_{L2} \mathrm{log}(1/\alpha)^{e_{L2} + 1} \partial_a [R(t) W(x^i)],
  * \f}
  *
  * where \f$\partial_a [R W] = \left(\partial_0 R(t), \partial_i
@@ -140,23 +145,22 @@ namespace gauges {
  * \f$\blacksquare\f$ Finally, the derivatives of \f$ T_3 \f$ are:
  *
  * \f[
- * \partial_a T_3 = -\partial_a(\mu_S/N) g_{bi} N^i
- *                  -(\mu_S/N) \partial_a(g_{bi}) N^i
- *                  -(\mu_S/N) g_{bi}\partial_a N^i,
+ * \partial_a T_3 = -\partial_a(\mu_S/\alpha) \gamma_{bi} \beta^i
+ *                  -(\mu_S/\alpha) \partial_a(\gamma_{bi}) \beta^i
+ *                  -(\mu_S/\alpha) \gamma_{bi}\partial_a \beta^i,
  * \f]
  *
  * where
  *
  * \f{align*}
- * \partial_a(\mu_S / N) =& (1/N)\partial_a \mu_S
- *                       - \frac{\mu_S}{N^2}\partial_a N, \,\,\mathrm{and}\\
- * \partial_a \mu_S =& \partial_a [A_S R(t) W(x^i)
- * \mathrm{log}(\sqrt{g}/N)^{e_S}], \\
+ * \partial_a(\mu_S / \alpha) =& (1/\alpha)\partial_a \mu_S
+ *                       - \frac{\mu_S}{\alpha^2}\partial_a \alpha,
+ * \,\,\mathrm{and}\\ \partial_a \mu_S =& \partial_a [A_S R(t) W(x^i)
+ * \mathrm{log}(\sqrt{\gamma}/\alpha)^{e_S}], \\
  *                  =& A_S R(t) W(x^i) \partial_a
- * [\mathrm{log}(\sqrt{g}/N)^{e_S}] \\
- *                  +& A_S \mathrm{log}(\sqrt{g} / N)^{e_S} \partial_a [R(t)
- * W(x^i)].
- * \f}
+ * [\mathrm{log}(\sqrt{\gamma}/\alpha)^{e_S}] \\
+ *                  +& A_S \mathrm{log}(\sqrt{\gamma} / \alpha)^{e_S} \partial_a
+ * [R(t) W(x^i)]. \f}
  */
 template <size_t SpatialDim, typename Frame>
 void damped_harmonic_rollon(

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedWaveHelpers.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedWaveHelpers.hpp
@@ -54,7 +54,7 @@ void spacetime_deriv_of_spatial_weight_function(
 /*
  * The log factor that appears in damped harmonic gauge source function.
  *
- * Calculates:  \f$ logF = \mathrm{log}(g^p/N) \f$.
+ * Calculates:  \f$ logF = \mathrm{log}(\gamma^p/\alpha) \f$.
  */
 template <typename DataType>
 void log_factor_metric_lapse(gsl::not_null<Scalar<DataType>*> logfac,

--- a/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
@@ -18,10 +18,10 @@ namespace Tags {
 /*!
  * \brief Conjugate momentum to the spacetime metric.
  *
- * \details If \f$ \psi_{ab} \f$ is the spacetime metric, and \f$ N \f$ and
- * \f$ N^i \f$ are the lapse and shift respectively, then we define
- * \f$ \Pi_{ab} = -\frac{1}{N} ( \partial_t \psi_{ab} + N^{i} \Phi_{iab} ) \f$
- * where \f$\Phi_{iab}\f$ is the variable defined by the tag Phi.
+ * \details If \f$ g_{ab} \f$ is the spacetime metric, and \f$ \alpha \f$ and
+ * \f$ \beta^i \f$ are the lapse and shift respectively, then we define
+ * \f$ \Pi_{ab} = -\frac{1}{\alpha} ( \partial_t g_{ab} + \beta^{i} \Phi_{iab} )
+ * \f$ where \f$\Phi_{iab}\f$ is the variable defined by the tag Phi.
  */
 template <typename DataType, size_t Dim, typename Frame>
 struct Pi : db::SimpleTag {
@@ -31,8 +31,8 @@ struct Pi : db::SimpleTag {
 /*!
  * \brief Auxiliary variable which is analytically the spatial derivative of the
  * spacetime metric
- * \details If \f$\psi_{ab}\f$ is the spacetime metric then we define
- * \f$\Phi_{iab} = \partial_i \psi_{ab}\f$
+ * \details If \f$g_{ab}\f$ is the spacetime metric then we define
+ * \f$\Phi_{iab} = \partial_i g_{ab}\f$
  */
 template <typename DataType, size_t Dim, typename Frame>
 struct Phi : db::SimpleTag {


### PR DESCRIPTION
## Proposed changes

Replace outdated notation in GH code documentation:
- \psi_{ab} -> g_{ab} (spacetime metric)
- N -> \alpha (lapse), N^i -> \beta^i (shift)
- g^{ij}/g_{ij} (spatial metric) -> \gamma^{ij}/\gamma_{ij}
- g^b_c, g_a^i etc. (spatial projectors) -> \gamma^b_c, \gamma_a^i
- t^a/t_a (timelike unit normal) -> n^a/n_a
- u^{\psi}_{ab}/v_\psi (char field/speed) -> u^{g}_{ab}/v_g
- \sqrt{g}/N (spatial det/lapse) -> \sqrt{\gamma}/\alpha

Files updated: Tags.hpp, Constraints.hpp, Characteristics.hpp, BjorhusImpl.hpp, DampedHarmonic.hpp/cpp, DampedWaveHelpers.hpp, Variables.hpp

@geoffrey4444  I think this takes care of a lot from #1514, but I'll leave the issue assigned to you so you can verify and fix anything else. That issues been open for almost 7 years now...

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
