### PR TITLE
Remove test_copy_semantics extra construction Args

### DIFF
--- a/tests/Unit/Framework/TestHelpers.hpp
+++ b/tests/Unit/Framework/TestHelpers.hpp
@@ -104,11 +104,8 @@ void test_move_semantics(T&& a, const T& comparison, Args&&... args) {
 
 /// Test for copy and move semantics assuming operator== is
 /// implemented correctly.
-///
-/// If T is not default constructible, pass additional arguments that
-/// are used to construct a T.
-template <typename T, typename... Args>
-void test_copy_semantics(const T& a, Args&&... args) {
+template <typename T>
+void test_copy_semantics(const T& a) {
   INFO("Copy semantics");
   static_assert(tt::has_equivalence_v<T>,
                 "Class has no operator== implemented");
@@ -140,7 +137,7 @@ void test_copy_semantics(const T& a, Args&&... args) {
   CHECK(b == a);
   CHECK_FALSE(b != a);
 
-  test_move_semantics(std::move(b), a, std::forward<Args>(args)...);
+  test_move_semantics(std::move(b), a);
 }
 
 // Test for iterators


### PR DESCRIPTION
The function has `static_assert(std::is_default_constructible_v<T>)`.

I could have instead modified the code to use the arguments instead of default-constructing, but seeing as nothing has cared so far it didn't seem worth it.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
