### PR TITLE
Fix compiler error on urania

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/Actions/ApplyBoundaryCorrections.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/ApplyBoundaryCorrections.hpp
@@ -115,6 +115,7 @@ bool receive_boundary_data(
     const gsl::not_null<db::DataBox<DbTagsList>*> box,
     const gsl::not_null<tuples::TaggedTuple<InboxTags...>*> inboxes) {
   constexpr size_t volume_dim = Metavariables::system::volume_dim;
+  constexpr size_t face_dim = volume_dim - 1;
 
   const auto needed_time = [&box]() {
     if constexpr (LocalTimeStepping) {
@@ -239,10 +240,10 @@ bool receive_boundary_data(
                   const gsl::not_null<
                       DirectionalIdMap<volume_dim, Mesh<volume_dim>>*>
                       neighbor_mesh) {
-                const Mesh<volume_dim - 1> neighbor_face_mesh =
+                const Mesh<face_dim> neighbor_face_mesh =
                     received_mortar_data->second.volume_mesh.slice_away(
                         sliced_away_dim);
-                const Mesh<volume_dim - 1> mortar_mesh =
+                const Mesh<face_dim> mortar_mesh =
                     ::dg::mortar_mesh(face_mesh, neighbor_face_mesh);
 
                 const auto project_boundary_mortar_data =

--- a/support/Environments/urania.sh
+++ b/support/Environments/urania.sh
@@ -55,6 +55,6 @@ spectre_run_cmake() {
           -D BUILD_PYTHON_BINDINGS=ON \
           -D MACHINE=Urania \
           -D SPEC_ROOT=/u/guilara/repos/spec \
-          -D Catch2_DIR=/u/guilara/repos/Catch2/install_dir/lib64/cmake/Catch2 \
+          -D SPECTRE_FETCH_MISSING_DEPS=ON \
           "$@" $SPECTRE_HOME
 }


### PR DESCRIPTION
## Proposed changes

Fixes "internal compiler error" with gcc11 on Urania. Also updates urania environment. Error is:

/u/guilara/repos/debug_spectre/spectre/src/Evolution/DiscontinuousGalerkin/Actions/ApplyBoundaryCorrections.hpp:242:28: internal compiler error: in lookup_template_class_1, at cp/pt.c:10007
242 |                 const Mesh<volume_dim - 1> neighbor_face_mesh =
        |                            ^~~~~~~~~~
0x177ca8d diagnostic_impl(rich_location*, diagnostic_metadata const*, int, char const*, __va_list_tag (*) [1], diagnostic_t)
....
Please submit a full bug report,
with preprocessed source if appropriate.
Please include the complete backtrace with any bug report.
See <https://gcc.gnu.org/bugs/> for instructions.



<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
