### PR TITLE
Fix compilation of EvolveGhValenciaDivCleanBns with FukaInitialData

### DIFF
--- a/src/PointwiseFunctions/AnalyticData/GrMhd/FukaInitialData.hpp
+++ b/src/PointwiseFunctions/AnalyticData/GrMhd/FukaInitialData.hpp
@@ -113,19 +113,23 @@ class FukaInitialData : public evolution::initial_data::InitialData,
         get<hydro::Tags::SpatialVelocity<DataVector, 3>>(result);
     const auto& spatial_metric =
         get<gr::Tags::SpatialMetric<DataVector, 3>>(result);
-    // Compute enthalpy from internal energy and pressure
-    auto& specific_enthalpy =
-        get<hydro::Tags::SpecificEnthalpy<DataVector>>(result);
-    get(specific_enthalpy) = DataVector(num_points);
-    for (size_t i = 0; i < num_points; ++i) {
-      const double local_rest_mass_density = get(rest_mass_density)[i];
-      if (equal_within_roundoff(local_rest_mass_density, 0.)) {
-        get(specific_enthalpy)[i] = 1.;
-      } else {
-        get(specific_enthalpy)[i] = get(hydro::relativistic_specific_enthalpy(
-            Scalar<double>(local_rest_mass_density),
-            Scalar<double>(get(specific_internal_energy)[i]),
-            Scalar<double>(get(pressure)[i])));
+    if constexpr (tmpl::list_contains_v<
+                      tmpl::list<RequestedTags...>,
+                      hydro::Tags::SpecificEnthalpy<DataVector>>) {
+      // Compute enthalpy from internal energy and pressure if requested
+      auto& specific_enthalpy =
+          get<hydro::Tags::SpecificEnthalpy<DataVector>>(result);
+      get(specific_enthalpy) = DataVector(num_points);
+      for (size_t i = 0; i < num_points; ++i) {
+        const double local_rest_mass_density = get(rest_mass_density)[i];
+        if (equal_within_roundoff(local_rest_mass_density, 0.)) {
+          get(specific_enthalpy)[i] = 1.;
+        } else {
+          get(specific_enthalpy)[i] = get(hydro::relativistic_specific_enthalpy(
+              Scalar<double>(local_rest_mass_density),
+              Scalar<double>(get(specific_internal_energy)[i]),
+              Scalar<double>(get(pressure)[i])));
+        }
       }
     }
     // Constant electron fraction specified by input file


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

`EvolveGhValenciaDivCleanBns` was failing to compile when specifying `FUKA_ROOT`. Codex helped me look through the compilation error and found that it was failing because the executable didn't request `SpecificEnthalpy`. So, it added a condition to check if `SpecificEnthalpy` is in `RequestedTags` before computing it.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
