### PR TITLE
Add a Claude/Codex skills for working on issues & fixing PR comments

### DIFF
--- a/.claude/skills/spectre-fix-issue/SKILL.md
+++ b/.claude/skills/spectre-fix-issue/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: spectre-fix-issue
+description: >
+  Fetch a GitHub issue by number. Trigger when the user references a GitHub
+  issue (e.g. "fix issue #1727", "work on #1727").
+allowed-tools: ["Bash"]
+argument-hint: "ISSUE_NUMBER [--repo OWNER/REPO]"
+---
+
+Read and follow instructions in file
+`$(git rev-parse --show-toplevel)/.skills/spectre-fix-issue/SKILL.md`

--- a/.claude/skills/spectre-fix-pr/SKILL.md
+++ b/.claude/skills/spectre-fix-pr/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: spectre-fix-pr
+description: >
+  Fetch PR review comments. Trigger when users reference a PR
+  (e.g. "address comments on PR #1234", "work on PR #1234 reviews").
+allowed-tools: ["Bash"]
+argument-hint: "PR_NUMBER [--repo OWNER/REPO]"
+---
+
+Read and follow instructions in file
+`$(git rev-parse --show-toplevel)/.skills/spectre-fix-pr/SKILL.md`

--- a/.codex/skills
+++ b/.codex/skills
@@ -1,0 +1,1 @@
+../.claude/skills

--- a/.gitignore
+++ b/.gitignore
@@ -75,8 +75,11 @@ tags
 # Keep Tags/ directories on case-insensitive file systems
 !Tags/
 
-# AI instructions
+# AI/LLM Agent/CLI tools
 AGENTS.md
-CLAUDE.md
+
 .aider*
-.claude
+
+CLAUDE.md
+.claude/settings.local.json
+CLAUDE.local.md

--- a/.skills/scripts/FetchIssue.py
+++ b/.skills/scripts/FetchIssue.py
@@ -1,0 +1,70 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+"""Fetch a GitHub issue and print it in a structured format for Claude."""
+
+import argparse
+import json
+import subprocess
+import sys
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Fetch a GitHub issue via gh CLI"
+    )
+    parser.add_argument("issue_number", help="Issue number (e.g. 1727)")
+    parser.add_argument(
+        "--repo",
+        default=None,
+        help="Repository in owner/repo form (default: current repo)",
+    )
+    args = parser.parse_args()
+
+    cmd = [
+        "gh",
+        "issue",
+        "view",
+        str(args.issue_number),
+        "--json",
+        (
+            "number,title,state,author,assignees,"
+            "createdAt,labels,url,body,comments"
+        ),
+    ]
+    if args.repo:
+        cmd.extend(["--repo", args.repo])
+
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"Error: {result.stderr.strip()}", file=sys.stderr)
+        sys.exit(1)
+
+    data = json.loads(result.stdout)
+
+    author = (data.get("author") or {}).get("login", "ghost")
+    labels = ", ".join(lbl["name"] for lbl in data.get("labels", []))
+    assignees = ", ".join(a["login"] for a in data.get("assignees", []))
+
+    print(f"Issue #{data['number']}: {data['title']}")
+    print(f"URL:     {data.get('url', '')}")
+    print(f"State:   {data['state']}")
+    print(f"Author:  {author}")
+    print(f"Created: {data['createdAt']}")
+    if assignees:
+        print(f"Assigned: {assignees}")
+    if labels:
+        print(f"Labels:  {labels}")
+    print()
+    print((data.get("body") or "").strip())
+
+    for comment in data.get("comments", []):
+        comment_author = (comment.get("author") or {}).get("login", "ghost")
+        print()
+        print("---")
+        print(f"Comment by: {comment_author} at {comment['createdAt']}")
+        print((comment.get("body") or "").strip())
+
+
+if __name__ == "__main__":
+    main()

