### PR TITLE
Increase timeout for ReadH5 and TransformVolumeData Python tests

### DIFF
--- a/tests/Unit/IO/H5/Python/CMakeLists.txt
+++ b/tests/Unit/IO/H5/Python/CMakeLists.txt
@@ -58,10 +58,12 @@ spectre_add_python_bindings_test(
   "Unit.IO.H5.Python.ReadH5"
   Test_ReadH5.py
   "unit;IO;H5;python"
-  PyH5)
+  PyH5
+  TIMEOUT 10)
 
 spectre_add_python_bindings_test(
   "Unit.IO.H5.Python.TransformVolumeData"
   Test_TransformVolumeData.py
   "unit;IO;H5;python"
-  PyH5)
+  PyH5
+  TIMEOUT 10)

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Test_RotatingStar.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/RelativisticEuler/Test_RotatingStar.cpp
@@ -67,6 +67,7 @@ void verify_solution_suite(
 }
 }  // namespace
 
+// [[Timeout, 10]]
 SPECTRE_TEST_CASE(
     "Unit.PointwiseFunctions.AnalyticSolutions.RelEuler.RotatingStar",
     "[Unit][PointwiseFunctions]") {


### PR DESCRIPTION
## Proposed changes

These tests were timing out in CI due to the default 2-second base timeout being too short for I/O-heavy tests.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
