### PR TITLE
Rename StepChoosers tags to LtsStepChoosers

### DIFF
--- a/src/Time/ChangeStepSize.hpp
+++ b/src/Time/ChangeStepSize.hpp
@@ -13,8 +13,8 @@
 #include "Time/AdaptiveSteppingDiagnostics.hpp"
 #include "Time/ChooseLtsStepSize.hpp"
 #include "Time/Tags/HistoryEvolvedVariables.hpp"
+#include "Time/Tags/LtsStepChoosers.hpp"
 #include "Time/Tags/MinimumTimeStep.hpp"
-#include "Time/Tags/StepChoosers.hpp"
 #include "Time/Time.hpp"
 #include "Time/TimeStepId.hpp"
 #include "Time/TimeStepRequest.hpp"
@@ -44,7 +44,7 @@ struct TimeStepper;
 ///
 /// \details
 /// Usually, the new step size is chosen by calling the StepChoosers from
-/// `Tags::StepChoosers`, restricted based on the allowed step sizes at the
+/// `Tags::LtsStepChoosers`, restricted based on the allowed step sizes at the
 /// current time, and limits from history initialization.
 ///
 /// If `Tags::FixedLtsRatio` is present in the DataBox and not empty, the
@@ -65,7 +65,7 @@ template <typename StepChoosersToUse = AllStepChoosers,
 struct ChangeStepSize {
   using const_global_cache_tags =
       tmpl::list<CacheTagPrefix<Tags::MinimumTimeStep>,
-                 CacheTagPrefix<Tags::StepChoosers>>;
+                 CacheTagPrefix<Tags::LtsStepChoosers>>;
 
   using return_tags = tmpl::list<Tags::DataBox>;
   using argument_tags = tmpl::list<>;
@@ -80,7 +80,7 @@ struct ChangeStepSize {
     const LtsTimeStepper& time_stepper =
         db::get<CacheTagPrefix<Tags::TimeStepper<LtsTimeStepper>>>(*box);
     const auto& step_choosers =
-        db::get<CacheTagPrefix<Tags::StepChoosers>>(*box);
+        db::get<CacheTagPrefix<Tags::LtsStepChoosers>>(*box);
 
     using history_tags = ::Tags::get_all_history_tags<DbTags>;
     bool can_change_step_size = true;

--- a/src/Time/OptionTags/CMakeLists.txt
+++ b/src/Time/OptionTags/CMakeLists.txt
@@ -8,8 +8,8 @@ spectre_target_headers(
   InitialSlabSize.hpp
   InitialTime.hpp
   InitialTimeStep.hpp
+  LtsStepChoosers.hpp
   MinimumTimeStep.hpp
-  StepChoosers.hpp
   TimeStepper.hpp
   VariableOrderAlgorithm.hpp
   )

--- a/src/Time/OptionTags/LtsStepChoosers.hpp
+++ b/src/Time/OptionTags/LtsStepChoosers.hpp
@@ -13,7 +13,7 @@
 namespace OptionTags {
 /// \ingroup OptionTagsGroup
 /// \ingroup TimeGroup
-struct StepChoosers {
+struct LtsStepChoosers {
   static constexpr Options::String help{
       "Limits on the LTS step size.  If the list is empty, the step:slab "
       "ratio will not be changed."};

--- a/src/Time/OptionTags/StepChoosers.hpp
+++ b/src/Time/OptionTags/StepChoosers.hpp
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include <cstddef>
 #include <memory>
 #include <vector>
 
@@ -15,10 +14,11 @@ namespace OptionTags {
 /// \ingroup OptionTagsGroup
 /// \ingroup TimeGroup
 struct StepChoosers {
-  static constexpr Options::String help{"Limits on LTS step size"};
+  static constexpr Options::String help{
+      "Limits on the LTS step size.  If the list is empty, the step:slab "
+      "ratio will not be changed."};
   using type =
       std::vector<std::unique_ptr<::StepChooser<StepChooserUse::LtsStep>>>;
-  static size_t lower_bound_on_size() { return 1; }
   using group = evolution::OptionTags::Group;
 };
 }  // namespace OptionTags

--- a/src/Time/Tags/CMakeLists.txt
+++ b/src/Time/Tags/CMakeLists.txt
@@ -14,8 +14,8 @@ spectre_target_headers(
   AdaptiveSteppingDiagnostics.hpp
   FixedLtsRatio.hpp
   HistoryEvolvedVariables.hpp
+  LtsStepChoosers.hpp
   MinimumTimeStep.hpp
-  StepChoosers.hpp
   StepNumberWithinSlab.hpp
   StepperErrorEstimatesEnabled.hpp
   StepperErrorTolerances.hpp

--- a/src/Time/Tags/LtsStepChoosers.hpp
+++ b/src/Time/Tags/LtsStepChoosers.hpp
@@ -8,7 +8,7 @@
 #include <vector>
 
 #include "DataStructures/DataBox/Tag.hpp"
-#include "Time/OptionTags/StepChoosers.hpp"
+#include "Time/OptionTags/LtsStepChoosers.hpp"
 #include "Time/StepChoosers/StepChooser.hpp"
 #include "Utilities/Serialization/Serialize.hpp"
 #include "Utilities/TMPL.hpp"
@@ -17,10 +17,10 @@ namespace Tags {
 /// \ingroup DataBoxTagsGroup
 /// \ingroup TimeGroup
 /// \brief Tag for a vector of ::StepChooser%s
-struct StepChoosers : db::SimpleTag {
+struct LtsStepChoosers : db::SimpleTag {
   using type =
       std::vector<std::unique_ptr<::StepChooser<StepChooserUse::LtsStep>>>;
-  using option_tags = tmpl::list<::OptionTags::StepChoosers>;
+  using option_tags = tmpl::list<::OptionTags::LtsStepChoosers>;
   static constexpr bool is_overlayable = true;
 
   static constexpr bool pass_metavariables = false;

--- a/src/Time/Tags/StepperErrorTolerancesCompute.hpp
+++ b/src/Time/Tags/StepperErrorTolerancesCompute.hpp
@@ -30,7 +30,7 @@ struct LtsStep;
 namespace Tags {
 template <Triggers::WhenToCheck WhenToCheck>
 struct EventsAndTriggers;
-struct StepChoosers;
+struct LtsStepChoosers;
 template <typename StepperInterface>
 struct TimeStepper;
 struct VariableOrderAlgorithm;
@@ -60,7 +60,7 @@ struct StepperErrorEstimatesEnabledCompute : db::ComputeTag,
   using argument_tags = tmpl::conditional_t<
       LocalTimeStepping,
       tmpl::list<::Tags::EventsAndTriggers<Triggers::WhenToCheck::AtSlabs>,
-                 CacheTagPrefix<::Tags::StepChoosers>>,
+                 CacheTagPrefix<::Tags::LtsStepChoosers>>,
       tmpl::list<::Tags::EventsAndTriggers<Triggers::WhenToCheck::AtSlabs>>>;
 
   static constexpr auto function = []() {
@@ -100,7 +100,7 @@ struct StepperErrorTolerancesCompute
   using argument_tags = tmpl::conditional_t<
       LocalTimeStepping,
       tmpl::list<::Tags::EventsAndTriggers<Triggers::WhenToCheck::AtSlabs>,
-                 CacheTagPrefix<::Tags::StepChoosers>,
+                 CacheTagPrefix<::Tags::LtsStepChoosers>,
                  CacheTagPrefix<::Tags::TimeStepper<::TimeStepper>>,
                  CacheTagPrefix<::Tags::VariableOrderAlgorithm>>,
       tmpl::list<::Tags::EventsAndTriggers<Triggers::WhenToCheck::AtSlabs>>>;

--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -218,7 +218,7 @@ Evolution:
   InitialSlabSize: 0.1
   VariableOrderAlgorithm:
     GoalOrder: 4
-  StepChoosers:
+  LtsStepChoosers:
     - LimitIncrease:
         Factor: 2
     - PreventRapidIncrease

--- a/support/Pipelines/Bbh/Ringdown.yaml
+++ b/support/Pipelines/Bbh/Ringdown.yaml
@@ -94,7 +94,7 @@ Evolution:
   InitialSlabSize: 0.1
   VariableOrderAlgorithm:
     GoalOrder: 4
-  StepChoosers:
+  LtsStepChoosers:
     - LimitIncrease:
         Factor: 2
     - ErrorControl:

--- a/tests/InputFiles/Burgers/Step.yaml
+++ b/tests/InputFiles/Burgers/Step.yaml
@@ -31,7 +31,7 @@ Evolution:
       Order: 3
   VariableOrderAlgorithm:
     GoalOrder: 3
-  StepChoosers:
+  LtsStepChoosers:
     - Cfl:
         SafetyFactor: 0.5
     - LimitIncrease:

--- a/tests/InputFiles/Cce/AnalyticTestBouncingBlackHole.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestBouncingBlackHole.yaml
@@ -56,7 +56,7 @@ Cce:
     VariableOrderAlgorithm:
       GoalOrder: 3
     MinimumTimeStep: 1e-7
-    StepChoosers:
+    LtsStepChoosers:
       - Constant: 0.1
       - LimitIncrease:
           Factor: 2

--- a/tests/InputFiles/Cce/AnalyticTestGaugeWave.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestGaugeWave.yaml
@@ -56,7 +56,7 @@ Cce:
     VariableOrderAlgorithm:
       GoalOrder: 3
     MinimumTimeStep: 1e-7
-    StepChoosers:
+    LtsStepChoosers:
       - Constant: 0.4
       - LimitIncrease:
           Factor: 2

--- a/tests/InputFiles/Cce/AnalyticTestLinearizedBondiSachs.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestLinearizedBondiSachs.yaml
@@ -56,7 +56,7 @@ Cce:
     VariableOrderAlgorithm:
       GoalOrder: 3
     MinimumTimeStep: 1e-7
-    StepChoosers:
+    LtsStepChoosers:
       - Constant: 0.4
       - LimitIncrease:
           Factor: 2

--- a/tests/InputFiles/Cce/AnalyticTestRobinsonTrautman.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestRobinsonTrautman.yaml
@@ -56,7 +56,7 @@ Cce:
     VariableOrderAlgorithm:
       GoalOrder: 3
     MinimumTimeStep: 1e-7
-    StepChoosers:
+    LtsStepChoosers:
       - Constant: 0.1
       - LimitIncrease:
           Factor: 2

--- a/tests/InputFiles/Cce/AnalyticTestRotatingSchwarzschild.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestRotatingSchwarzschild.yaml
@@ -56,7 +56,7 @@ Cce:
     VariableOrderAlgorithm:
       GoalOrder: 3
     MinimumTimeStep: 1e-7
-    StepChoosers:
+    LtsStepChoosers:
       - Constant: 0.2
       - LimitIncrease:
           Factor: 2

--- a/tests/InputFiles/Cce/AnalyticTestTeukolskyWave.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestTeukolskyWave.yaml
@@ -56,7 +56,7 @@ Cce:
     VariableOrderAlgorithm:
       GoalOrder: 3
     MinimumTimeStep: 1e-7
-    StepChoosers:
+    LtsStepChoosers:
       - Constant: 0.5
       - LimitIncrease:
           Factor: 2

--- a/tests/InputFiles/Cce/AnalyticTestVolumeNewmanPenroseSpinCoefficients.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestVolumeNewmanPenroseSpinCoefficients.yaml
@@ -118,7 +118,7 @@ Cce:
     VariableOrderAlgorithm:
       GoalOrder: 3
     MinimumTimeStep: 1e-7
-    StepChoosers:
+    LtsStepChoosers:
       - Constant: 0.1
       - LimitIncrease:
           Factor: 2

--- a/tests/InputFiles/Cce/AnalyticTestVolumeWeylScalars.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestVolumeWeylScalars.yaml
@@ -73,7 +73,7 @@ Cce:
     VariableOrderAlgorithm:
       GoalOrder: 3
     MinimumTimeStep: 1e-7
-    StepChoosers:
+    LtsStepChoosers:
       - Constant: 0.1
       - LimitIncrease:
           Factor: 2

--- a/tests/InputFiles/Cce/CharacteristicExtract.yaml
+++ b/tests/InputFiles/Cce/CharacteristicExtract.yaml
@@ -76,7 +76,7 @@ Cce:
     VariableOrderAlgorithm:
       GoalOrder: 3
     MinimumTimeStep: 1e-7
-    StepChoosers:
+    LtsStepChoosers:
       - Constant: 0.1 # Don't take steps bigger than 0.1M
       - LimitIncrease:
           Factor: 2

--- a/tests/InputFiles/Cce/KleinGordonCharacteristicExtract.yaml
+++ b/tests/InputFiles/Cce/KleinGordonCharacteristicExtract.yaml
@@ -55,7 +55,7 @@ Cce:
     VariableOrderAlgorithm:
       GoalOrder: 3
     MinimumTimeStep: 1e-7
-    StepChoosers:
+    LtsStepChoosers:
       - Constant: 0.1 # Don't take steps bigger than 0.1M
       - LimitIncrease:
           Factor: 2

--- a/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski1D.yaml
+++ b/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski1D.yaml
@@ -38,7 +38,7 @@ Evolution:
   TimeStepper:
     AdamsBashforth:
       Order: 3
-  StepChoosers:
+  LtsStepChoosers:
     - LimitIncrease:
         Factor: 2
     - PreventRapidIncrease

--- a/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski2D.yaml
+++ b/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski2D.yaml
@@ -38,7 +38,7 @@ Evolution:
   TimeStepper:
     AdamsBashforth:
       Order: 3
-  StepChoosers:
+  LtsStepChoosers:
     - LimitIncrease:
         Factor: 2
     - PreventRapidIncrease

--- a/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski3D.yaml
+++ b/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski3D.yaml
@@ -53,7 +53,7 @@ Evolution:
   TimeStepper:
     AdamsBashforth:
       Order: 3
-  StepChoosers:
+  LtsStepChoosers:
     - LimitIncrease:
         Factor: 2
     - PreventRapidIncrease

--- a/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
@@ -23,7 +23,7 @@ Evolution:
   InitialSlabSize: 0.25
   VariableOrderAlgorithm:
     GoalOrder: 3
-  StepChoosers:
+  LtsStepChoosers:
     - LimitIncrease:
         Factor: 2
     - PreventRapidIncrease

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -35,7 +35,7 @@ Evolution:
   InitialSlabSize: 0.001
   VariableOrderAlgorithm:
     GoalOrder: 4
-  StepChoosers:
+  LtsStepChoosers:
     - LimitIncrease:
         Factor: 2
     - ElementSizeCfl:

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
@@ -27,7 +27,7 @@ Evolution:
     AdamsBashforth:
       Order: 3
   # StepChoosers are needed only for local time stepping
-  # StepChoosers:
+  # LtsStepChoosers:
   #   - LimitIncrease:
   #       Factor: 2
   #   - PreventRapidIncrease

--- a/tests/InputFiles/ScalarTensor/KerrSchildSphericalHarmonic.yaml
+++ b/tests/InputFiles/ScalarTensor/KerrSchildSphericalHarmonic.yaml
@@ -30,7 +30,7 @@ Evolution:
   InitialSlabSize: 0.001
   VariableOrderAlgorithm:
     GoalOrder: 3
-  StepChoosers:
+  LtsStepChoosers:
     - LimitIncrease:
         Factor: 2
     - PreventRapidIncrease

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
@@ -76,7 +76,6 @@
 #include "Time/StepChoosers/StepChooser.hpp"
 #include "Time/Tags/AdaptiveSteppingDiagnostics.hpp"
 #include "Time/Tags/HistoryEvolvedVariables.hpp"
-#include "Time/Tags/StepChoosers.hpp"
 #include "Time/Tags/Time.hpp"
 #include "Time/Tags/TimeStep.hpp"
 #include "Time/Tags/TimeStepId.hpp"

--- a/tests/Unit/Time/OptionTags/CMakeLists.txt
+++ b/tests/Unit/Time/OptionTags/CMakeLists.txt
@@ -6,8 +6,8 @@ set(LIBRARY_SOURCES
   OptionTags/Test_InitialSlabSize.cpp
   OptionTags/Test_InitialTime.cpp
   OptionTags/Test_InitialTimeStep.cpp
+  OptionTags/Test_LtsStepChoosers.cpp
   OptionTags/Test_MinimumTimeStep.cpp
-  OptionTags/Test_StepChoosers.cpp
   OptionTags/Test_TimeStepper.cpp
   OptionTags/Test_VariableOrderAlgorithm.cpp
   PARENT_SCOPE)

--- a/tests/Unit/Time/OptionTags/Test_LtsStepChoosers.cpp
+++ b/tests/Unit/Time/OptionTags/Test_LtsStepChoosers.cpp
@@ -7,7 +7,7 @@
 
 #include "Framework/TestCreation.hpp"
 #include "Options/Protocols/FactoryCreation.hpp"
-#include "Time/OptionTags/StepChoosers.hpp"
+#include "Time/OptionTags/LtsStepChoosers.hpp"
 #include "Time/StepChoosers/LimitIncrease.hpp"
 #include "Time/StepChoosers/StepChooser.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
@@ -23,9 +23,9 @@ struct Metavariables {
   };
 };
 
-SPECTRE_TEST_CASE("Unit.Time.OptionTags.StepChoosers", "[Unit][Time]") {
+SPECTRE_TEST_CASE("Unit.Time.OptionTags.LtsStepChoosers", "[Unit][Time]") {
   const auto choosers =
-      TestHelpers::test_option_tag<OptionTags::StepChoosers, Metavariables>(
+      TestHelpers::test_option_tag<OptionTags::LtsStepChoosers, Metavariables>(
           "- LimitIncrease:\n"
           "    Factor: 3.0\n");
   CHECK(choosers.size() == 1);

--- a/tests/Unit/Time/Tags/CMakeLists.txt
+++ b/tests/Unit/Time/Tags/CMakeLists.txt
@@ -6,8 +6,8 @@ set(LIBRARY_SOURCES
   Tags/Test_AdaptiveSteppingDiagnostics.cpp
   Tags/Test_FixedLtsRatio.cpp
   Tags/Test_HistoryEvolvedVariables.cpp
+  Tags/Test_LtsStepChoosers.cpp
   Tags/Test_MinimumTimeStep.cpp
-  Tags/Test_StepChoosers.cpp
   Tags/Test_StepNumberWithinSlab.cpp
   Tags/Test_StepperErrorEstimatesEnabled.cpp
   Tags/Test_StepperErrorTolerances.cpp

--- a/tests/Unit/Time/Tags/Test_LtsStepChoosers.cpp
+++ b/tests/Unit/Time/Tags/Test_LtsStepChoosers.cpp
@@ -7,8 +7,8 @@
 #include <string>
 
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
-#include "Time/Tags/StepChoosers.hpp"
+#include "Time/Tags/LtsStepChoosers.hpp"
 
-SPECTRE_TEST_CASE("Unit.Time.Tags.StepChoosers", "[Unit][Time]") {
-  TestHelpers::db::test_simple_tag<Tags::StepChoosers>("StepChoosers");
+SPECTRE_TEST_CASE("Unit.Time.Tags.LtsStepChoosers", "[Unit][Time]") {
+  TestHelpers::db::test_simple_tag<Tags::LtsStepChoosers>("LtsStepChoosers");
 }

--- a/tests/Unit/Time/Tags/Test_StepperErrorTolerancesCompute.cpp
+++ b/tests/Unit/Time/Tags/Test_StepperErrorTolerancesCompute.cpp
@@ -27,7 +27,7 @@
 #include "Time/StepChoosers/LimitIncrease.hpp"
 #include "Time/StepChoosers/StepChooser.hpp"
 #include "Time/StepperErrorTolerances.hpp"
-#include "Time/Tags/StepChoosers.hpp"
+#include "Time/Tags/LtsStepChoosers.hpp"
 #include "Time/Tags/StepperErrorEstimatesEnabled.hpp"
 #include "Time/Tags/StepperErrorTolerances.hpp"
 #include "Time/Tags/StepperErrorTolerancesCompute.hpp"
@@ -145,11 +145,11 @@ SPECTRE_TEST_CASE("Unit.Time.Tags.StepperErrorTolerancesCompute",
           all_orders ? StepperErrorTolerances::Estimates::AllOrders
                      : StepperErrorTolerances::Estimates::StepperOrder;
 
-      db::mutate<Tags::StepChoosers,
+      db::mutate<Tags::LtsStepChoosers,
                  Tags::EventsAndTriggers<Triggers::WhenToCheck::AtSlabs>>(
-          [](const gsl::not_null<Tags::StepChoosers::type*> choosers,
+          [](const gsl::not_null<Tags::LtsStepChoosers::type*> choosers,
              const gsl::not_null<EventsAndTriggers*> events) {
-            *choosers = TestHelpers::test_creation<Tags::StepChoosers::type,
+            *choosers = TestHelpers::test_creation<Tags::LtsStepChoosers::type,
                                                    Metavariables>(
                 "- ErrorControl:\n"
                 "    SafetyFactor: 0.95\n"
@@ -171,9 +171,9 @@ SPECTRE_TEST_CASE("Unit.Time.Tags.StepperErrorTolerancesCompute",
       CHECK(db::get<Tags::StepperErrorTolerances<AltEvolvedVariablesTag>>(*box)
                 .estimates == StepperErrorTolerances::Estimates::None);
 
-      db::mutate<Tags::StepChoosers>(
-          [](const gsl::not_null<Tags::StepChoosers::type*> choosers) {
-            *choosers = TestHelpers::test_creation<Tags::StepChoosers::type,
+      db::mutate<Tags::LtsStepChoosers>(
+          [](const gsl::not_null<Tags::LtsStepChoosers::type*> choosers) {
+            *choosers = TestHelpers::test_creation<Tags::LtsStepChoosers::type,
                                                    Metavariables>(
                 "- LimitIncrease:\n"
                 "    Factor: 2\n"
@@ -186,9 +186,9 @@ SPECTRE_TEST_CASE("Unit.Time.Tags.StepperErrorTolerancesCompute",
       CHECK(db::get<Tags::StepperErrorTolerances<AltEvolvedVariablesTag>>(*box)
                 .estimates == StepperErrorTolerances::Estimates::None);
 
-      db::mutate<Tags::StepChoosers>(
-          [](const gsl::not_null<Tags::StepChoosers::type*> choosers) {
-            *choosers = TestHelpers::test_creation<Tags::StepChoosers::type,
+      db::mutate<Tags::LtsStepChoosers>(
+          [](const gsl::not_null<Tags::LtsStepChoosers::type*> choosers) {
+            *choosers = TestHelpers::test_creation<Tags::LtsStepChoosers::type,
                                                    Metavariables>("");
           },
           box);
@@ -198,9 +198,9 @@ SPECTRE_TEST_CASE("Unit.Time.Tags.StepperErrorTolerancesCompute",
       CHECK(db::get<Tags::StepperErrorTolerances<AltEvolvedVariablesTag>>(*box)
                 .estimates == StepperErrorTolerances::Estimates::None);
 
-      db::mutate<Tags::StepChoosers>(
-          [](const gsl::not_null<Tags::StepChoosers::type*> choosers) {
-            *choosers = TestHelpers::test_creation<Tags::StepChoosers::type,
+      db::mutate<Tags::LtsStepChoosers>(
+          [](const gsl::not_null<Tags::LtsStepChoosers::type*> choosers) {
+            *choosers = TestHelpers::test_creation<Tags::LtsStepChoosers::type,
                                                    Metavariables>(
                 "- ErrorControl:\n"
                 "    SafetyFactor: 0.95\n"
@@ -227,9 +227,9 @@ SPECTRE_TEST_CASE("Unit.Time.Tags.StepperErrorTolerancesCompute",
       CHECK(db::get<Tags::StepperErrorTolerances<AltEvolvedVariablesTag>>(*box)
                 .estimates == StepperErrorTolerances::Estimates::None);
 
-      db::mutate<Tags::StepChoosers>(
-          [](const gsl::not_null<Tags::StepChoosers::type*> choosers) {
-            *choosers = TestHelpers::test_creation<Tags::StepChoosers::type,
+      db::mutate<Tags::LtsStepChoosers>(
+          [](const gsl::not_null<Tags::LtsStepChoosers::type*> choosers) {
+            *choosers = TestHelpers::test_creation<Tags::LtsStepChoosers::type,
                                                    Metavariables>(
                 "- ErrorControl:\n"
                 "    SafetyFactor: 0.95\n"
@@ -258,9 +258,9 @@ SPECTRE_TEST_CASE("Unit.Time.Tags.StepperErrorTolerancesCompute",
                                                 .absolute = 1.0e-5,
                                                 .relative = 1.0e-8});
 
-      db::mutate<Tags::StepChoosers>(
-          [](const gsl::not_null<Tags::StepChoosers::type*> choosers) {
-            *choosers = TestHelpers::test_creation<Tags::StepChoosers::type,
+      db::mutate<Tags::LtsStepChoosers>(
+          [](const gsl::not_null<Tags::LtsStepChoosers::type*> choosers) {
+            *choosers = TestHelpers::test_creation<Tags::LtsStepChoosers::type,
                                                    Metavariables>(
                 "- ErrorControl:\n"
                 "    SafetyFactor: 0.95\n"
@@ -286,11 +286,11 @@ SPECTRE_TEST_CASE("Unit.Time.Tags.StepperErrorTolerancesCompute",
               Catch::Matchers::ContainsSubstring(
                   " must use the same tolerances."));
 
-      db::mutate<Tags::StepChoosers,
+      db::mutate<Tags::LtsStepChoosers,
                  Tags::EventsAndTriggers<Triggers::WhenToCheck::AtSlabs>>(
-          [](const gsl::not_null<Tags::StepChoosers::type*> choosers,
+          [](const gsl::not_null<Tags::LtsStepChoosers::type*> choosers,
              const gsl::not_null<EventsAndTriggers*> events) {
-            *choosers = TestHelpers::test_creation<Tags::StepChoosers::type,
+            *choosers = TestHelpers::test_creation<Tags::LtsStepChoosers::type,
                                                    Metavariables>("");
             *events =
                 TestHelpers::test_creation<EventsAndTriggers, Metavariables>(
@@ -316,11 +316,11 @@ SPECTRE_TEST_CASE("Unit.Time.Tags.StepperErrorTolerancesCompute",
       CHECK(db::get<Tags::StepperErrorTolerances<AltEvolvedVariablesTag>>(*box)
                 .estimates == StepperErrorTolerances::Estimates::None);
 
-      db::mutate<Tags::StepChoosers,
+      db::mutate<Tags::LtsStepChoosers,
                  Tags::EventsAndTriggers<Triggers::WhenToCheck::AtSlabs>>(
-          [](const gsl::not_null<Tags::StepChoosers::type*> choosers,
+          [](const gsl::not_null<Tags::LtsStepChoosers::type*> choosers,
              const gsl::not_null<EventsAndTriggers*> events) {
-            *choosers = TestHelpers::test_creation<Tags::StepChoosers::type,
+            *choosers = TestHelpers::test_creation<Tags::LtsStepChoosers::type,
                                                    Metavariables>("");
             *events =
                 TestHelpers::test_creation<EventsAndTriggers, Metavariables>(
@@ -357,7 +357,7 @@ SPECTRE_TEST_CASE("Unit.Time.Tags.StepperErrorTolerancesCompute",
 
     auto box = db::create<
         db::AddSimpleTags<
-            Tags::StepChoosers,
+            Tags::LtsStepChoosers,
             Tags::EventsAndTriggers<Triggers::WhenToCheck::AtSlabs>,
             Tags::ConcreteTimeStepper<LtsTimeStepper>,
             Tags::VariableOrderAlgorithm>,

--- a/tests/Unit/Time/Test_ChangeStepSize.cpp
+++ b/tests/Unit/Time/Test_ChangeStepSize.cpp
@@ -24,8 +24,8 @@
 #include "Time/Tags/AdaptiveSteppingDiagnostics.hpp"
 #include "Time/Tags/FixedLtsRatio.hpp"
 #include "Time/Tags/HistoryEvolvedVariables.hpp"
+#include "Time/Tags/LtsStepChoosers.hpp"
 #include "Time/Tags/MinimumTimeStep.hpp"
-#include "Time/Tags/StepChoosers.hpp"
 #include "Time/Tags/TimeStep.hpp"
 #include "Time/Tags/TimeStepId.hpp"
 #include "Time/Tags/TimeStepper.hpp"
@@ -73,12 +73,12 @@ void check(const bool time_runs_forward,
           std::make_unique<StepChoosers::Constant>(2. * request));
 
   auto box = db::create<
-      db::AddSimpleTags<Parallel::Tags::MetavariablesImpl<Metavariables>,
-                        Tags::ConcreteTimeStepper<LtsTimeStepper>,
-                        Tags::MinimumTimeStep, Tags::TimeStepId,
-                        Tags::Next<Tags::TimeStepId>, Tags::TimeStep,
-                        Tags::StepChoosers, Tags::HistoryEvolvedVariables<Var>,
-                        Tags::AdaptiveSteppingDiagnostics>,
+      db::AddSimpleTags<
+          Parallel::Tags::MetavariablesImpl<Metavariables>,
+          Tags::ConcreteTimeStepper<LtsTimeStepper>, Tags::MinimumTimeStep,
+          Tags::TimeStepId, Tags::Next<Tags::TimeStepId>, Tags::TimeStep,
+          Tags::LtsStepChoosers, Tags::HistoryEvolvedVariables<Var>,
+          Tags::AdaptiveSteppingDiagnostics>,
       db::AddComputeTags<time_stepper_ref_tags<LtsTimeStepper>>>(
       Metavariables{}, std::move(time_stepper), 1e-8,
       TimeStepId(time_runs_forward, 0, time, 1, initial_step_size,
@@ -125,13 +125,13 @@ void test_fixed_lts_ratio() {
   auto box = db::create<
       db::AddSimpleTags<Parallel::Tags::MetavariablesImpl<Metavariables>,
                         Tags::ConcreteTimeStepper<LtsTimeStepper>,
-                        Tags::StepChoosers, Tags::MinimumTimeStep,
+                        Tags::LtsStepChoosers, Tags::MinimumTimeStep,
                         Tags::FixedLtsRatio, Tags::TimeStepId, Tags::TimeStep,
                         Tags::Next<Tags::TimeStepId>,
                         Tags::HistoryEvolvedVariables<Var>,
                         Tags::AdaptiveSteppingDiagnostics>,
       db::AddComputeTags<time_stepper_ref_tags<LtsTimeStepper>>>(
-      Metavariables{}, std::move(time_stepper), Tags::StepChoosers::type{},
+      Metavariables{}, std::move(time_stepper), Tags::LtsStepChoosers::type{},
       1e-10, std::optional<size_t>(8), initial_id, initial_step, next_id,
       std::move(history), AdaptiveSteppingDiagnostics{1, 2, 3, 4, 5});
 

--- a/tests/Unit/Time/Test_ChangeTimeStepperOrder.cpp
+++ b/tests/Unit/Time/Test_ChangeTimeStepperOrder.cpp
@@ -42,8 +42,8 @@
 #include "Time/StepperErrorEstimate.hpp"
 #include "Time/Tags/AdaptiveSteppingDiagnostics.hpp"
 #include "Time/Tags/HistoryEvolvedVariables.hpp"
+#include "Time/Tags/LtsStepChoosers.hpp"
 #include "Time/Tags/MinimumTimeStep.hpp"
-#include "Time/Tags/StepChoosers.hpp"
 #include "Time/Tags/StepperErrorTolerancesCompute.hpp"
 #include "Time/Tags/StepperErrors.hpp"
 #include "Time/Tags/Time.hpp"
@@ -366,7 +366,7 @@ double run(std::unique_ptr<LtsTimeStepper> time_stepper, const double tolerance,
           ::Tags::EventsAndTriggers<Triggers::WhenToCheck::AtSlabs>,
           Tags::VariableOrderAlgorithm, ::Tags::TimeStepId,
           ::Tags::Next<::Tags::TimeStepId>, ::Tags::TimeStep, ::Tags::Time,
-          ::Tags::AdaptiveSteppingDiagnostics, ::Tags::StepChoosers,
+          ::Tags::AdaptiveSteppingDiagnostics, ::Tags::LtsStepChoosers,
           ::Tags::MinimumTimeStep, System::variables_tag, dt_variables_tag,
           history_tag, ::Tags::StepperErrors<System::variables_tag>>,
       tmpl::push_back<


### PR DESCRIPTION
Step choosers are used for other things too, so make it obvious what
this set is for and that it's not used in GTS.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
The `StepChoosers` option in the `Evolution` section of the input file for evolutions with local time stepping has been renamed to `LtsStepChoosers`.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