--- a/.skills/scripts/FetchIssue.py
+++ b/.skills/scripts/FetchIssue.py
@@ -1,12 +1,55 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-"""Fetch a GitHub issue and print it in a structured format for Claude."""
+"""Fetch a GitHub issue and print it in a structured format for Claude.
+
+If the issue is a random test failure (title contains 'random failure in'
+and the body/comments contain MAKE_GENERATOR seed lines), a compact
+[RANDOM_FAILURE] format is emitted instead of the full issue text.
+"""
 
 import argparse
 import json
+import re
 import subprocess
 import sys
+
+
+def is_random_failure(title, all_text):
+    """Return True if this looks like a MAKE_GENERATOR random failure issue."""
+    if "random failure in" not in title.lower():
+        return False
+    return bool(re.search(r"Seed is:\s*\d+\s+from", all_text))
+
+
+def extract_make_generator_seeds(all_text):
+    """Parse 'Seed is: N from path:line' entries, returning {path:line: [seeds]}.
+
+    CI logs often wrap long paths at '/' boundaries, so we strip
+    timestamps and collapse continuation lines before matching.
+    """
+    # Strip CI log timestamps (e.g. "2023-09-11T19:44:29.1292895Z   ")
+    text = re.sub(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z\s*", "", all_text)
+    # Collapse lines where a path wraps after a '/'
+    text = re.sub(r"/\s*\n\s*", "/", text)
+    pattern = r"Seed is:\s*(\d+)\s+from\s+(.*?\.[hct]pp:\d+)"
+    matches = re.findall(pattern, text)
+
+    grouped = {}
+    for seed, raw_path in matches:
+        # Canonicalize: keep only the part after tests/Unit/
+        m = re.search(r"tests/Unit/(.*)", raw_path)
+        canonical = m.group(1) if m else raw_path
+        grouped.setdefault(canonical, [])
+        if seed not in grouped[canonical]:
+            grouped[canonical].append(seed)
+    return grouped
+
+
+def extract_test_name(title):
+    """Extract the test name from a 'Random failure in TEST' title."""
+    m = re.search(r"[Rr]andom\s+[Ff]ailure\s+in\s+(\S+)", title)
+    return m.group(1) if m else title
 
 
 def main():
@@ -18,6 +61,11 @@ def main():
         "--repo",
         default=None,
         help="Repository in owner/repo form (default: current repo)",
+    )
+    parser.add_argument(
+        "--full",
+        action="store_true",
+        help="Always print full issue text, bypassing random-failure detection",
     )
     args = parser.parse_args()
 
@@ -42,6 +90,26 @@ def main():
 
     data = json.loads(result.stdout)
 
+    title = data.get("title", "")
+    body = data.get("body", "") or ""
+    comments = data.get("comments", [])
+    all_text = body + "\n" + "\n".join((c.get("body") or "") for c in comments)
+
+    # --- Random failure detection ---
+    if not args.full and is_random_failure(title, all_text):
+        seeds = extract_make_generator_seeds(all_text)
+        test_name = extract_test_name(title)
+        print("[RANDOM_FAILURE]")
+        print(f"Issue #{data['number']}: {title}")
+        print(f"URL: {data.get('url', '')}")
+        print(f"Test: {test_name}")
+        print()
+        print("Seeds by location (paths relative to tests/Unit/):")
+        for path_line, seed_list in seeds.items():
+            print(f"  {path_line} -> {', '.join(seed_list)}")
+        sys.exit(0)
+
+    # --- Normal issue output ---
     author = (data.get("author") or {}).get("login", "ghost")
     labels = ", ".join(lbl["name"] for lbl in data.get("labels", []))
     assignees = ", ".join(a["login"] for a in data.get("assignees", []))
@@ -58,7 +126,7 @@ def main():
     print()
     print((data.get("body") or "").strip())
 
-    for comment in data.get("comments", []):
+    for comment in comments:
         comment_author = (comment.get("author") or {}).get("login", "ghost")
         print()
         print("---")

