### PR TITLE
Add ResignCommits.sh to re-attribute and sign container commits

### DIFF
--- a/tools/ResignCommits.sh
+++ b/tools/ResignCommits.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# Re-attributes a range of commits from the given starting commit hash to HEAD,
+# resetting the author and committer to the current git identity. Signing is
+# controlled by the git config (commit.gpgsign). Intended to be run outside the
+# container after a Claude Code session.
+#
+# Usage: ResignCommits.sh <first-commit-hash>
+
+set -e
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <first-commit-hash>"
+    echo ""
+    echo "Re-attributes all commits from <first-commit-hash> to HEAD"
+    echo "using the current git user.name and user.email."
+    exit 1
+fi
+
+FIRST_COMMIT="$1"
+
+# Verify the commit exists
+if ! git cat-file -e "${FIRST_COMMIT}^{commit}" 2>/dev/null; then
+    echo "Error: '${FIRST_COMMIT}' is not a valid commit in this repository."
+    exit 2
+fi
+
+# Abort if any merge commits exist in the range
+MERGE_COMMITS=$(git rev-list --merges "${FIRST_COMMIT}^..HEAD")
+if [ -n "${MERGE_COMMITS}" ]; then
+    echo "Error: Merge commits found in the range ${FIRST_COMMIT}..HEAD."
+    echo "ResignCommits.sh is not designed to handle merge commits."
+    echo ""
+    echo "Merge commits in range:"
+    git log --oneline --merges "${FIRST_COMMIT}^..HEAD"
+    exit 3
+fi
+
+echo "Re-attributing commits from ${FIRST_COMMIT} to HEAD..."
+AMEND_CMD='git commit --amend --no-edit --reset-author'
+git rebase --exec "${AMEND_CMD}" "${FIRST_COMMIT}^"
+
+echo ""
+echo "Done. Verify with: git log --show-signature"


### PR DESCRIPTION
## Proposed changes

When working in a container, especially when using a coding agent like Claude Code in a container, I don't forward my PGP key or the normal git credentials. This is for security and privacy reasons. However, before pushing to GitHub I want the commits to be updated with the correct author from outside the container and by signing the commit with a PGP key.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
