### PR TITLE
Add Claude review skill

### DIFF
--- a/.claude/skills/spectre-review/SKILL.md
+++ b/.claude/skills/spectre-review/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: spectre-review
+description: SpECTRE code review (PR or local commits)
+argument-hint: "[PR#] [clang-tidy] [coverage]"
+allowed-tools: ["Bash", "Read", "Grep", "Glob", "Agent", "AskUserQuestion", "TaskCreate", "TaskUpdate", "TaskList"]
+disable-model-invocation: true
+---
+
+Read and follow instructions in file
+`$(git rev-parse --show-toplevel)/.skills/spectre-review/SKILL.md`

--- a/.skills/spectre-review/SKILL.md
+++ b/.skills/spectre-review/SKILL.md
@@ -1,0 +1,172 @@
+# SpECTRE Code Review
+
+**Arguments**: $ARGUMENTS
+**Current branch**: !`git branch --show-current`
+
+Perform a thorough code review of SpECTRE changes. Follow every step below
+precisely. Read `references/spectre-rules.md` for the full SpECTRE code rules
+reference -- provide it to review agents.
+
+## Step 1: Parse Arguments & Acquire Diff
+
+Parse `$ARGUMENTS`:
+- **Number present** (e.g. `1234`): PR mode. Fetch with:
+  `gh pr diff <N> --repo sxs-collaboration/spectre` and
+  `gh pr view <N> --repo sxs-collaboration/spectre --json
+  title,body,headRefName,baseRefName`
+- **No number**: Local mode. Use `git diff develop...HEAD` for committed
+  changes, plus `git diff` and `git diff --cached` for uncommitted changes. If
+  no diff, fall back to `git diff HEAD~1`.
+- **"clang-tidy" present**: Enable the clang-tidy step.
+- **"coverage" present**: Enable the targeted code coverage step.
+
+Save the diff. Extract the list of changed files categorized by type (C++
+`.cpp/.hpp/.tpp`, Python `.py`, CMake `CMakeLists.txt`, other).
+
+Create a task list tracking all review steps.
+
+## Step 2: Formatting Checks (run in parallel)
+
+### C++ (clang-format)
+For each changed C++ file:
+1. Parse diff hunk headers (`@@ +START,COUNT @@`) to get changed line ranges
+2. Expand each range by +/-4 lines (clamped to file bounds)
+3. Run: `clang-format -style=file --lines=START:END [--lines=...] FILEPATH`
+4. Diff against original. Collect any formatting differences.
+
+### Python (black + isort)
+For each changed `.py` file (excluding `external/`):
+```
+black --check --diff FILEPATH
+isort --check-only --diff FILEPATH
+```
+
+## Step 3: CI Pre-Checks on Changed Files
+
+Check each changed file for issues that SpECTRE CI (`tools/FileTestDefs.sh`,
+`tools/CheckFiles.sh`) will flag. Only check lines/patterns introduced in the
+diff, not pre-existing issues.
+
+**All files**: lines >80 chars (excluding URLs, NOLINT, #include, \snippet,
+\image, \link, import); missing MIT license header; no final newline; tabs;
+trailing whitespace; carriage returns
+
+**C++ files (.cpp/.hpp/.tpp)**:
+- Missing `#pragma once` in headers
+- `#include <iostream>` -> use `Parallel/Printf/Printf.hpp`
+- `#include <lrtslock.h>` -> use `<converse.h>`
+- `std::enable_if` -> use `requires`
+- `namespace _details` -> use `_detail`
+- `struct TD;` / `class TD;` (debug artifacts)
+- `.ckLocal()` -> `Parallel::local()`
+- `.ckLocalBranch()` -> `Parallel::local_branch()`
+- `return Py_None;` -> `Py_RETURN_NONE`
+- Text after `/*!` on same line
+- `Ls` abbreviation -> use `List`
+- Doxygen (`///` or `/*!`) in `.cpp` files (only use `//` comments in cpp)
+- Top-level `const` on value parameters in function declarations (`.hpp`) ->
+  remove `const` from the declaration (keep in definition)
+- TODO/FIXME comments (not allowed)
+
+**Test files**:
+- `TEST_CASE` instead of `SPECTRE_TEST_CASE`
+- `Approx(` instead of `approx`
+
+**CMake**: New C++ files in a directory must be listed in that directory's
+CMakeLists.txt; removed files must be removed; entries should be alphabetical.
+
+**LLM Comments**: Identify comments that seem like notes from a coding agent
+during its thinking process.
+
+### Include Order (C++ files in diff)
+Verify:
+1. (Tests) `"Framework/TestingFramework.hpp"` first, then blank line
+2. (`.cpp` with `.hpp`) Corresponding `.hpp`, then blank line
+3. STL/external `<headers>` alphabetical
+4. Blank line
+5. SpECTRE `"headers"` alphabetical
+
+### Commit Messages (local mode only)
+Check no commit starts with (case-insensitive): fixup, wip, fixme, deleteme,
+rebaseme, testing, rebase.
+
+## Step 4: Code Review (2 Parallel Agents)
+
+Launch 2 parallel agents. Provide each with the full diff and the
+contents of `references/spectre-rules.md`.
+
+### Agent A: Style, Patterns & Idioms
+Instructions for the agent:
+- Check the diff against every rule in **Banned Patterns** and **Style Rules**
+- Check for **Prefer-Library Patterns** (manual tensor loops that should use
+  EagerMath)
+- When you spot a suspicious pattern NOT in the checklist (e.g., a manual matrix
+  operation, a loop that looks like it reimplements an existing utility), use
+  `grep -r` in `src/DataStructures/Tensor/EagerMath/`, `src/DataStructures/`,
+  `src/NumericalAlgorithms/`, or `src/Utilities/` to find an existing utility
+- Only flag issues in lines that the diff introduces (not pre-existing code)
+- For each finding: `file:line`, severity (`critical`/`important`/`suggestion`),
+  explanation
+
+### Agent B: Bugs, Logic, Tests & Documentation
+Instructions for the agent:
+- Read each changed file in full (not just the diff) to understand surrounding
+  context
+- Look for: logic errors, off-by-one, uninitialized variables, NaN handling,
+  race conditions, incorrect template instantiations, virtual inheritance issues
+  (most-derived must init virtual bases)
+- Check that new/changed public API in `.hpp` files has Doxygen documentation
+- Check that new source files have corresponding tests (`src/Foo/Bar.hpp` ->
+  `tests/Unit/Foo/Test_Bar.cpp`)
+- Check that new `.cpp`/`.hpp` files are listed in their `CMakeLists.txt`
+- Only flag issues introduced by the diff
+- For each finding: `file:line`, severity, explanation
+
+## Step 5: clang-tidy (if requested)
+
+If "clang-tidy" was in arguments:
+1. Check for `build/compile_commands.json`. If missing, report that clang-tidy
+   requires a configured build directory and skip.
+2. For each changed `.cpp` file: `clang-tidy -p build/ FILEPATH 2>&1`
+3. Filter output to only warnings on lines in the diff.
+
+## Step 6: Code Coverage (if requested)
+
+If "coverage" was in arguments:
+Read `references/coverage-steps.md` and follow those instructions exactly.
+
+## Step 7: Self-Review Prune
+
+Combine all findings from steps 2-6. Review each finding and REMOVE only clear
+non-issues:
+- False positives (pattern match that isn't the actual flagged issue)
+- Pre-existing issues not introduced by this diff
+- Issues suppressed by `// NOLINT(...)` comments
+- Exact duplicates between agents or between agents and formatting/CI checks
+
+Assign each remaining finding a confidence score (0-100). Remove findings
+below 50. Keep all findings scoring 50 or above -- err on the side of including
+borderline issues rather than missing real ones.
+
+## Step 8: Lightweight Model Critique
+
+Spawn an agent using the cheapest available model (Claude Code: `haiku`;
+Codex: `gpt-5.4-mini`). Provide it with:
+- The list of pruned findings (with scores)
+- A summary of what the diff does
+
+Ask the critique agent to:
+1. Score each finding 0-100 for "is this a real, actionable issue?"
+2. Flag any remaining false positives with reasoning
+3. Note if important issues seem to be missing
+4. Return scores and feedback
+
+After receiving the critique agent's feedback:
+- Remove findings scored < 40
+- Downgrade severity (e.g., important -> suggestion) for findings scored
+  40-60
+- Consider adding issues the critique agent suggested (verify them first)
+
+## Step 9: Final Report
+
+Read `references/report-template.md` and present the report in that format.

--- a/.skills/spectre-review/references/coverage-steps.md
+++ b/.skills/spectre-review/references/coverage-steps.md
@@ -1,0 +1,147 @@
+# Code Coverage Steps
+
+These instructions are followed by the orchestrator when "coverage" was in
+the review arguments. Execute all sub-steps below exactly as written.
+
+### 6a. Check out PR branch (PR mode only)
+
+Coverage must be measured against the actual PR code, not the current working
+tree. Before building or running any tests:
+
+1. Record the current branch and stash any uncommitted changes so they can be
+   restored afterwards:
+   ```bash
+   ORIGINAL_BRANCH=$(git branch --show-current)
+   STASH_RESULT=$(git stash push --include-untracked -m "coverage-stash" 2>&1)
+   STASHED=$([[ "$STASH_RESULT" == *"Saved"* ]] && echo yes || echo no)
+   ```
+2. Attempt to check out the PR branch using the GitHub CLI:
+   ```bash
+   gh pr checkout <N> --repo sxs-collaboration/spectre 2>&1
+   ```
+   If that fails (e.g. SSH key / remote mismatch), fall back to:
+   ```bash
+   git fetch upstream pull/<N>/head:pr-<N> 2>&1
+   git checkout pr-<N> 2>&1
+   ```
+3. **Handle checkout conflicts explicitly.** If checkout fails with any error
+   (e.g. "Your local changes to the following files would be overwritten",
+   "untracked working tree files would be overwritten by checkout", or "Please
+   commit your changes or stash them"), do NOT attempt to force-checkout.
+   Instead, abort coverage and report clearly:
+   > "Coverage analysis skipped: checking out PR branch '<headRefName>' failed
+   > because the following local files conflict with the PR:
+   >   <list conflicting files from the git error message>
+   > Please resolve the conflict manually (commit, stash, or delete those files)
+   > and re-run the review with 'coverage'."
+   Then restore the original branch and pop the stash (step 5) and skip all
+   remaining coverage steps.
+4. Verify the checkout succeeded by comparing HEAD to the expected PR commit:
+   ```bash
+   git log --oneline -1
+   gh pr view <N> --repo sxs-collaboration/spectre \
+       --json headRefOid -q .headRefOid
+   ```
+   The two commit hashes should match (or the local log should show the PR
+   branch name). If they differ, report: "Coverage skipped: checkout succeeded
+   but HEAD does not match PR head — local branch may be stale."
+5. **Restore step (must run after all coverage steps, or on any failure after
+   this point):** at the end of Step 6f, restore the original working state:
+   ```bash
+   git checkout "$ORIGINAL_BRANCH"
+   [[ "$STASHED" == "yes" ]] && git stash pop
+   ```
+
+### 6b. Prerequisites & Build Verification
+
+1. Check `build/compile_commands.json` exists. If missing, skip with: "Coverage
+   requires a configured build directory."
+2. Check `build/CMakeCache.txt` for `COVERAGE:BOOL=ON`. If not found, skip with:
+   "Build not compiled with -DCOVERAGE=ON. Rebuild with
+   `cmake -DCOVERAGE=ON ..` to enable coverage."
+3. Check `lcov` is available.
+4. **Verify the gcov wrapper is functional.** For Clang builds,
+   `build/llvm-gcov.sh` may contain `LLVM_COV_BIN-NOTFOUND` if `llvm-cov` was
+   not found at CMake configure time. Check:
+   ```bash
+   grep "NOTFOUND" build/llvm-gcov.sh
+   ```
+   If found, locate the correct binary and fix the wrapper in-place:
+   ```bash
+   LLVM_VER=$(clang++ --version | grep -oP '\d+' | head -1)
+   LLVM_COV=$(which llvm-cov-${LLVM_VER} 2>/dev/null || which llvm-cov)
+   printf '#!/bin/bash\nexec %s gcov "$@"\n' "$LLVM_COV" > build/llvm-gcov.sh
+   chmod +x build/llvm-gcov.sh
+   ```
+5. Determine the gcov tool and **always use its absolute path** to avoid lcov
+   failing with "No such file or directory" when it resolves relative paths
+   from a different working directory:
+   - Clang: `GCOV=$(realpath build/llvm-gcov.sh)`
+   - GNU: `GCOV=$(which gcov)`
+6. **Verify objects are instrumented.** Pick one `.o` file for a changed source
+   and check it has coverage symbols:
+   ```bash
+   nm <path/to/the_file.cpp.o> 2>/dev/null | grep -c "__llvm_gcov_ctr\|__gcov_"
+   ```
+   If the count is 0, objects were compiled before coverage was enabled —
+   rebuild the relevant test targets:
+   ```bash
+   cmake --build build --target <TestTarget> -- -j$(nproc)
+   ```
+   Re-check instrumentation after the rebuild. If still 0, skip coverage with:
+   "Objects lack coverage instrumentation even after rebuild. Check that the
+   build was configured with -DCOVERAGE=ON before compiling."
+
+### 6c. Map changed files to test targets
+For each changed C++ file under `src/`:
+1. Find the corresponding test directory: `src/A/B/C.hpp` -> `tests/Unit/A/B/`
+2. Walk up directories reading `CMakeLists.txt` files for `set(LIBRARY
+   "Test_...")` to find the test binary name. Test naming is NOT a simple
+   transform (e.g., `Test_DomainCreators`, `Test_EllipticDG`, `Test_DgSubcell`),
+   so CMakeLists.txt parsing is required.
+3. Verify each binary exists in `build/bin/`. If not, build it: `cmake --build
+   build --target <Target> -- -j$(nproc)`
+4. If >5 unique test targets, ask the user before proceeding.
+
+### 6d. Run tests and capture coverage
+For each test target (using `$GCOV` absolute path from Step 6b):
+```bash
+lcov --gcov-tool $GCOV --directory build/ --zerocounters
+build/bin/<TestTarget>
+lcov --gcov-tool $GCOV --capture --rc lcov_branch_coverage=0 \
+  --directory build/ --output-file /tmp/coverage_<TestTarget>.info
+```
+After the lcov capture, verify `.gcda` files were actually produced:
+```bash
+find build/ -name "*.gcda" | grep -q .
+```
+If no `.gcda` files are found, report:
+> "No coverage data files (.gcda) generated. Possible causes: (1) objects were
+> not compiled with --coverage (rebuild required after confirming
+> -DCOVERAGE=ON), (2) test binary exited before writing data, (3) build
+> directory path mismatch between compile and run."
+Then skip remaining coverage steps (but still run Step 6f to restore the
+branch).
+
+### 6e. Filter to changed lines only
+1. Merge .info files: `lcov --add-tracefile ... --output-file
+   /tmp/coverage_merged.info`
+2. Extract only changed source files: `lcov --extract /tmp/coverage_merged.info
+   '<abs-path-to-file>' ... -o /tmp/coverage_filtered.info`
+3. Parse `DA:<line>,<count>` entries from the filtered .info file
+4. Cross-reference with diff hunk headers: only report lines that are both NEW
+   in the diff AND have execution_count == 0. **Use new-file line numbers from
+   the diff** — after checking out the PR branch these match the files on disk
+   exactly. Do not use base-branch line numbers, which are offset from the PR.
+5. Group uncovered lines into contiguous ranges
+
+### 6f. Cleanup
+Remove temporary .info files to avoid polluting subsequent builds:
+```bash
+rm -f /tmp/coverage_*.info /tmp/coverage_merged.info /tmp/coverage_filtered.info
+```
+Then restore the original branch and unstash local changes (PR mode only):
+```bash
+git checkout "$ORIGINAL_BRANCH"
+[[ "$STASHED" == "yes" ]] && git stash pop
+```

--- a/.skills/spectre-review/references/report-template.md
+++ b/.skills/spectre-review/references/report-template.md
@@ -1,0 +1,42 @@
+# Final Report Template
+
+Present a clean report in the format below. Be brief and specific. No emojis.
+Link to files and lines.
+
+```
+### SpECTRE Code Review
+
+**Reviewing**: [PR #N: title | local changes on branch `name`]
+**Files changed**: N (X C++, Y Python, Z CMake)
+
+#### Formatting
+[clang-format / black / isort changes, or "No formatting issues."]
+
+#### Critical Issues
+N. **Description** `file:line`
+   Explanation and suggested fix.
+
+#### Important Issues
+N. **Description** `file:line`
+   Explanation.
+
+#### Suggestions
+N. **Description** `file:line`
+   Explanation.
+
+#### CI Pre-Check Warnings
+[Issues that CI will flag, or "None."]
+
+[If clang-tidy ran:]
+#### clang-tidy
+[Findings or "No issues."]
+
+[If coverage ran:]
+#### Code Coverage (changed lines)
+[Uncovered changed lines per file, or "All changed lines are covered by tests."]
+[Files with no test target: "Coverage not checked: file1.cpp, file2.hpp (no test
+target found)"]
+```
+
+If no issues at all: "No issues found. Checked style, patterns, bugs,
+formatting, and CI compliance."

--- a/.skills/spectre-review/references/spectre-rules.md
+++ b/.skills/spectre-review/references/spectre-rules.md
@@ -1,0 +1,96 @@
+# SpECTRE Code Rules Reference
+
+## Banned Patterns
+- `#include <iostream>` -> `Parallel/Printf/Printf.hpp` with `Parallel::printf`
+- `#include <lrtslock.h>` -> `#include <converse.h>`
+- `std::enable_if` -> C++20 `requires` clause
+- `||` `&&` `!` (logical operators) -> `or` `and` `not` (C++ alternative
+  tokens). Note: `!=` is fine.
+- `.ckLocal()` -> `Parallel::local(proxy)`
+- `.ckLocalBranch()` -> `Parallel::local_branch(proxy)`
+- `return Py_None;` -> `Py_RETURN_NONE`
+- `TEST_CASE(` -> `SPECTRE_TEST_CASE(`
+- `Approx(` in tests -> `approx` from `Framework/TestingFramework.hpp`
+- `namespace _details` / `namespace details` -> `_detail` / `detail`
+- `boost::optional` / `boost/optional.hpp` -> `std::optional`
+- `mutable` member variables -> avoid (race conditions in parallel); discuss
+  with core devs
+- `struct TD;` / `class TD;` -> remove (debug artifacts)
+- `Ls` as abbreviation -> use `List`
+- `int` for container sizes/indices -> `size_t`
+- `noexcept` -> don't add unless overriding a signature that requires it
+
+## Prefer-Library Patterns
+When you see manual loops over Tensor indices, suggest the existing utility:
+- Dot product -> `DataStructures/Tensor/EagerMath/DotProduct.hpp`
+- Cross product -> `EagerMath/CrossProduct.hpp`
+- Trace -> `EagerMath/Trace.hpp`
+- Determinant -> `EagerMath/Determinant.hpp` or `DeterminantAndInverse.hpp`
+- Magnitude/norm -> `EagerMath/Magnitude.hpp` or `Norms.hpp`
+- Outer product -> `EagerMath/OuterProduct.hpp`
+- Raise/lower index -> `EagerMath/RaiseOrLowerIndex.hpp`
+- Gram-Schmidt -> `EagerMath/GramSchmidtOrthonormalize.hpp`
+- Frame transform -> `EagerMath/FrameTransform.hpp`
+- Cartesian<->Spherical -> `EagerMath/CartesianToSpherical.hpp`
+
+If you spot a tensor loop not covered above, grep
+`src/DataStructures/Tensor/EagerMath/` and `src/NumericalAlgorithms/` for an
+existing utility before suggesting the author write their own. Encourage use
+of tensor expressions `src/DataStructures/Tensor/Expressions/`.
+
+For general relativity, generalized harmonic, CCZ4, apparent horizons, and
+GRMHD, many manipulations like shift from spacetime metric, lapse from spacetime
+metric, derivative of shift, etc. are implemented as functions in
+`src/PointwiseFunctions/GeneralRelativity` or `src/PointwiseFunctions/Hydro`.
+
+## Style Rules
+- **Naming**: CamelCase for classes, template params, files, dirs. snake_case
+  for functions, variables. SCREAMING_SNAKE_CASE for macros. Trailing `_` on
+  private members. Unused params: `/*name*/`.
+- **Almost always `auto`** except expression templates (e.g. `DataVector`)
+- **Braces on all loops and if/else** (no braceless one-liners)
+- **Return by value** preferred. Mutable out-params: `gsl::not_null<T*>` (listed
+  first in arg list).
+- **`std::move`** into members from by-value constructor parameters
+- **`get<a,b>(tensor)`** when indices are compile-time known
+- **Explicit double literals**: `2.0` or `2.`, never bare `2` in floating-point
+  context
+- **`#pragma once`** for header guards (not `#ifndef`)
+- **`override`** keyword on all virtual overrides
+- **`const`** on all immutable objects
+- **No top-level `const` on value parameters in declarations**: In `.hpp`
+  forward declarations, don't mark value parameters (including pointer-by-value)
+  as `const`. `const` is fine in the corresponding definition. Example:
+  `void foo(int x, double* ptr);` (declaration) vs
+  `void foo(const int x, double* const ptr) { ... }` (definition).
+- **Templates**: prefer definitions in `.cpp` with explicit instantiations
+  (`GENERATE_EXPLICIT_INSTANTIATIONS`)
+- **Internal namespaces**: `LibraryOrFile_detail` (e.g. `Tensor_detail`)
+- **Macros**: avoid if possible; use `constexpr` or templates. Macro vars: add
+  suffix to avoid collisions.
+- **Error messages**: descriptive, include runtime values. Bad: "Size
+  mismatch". Good: "The number of grid points in matrix 'F' (N) != determinant
+  grid points (M)."
+- **Header order**: (1) TestingFramework.hpp + blank (tests), (2) corresponding
+  .hpp + blank (.cpp files), (3) STL/external `<>` alphabetical, (4) blank, (5)
+  SpECTRE `""` alphabetical
+- **Doxygen**: required for all public API in `.hpp`. Use `///` or `/*!`. NO
+  doxygen in `.cpp`. Use `\f$...\f$` for inline math, `align` env (not
+  `eqnarray`) for multi-line. Blank doxygen line before/after out-of-line
+  equations.
+- **CMake lists**: alphabetical. Use `${LIBRARY}` variable, not hardcoded names.
+
+## Test Requirements
+- Files: `tests/Unit/<mirrors_src>/Test_<SourceFile>.cpp`
+- First include: `"Framework/TestingFramework.hpp"` (blank line after)
+- All helper classes/functions in anonymous `namespace {}`
+- Test macro: `SPECTRE_TEST_CASE("Unit.Category.Name", "[Unit][Category]")`
+- Floating-point: `CHECK_ITERABLE_APPROX` (not `Approx`)
+- Completion: < 5 seconds (prefer < 0.5s)
+- Random values: `MAKE_GENERATOR(gen)`, test 10^4 times for tolerance
+- Error tests: `CHECK_THROWS_WITH` inside `#ifdef SPECTRE_DEBUG`
+- Pointwise functions: test with analytic solution AND random-value comparison
+  via `pypp::check_with_random_values()`
+- Use meromorphic tests: like `sin^2(x)+cos^2(x)=1` or that a spacetime vector
+  in general relativity that should be null is actually null. I.e, test
+  identities.

--- a/cmake/SetupFormaline.cmake
+++ b/cmake/SetupFormaline.cmake
@@ -9,6 +9,7 @@ set(SPECTRE_FORMALINE_LOCATIONS
   .claude
   .clang-format
   .clang-tidy
+  .claude
   .codecov.yaml
   .codex
   .devcontainer

--- a/tools/FileTestDefs.sh
+++ b/tools/FileTestDefs.sh
@@ -260,7 +260,8 @@ long_lines_exclude() {
         grep -v 'import' | \
         grep -v '\\link' | \
         grep -v '\\endlink' | \
-        grep -v 'CopyFiles:'
+        grep -v 'CopyFiles:' | \
+        grep -v '^allowed-tools:'
 }
 long_lines() {
     whitelist "$1" \

--- a/tools/FileTestDefs.sh
+++ b/tools/FileTestDefs.sh
@@ -265,6 +265,7 @@ long_lines_exclude() {
 }
 long_lines() {
     whitelist "$1" \
+              '.claude/skills/*' \
               '.cmake$' \
               '.css$' \
               '.github/workflows/*' \


### PR DESCRIPTION
## Proposed changes

Adds a Claude Code skill for reviewing PRs. This supports reviewing local code and code on GitHub. It must be triggered explicitly with `/spectre-review`, it will not be picked up implicitly. This is intentional.

Usage:
```
/spectre-review PR# clang-tidy coverage
```
The PR# is necessary but can be `local` to do the current branch since (local) `develop`.  Specify `clang-tidy` to run clang-tidy on the diff. Can specify newer versions, e.g. clang-tidy-21 if you want. Specifying `coverage` will have Claude checkout the PR, then recompile and run the necessary targets to get coverage for the PR. Note that this requires having coverage enabled in the `spectre_repo/build` build directory. I expect you can add prose afterward to tell it a different build directory.

Here's the result of a run over https://github.com/sxs-collaboration/spectre/pull/7041 It does a very good job. I think the only "false positive" is the use-after move in the move constructor (at least I think that C++ code is fine).

<details>

  SpECTRE Code Review

  Reviewing: PR #7041: Add TensorYlm filter to GH and CSW evolutions
  Files changed: 58 (15 C++, 1 CMake, 42 YAML/other)

  Formatting

  No clang-format issues on the critical C++ files. Three files show version-sensitive formatting diffs on C++20 requires clauses (ExponentialFilter.hpp:129-131, Test_ApplyTensorYlmFilter.cpp in both CSW and
  GH test files) — verify in CI, not definitive failures.

  Critical Issues

  1. Dangling reference in Exponential::filter_matrices() src/NumericalAlgorithms/LinearOperators/ExponentialFilter.cpp:67
  The local const Matrix empty{} is initialized on the stack and all Dim slots of the returned array are initialized to std::cref(empty). For mesh dimensions with Spectral::Basis::SphericalHarmonic, the loop
  continues, leaving those slots pointing to empty. When filter_matrices() returns, empty is destroyed. The caller (operator()(vars, mesh)) immediately passes the returned array to
  apply_matrices(filter_matrices(mesh), ...), which dereferences each reference_wrapper to read .columns(). This is formally undefined behavior confirmed by clang-analyzer-core.StackAddressEscape. Fix: make
  empty static:
  static const Matrix empty{};
  2. Use-after-move in TensorYlmFilter move constructor (CSW) src/Evolution/Systems/CurvedScalarWave/ApplyTensorYlmFilter.cpp:222-225
  TensorYlmFilter::TensorYlmFilter(TensorYlmFilter&& rhs)
      : Filters::Filter(std::move(rhs)),           // rhs is moved here
        num_modes_to_kill_(rhs.num_modes_to_kill_), // accesses moved-from rhs
        half_power_(std::move(rhs.half_power_)) {}  // accesses moved-from rhs
  2. std::move(rhs) moves the entire rhs object to the base; the subsequent accesses to rhs.num_modes_to_kill_ and rhs.half_power_ are on a potentially-moved-from object. While PUP::able likely doesn't zero
  trivial members, this is fragile and clang-tidy flags it as bugprone-use-after-move. Fix: capture the derived-class members before moving the base, or use static_cast<Filters::Filter&&>(rhs) to move only
  the base subobject:
  TensorYlmFilter::TensorYlmFilter(TensorYlmFilter&& rhs)
      : Filters::Filter(static_cast<Filters::Filter&&>(rhs)),
        num_modes_to_kill_(rhs.num_modes_to_kill_),
        half_power_(std::move(rhs.half_power_)) {}
  2. Same issue in operator=(TensorYlmFilter&&). Same pattern in GeneralizedHarmonic/ApplyTensorYlmFilter.cpp:376-379.
  3. Stale filter matrices after assignment src/Evolution/Systems/CurvedScalarWave/ApplyTensorYlmFilter.cpp:214-219 (and GH equivalent)
  Both copy and move operator= copy num_modes_to_kill_ and half_power_ but do not reset cached_l_max_. If you assign a filter with different num_modes_to_kill_ to an existing filter that already has
  cached_l_max_ == L, and then call operator() on a mesh with the same L, the check if (cached_l_max_ != l_max) is false and the old filter matrices (computed with the old parameters) are silently reused,
  producing wrong results. Fix: add cached_l_max_ = std::numeric_limits<size_t>::max(); (see also issue I5 below) at the start of each assignment operator.
  4. Missing #include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp" in GH filter src/Evolution/Systems/GeneralizedHarmonic/ApplyTensorYlmFilter.cpp:438
  TensorYlmFilter::operator() calls determinant_and_inverse(jac_grid_to_inertial), but DeterminantAndInverse.hpp is not included in this file. The CSW version correctly includes it. If the call is currently
  served by an indirect include, this will silently break when header dependencies change.

  Important Issues

  5. cached_l_max_ = 0 sentinel collides with valid l_max == 0 src/Evolution/Systems/CurvedScalarWave/ApplyTensorYlmFilter.hpp:179 (and GH)
  cached_l_max_ is initialized to 0, which is also what mesh.extents(1) - 1 would return for a SphericalHarmonic mesh with 1 point. On the first call with such a mesh, the cache check if (cached_l_max_ !=
  l_max) is false, so fill_filter is never called and the filter matrices remain empty, producing wrong results. Use std::numeric_limits<size_t>::max() as the "not yet initialized" sentinel:
  mutable size_t cached_l_max_{std::numeric_limits<size_t>::max()};
  5. (Also fixes issue C3 above if reset in assignment operators.)
  6. Behavioral change: GhMhdBondiMichel.yaml previously had Enable: false tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
  The old input file had Enable: false with an ExpFilter0 entry, meaning filtering was disabled at runtime. The new file registers FilterGhVariables with an ExponentialFilter that is always applied (there is
  no Enable option in the new scheme). This is a silent behavioral change: runs using this input file will now apply the GH exponential filter when they previously did not. Confirm this is intentional; if
  not, change to FilterGhVariables: [].
  7. Thread-safety: returned const Matrix& used after lock release src/NumericalAlgorithms/LinearOperators/ExponentialFilter.cpp:55-61
  The filter_matrix() method holds std::lock_guard<std::mutex> while inserting into the static std::map, then returns iter->second as a const Matrix& — which is used by the caller after the lock is released.
  While std::map does not invalidate iterators/references on insert, a concurrent write (another thread inserting a different key) while the caller reads the matrix via the returned reference is a data race
  under the C++ memory model. In SpECTRE's SMP Charm++ model, multiple elements on one node can call this concurrently. Consider a std::shared_mutex with shared_lock for reads, or document the assumption that
   this is safe in SpECTRE's threading model.

  Suggestions

  8. TensorYlmFilter::operator() (the DataBox mutator) not tested directly tests/Unit/Evolution/Systems/CurvedScalarWave/Test_ApplyTensorYlmFilter.cpp,
  tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_ApplyTensorYlmFilter.cpp
  Coverage analysis confirms that the entire body of TensorYlmFilter::operator() in both CSW and GH is uncovered by the test suite. The tests call lower-level free functions via a lambda, but never
  instantiate the class and call its operator() on an actual SphericalHarmonic-basis Mesh. The caching logic, the non-SphericalHarmonic early-return path, and the Jacobian inversion inside operator() are all
  untested. Add a test that constructs a TensorYlmFilter, calls it on a spherical-harmonic mesh, and verifies the output.
  9. Exponential::filter_matrices() YLM-skip branch uncovered src/NumericalAlgorithms/LinearOperators/ExponentialFilter.cpp:73
  The continue branch inside filter_matrices() that skips SphericalHarmonic-basis dimensions is never hit by Test_LinearOperators. This is the key new behavior of the Exponential filter in this PR. Add a test
   that constructs a Mesh<3> with SphericalHarmonic basis in 2 angular dimensions and calls filter_matrices().
  10. TensorYlmFilter::blocks_to_filter() always returns std::nullopt src/Evolution/Systems/CurvedScalarWave/ApplyTensorYlmFilter.hpp:147 (and GH)
  The blocks_to_filter() method is hardcoded to return std::nullopt, meaning the TensorYlm filter always applies to all blocks with no way for users to restrict it. Add a comment (or Doxygen entry) explaining
   this limitation.
  11. FilterAction.hpp:27-28 include order: TaggedTuple.hpp after TMPL.hpp src/ParallelAlgorithms/Actions/FilterAction.hpp:27
  "Utilities/TMPL.hpp" appears before "Utilities/TaggedTuple.hpp". Alphabetically TaggedTuple < TMPL, so these should be swapped. SpECTRE CI will flag this.

  CI Pre-Check Warnings

  - src/ParallelAlgorithms/Actions/FilterAction.hpp:27-28: SpECTRE "" include section has "Utilities/TMPL.hpp" before "Utilities/TaggedTuple.hpp" — violates alphabetical include order. Will fail CI.

  clang-tidy

  - ExponentialFilter.cpp:67: clang-analyzer-core.StackAddressEscape — stack-address escape for empty in filter_matrices() (same as Critical issue 1)
  - ExponentialFilter.cpp:55: modernize-use-scoped-lock — use std::scoped_lock instead of std::lock_guard<std::mutex>
  - CurvedScalarWave/ApplyTensorYlmFilter.cpp:224-225: bugprone-use-after-move — rhs.* accessed after std::move(rhs) in move constructor (same as Critical issue 2)
  - GeneralizedHarmonic/ApplyTensorYlmFilter.cpp:378-379: bugprone-use-after-move — same as above

  Code Coverage (changed lines)

  The following newly-introduced lines are not covered by the unit tests:

  src/Evolution/Systems/CurvedScalarWave/ApplyTensorYlmFilter.cpp — 33 uncovered new lines:
  - Lines 209–212: copy constructor body
  - Lines 214–219: copy assignment operator body
  - Lines 247, 254–272, 276–281: entire TensorYlmFilter::operator() body (the main new callable)
  - Lines 288–289: operator!=

  src/Evolution/Systems/GeneralizedHarmonic/ApplyTensorYlmFilter.cpp — 43 uncovered new lines:
  - Lines 363–366: copy constructor body
  - Lines 368–373: copy assignment operator body
  - Lines 401, 407–414, 417–434, 438–444: entire TensorYlmFilter::operator() body
  - Lines 451–452: operator!=

  src/NumericalAlgorithms/LinearOperators/ExponentialFilter.cpp — 1 uncovered new line:
  - Line 73: the continue branch skipping SphericalHarmonic-basis dimensions in filter_matrices()


</details

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