--- a/.skills/scripts/FetchPrComments.py
+++ b/.skills/scripts/FetchPrComments.py
@@ -1,0 +1,255 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+"""Fetch PR review data and print it in a structured format for Claude."""
+
+import argparse
+import json
+import subprocess
+import sys
+
+
+def run_gh_command(cmd):
+    """Run a gh CLI command and return parsed JSON, or exit on error."""
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"Error: {result.stderr.strip()}", file=sys.stderr)
+        sys.exit(1)
+    return json.loads(result.stdout)
+
+
+def fetch_pr_metadata(pr_number, repo=None):
+    """Fetch PR metadata, comments, reviews, and files via gh pr view."""
+    cmd = [
+        "gh",
+        "pr",
+        "view",
+        str(pr_number),
+        "--json",
+        (
+            "number,title,state,author,baseRefName,headRefName,"
+            "body,comments,reviews,files,url,createdAt,reviewDecision"
+        ),
+    ]
+    if repo:
+        cmd.extend(["--repo", repo])
+    return run_gh_command(cmd)
+
+
+def fetch_review_threads(pr_number, repo=None):
+    """Fetch review threads with resolution status via GraphQL API."""
+    if repo:
+        owner, name = repo.split("/", 1)
+    else:
+        detect_cmd = ["gh", "repo", "view", "--json", "owner,name"]
+        repo_data = run_gh_command(detect_cmd)
+        owner = repo_data["owner"]["login"]
+        name = repo_data["name"]
+
+    query = """query {
+      repository(owner:"%s", name:"%s") {
+        pullRequest(number:%d) {
+          reviewThreads(first:100) {
+            totalCount
+            pageInfo { hasNextPage }
+            nodes {
+              isResolved
+              isOutdated
+              path
+              line
+              originalLine
+              startLine
+              originalStartLine
+              subjectType
+              comments(first:50) {
+                nodes {
+                  body
+                  author { login }
+                  path
+                  diffHunk
+                  line
+                  originalLine
+                  startLine
+                  originalStartLine
+                  createdAt
+                }
+              }
+            }
+          }
+        }
+      }
+    }""" % (owner, name, int(pr_number))
+
+    cmd = ["gh", "api", "graphql", "-f", f"query={query}"]
+    data = run_gh_command(cmd)
+
+    threads_data = (
+        data.get("data", {})
+        .get("repository", {})
+        .get("pullRequest", {})
+        .get("reviewThreads", {})
+    )
+
+    if threads_data.get("pageInfo", {}).get("hasNextPage"):
+        print(
+            (
+                "WARNING: PR has more than 100 review threads. "
+                "Only the first 100 are shown."
+            ),
+            file=sys.stderr,
+        )
+
+    return threads_data.get("nodes", [])
+
+
+def print_pr_header(data):
+    """Print PR metadata header."""
+    author = (data.get("author") or {}).get("login", "ghost")
+    print(f"PR #{data['number']}: {data['title']}")
+    print(f"URL:             {data.get('url', '')}")
+    print(f"State:           {data['state']}")
+    print(f"Author:          {author}")
+    print(f"Created:         {data['createdAt']}")
+    print(f"Base <- Head:    {data['baseRefName']} <- {data['headRefName']}")
+    print(f"Review decision: {data.get('reviewDecision', 'NONE')}")
+
+
+def print_changed_files(files):
+    """Print changed files list with addition/deletion counts."""
+    print()
+    print("=" * 60)
+    print("CHANGED FILES")
+    print("=" * 60)
+    for f in files:
+        print(f"  +{f['additions']:-4d} -{f['deletions']:-4d}  {f['path']}")
+    total_add = sum(f["additions"] for f in files)
+    total_del = sum(f["deletions"] for f in files)
+    print(f"  {'':>10}  ({len(files)} files, +{total_add} -{total_del} total)")
+
+
+def print_pr_body(body):
+    """Print PR description."""
+    body = (body or "").strip()
+    if body:
+        print()
+        print("=" * 60)
+        print("PR DESCRIPTION")
+        print("=" * 60)
+        print(body)
+
+
+def print_top_level_comments(comments):
+    """Print top-level PR conversation comments."""
+    if not comments:
+        return
+    print()
+    print("=" * 60)
+    print(f"TOP-LEVEL COMMENTS ({len(comments)})")
+    print("=" * 60)
+    for c in comments:
+        author = (c.get("author") or {}).get("login", "ghost")
+        print()
+        print(f"--- Comment by {author} at {c['createdAt']} ---")
+        print((c.get("body") or "").strip())
+
+
+def print_review_summaries(reviews):
+    """Print review summaries (APPROVED, CHANGES_REQUESTED, etc.)."""
+    summaries = [r for r in reviews if (r.get("body") or "").strip()]
+    if not summaries:
+        return
+    print()
+    print("=" * 60)
+    print(f"REVIEW SUMMARIES ({len(summaries)})")
+    print("=" * 60)
+    for r in summaries:
+        author = (r.get("author") or {}).get("login", "ghost")
+        state = r.get("state", "COMMENTED")
+        print()
+        print(f"--- [{state}] Review by {author} at {r['submittedAt']} ---")
+        print((r.get("body") or "").strip())
+
+
+def print_review_threads(threads):
+    """Print inline review threads grouped by resolution status."""
+    if not threads:
+        print()
+        print("=" * 60)
+        print("INLINE REVIEW THREADS")
+        print("=" * 60)
+        print("  (none)")
+        return
+
+    unresolved = [t for t in threads if not t["isResolved"]]
+    resolved = [t for t in threads if t["isResolved"]]
+
+    print()
+    print("=" * 60)
+    print(
+        "INLINE REVIEW THREADS "
+        f"({len(unresolved)} unresolved, {len(resolved)} resolved)"
+    )
+    print("=" * 60)
+
+    for label, group in [("UNRESOLVED", unresolved), ("RESOLVED", resolved)]:
+        if not group:
+            continue
+        print()
+        print(f"--- {label} THREADS ---")
+        for i, thread in enumerate(group, 1):
+            status_tags = []
+            if thread["isResolved"]:
+                status_tags.append("[RESOLVED]")
+            else:
+                status_tags.append("[UNRESOLVED]")
+            if thread["isOutdated"]:
+                status_tags.append("[OUTDATED]")
+
+            path = thread.get("path", "unknown")
+            line = thread.get("line") or thread.get("originalLine")
+            line_info = f":{line}" if line else ""
+
+            print()
+            print(f"  Thread {i}: {' '.join(status_tags)} {path}{line_info}")
+
+            comments = thread.get("comments", {}).get("nodes", [])
+            for j, c in enumerate(comments):
+                author = (c.get("author") or {}).get("login", "ghost")
+                print(f"    [{author} at {c['createdAt']}]")
+
+                diff_hunk = c.get("diffHunk", "")
+                if diff_hunk and j == 0:
+                    for hunk_line in diff_hunk.split("\n"):
+                        print(f"      {hunk_line}")
+
+                body = (c.get("body") or "").strip()
+                if body:
+                    for body_line in body.split("\n"):
+                        print(f"    {body_line}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Fetch PR review data via gh CLI and GraphQL"
+    )
+    parser.add_argument("pr_number", help="Pull request number (e.g. 1234)")
+    parser.add_argument(
+        "--repo",
+        default=None,
+        help="Repository in owner/repo form (default: current repo)",
+    )
+    args = parser.parse_args()
+
+    pr_data = fetch_pr_metadata(args.pr_number, args.repo)
+    threads = fetch_review_threads(args.pr_number, args.repo)
+
+    print_pr_header(pr_data)
+    print_changed_files(pr_data.get("files", []))
+    print_pr_body(pr_data.get("body"))
+    print_top_level_comments(pr_data.get("comments", []))
+    print_review_summaries(pr_data.get("reviews", []))
+    print_review_threads(threads)
+
+
+if __name__ == "__main__":
+    main()

