### PR TITLE
Update hpcprof command in developer guides

### DIFF
--- a/docs/DevGuide/Profiling.md
+++ b/docs/DevGuide/Profiling.md
@@ -45,9 +45,15 @@ slowly.
 
 Once the run is complete, run
 ```
+hpcprof hpctoolkit-EXEC-measurements
+```
+or if HPCToolkit version < 2024, run
+```
 hpcprof -I /path/to/spectre/src/+ hpctoolkit-EXEC-measurements
 ```
-Note that the `+` is a literal `+` symbol. This will create the directory
+Note that the `+` is a literal `+` symbol.
+
+This will create the directory
 ```
 hpctoolkit-EXEC-database
 ```


### PR DESCRIPTION
## Proposed changes

It seems as of HPCToolkit 2024, the `-I` flag is deprecated and it finds the source files by default from the debug symbols of the executable. The new command in the commit worked for me on mbot.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
