### PR TITLE
Add coding agent as co-author to review checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,6 +24,11 @@ lines below.
   [code review guide](https://spectre-code.org/code_review_guide.html).
 - [ ] The PR lists upgrade instructions and is labeled `bugfix` or
   `new feature` if appropriate.
+- [ ] If a coding agent is used, have one of
+      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
+      "Co-Authored-by: Codex <noreply@openai.com>", or
+      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
+      as the last line of the commit, depending on the agent.
 
 ### Further comments
 


### PR DESCRIPTION
## Proposed changes

This allows us to track what commits were co-author by a coding agent and what weren't, in case we ever need that.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