--- a/.skills/spectre-fix-issue/RANDOM_FAILURE.md
+++ b/.skills/spectre-fix-issue/RANDOM_FAILURE.md
@@ -1,0 +1,105 @@
+# Fixing a Random Test Failure
+
+You have a random test failure issue. The script output above contains
+the test name and a list of `file:line` locations with their failing seeds.
+
+## Background
+
+`MAKE_GENERATOR(gen)` (defined in `tests/Unit/Framework/TestHelpers.hpp`)
+creates a `std::mt19937` with a random seed. `MAKE_GENERATOR(gen, SEED)`
+uses the provided constant instead, making the test deterministic. On
+failure, prints `Seed is: N from file:line` so the failure can be replayed.
+
+## Strategy A -- Seed from a test file
+
+Use when the `file:line` points to a test file (not
+`CheckWithRandomValues.hpp`).
+
+1. Open the file at the indicated line (line numbers may have shifted -- search
+   nearby for `MAKE_GENERATOR`).
+2. Change `MAKE_GENERATOR(gen);` to `MAKE_GENERATOR(gen, SEED);` using the
+   first seed listed for that location.
+3. Build and run to reproduce the failure (see Workflow below).
+4. The failure is almost always a numerical tolerance issue. Increase the
+   comparison tolerance **locally** (only on the specific failing check):
+   - `Approx custom_approx = Approx::custom().epsilon(TOL).scale(1.0);`
+   - For scalars: `CHECK(expected == custom_approx(computed));`
+   - For iterables:
+     `CHECK_ITERABLE_CUSTOM_APPROX(expected, computed, custom_approx);`
+   - Start with `1.0e-14` and multiply by 10 until the test passes. Keep the
+     tolerance as small as possible.
+5. Remove the seed so it returns to `MAKE_GENERATOR(gen);`.
+6. Verify with `ctest --repeat-until-fail 1000 -R "TEST_NAME"` in the build
+   directory. If any iterations fail, fix those too. Repeat until all 1000 pass.
+
+## Strategy B -- Seed from CheckWithRandomValues.hpp
+
+Use when the `file:line` points to `Framework/CheckWithRandomValues.hpp`.
+
+`check_with_random_values()` already accepts `epsilon` and `seed` parameters
+(in `tests/Unit/Framework/CheckWithRandomValues.hpp`). The fix is:
+
+1. Find the calling test's `check_with_random_values` invocation.
+2. Pass the failing seed as the last argument and adjust `epsilon` as needed.
+   For example, if the original call is:
+   ```cpp
+   pypp::check_with_random_values<1>(
+       &Foo::bar<DataType>, klass, "Module", "function",
+       {{{-10.0, 10.0}}}, member_vars, used_for_size);
+   ```
+   add `epsilon` (default is `1.0e-12`) and the seed:
+   ```cpp
+   pypp::check_with_random_values<1>(
+       &Foo::bar<DataType>, klass, "Module", "function",
+       {{{-10.0, 10.0}}}, member_vars, used_for_size,
+       1.0e-12, FAILING_SEED);
+   ```
+3. Build and run to reproduce the failure.
+4. Increase the `epsilon` parameter until the test passes (start at `1.0e-12`,
+   multiply by 10). Keep as small as possible.
+5. Remove the explicit seed argument after the fix.
+6. Verify with `ctest --repeat-until-fail 1000 -R "TEST_NAME"`.
+
+## Workflow
+
+For each `file:line` + seed(s) entry from the script output:
+
+1. **Set seed** per Strategy A or B above.
+2. **Find build target**:
+   ```
+   cd build && ctest --show-only=json-v1 -R "TEST_NAME"
+   ```
+   Parse the JSON output for the binary path (first element of `"command"`).
+3. **Build**: `ninja -C build <binary_name>`
+4. **Run**: `build/bin/<binary_name> "TEST_NAME"`
+5. **If test does NOT fail**: STOP and report to the user that the failure
+   cannot be reproduced (code may have changed since the issue was filed).
+6. **Investigate the root cause** before applying a tolerance fix. Read the
+   error output to identify the failing comparison (e.g. which function's
+   result is being compared). Then trace through the call chain of the
+   function under test to determine the source of the numerical error:
+   - **Iterative solver / root-find**: Look for convergence tolerances,
+     iteration counts, or precision parameters that could be tightened.
+   - **Adjustable numerical parameter**: Look for step sizes, interpolation
+     orders, or quadrature rules that could be refined.
+   - **Inherent floating-point accumulation**: If the computation is fully
+     analytical (no iteration, no adjustable precision knobs), the error is
+     unavoidable in double precision.
+
+   If you find an adjustable parameter, fix that instead of loosening the
+   test tolerance. If the error is inherent, proceed with the tolerance fix
+   and document the root cause in a C++ comment next to the tolerance change.
+7. **Apply fix**: verify the test passes with the seed, then remove the seed
+   and run `ctest --repeat-until-fail 1000 -R "TEST_NAME"`.
+8. If multiple `file:line` entries exist, repeat for each one.
+9. **Report a summary** of all changes at the end: list every file, line, and
+   what was changed (tolerance epsilon, solver parameter, etc.) so the user
+   can assess whether any changes are too large or need further review.
+
+## Important notes
+
+- The build directory is `build/` under the repository root.
+- Do NOT modify global `approx` in `tests/Unit/Framework/TestingFramework.hpp`.
+- Always remove explicit seeds before committing -- the seed is only for
+  reproducing the failure, not for the final code.
+- If multiple distinct test files have seeds, investigate each independently.

