### PR TITLE
Fix journal macro expansion in docs

### DIFF
--- a/docs/Dependencies.bib
+++ b/docs/Dependencies.bib
@@ -125,7 +125,7 @@
 @ARTICLE{Libsharp,
   author =       {{Reinecke}, M. and {Seljebotn}, D.~S.},
   title =        "{Libsharp - spherical harmonic transforms revisited}",
-  journal =      {\aap},
+  journal =      {Astronomy and Astrophysics},
   keywords =     {methods: numerical, cosmic background radiation, large-scale
                   structure of Universe, Physics - Computational Physics},
   year =         2013,

--- a/docs/DevGuide/WritingDox.md
+++ b/docs/DevGuide/WritingDox.md
@@ -184,6 +184,9 @@ entry. Else, use the URL provided by the publisher.
 - Make sure to wrap strings in the BibTeX entries in `{}` when capitalization is
 important, or when BibTeX keywords should be ignored (e.g. `and` in author
 lists).
+- Spell out journal names directly instead of using LaTeX macros such as
+  `\apj` or `\mnras`, since Doxygen does not expand those macros in the
+  generated bibliography.
 
 To cite an entry from the `docs/References.bib` file in the documentation, use
 the Doxygen keyword

--- a/docs/References.bib
+++ b/docs/References.bib
@@ -106,7 +106,7 @@
   author =       {Dinshaw Balsara},
   title =        {Total Variation Diminishing Scheme for Relativistic
                   Magnetohydrodynamics},
-  journal =      {The Astrophysical Journal Supplement Series},
+  journal =      {Astrophysical Journal, Supplement},
 }
 
 @article{Balsara2016780,
@@ -229,7 +229,7 @@
   eprint         = "1101.3573",
   archivePrefix  = "arXiv",
   primaryClass   = "astro-ph.HE",
-  journal        = "The Astrophysical Journal Supplement Series",
+  journal        = "Astrophysical Journal, Supplement",
   number         = "1",
   pages          = "6",
   volume         = "193",
@@ -1045,7 +1045,7 @@ eprint = {https://doi.org/10.1137/0916035}
   title =        "{A Numerical Study of Relativistic Bondi-Hoyle Accretion onto
                   a Moving Black Hole: Axisymmetric Computations in a
                   Schwarzschild Background}",
-  journal =      {\apj},
+  journal =      {The Astrophysical Journal},
   year =         1998,
   month =        "Feb",
   volume =       494,
@@ -1360,7 +1360,7 @@ eprint = {https://doi.org/10.1137/0916035}
        author = {{Heger}, A. and {Woosley}, S.~E. and {Spruit}, H.~C.},
         title = "{Presupernova Evolution of Differentially Rotating Massive
          Stars Including Magnetic Fields}",
-      journal = {\apj},
+      journal = {The Astrophysical Journal},
      keywords = {Stars: Pulsars: General, Stars: Evolution, Stars: Magnetic
       Fields, Stars: Rotation, Astrophysics},
          year = 2005,
@@ -2192,7 +2192,7 @@ journal = {The Astrophysical Journal}
        author = {{O'Connor}, Evan},
         title = "{An Open-source Neutrino Radiation Hydrodynamics Code for
          Core-collapse Supernovae}",
-      journal = {\apjs},
+      journal = {Astrophysical Journal, Supplement},
      keywords = {black hole physics, hydrodynamics, neutrinos, radiative
       transfer, stars: neutron, supernovae: general, Astrophysics - High
       Energy Astrophysical Phenomena, Nuclear Theory},
@@ -2395,7 +2395,7 @@ archivePrefix = {arXiv},
   author =       {{Penner}, A.~J.},
   title =        "{General relativistic magnetohydrodynamic Bondi-Hoyle
                   accretion}",
-  journal =      {\mnras},
+  journal =      {Monthly Notices of the Royal Astronomical Society},
   year =         2011,
   month =        "Jun",
   volume =       414,
@@ -2446,7 +2446,7 @@ archivePrefix = {arXiv},
         title = "{A new moment-based general-relativistic neutrino-radiation
         transport code: Methods and first applications to neutron star
         mergers}",
-      journal = {\mnras},
+      journal = {Monthly Notices of the Royal Astronomical Society},
      keywords = {neutrinos, methods: numerical, neutron star mergers,
      Astrophysics - High Energy Astrophysical Phenomena, General Relativity
      and Quantum Cosmology},
@@ -2493,7 +2493,7 @@ archivePrefix = {arXiv},
         {Abdikamalov}, Ernazar and {O'Connor}, Evan and {Sullivan}, Chris},
         title = "{Equation of state effects on gravitational waves from
          rotating core collapse}",
-      journal = {\prd},
+      journal = {Phys. Rev. D},
      keywords = {Astrophysics - High Energy Astrophysical Phenomena},
          year = 2017,
         month = mar,

--- a/tools/CheckMetadata.py
+++ b/tools/CheckMetadata.py
@@ -12,6 +12,7 @@ import urllib
 
 import git
 import pybtex
+import pybtex.database
 import yaml
 
 VERSION_PATTERN = r"(\d{4})\.(\d{2})\.(\d{2})(\.\d+)?"
@@ -269,6 +270,30 @@ class TestMetadata(unittest.TestCase):
             ref_text = to_plaintext_reference(entry)
             if key == "charmpp":
                 self.assertEqual(ref_text, charmpp_ref)
+
+    def test_documentation_bibliography_journal_names(self):
+        for bibliography_file in [
+            "docs/References.bib",
+            "docs/Dependencies.bib",
+        ]:
+            references = pybtex.database.parse_file(
+                os.path.join(self.repo.working_dir, bibliography_file)
+            )
+            journal_macros = [
+                f"{key}: {entry.fields['journal']}"
+                for key, entry in references.entries.items()
+                if "journal" in entry.fields
+                and entry.fields["journal"].startswith("\\")
+            ]
+            self.assertEqual(
+                journal_macros,
+                [],
+                (
+                    f"Journal names in '{bibliography_file}' should be written"
+                    " out directly because Doxygen does not expand LaTeX"
+                    f" macros: {journal_macros}"
+                ),
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

Fixes #6469 

Replace LaTeX journal macros in documentation bibliographies with plain-text names that Doxygen renders correctly, document the rule in the writing guide, and add a metadata check to catch regressions.

Standardize ApJS entries on 'Astrophysical Journal, Supplement' (matching https://ui.adsabs.harvard.edu/help/actions/journal-macros) while keeping the bibliography free of journal macros.

### AI usage
Co-authored by Codex.

I reviewed every line of modifications myself, and a review using the spectre-review skill found no issues.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