--- a/.skills/spectre-fix-issue/SKILL.md
+++ b/.skills/spectre-fix-issue/SKILL.md
@@ -1,0 +1,12 @@
+Run the fetch script to retrieve the issue title, body, and comments:
+
+```
+python3 \
+  "$(git rev-parse --show-toplevel)/.skills/scripts/FetchIssue.py" \
+  <number> [--repo owner/repo]
+```
+
+- Extract the issue number from the user's message.
+- Pass `--repo owner/repo` if the user specifies a repo or says "upstream"
+  (for SpECTRE, upstream is `sxs-collaboration/spectre`).
+- Summarize the issue, then proceed with the user's request.

--- a/.skills/spectre-fix-issue/SKILL.md
+++ b/.skills/spectre-fix-issue/SKILL.md
@@ -3,10 +3,20 @@ Run the fetch script to retrieve the issue title, body, and comments:
 ```
 python3 \
   "$(git rev-parse --show-toplevel)/.skills/scripts/FetchIssue.py" \
-  <number> [--repo owner/repo]
+  <number> [--repo owner/repo] [--full]
 ```
 
 - Extract the issue number from the user's message.
 - Pass `--repo owner/repo` if the user specifies a repo or says "upstream"
   (for SpECTRE, upstream is `sxs-collaboration/spectre`).
-- Summarize the issue, then proceed with the user's request.
+- Pass `--full` if the user explicitly asks for the full/unshortened issue
+  text (e.g. "show me the full issue", "don't shorten it", "skip random
+  failure handling"). Do NOT pass `--full` by default.
+
+**If the output starts with `[RANDOM_FAILURE]`**: Read and follow the
+instructions in
+`$(git rev-parse --show-toplevel)/.skills/spectre-fix-issue/RANDOM_FAILURE.md`
+using the seed data from the script output. Mention to the user that they can
+ask for the full issue text if they need it.
+
+**Otherwise**: Summarize the issue, then proceed with the user's request.

--- a/.skills/spectre-fix-pr/SKILL.md
+++ b/.skills/spectre-fix-pr/SKILL.md
@@ -1,0 +1,27 @@
+Run the fetch script to retrieve PR metadata, review comments, and changed
+files:
+
+```
+python3 \
+  "$(git rev-parse --show-toplevel)/.skills/scripts/FetchPrComments.py" \
+  <number> [--repo owner/repo]
+```
+
+- Extract the PR number from the user's message.
+- Pass `--repo owner/repo` if the user specifies a repo or says "upstream"
+  (for SpECTRE, upstream is `sxs-collaboration/spectre`).
+
+After fetching the PR data:
+
+1. **Summarize the review** before starting work: list the total number of
+   threads, how many are unresolved, and the files affected.
+2. **Prioritize UNRESOLVED threads** -- these are the comments that still need
+   to be addressed. Start with unresolved, non-outdated threads first.
+3. **Group by file** -- work through comments file-by-file rather than jumping
+   around, since multiple threads often apply to the same file.
+4. **Use the diff hunk context** -- each inline comment includes the surrounding
+   diff hunk so you can understand exactly what code the reviewer is referring
+   to.
+5. **Check OUTDATED threads** -- these refer to code that has since changed.
+   Verify whether the concern still applies before making changes.
+6. **Skip resolved threads** unless the user specifically asks about them.

--- a/cmake/SetupFormaline.cmake
+++ b/cmake/SetupFormaline.cmake
@@ -6,9 +6,11 @@
 # directory that are tracked by Git. I.e.
 #   git ls-tree --full-tree --name-only HEAD
 set(SPECTRE_FORMALINE_LOCATIONS
+  .claude
   .clang-format
   .clang-tidy
   .codecov.yaml
+  .codex
   .devcontainer
   .dockerignore
   .github
@@ -24,6 +26,7 @@ set(SPECTRE_FORMALINE_LOCATIONS
   Metadata.yaml
   pyproject.toml
   README.md
+  .skills
   setup.cfg
   src
   support

--- a/tools/FileTestDefs.sh
+++ b/tools/FileTestDefs.sh
@@ -461,7 +461,11 @@ license() {
               'RotatingStarId_Hybrid.dat$' \
               'support/Profiling/ScoreP/spectre.flt' \
               'support/TeXLive/texlive.profile' \
-              'tests/InputFiles/GrMhd/GhValenciaDivClean/EvolutionParameters.perl' && \
+              'tests/InputFiles/GrMhd/GhValenciaDivClean/EvolutionParameters.perl' \
+              '\.skills/.*\.md$' \
+              '\.codex/.*\.md$' \
+              '\.agents/.*\.md$' \
+              '\.claude/.*\.md$' && \
         ! staged_grep -q "Distributed under the MIT License" "$1"
 }
 license_report() {


### PR DESCRIPTION
## Proposed changes

The default approach for Claude Code to read a GitHub issue seems to be searching the web. This is very inefficient considering we can have the `gh` CLI utility fetch it, but that has some quirks/bugs. This is why there's the extra step of using a Python script to parse the GitHub issue.

Here is an example of how I used it:

```
❯ Read GitHub issue 1756 and print the comment history to screen

● Skill(gh-issue-reader)
  ⎿  Successfully loaded skill · 1 tool allowed

● Bash(git -C /home/fs01/nd357/spectre rev-parse --show-toplevel)
  ⎿  /home/fs01/nd357/spectre

  Read 1 file (ctrl+o to expand)

● Bash(python3 "$(git -C /home/fs01/nd357/spectre rev-parse --show-toplevel)/.skills/scripts/FetchIssue.py" 1756 --repo sxs-collaboration/spectre)
  ⎿  Issue #1756: Provide instructions to specify a seed for random tests
     URL:     https://github.com/sxs-collaboration/spectre/issues/1756
     State:   OPEN
     … +20 lines (ctrl+o to expand)

● Here's the full issue and comment history for sxs-collaboration/spectre#1756:

  ---
  Issue #1756: Provide instructions to specify a seed for random tests

  State: OPEN | Author: nilsvu | Created: 2019-11-04

  Body:
  The issue requests adding developer guide instructions for setting the seed for random tests when one fails and needs investigation. Two open questions:
  1. Could reproducing failures depend on the build environment (compiler, OS, etc.)?
  2. Can Catch2's --rng-seed option be used to set the seed without recompiling?

  ---
  Comment History

  1. nilsdeppe (2020-02-27): Can't find the ctest flag. Adding a flag to RunTests directly might be possible but would require a global variable, which isn't ideal.
  2. nilsvu (2020-02-27): Correction — it's a Catch2 flag, not ctest: https://github.com/catchorg/Catch2/blob/master/docs/command-line.md#rng-seed
  3. nilsdeppe (2020-02-27): That flag seeds std::rand, but SpECTRE uses the more robust mt19937 generator, so it likely won't work.

  ---
  The issue has been open since 2019 with no resolution. The core problem remains: there's no easy way to specify a seed for SpECTRE's MAKE_GENERATOR-based random tests without recompiling.
```

The more interesting use-case is having Claude Code fix issues with just giving it an issue number.

Here is the example for the second skill, getting PR comments to fix them:

```
❯ Show me the comments on PR 7158 so I can work on them.

● Skill(gh-pr-comments)
  ⎿  Successfully loaded skill · 1 tool allowed

  Read 1 file (ctrl+o to expand)

● Bash(python3 "$(git rev-parse --show-toplevel)/.skills/scripts/FetchPrComments.py" 7158 --repo sxs-collaboration/spectre)
  ⎿  PR #7158: Move serialize_and_deserialize into src
     URL:             https://github.com/sxs-collaboration/spectre/pull/7158
     State:           OPEN
     … +55 lines (ctrl+o to expand)

● PR #7158: Move serialize_and_deserialize into src

  Status: OPEN, APPROVED
  Author: nilsdeppe
  Base: develop <- fix_1727

  Review Summary

  - 1 unresolved thread, 0 resolved
  - Reviewer: wthrowe — requested changes, then approved after fixes

  Unresolved Thread

  Thread 1 — src/Utilities/Serialization/Serialize.hpp:89 (OUTDATED)
  wthrowe suggests changing the word "converting" to "copying" in the doc comment:

  ▎ * converting objects that store state in a way only accessible via PUP.
  ▎ converting -> copying?

  Top-level Comments

  wthrowe approved with "Looks good. Squash." and noted clang-tidy complaints are unrelated. nilsdeppe confirmed rebased and squashed.

  ---
  This is a minor documentation wording fix. The thread is marked OUTDATED (code may have changed since), so let me check if this line still exists in the current state of the file.

  Searched for 4 patterns (ctrl+o to expand)

● The serialize_and_deserialize function doesn't appear to exist in the current file on this branch. This PR is against the develop branch (not main), and the thread is marked OUTDATED.

  Let me check what branch we're on and whether this code exists here.

  Read 1 file (ctrl+o to expand)

● The serialize_and_deserialize function hasn't been added to this branch — this PR is on the fix_1727 branch targeting develop upstream. The comment is OUTDATED and the PR is already APPROVED with the
  reviewer saying "Looks good. Squash."

  Bottom line: There's nothing actionable for you on this PR from your current branch. The single unresolved thread was a minor doc wording suggestion ("converting" → "copying"), the code is on a different
  branch (fix_1727), and the reviewer has already approved. The PR author (nilsdeppe) has already rebased and squashed.

  Would you like to check out that branch to make the fix, or is there something else you'd like to work on?
```

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
