### PR TITLE
Update Evolution/DgSubcell to handle cartoon bases

### DIFF
--- a/src/Evolution/DgSubcell/Actions/Initialize.hpp
+++ b/src/Evolution/DgSubcell/Actions/Initialize.hpp
@@ -41,6 +41,7 @@
 #include "Evolution/DgSubcell/Tags/TciStatus.hpp"
 #include "Evolution/Initialization/SetVariables.hpp"
 #include "NumericalAlgorithms/Interpolation/IrregularInterpolant.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Parallel/AlgorithmExecution.hpp"
 #include "Parallel/GlobalCache.hpp"
@@ -153,7 +154,8 @@ struct SetSubcellGrid {
     const Element<Dim>& element = db::get<::domain::Tags::Element<Dim>>(box);
 
     for (size_t d = 0; d < Dim; ++d) {
-      if (subcell_options.persson_num_highest_modes() >= dg_mesh.extents(d)) {
+      if (subcell_options.persson_num_highest_modes() >= dg_mesh.extents(d) and
+          dg_mesh.basis(d) != Spectral::Basis::Cartoon) {
         ERROR("Number of the highest modes to be monitored by the Persson TCI ("
               << subcell_options.persson_num_highest_modes()
               << ") must be smaller than the extent of the DG mesh ("

--- a/src/Evolution/DgSubcell/BackgroundGrVars.hpp
+++ b/src/Evolution/DgSubcell/BackgroundGrVars.hpp
@@ -23,12 +23,14 @@
 #include "Domain/Structure/Element.hpp"
 #include "Domain/Structure/ElementId.hpp"
 #include "Domain/Tags.hpp"
+#include "Evolution/DgSubcell/Mesh.hpp"
 #include "Evolution/DgSubcell/Tags/Coordinates.hpp"
 #include "Evolution/DgSubcell/Tags/DidRollback.hpp"
 #include "Evolution/DgSubcell/Tags/Inactive.hpp"
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
 #include "Evolution/DgSubcell/Tags/OnSubcellFaces.hpp"
 #include "Evolution/Initialization/InitialData.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
@@ -139,27 +141,22 @@ struct BackgroundGrVars : tt::ConformsTo<db::protocols::Mutator> {
                                solution_or_data);
           }
           if constexpr (not std::is_same_v<
-                        typename SubcellFaceGrVars::value_type::tags_list,
-                        tmpl::list<>>){
+                            typename SubcellFaceGrVars::value_type::tags_list,
+                            tmpl::list<>>) {
             face_centered_impl(subcell_face_gr_vars, time, functions_of_time,
                                logical_to_grid_map, grid_to_inertial_map,
                                subcell_mesh, solution_or_data);
           }
         }
       }
-
     } else {
       // Initialization phase
       (*inactive_gr_vars).initialize(num_subcell_pts);
 
-      ASSERT(Mesh<volume_dim>(subcell_mesh.extents(0), subcell_mesh.basis(0),
-                              subcell_mesh.quadrature(0)) == subcell_mesh,
-             "The subcell mesh must have isotropic basis, quadrature. and "
-             "extents but got "
-                 << subcell_mesh);
+      fd::verify_subcell_mesh(subcell_mesh);
       if constexpr (not std::is_same_v<
-                    typename SubcellFaceGrVars::value_type::tags_list,
-                    tmpl::list<>>){
+                        typename SubcellFaceGrVars::value_type::tags_list,
+                        tmpl::list<>>) {
         const size_t num_face_centered_mesh_grid_pts =
             (subcell_mesh.extents(0) + 1) * subcell_mesh.extents(1) *
             subcell_mesh.extents(2);
@@ -209,16 +206,13 @@ struct BackgroundGrVars : tt::ConformsTo<db::protocols::Mutator> {
       const domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, volume_dim>&
           grid_to_inertial_map,
       const Mesh<volume_dim>& subcell_mesh, const T& solution_or_data) {
-    ASSERT(Mesh<volume_dim>(subcell_mesh.extents(0), subcell_mesh.basis(0),
-                            subcell_mesh.quadrature(0)) == subcell_mesh,
-           "The subcell mesh must have isotropic basis, quadrature. and "
-           "extents but got "
-               << subcell_mesh);
+    const size_t comp_dim = fd::get_computational_dim(subcell_mesh);
+    fd::verify_subcell_mesh(subcell_mesh);
 
-    for (size_t dim = 0; dim < volume_dim; ++dim) {
-      const auto basis = make_array<volume_dim>(subcell_mesh.basis(0));
-      auto quadrature = make_array<volume_dim>(subcell_mesh.quadrature(0));
-      auto extents = make_array<volume_dim>(subcell_mesh.extents(0));
+    for (size_t dim = 0; dim < comp_dim; ++dim) {
+      const auto basis = subcell_mesh.basis();
+      auto quadrature = subcell_mesh.quadrature();
+      auto extents = subcell_mesh.extents().indices();
 
       gsl::at(extents, dim) = subcell_mesh.extents(0) + 1;
       gsl::at(quadrature, dim) = Spectral::Quadrature::FaceCentered;

--- a/src/Evolution/DgSubcell/Matrices.cpp
+++ b/src/Evolution/DgSubcell/Matrices.cpp
@@ -12,6 +12,7 @@
 #include "DataStructures/IndexIterator.hpp"
 #include "DataStructures/Matrix.hpp"
 #include "Domain/Structure/Side.hpp"
+#include "Evolution/DgSubcell/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "NumericalAlgorithms/Spectral/CollocationPoints.hpp"
 #include "NumericalAlgorithms/Spectral/InterpolationMatrix.hpp"
@@ -33,14 +34,18 @@ namespace evolution::dg::subcell::fd {
 const Matrix& projection_matrix(
     const Mesh<1>& dg_mesh, const size_t subcell_extents,
     const Spectral::Quadrature& subcell_quadrature) {
-  ASSERT(dg_mesh.basis(0) == Spectral::Basis::Legendre,
-         "FD Subcell projection only supports Legendre basis right now but got "
-         "basis "
+  ASSERT(dg_mesh.basis(0) == Spectral::Basis::Legendre or
+             dg_mesh.basis(0) == Spectral::Basis::Cartoon,
+         "FD Subcell projection only supports Legendre or Cartoon bases right "
+         "now but got basis "
              << dg_mesh.basis(0));
   ASSERT(subcell_quadrature == Spectral::Quadrature::FaceCentered or
-             subcell_quadrature == Spectral::Quadrature::CellCentered,
+             subcell_quadrature == Spectral::Quadrature::CellCentered or
+             subcell_quadrature == Spectral::Quadrature::AxialSymmetry or
+             subcell_quadrature == Spectral::Quadrature::SphericalSymmetry,
          "subcell_quadrature option in projection_matrix should be "
-         "FaceCentered or CellCentered");
+         "FaceCentered, CellCentered, or a Cartoon quadrature, but got "
+             << subcell_quadrature);
   static const auto cache = make_static_cache<
       CacheRange<
           Spectral::minimum_number_of_points<
@@ -66,6 +71,10 @@ const Matrix& projection_matrix(
                 Mesh<1>{local_num_fd_points, Spectral::Basis::FiniteDifference,
                         local_subcell_quadrature}));
       });
+  if (dg_mesh.basis(0) == Spectral::Basis::Cartoon) {
+    static const Matrix cartoon_matrix{1, 1, 1.0};
+    return cartoon_matrix;
+  }
   return cache(dg_mesh.extents(0), subcell_extents, dg_mesh.quadrature(0),
                subcell_quadrature);
 }
@@ -213,88 +222,97 @@ template <Spectral::Quadrature QuadratureType, size_t NumDgGridPoints1d,
           size_t Dim>
 Matrix reconstruction_matrix_cache_impl_helper(
     const Index<Dim>& subcell_extents) {
-  // We currently require all dimensions to have the same number of grid
-  // points.
-  const Index<Dim> dg_extents{NumDgGridPoints1d};
-  const Matrix& proj_matrix =
-      projection_matrix_all_dimensions<QuadratureType, NumDgGridPoints1d>(
-          subcell_extents);
-  const size_t num_pts = dg_extents.product();
-  const size_t num_subcells = subcell_extents.product();
+  if constexpr (QuadratureType == Spectral::Quadrature::SphericalSymmetry or
+                QuadratureType == Spectral::Quadrature::AxialSymmetry) {
+    ASSERT(Dim == 1,
+           "Cartoon basis should never be the first basis: only a mesh slice "
+           "should get here, got Dim = "
+               << Dim);
+    return Matrix{1, 1, 1.0};
+  } else {
+    // We currently require all dimensions to have the same number of grid
+    // points.
+    const Index<Dim> dg_extents{NumDgGridPoints1d};
+    const Matrix& proj_matrix =
+        projection_matrix_all_dimensions<QuadratureType, NumDgGridPoints1d>(
+            subcell_extents);
+    const size_t num_pts = dg_extents.product();
+    const size_t num_subcells = subcell_extents.product();
 
-  const size_t reconstruction_rows_and_cols = num_pts + 1;
-  Matrix lhs_recons_matrix(reconstruction_rows_and_cols,
-                           reconstruction_rows_and_cols, 0.0);
-  // We use rhs_recons_matrix here as a temp buffer, we will fill it later.
-  Matrix rhs_recons_matrix(num_pts + 1, num_subcells);
-  dgemm_<true>('T', 'N', proj_matrix.columns(), proj_matrix.columns(),
-               proj_matrix.rows(), 2.0, proj_matrix.data(),
-               proj_matrix.spacing(), proj_matrix.data(), proj_matrix.spacing(),
-               0.0, rhs_recons_matrix.data(), rhs_recons_matrix.spacing());
+    const size_t reconstruction_rows_and_cols = num_pts + 1;
+    Matrix lhs_recons_matrix(reconstruction_rows_and_cols,
+                             reconstruction_rows_and_cols, 0.0);
+    // We use rhs_recons_matrix here as a temp buffer, we will fill it later.
+    Matrix rhs_recons_matrix(num_pts + 1, num_subcells);
+    dgemm_<true>('T', 'N', proj_matrix.columns(), proj_matrix.columns(),
+                 proj_matrix.rows(), 2.0, proj_matrix.data(),
+                 proj_matrix.spacing(), proj_matrix.data(),
+                 proj_matrix.spacing(), 0.0, rhs_recons_matrix.data(),
+                 rhs_recons_matrix.spacing());
 
-  for (size_t l = 0; l < num_pts; ++l) {
-    for (size_t j = 0; j < num_pts; ++j) {
-      lhs_recons_matrix(l, j) = rhs_recons_matrix(j, l);
-    }
-  }
-
-  std::array<const DataVector*, Dim> weights{};
-  for (size_t d = 0; d < Dim; ++d) {
-    gsl::at(weights, d) =
-        &Spectral::quadrature_weights<Spectral::Basis::Legendre,
-                                      QuadratureType>(dg_extents[d]);
-  }
-  for (IndexIterator<Dim> dg_it(dg_extents); dg_it; ++dg_it) {
-    lhs_recons_matrix(dg_it.collapsed_index(), num_pts) =
-        -(*weights[0])[dg_it()[0]];
-    lhs_recons_matrix(num_pts, dg_it.collapsed_index()) =
-        (*weights[0])[dg_it()[0]];
-    for (size_t i = 1; i < Dim; ++i) {
-      lhs_recons_matrix(dg_it.collapsed_index(), num_pts) *=
-          (*gsl::at(weights, i))[dg_it()[i]];
-      lhs_recons_matrix(num_pts, dg_it.collapsed_index()) *=
-          (*gsl::at(weights, i))[dg_it()[i]];
-    }
-  }
-
-  for (size_t k = 0; k < num_subcells; ++k) {
     for (size_t l = 0; l < num_pts; ++l) {
-      rhs_recons_matrix(l, k) = 2.0 * proj_matrix(k, l);
+      for (size_t j = 0; j < num_pts; ++j) {
+        lhs_recons_matrix(l, j) = rhs_recons_matrix(j, l);
+      }
     }
-  }
 
-  double deltas = 2.0 / subcell_extents[0];
-  for (size_t d = 1; d < Dim; ++d) {
-    deltas *= 2.0 / subcell_extents[d];
-  }
-  for (size_t i = 0; i < num_subcells; ++i) {
-    rhs_recons_matrix(num_pts, i) = deltas;
-  }
-  for (IndexIterator<Dim> it(subcell_extents); it; ++it) {
-    rhs_recons_matrix(num_pts, it.collapsed_index()) *=
-        integration_weight(subcell_extents, *it);
-  }
-
-  const Matrix inv_lhs_recons_matrix = inv(lhs_recons_matrix);
-  Matrix full_recons_matrix(inv_lhs_recons_matrix.rows(),
-                            rhs_recons_matrix.columns());
-  // Do matrix multipy with dgemm_ directly because that seems to be faster
-  // than Blaze.
-  dgemm_<true>('N', 'N', inv_lhs_recons_matrix.rows(),
-               rhs_recons_matrix.columns(), inv_lhs_recons_matrix.columns(),
-               1.0, inv_lhs_recons_matrix.data(),
-               inv_lhs_recons_matrix.spacing(), rhs_recons_matrix.data(),
-               rhs_recons_matrix.spacing(), 0.0, full_recons_matrix.data(),
-               full_recons_matrix.spacing());
-  // exclude bottom row for Lagrange multiplier.
-  Matrix reduced_recons_matrix(num_pts, num_subcells);
-  for (size_t i = 0; i < num_pts; ++i) {
-    for (size_t j = 0; j < num_subcells; ++j) {
-      reduced_recons_matrix(i, j) = full_recons_matrix(i, j);
+    std::array<const DataVector*, Dim> weights{};
+    for (size_t d = 0; d < Dim; ++d) {
+      gsl::at(weights, d) =
+          &Spectral::quadrature_weights<Spectral::Basis::Legendre,
+                                        QuadratureType>(dg_extents[d]);
     }
-  }
+    for (IndexIterator<Dim> dg_it(dg_extents); dg_it; ++dg_it) {
+      lhs_recons_matrix(dg_it.collapsed_index(), num_pts) =
+          -(*weights[0])[dg_it()[0]];
+      lhs_recons_matrix(num_pts, dg_it.collapsed_index()) =
+          (*weights[0])[dg_it()[0]];
+      for (size_t i = 1; i < Dim; ++i) {
+        lhs_recons_matrix(dg_it.collapsed_index(), num_pts) *=
+            (*gsl::at(weights, i))[dg_it()[i]];
+        lhs_recons_matrix(num_pts, dg_it.collapsed_index()) *=
+            (*gsl::at(weights, i))[dg_it()[i]];
+      }
+    }
 
-  return reduced_recons_matrix;
+    for (size_t k = 0; k < num_subcells; ++k) {
+      for (size_t l = 0; l < num_pts; ++l) {
+        rhs_recons_matrix(l, k) = 2.0 * proj_matrix(k, l);
+      }
+    }
+
+    double deltas = 2.0 / subcell_extents[0];
+    for (size_t d = 1; d < Dim; ++d) {
+      deltas *= 2.0 / subcell_extents[d];
+    }
+    for (size_t i = 0; i < num_subcells; ++i) {
+      rhs_recons_matrix(num_pts, i) = deltas;
+    }
+    for (IndexIterator<Dim> it(subcell_extents); it; ++it) {
+      rhs_recons_matrix(num_pts, it.collapsed_index()) *=
+          integration_weight(subcell_extents, *it);
+    }
+
+    const Matrix inv_lhs_recons_matrix = inv(lhs_recons_matrix);
+    Matrix full_recons_matrix(inv_lhs_recons_matrix.rows(),
+                              rhs_recons_matrix.columns());
+    // Do matrix multipy with dgemm_ directly because that seems to be faster
+    // than Blaze.
+    dgemm_<true>('N', 'N', inv_lhs_recons_matrix.rows(),
+                 rhs_recons_matrix.columns(), inv_lhs_recons_matrix.columns(),
+                 1.0, inv_lhs_recons_matrix.data(),
+                 inv_lhs_recons_matrix.spacing(), rhs_recons_matrix.data(),
+                 rhs_recons_matrix.spacing(), 0.0, full_recons_matrix.data(),
+                 full_recons_matrix.spacing());
+    // exclude bottom row for Lagrange multiplier.
+    Matrix reduced_recons_matrix(num_pts, num_subcells);
+    for (size_t i = 0; i < num_pts; ++i) {
+      for (size_t j = 0; j < num_subcells; ++j) {
+        reduced_recons_matrix(i, j) = full_recons_matrix(i, j);
+      }
+    }
+    return reduced_recons_matrix;
+  }
 }
 
 template <Spectral::Quadrature QuadratureType, size_t NumDgGridPoints,
@@ -320,13 +338,14 @@ const Matrix& reconstruction_matrix_impl(
 template <size_t Dim>
 const Matrix& reconstruction_matrix(const Mesh<Dim>& dg_mesh,
                                     const Index<Dim>& subcell_extents) {
-  ASSERT(dg_mesh.basis(0) == Spectral::Basis::Legendre,
-         "FD Subcell reconstruction only supports Legendre basis right now.");
-  ASSERT(dg_mesh == Mesh<Dim>(dg_mesh.extents(0), dg_mesh.basis(0),
-                              dg_mesh.quadrature(0)),
-         "The mesh must be uniform but is " << dg_mesh);
-  ASSERT(subcell_extents == Index<Dim>(subcell_extents[0]),
-         "The subcell mesh must be uniform but is " << subcell_extents);
+  ASSERT(dg_mesh.basis(0) == Spectral::Basis::Legendre or
+             dg_mesh.basis(0) == Spectral::Basis::Cartoon,
+         "FD Subcell reconstruction only supports Legendre or Cartoon bases "
+         "right now, got "
+             << dg_mesh);
+  verify_subcell_mesh(dg_mesh);
+  verify_subcell_extents(subcell_extents);
+
   switch (dg_mesh.quadrature(0)) {
     case Spectral::Quadrature::GaussLobatto:
       return reconstruction_matrix_impl<Spectral::Quadrature::GaussLobatto>(
@@ -340,8 +359,25 @@ const Matrix& reconstruction_matrix(const Mesh<Dim>& dg_mesh,
           std::make_index_sequence<
               Spectral::maximum_number_of_points<Spectral::Basis::Legendre> +
               1>{});
+    case Spectral::Quadrature::AxialSymmetry:
+      [[fallthrough]];
+    case Spectral::Quadrature::SphericalSymmetry:
+      ASSERT(Dim == 1,
+             "Cartoon basis should only be used with DimByDim reconstruction, "
+             "so only a mesh slice "
+             "should get here, got Dim = "
+                 << Dim);
+      return reconstruction_matrix_impl<
+          Spectral::Quadrature::SphericalSymmetry>(
+          dg_mesh, subcell_extents,
+          std::make_index_sequence<
+              Spectral::maximum_number_of_points<Spectral::Basis::Cartoon> +
+              1>{});
     default:
-      ERROR("Unsupported quadrature type in FD subcell reconstruction matrix");
+      ERROR(
+          "Unsupported quadrature type in FD subcell reconstruction "
+          "matrix, got "
+          << dg_mesh.quadrature(0));
   };
 }
 

--- a/src/Evolution/DgSubcell/Mesh.cpp
+++ b/src/Evolution/DgSubcell/Mesh.cpp
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <cstddef>
+#include <string>
 
 #include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
@@ -15,21 +16,179 @@
 
 namespace evolution::dg::subcell::fd {
 template <size_t Dim>
+size_t get_computational_dim(const Mesh<Dim>& subcell_mesh) {
+  if constexpr (Dim == 3) {
+    if (subcell_mesh.quadrature(2) == Spectral::Quadrature::SphericalSymmetry) {
+      return 1;
+    } else if (subcell_mesh.quadrature(2) ==
+               Spectral::Quadrature::AxialSymmetry) {
+      return 2;
+    } else {
+      return 3;
+    }
+  } else {
+    return Dim;
+  }
+}
+
+template <size_t Dim>
+size_t get_computational_dim(const Index<Dim>& subcell_extents) {
+  if constexpr (Dim == 3) {
+    if (subcell_extents[1] == 1) {
+      return 1;
+    } else if (subcell_extents[2] == 1) {
+      return 2;
+    } else {
+      return 3;
+    }
+  } else {
+    return Dim;
+  }
+}
+
+template <size_t Dim>
+void verify_subcell_mesh(const Mesh<Dim>& subcell_mesh, const bool neighbor) {
+  const std::string neighbor_str = neighbor ? " neighbor" : "";
+  if constexpr (Dim == 3) {
+    if (subcell_mesh.quadrature(2) == Spectral::Quadrature::AxialSymmetry) {
+      // Checking for spherical symmetry
+      ASSERT(
+          subcell_mesh.basis(2) == Spectral::Basis::Cartoon and
+              subcell_mesh.basis(0) != Spectral::Basis::Cartoon,
+          "Got a" << neighbor_str
+                  << " basis with an invalid combination of Cartoon bases, got "
+                  << subcell_mesh);
+      ASSERT(subcell_mesh.slice_away(2) == Mesh<2>(subcell_mesh.extents(0),
+                                                   subcell_mesh.basis(0),
+                                                   subcell_mesh.quadrature(0)),
+             "The non-cartoon"
+                 << neighbor_str
+                 << " subcell sub-mesh must have isotropic basis, "
+                    "quadrature, and extents but got "
+                 << subcell_mesh);
+    } else if (subcell_mesh.quadrature(2) ==
+               Spectral::Quadrature::SphericalSymmetry) {
+      // Checking for axial symmetry
+      ASSERT(
+          subcell_mesh.slice_away(0) ==
+              Mesh<2>(1, Spectral::Basis::Cartoon,
+                      Spectral::Quadrature::SphericalSymmetry),
+          "Got a" << neighbor_str
+                  << " basis with an invalid combination of Cartoon bases, got "
+                  << subcell_mesh);
+    } else {
+      ASSERT(
+          Mesh<Dim>(subcell_mesh.extents(0), subcell_mesh.basis(0),
+                    subcell_mesh.quadrature(0)) == subcell_mesh,
+          "The" << neighbor_str
+                << " subcell mesh must have isotropic basis, quadrature, and "
+                   "extents but got "
+                << subcell_mesh);
+    }
+  } else {
+    ASSERT(Mesh<Dim>(subcell_mesh.extents(0), subcell_mesh.basis(0),
+                     subcell_mesh.quadrature(0)) == subcell_mesh,
+           "The" << neighbor_str
+                 << " subcell mesh must have isotropic basis, quadrature, and "
+                    "extents but got "
+                 << subcell_mesh);
+  }
+}
+
+template <size_t Dim>
+void verify_subcell_extents(const Index<Dim>& subcell_extents,
+                            const bool neighbor) {
+  const std::string neighbor_str = neighbor ? " neighbor" : "";
+  if constexpr (Dim == 3) {
+    if (subcell_extents[1] == 1) {
+      // Checking for spherical symmetry
+      ASSERT(
+          subcell_extents[0] != 1 and subcell_extents[2] == 1,
+          "The" << neighbor_str
+                << " subcell extents are neither isotropic nor a valid cartoon "
+                   "pattern, got "
+                << subcell_extents);
+    } else if (subcell_extents[2] == 1) {
+      // Checking for axial symmetry
+      ASSERT(
+          subcell_extents.slice_away(2) == Index<2>(subcell_extents[0]),
+          "The" << neighbor_str
+                << " subcell extents are neither isotropic nor a valid cartoon "
+                   "pattern, got "
+                << subcell_extents);
+    } else {
+      ASSERT(subcell_extents == Index<Dim>(subcell_extents[0]),
+             "The" << neighbor_str << " subcell mesh must be uniform but is "
+                   << subcell_extents);
+    }
+  } else {
+    ASSERT(subcell_extents == Index<Dim>(subcell_extents[0]),
+           "The" << neighbor_str << " subcell mesh must be uniform but is "
+                 << subcell_extents);
+  }
+}
+
+template <size_t Dim>
 Mesh<Dim> mesh(const Mesh<Dim>& dg_mesh) {
-  ASSERT(dg_mesh.basis() == make_array<Dim>(Spectral::Basis::Legendre) or
-             dg_mesh.basis() == make_array<Dim>(Spectral::Basis::Chebyshev),
-         "The DG basis for computing the subcell mesh must be Legendre or "
-         "Chebyshev but got DG mesh"
-             << dg_mesh);
-  ASSERT(dg_mesh.quadrature() == make_array<Dim>(Spectral::Quadrature::Gauss) or
-             dg_mesh.quadrature() ==
-                 make_array<Dim>(Spectral::Quadrature::GaussLobatto),
-         "The DG quadrature for computing the subcell mesh must be Gauss or "
-         "GaussLobatto but got DG mesh"
-             << dg_mesh);
+  if (dg_mesh.basis(Dim - 1) != Spectral::Basis::Cartoon) {
+    ASSERT(dg_mesh.basis() == make_array<Dim>(Spectral::Basis::Legendre) or
+               dg_mesh.basis() == make_array<Dim>(Spectral::Basis::Chebyshev),
+           "The DG basis for computing the subcell mesh must be Legendre or "
+           "Chebyshev but got DG mesh"
+               << dg_mesh);
+    ASSERT(
+        dg_mesh.quadrature() == make_array<Dim>(Spectral::Quadrature::Gauss) or
+            dg_mesh.quadrature() ==
+                make_array<Dim>(Spectral::Quadrature::GaussLobatto),
+        "The DG quadrature for computing the subcell mesh must be Gauss or "
+        "GaussLobatto but got DG mesh"
+            << dg_mesh);
+  }
   std::array<size_t, Dim> extents{};
   for (size_t d = 0; d < Dim; ++d) {
     gsl::at(extents, d) = 2 * dg_mesh.extents(d) - 1;
+  }
+  if constexpr (Dim == 3) {
+    if (dg_mesh.basis(1) == Spectral::Basis::Cartoon and
+        dg_mesh.basis(2) == Spectral::Basis::Cartoon) {
+      ASSERT(dg_mesh.basis(0) == Spectral::Basis::Legendre or
+                 dg_mesh.basis(0) == Spectral::Basis::Chebyshev,
+             "The DG mesh that is being converted to subcell can only mix "
+             "Legendre or Chebyshev with Cartoon, but got "
+                 << dg_mesh);
+      ASSERT(dg_mesh.slice_away(0).quadrature() ==
+                 make_array<2>(Spectral::Quadrature::SphericalSymmetry),
+             "Invalid combination of Cartoon bases, got " << dg_mesh);
+      return Mesh<3>{extents,
+                     {Spectral::Basis::FiniteDifference,
+                      Spectral::Basis::Cartoon, Spectral::Basis::Cartoon},
+                     {Spectral::Quadrature::CellCentered,
+                      Spectral::Quadrature::SphericalSymmetry,
+                      Spectral::Quadrature::SphericalSymmetry}};
+    } else if (dg_mesh.basis(2) == Spectral::Basis::Cartoon) {
+      ASSERT(dg_mesh.slice_away(2).basis() ==
+                     make_array<2>(Spectral::Basis::Legendre) or
+                 dg_mesh.slice_away(2).basis() ==
+                     make_array<2>(Spectral::Basis::Chebyshev),
+             "The DG mesh that is being converted to subcell can only mix "
+             "Legendre or Chebyshev with Cartoon, but got "
+                 << dg_mesh);
+      ASSERT(
+          dg_mesh.slice_away(2).quadrature() ==
+                  make_array<2>(Spectral::Quadrature::Gauss) or
+              dg_mesh.slice_away(2).quadrature() ==
+                  make_array<2>(Spectral::Quadrature::GaussLobatto),
+          "The DG quadrature for computing the subcell mesh must be Gauss or "
+          "GaussLobatto with a Cartoon quadrature but got DG mesh"
+              << dg_mesh);
+      return Mesh<3>{
+          extents,
+          {Spectral::Basis::FiniteDifference, Spectral::Basis::FiniteDifference,
+           Spectral::Basis::Cartoon},
+          {Spectral::Quadrature::CellCentered,
+           Spectral::Quadrature::CellCentered,
+           Spectral::Quadrature::AxialSymmetry}};
+    }
   }
   return Mesh<Dim>{extents, Spectral::Basis::FiniteDifference,
                    Spectral::Quadrature::CellCentered};
@@ -38,15 +197,18 @@ Mesh<Dim> mesh(const Mesh<Dim>& dg_mesh) {
 template <size_t Dim>
 Mesh<Dim> dg_mesh(const Mesh<Dim>& subcell_mesh, const Spectral::Basis basis,
                   const Spectral::Quadrature quadrature) {
-  ASSERT(subcell_mesh.basis() ==
-             make_array<Dim>(Spectral::Basis::FiniteDifference),
-         "The basis for computing the DG mesh must be FiniteDifference but got "
-             << subcell_mesh);
-  ASSERT(
-      subcell_mesh.quadrature() ==
-          make_array<Dim>(Spectral::Quadrature::CellCentered),
-      "The quadrature for computing the DG mesh must be CellCentered but got "
-          << subcell_mesh);
+  if (subcell_mesh.basis(Dim - 1) != Spectral::Basis::Cartoon) {
+    ASSERT(
+        subcell_mesh.basis() ==
+            make_array<Dim>(Spectral::Basis::FiniteDifference),
+        "The basis for computing the DG mesh must be FiniteDifference but got "
+            << subcell_mesh);
+    ASSERT(
+        subcell_mesh.quadrature() ==
+            make_array<Dim>(Spectral::Quadrature::CellCentered),
+        "The quadrature for computing the DG mesh must be CellCentered but got "
+            << subcell_mesh);
+  }
   ASSERT(
       basis == Spectral::Basis::Legendre or basis == Spectral::Basis::Chebyshev,
       "The DG basis must be Legendre or Chebyshev but got " << basis);
@@ -61,8 +223,60 @@ Mesh<Dim> dg_mesh(const Mesh<Dim>& subcell_mesh, const Spectral::Basis basis,
            "Subcell mesh must have odd extents " << subcell_mesh);
     gsl::at(extents, d) = (subcell_mesh.extents(d) + 1) / 2;
   }
+  if constexpr (Dim == 3) {
+    if (subcell_mesh.basis(1) == Spectral::Basis::Cartoon and
+        subcell_mesh.basis(2) == Spectral::Basis::Cartoon) {
+      ASSERT(subcell_mesh.basis(0) == Spectral::Basis::FiniteDifference,
+             "The basis for computing the DG mesh can only mix "
+             "FiniteDifference with Cartoon, but got "
+                 << subcell_mesh);
+      ASSERT(subcell_mesh.slice_away(0).quadrature() ==
+                 make_array<2>(Spectral::Quadrature::SphericalSymmetry),
+             "Invalid combination of Cartoon bases, got " << subcell_mesh);
+      return Mesh<3>{
+          extents,
+          {basis, Spectral::Basis::Cartoon, Spectral::Basis::Cartoon},
+          {quadrature, Spectral::Quadrature::SphericalSymmetry,
+           Spectral::Quadrature::SphericalSymmetry}};
+    } else if (subcell_mesh.basis(2) == Spectral::Basis::Cartoon) {
+      ASSERT(subcell_mesh.slice_away(2).basis() ==
+                 make_array<2>(Spectral::Basis::FiniteDifference),
+             "The basis for computing the DG mesh can only mix "
+             "FiniteDifference with Cartoon, but got "
+                 << subcell_mesh);
+      ASSERT(subcell_mesh.slice_away(2).quadrature() ==
+                 make_array<2>(Spectral::Quadrature::CellCentered),
+             "The quadrature for computing the DG mesh, if not a Cartoon "
+             "quadrature, must be CellCentered "
+             "but got "
+                 << subcell_mesh);
+      return Mesh<3>{
+          extents,
+          {basis, basis, Spectral::Basis::Cartoon},
+          {quadrature, quadrature, Spectral::Quadrature::AxialSymmetry}};
+    }
+  }
   return Mesh<Dim>{extents, basis, quadrature};
 }
+
+template size_t get_computational_dim(const Mesh<1>& subcell_mesh);
+template size_t get_computational_dim(const Mesh<2>& subcell_mesh);
+template size_t get_computational_dim(const Mesh<3>& subcell_mesh);
+template size_t get_computational_dim(const Index<1>& subcell_extents);
+template size_t get_computational_dim(const Index<2>& subcell_extents);
+template size_t get_computational_dim(const Index<3>& subcell_extents);
+template void verify_subcell_mesh(const Mesh<1>& subcell_mesh,
+                                  const bool neighbor);
+template void verify_subcell_mesh(const Mesh<2>& subcell_mesh,
+                                  const bool neighbor);
+template void verify_subcell_mesh(const Mesh<3>& subcell_mesh,
+                                  const bool neighbor);
+template void verify_subcell_extents(const Index<1>& subcell_extents,
+                                     const bool neighbor);
+template void verify_subcell_extents(const Index<2>& subcell_extents,
+                                     const bool neighbor);
+template void verify_subcell_extents(const Index<3>& subcell_extents,
+                                     const bool neighbor);
 
 template Mesh<1> mesh(const Mesh<1>& dg_mesh);
 template Mesh<2> mesh(const Mesh<2>& dg_mesh);

--- a/src/Evolution/DgSubcell/Mesh.hpp
+++ b/src/Evolution/DgSubcell/Mesh.hpp
@@ -11,6 +11,8 @@
 /// \cond
 template <size_t Dim>
 class Mesh;
+template <size_t Dim>
+class Index;
 /// \endcond
 
 namespace evolution::dg::subcell::fd {
@@ -28,4 +30,39 @@ Mesh<Dim> mesh(const Mesh<Dim>& dg_mesh);
 template <size_t Dim>
 Mesh<Dim> dg_mesh(const Mesh<Dim>& subcell_mesh, Spectral::Basis basis,
                   Spectral::Quadrature quadrature);
+
+/*!
+ * \brief Computes the computational dimension from the subcell mesh, which
+ * can be less than `Dim` when Cartoon bases are used.
+ */
+template <size_t Dim>
+size_t get_computational_dim(const Mesh<Dim>& subcell_mesh);
+
+/*!
+ * \brief Computes the computational dimension from the subcell extents, which
+ * can be less than `Dim` when Cartoon bases are used.
+ */
+template <size_t Dim>
+size_t get_computational_dim(const Index<Dim>& subcell_extents);
+
+/*!
+ * \brief Verifies the passed subcell mesh is valid, i.e. properly using
+ * Cartoon bases and isotropic in non-Cartoon extents.
+ *
+ * The \p neighbor argument should be set to `true` when checking a neighbor's
+ * mesh (only the output of the assert is modified).
+ */
+template <size_t Dim>
+void verify_subcell_mesh(const Mesh<Dim>& subcell_mesh, bool neighbor = false);
+
+/*!
+ * \brief Verifies the passed subcell extents are valid, i.e. fully isotropic
+ * or deviating in a Cartoon-specific manner.
+ *
+ * The \p neighbor argument should be set to `true` when checking a neighbor's
+ * mesh (only the output of the assert is modified).
+ */
+template <size_t Dim>
+void verify_subcell_extents(const Index<Dim>& subcell_extents,
+                            bool neighbor = false);
 }  // namespace evolution::dg::subcell::fd

--- a/src/Evolution/DgSubcell/NeighborRdmpAndVolumeData.cpp
+++ b/src/Evolution/DgSubcell/NeighborRdmpAndVolumeData.cpp
@@ -38,10 +38,7 @@ void insert_or_update_neighbor_volume_data(
     const Mesh<Dim>& subcell_mesh, const size_t number_of_ghost_zones,
     const DirectionalIdMap<Dim, std::optional<intrp::Irregular<Dim>>>&
         neighbor_dg_to_fd_interpolants) {
-  ASSERT(neighbor_mesh == Mesh<Dim>(neighbor_mesh.extents(0),
-                                    neighbor_mesh.basis(0),
-                                    neighbor_mesh.quadrature(0)),
-         "The neighbor mesh must be uniform but is " << neighbor_mesh);
+  fd::verify_subcell_mesh(neighbor_mesh, true);
   ASSERT(neighbor_subcell_data.size() != 0,
          "neighbor_subcell_data must be non-empty");
   const size_t end_of_volume_data =

--- a/src/Evolution/DgSubcell/SetInterpolators.hpp
+++ b/src/Evolution/DgSubcell/SetInterpolators.hpp
@@ -21,6 +21,7 @@
 #include "Domain/Structure/ElementId.hpp"
 #include "Domain/Tags.hpp"
 #include "Evolution/DgSubcell/GhostZoneLogicalCoordinates.hpp"
+#include "Evolution/DgSubcell/Mesh.hpp"
 #include "Evolution/DgSubcell/SliceTensor.hpp"
 #include "Evolution/DgSubcell/SubcellOptions.hpp"
 #include "Evolution/DgSubcell/Tags/Interpolators.hpp"
@@ -121,10 +122,13 @@ struct SetInterpolators {
         //    ghost zones.
         // 3. Create interpolators
 
-        if (not is_isotropic(neighbor_fd_mesh)) {
+        if (not is_isotropic(neighbor_fd_mesh) and
+            neighbor_fd_mesh.basis(Dim - 1) != Spectral::Basis::Cartoon) {
           ERROR("We assume an isotropic mesh but got "
                 << neighbor_fd_mesh << " ElementID is " << element.id());
         }
+        // Extra checks for cartoon meshes not checked above
+        fd::verify_subcell_mesh(neighbor_fd_mesh, true);
 
         const auto get_logical_coords = [&element, &neighbor_id, &direction](
                                             const auto& map,

--- a/src/Evolution/DgSubcell/SliceData.cpp
+++ b/src/Evolution/DgSubcell/SliceData.cpp
@@ -94,12 +94,20 @@ DirectionMap<Dim, DataVector> slice_data_impl(
     const size_t num_sliced_pts =
         number_of_ghost_points * subcell_extents.slice_away(d).product();
 
-    ASSERT(num_sliced_pts <= num_pts,
-           "Number of ghost points (" << number_of_ghost_points
-                                      << ") is larger than the subcell mesh "
-                                         "extent to the slicing direction ("
-                                      << subcell_extents.indices().at(d)
-                                      << ") ");
+    // Note that Cartoon dimensions fail this assert but they will never be in
+    // directions_to_slice
+    if (Dim != 3 or
+        std::find_if(directions_to_slice.begin(), directions_to_slice.end(),
+                     [d](const Direction<Dim>& i) {
+                       return i.dimension() == d;
+                     }) != directions_to_slice.end()) {
+      ASSERT(num_sliced_pts <= num_pts,
+             "Number of ghost points (" << number_of_ghost_points
+                                        << ") is larger than the subcell mesh "
+                                           "extent to the slicing direction ("
+                                        << subcell_extents.indices().at(d)
+                                        << ")");
+    }
 
     gsl::at(result_grid_points, d) = num_sliced_pts;
   }

--- a/tests/Unit/Evolution/DgSubcell/Actions/Test_Initialize.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Actions/Test_Initialize.cpp
@@ -649,6 +649,73 @@ void test(const bool always_use_subcell, const bool interior_element,
   CHECK_ITERABLE_APPROX(get<Var1>(vars), get<Var1>(expected_vars));
 }
 
+void test_cartoon() {
+  // Test that SetSubcellGrid does not ERROR for a 3D cartoon DG mesh even
+  // when persson_num_highest_modes >= extent for the Cartoon dimensions.
+  using metavars3 = Metavariables<3, false, true>;
+  using comp3 = Component<3, metavars3>;
+  metavars3::FdInitialDataTci::invoked = false;
+  metavars3::SetInitialRdmpData::invoked = false;
+
+  const Mesh<3> cartoon_dg_mesh{
+      {{5, 1, 1}},
+      {Spectral::Basis::Legendre, Spectral::Basis::Cartoon,
+       Spectral::Basis::Cartoon},
+      {Spectral::Quadrature::GaussLobatto,
+       Spectral::Quadrature::SphericalSymmetry,
+       Spectral::Quadrature::SphericalSymmetry}};
+  const Mesh<3> cartoon_subcell_mesh =
+      evolution::dg::subcell::fd::mesh(cartoon_dg_mesh);
+
+  // persson_num_highest_modes = 4 (passed as first arg to SubcellOptions).
+  // For Cartoon dims (extent 1): 4 >= 1 but Cartoon -> should not ERROR.
+  // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDelete)
+  ActionTesting::MockRuntimeSystem<metavars3> runner3{
+      {std::unique_ptr<evolution::initial_data::InitialData>(
+           std::make_unique<SystemAnalyticSolution>()),
+       evolution::dg::subcell::SubcellOptions{
+           evolution::dg::subcell::SubcellOptions{
+               4.1, 4_st, 1.0e-3, 1.0e-4, false, false,
+               evolution::dg::subcell::fd::ReconstructionMethod::DimByDim,
+               false, std::optional<std::vector<std::string>>{},
+               ::fd::DerivativeOrder::Two, 1, 1, 1},
+           TestCreator<3>{}}}};
+
+  const ElementId<3> self_id3{0};
+  const Element<3> isolated_element{self_id3, {}};
+  const auto logical_coords3 = logical_coordinates(cartoon_dg_mesh);
+  const auto make_element_map3 = [](const auto& element_id) {
+    return ElementMap<3, Frame::Grid>{
+        element_id,
+        domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Grid>(
+            domain::CoordinateMaps::Identity<3>{})};
+  };
+  const auto grid_to_inertial_map3 =
+      domain::make_coordinate_map_base<Frame::Grid, Frame::Inertial>(
+          domain::CoordinateMaps::Identity<3>{});
+  const std::unordered_map<
+      std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+      functions_of_time3{};
+
+  ActionTesting::emplace_array_component_and_initialize<comp3>(
+      &runner3, ActionTesting::NodeId{0}, ActionTesting::LocalCoreId{0},
+      self_id3,
+      {1.3, cartoon_dg_mesh, isolated_element,
+       clone_unique_ptrs(functions_of_time3), logical_coords3,
+       make_element_map3(self_id3), grid_to_inertial_map3->get_clone(),
+       Variables<tmpl::list<Var1>>{
+           cartoon_subcell_mesh.number_of_grid_points()},
+       Variables<tmpl::list<::Tags::dt<Var1>>>{
+           cartoon_subcell_mesh.number_of_grid_points()},
+       typename ::Tags::HistoryEvolvedVariables<
+           Tags::Variables<tmpl::list<Var1>>>::type{}});
+
+  ActionTesting::next_action<comp3>(make_not_null(&runner3), self_id3);
+  CHECK(ActionTesting::get_databox_tag<comp3,
+                                       evolution::dg::subcell::Tags::Mesh<3>>(
+            runner3, self_id3) == cartoon_subcell_mesh);
+}
+
 SPECTRE_TEST_CASE("Unit.Evolution.Subcell.Actions.Initialize",
                   "[Evolution][Unit]") {
   register_classes_with_charm<
@@ -680,5 +747,6 @@ SPECTRE_TEST_CASE("Unit.Evolution.Subcell.Actions.Initialize",
       }
     }
   }
+  test_cartoon();
 }
 }  // namespace

--- a/tests/Unit/Evolution/DgSubcell/Test_BackgroundGrVars.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_BackgroundGrVars.cpp
@@ -434,6 +434,167 @@ void test_for_rollback(const gsl::not_null<std::mt19937*> gen) {
   test<TestMovingMesh, false>(gen, false);
 }
 
+std::array<Mesh<3>, 3> create_axial_face_centered_meshes(
+    const Mesh<3>& cell_centered_mesh) {
+  std::array<Mesh<3>, 3> face_centered_meshes{};
+  for (size_t dim = 0; dim < 2; ++dim) {
+    auto basis = cell_centered_mesh.basis();
+    auto quadrature = cell_centered_mesh.quadrature();
+    auto extents = cell_centered_mesh.extents().indices();
+    gsl::at(extents, dim) = cell_centered_mesh.extents(0) + 1;
+    gsl::at(quadrature, dim) = Spectral::Quadrature::FaceCentered;
+    gsl::at(face_centered_meshes, dim) = Mesh<3>{extents, basis, quadrature};
+  }
+  return face_centered_meshes;
+}
+
+template <bool ComputeOnlyOnRollback>
+void test_cartoon(const bool did_rollback) {
+  // Test BackgroundGrVars with an axially symmetric subcell mesh:
+  // - Dims 0 and 1: FiniteDifference / CellCentered
+  // - Dim 2: Cartoon / AxialSymmetry (extent 1)
+  // This exercises the Cartoon branches in both the initialization-phase
+  // isotropy assert and in face_centered_impl (comp_dim == 2).
+  CAPTURE(ComputeOnlyOnRollback);
+  CAPTURE(did_rollback);
+
+  const double initial_time = 0.5;
+
+  const size_t num_dg_pts = 3;
+  const auto brick = create_a_brick<false>(num_dg_pts, initial_time);
+
+  const auto domain = brick.create_domain();
+  const auto element_id = ElementId<3>{0};
+  Element<3> element = domain::create_initial_element(
+      element_id, domain.blocks(),
+      std::vector<std::array<size_t, 3>>{{0, 0, 0}});
+
+  // Axially symmetric subcell mesh: FD in xi/eta, Cartoon in zeta.
+  const Mesh<3> dg_mesh{
+      {{num_dg_pts, num_dg_pts, 1}},
+      {Spectral::Basis::Legendre, Spectral::Basis::Legendre,
+       Spectral::Basis::Cartoon},
+      {Spectral::Quadrature::GaussLobatto, Spectral::Quadrature::GaussLobatto,
+       Spectral::Quadrature::AxialSymmetry}};
+  const Mesh<3> subcell_mesh = evolution::dg::subcell::fd::mesh(dg_mesh);
+
+  const auto face_centered_meshes =
+      create_axial_face_centered_meshes(subcell_mesh);
+
+  const auto& block = domain.blocks()[element_id.block_id()];
+  const auto element_map = ElementMap<3, Frame::Grid>{element_id, block};
+
+  std::unique_ptr<::domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, 3>>
+      grid_to_inertial_map;
+  if (block.is_time_dependent()) {
+    grid_to_inertial_map = block.moving_mesh_grid_to_inertial_map().get_clone();
+  } else {
+    grid_to_inertial_map =
+        ::domain::make_coordinate_map_base<Frame::Grid, Frame::Inertial>(
+            ::domain::CoordinateMaps::Identity<3>{});
+  }
+
+  const auto compute_inertial_coords = [&grid_to_inertial_map, &element_map,
+                                        &brick](const Mesh<3> mesh,
+                                                const double time) {
+    return (*grid_to_inertial_map)(element_map(logical_coordinates(mesh)), time,
+                                   brick.functions_of_time());
+  };
+
+  const auto subcell_inertial_coords =
+      compute_inertial_coords(subcell_mesh, initial_time);
+
+  using gr_variables_tag =
+      ::Tags::Variables<SystemForTest::spacetime_variables_tag::tags_list>;
+  using inactive_gr_variables_tag =
+      evolution::dg::subcell::Tags::Inactive<gr_variables_tag>;
+  using subcell_face_gr_variables_tag =
+      evolution::dg::subcell::Tags::OnSubcellFaces<
+          typename SystemForTest::flux_spacetime_variables_tag, 3>;
+
+  const auto solution = []() {
+    return RelativisticEuler::Solutions::TovStar{
+        1.0e-3, EquationsOfState::PolytropicFluid<true>{100.0, 2.0}.get_clone(),
+        RelativisticEuler::Solutions::TovCoordinates::Schwarzschild};
+  }();
+
+  const auto dg_gr_vars = [&compute_inertial_coords, &dg_mesh, &initial_time,
+                           &solution]() {
+    gr_variables_tag::type gr_vars{dg_mesh.number_of_grid_points()};
+    gr_vars.assign_subset(evolution::Initialization::initial_data(
+        solution, compute_inertial_coords(dg_mesh, initial_time), initial_time,
+        typename gr_variables_tag::tags_list{}));
+    return gr_vars;
+  }();
+
+  auto box = [&block, &brick, &dg_gr_vars, &element, &element_id,
+              &grid_to_inertial_map, &initial_time, &solution,
+              &subcell_inertial_coords, &subcell_mesh]() {
+    typename subcell_face_gr_variables_tag::type face_gr_vars{};
+    return db::create<db::AddSimpleTags<
+        ::Tags::Time, domain::Tags::Domain<3>, domain::Tags::Element<3>,
+        domain::Tags::ElementMap<3, Frame::Grid>,
+        domain::CoordinateMaps::Tags::CoordinateMap<3, Frame::Grid,
+                                                    Frame::Inertial>,
+        domain::Tags::FunctionsOfTimeInitialize,
+        evolution::dg::subcell::Tags::Mesh<3>,
+        evolution::dg::subcell::Tags::Coordinates<3, Frame::Inertial>,
+        gr_variables_tag, inactive_gr_variables_tag,
+        subcell_face_gr_variables_tag,
+        evolution::dg::subcell::Tags::DidRollback,
+        evolution::initial_data::Tags::InitialData>>(
+        initial_time, brick.create_domain(), element,
+        ElementMap<3, Frame::Grid>{
+            element_id,
+            block.is_time_dependent()
+                ? block.moving_mesh_logical_to_grid_map().get_clone()
+                : block.stationary_map().get_to_grid_frame()},
+        std::move(grid_to_inertial_map),
+        clone_unique_ptrs(brick.functions_of_time()), subcell_mesh,
+        subcell_inertial_coords, dg_gr_vars,
+        typename inactive_gr_variables_tag::type{}, face_gr_vars, false,
+        solution.get_clone());
+  }();
+
+  // Apply the mutator for the initialization phase. This exercises the
+  // AxialSymmetry branch of the isotropic-mesh assert and the comp_dim==2
+  // loop in face_centered_impl.
+  db::mutate_apply<evolution::dg::subcell::BackgroundGrVars<
+      SystemForTest, MetavariablesForTest, ComputeOnlyOnRollback>>(
+      make_not_null(&box));
+
+  // Check that inactive GR vars were initialized with the correct number of
+  // grid points.
+  CHECK(get<inactive_gr_variables_tag>(box).number_of_grid_points() ==
+        subcell_mesh.number_of_grid_points());
+
+  // Check face-centered vars were initialized for comp_dim=2 faces only
+  // (dims 0 and 1 should have grid points; dim 2 is Cartoon and not filled).
+  for (size_t d = 0; d < 2; ++d) {
+    CHECK(gsl::at(get<subcell_face_gr_variables_tag>(box), d)
+              .number_of_grid_points() ==
+          gsl::at(face_centered_meshes, d).number_of_grid_points());
+  }
+
+  // Verify the cell-centered GR vars match the analytic solution.
+  const auto expected_cell_centered_gr_vars = solution.variables(
+      subcell_inertial_coords, initial_time, gr_variables_tag::tags_list{});
+  tmpl::for_each<gr_variables_tag::tags_list>(
+      [&box, &expected_cell_centered_gr_vars](const auto tag_v) {
+        using tag = tmpl::type_from<decltype(tag_v)>;
+        CHECK_ITERABLE_APPROX(get<evolution::dg::subcell::Tags::Inactive<tag>>(
+                                  get<inactive_gr_variables_tag>(box)),
+                              get<tag>(expected_cell_centered_gr_vars));
+      });
+}
+
+void test_cartoon_for_rollback() {
+  test_cartoon<true>(true);
+  test_cartoon<true>(false);
+  test_cartoon<false>(true);
+  test_cartoon<false>(false);
+}
+
 SPECTRE_TEST_CASE("Unit.Evolution.Subcell.Actions.BackgroundGrVars",
                   "[Unit][Evolution]") {
   MAKE_GENERATOR(gen);
@@ -443,6 +604,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Subcell.Actions.BackgroundGrVars",
 
   test_for_rollback<false>(make_not_null(&gen));
   test_for_rollback<false>(make_not_null(&gen));
+
+  test_cartoon_for_rollback();
 }
 
 }  // namespace

--- a/tests/Unit/Evolution/DgSubcell/Test_Matrices.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_Matrices.cpp
@@ -229,6 +229,195 @@ void reconstruction_matrix(const double eps) {
   }
 }
 
+void test_cartoon_matrices() {
+  for (const auto quad : {Spectral::Quadrature::SphericalSymmetry,
+                          Spectral::Quadrature::AxialSymmetry}) {
+    // projection_matrix for a Cartoon dimension returns a 1x1 identity matrix.
+    const Mesh<1> cartoon_mesh{1, Spectral::Basis::Cartoon, quad};
+    const Matrix& proj_mat =
+        projection_matrix(cartoon_mesh, /*subcell_extents=*/1, quad);
+    REQUIRE(proj_mat.rows() == 1);
+    REQUIRE(proj_mat.columns() == 1);
+    CHECK(proj_mat(0, 0) == approx(1.0));
+    // reconstruction_matrix for a Cartoon 1D mesh returns a 1x1 identity
+    // matrix.
+    const Index<1> cartoon_subcell_extents{1};
+    const Matrix& rec_mat = subcell::fd::reconstruction_matrix(
+        cartoon_mesh, cartoon_subcell_extents);
+    REQUIRE(rec_mat.rows() == 1);
+    REQUIRE(rec_mat.columns() == 1);
+    CHECK(rec_mat(0, 0) == approx(1.0));
+  }
+#ifdef SPECTRE_DEBUG
+  // projection_matrix: unsupported subcell_quadrature.
+  CHECK_THROWS_WITH(
+      projection_matrix(Mesh<1>{3, Spectral::Basis::Legendre,
+                                Spectral::Quadrature::GaussLobatto},
+                        5, Spectral::Quadrature::GaussLobatto),
+      Catch::Matchers::ContainsSubstring(
+          "subcell_quadrature option in projection_matrix should be"));
+  // projection_matrix: unsupported basis (not Legendre or Cartoon).
+  CHECK_THROWS_WITH(
+      projection_matrix(Mesh<1>{3, Spectral::Basis::Chebyshev,
+                                Spectral::Quadrature::GaussLobatto},
+                        5, Spectral::Quadrature::CellCentered),
+      Catch::Matchers::ContainsSubstring(
+          "FD Subcell projection only supports Legendre or Cartoon bases"));
+  // reconstruction_matrix: unsupported basis at dim 0.
+  CHECK_THROWS_WITH(
+      subcell::fd::reconstruction_matrix(
+          Mesh<1>{3, Spectral::Basis::Chebyshev,
+                  Spectral::Quadrature::GaussLobatto},
+          Index<1>{5}),
+      Catch::Matchers::ContainsSubstring(
+          "FD Subcell reconstruction only supports Legendre or Cartoon bases"));
+  // reconstruction_matrix 1D: non-uniform subcell extents (trivially can't
+  // fail for 1D since Index<1> is always "uniform", so test non-uniform mesh
+  // instead via 2D).
+  CHECK_THROWS_WITH(
+      subcell::fd::reconstruction_matrix(
+          Mesh<2>{{3, 4},
+                  {Spectral::Basis::Legendre, Spectral::Basis::Legendre},
+                  {Spectral::Quadrature::GaussLobatto,
+                   Spectral::Quadrature::GaussLobatto}},
+          Index<2>{5}),
+      Catch::Matchers::ContainsSubstring(
+          "The subcell mesh must have isotropic basis"));
+  CHECK_THROWS_WITH(
+      subcell::fd::reconstruction_matrix(
+          Mesh<2>{3, Spectral::Basis::Legendre,
+                  Spectral::Quadrature::GaussLobatto},
+          Index<2>{{5, 7}}),
+      Catch::Matchers::ContainsSubstring("The subcell mesh must be uniform"));
+#endif
+}
+
+// Tests projection for 3D meshes with trailing Cartoon dimensions:
+// {Legendre, Legendre, Cartoon} (axial symmetry) and
+// {Legendre, Cartoon, Cartoon} (spherical symmetry).
+// Reconstruction is not tested here because DimByDim reconstruction passes
+// 1D slices, which are already covered by test_cartoon_matrices.
+template <size_t MaxPts, Spectral::Quadrature QuadratureType>
+void test_cartoon_mixed_matrices() {
+  for (size_t num_pts_1d = std::max(
+           static_cast<size_t>(2),
+           Spectral::minimum_number_of_points<Spectral::Basis::Legendre,
+                                              QuadratureType>);
+       num_pts_1d < MaxPts + 1; ++num_pts_1d) {
+    CAPTURE(num_pts_1d);
+    const size_t num_subcells_1d = 2 * num_pts_1d - 1;
+
+    for (const bool axial : {true, false}) {
+      CAPTURE(axial);
+      // axial  => {Legendre, Legendre, Cartoon}, AxialSymmetry
+      // !axial => {Legendre, Cartoon,  Cartoon}, SphericalSymmetry
+      const std::array<size_t, 3> dg_extents_arr{
+          num_pts_1d, axial ? num_pts_1d : 1_st, 1_st};
+      const std::array<Spectral::Basis, 3> bases{
+          Spectral::Basis::Legendre,
+          axial ? Spectral::Basis::Legendre : Spectral::Basis::Cartoon,
+          Spectral::Basis::Cartoon};
+      const auto cartoon_quad = axial ? Spectral::Quadrature::AxialSymmetry
+                                      : Spectral::Quadrature::SphericalSymmetry;
+      const std::array<Spectral::Quadrature, 3> quadratures{
+          QuadratureType, axial ? QuadratureType : cartoon_quad, cartoon_quad};
+
+      const Mesh<3> dg_mesh{dg_extents_arr, bases, quadratures};
+      const auto logical_coords = logical_coordinates(dg_mesh);
+
+      const std::array<size_t, 3> subcell_extents_arr{
+          num_subcells_1d, axial ? num_subcells_1d : 1_st, 1_st};
+      const Index<3> subcell_extents{subcell_extents_arr};
+      const size_t num_subcells = subcell_extents.product();
+
+      const size_t poly_degree = std::min(num_pts_1d - 2, 6_st);
+      const DataVector nodal_coeffs =
+          TestHelpers::evolution::dg::subcell::cell_values(poly_degree,
+                                                           logical_coords);
+
+      // Build projection matrices per dimension.
+      const Matrix empty{};
+      auto projection_mat = make_array<3>(std::cref(empty));
+      for (size_t d = 0; d < 3; ++d) {
+        const auto subcell_quad = gsl::at(bases, d) == Spectral::Basis::Cartoon
+                                      ? gsl::at(quadratures, d)
+                                      : Spectral::Quadrature::CellCentered;
+        gsl::at(projection_mat, d) = std::cref(projection_matrix(
+            dg_mesh.slice_through(d), subcell_extents[d], subcell_quad));
+      }
+
+      // Project DG -> subcell.
+      DataVector subcell_values(num_subcells, 0.0);
+      apply_matrices(make_not_null(&subcell_values), projection_mat,
+                     nodal_coeffs, dg_mesh.extents());
+
+      // The projected values should match the test polynomial evaluated at the
+      // subcell collocation points.
+      const std::array<Spectral::Basis, 3> subcell_bases{
+          Spectral::Basis::FiniteDifference,
+          axial ? Spectral::Basis::FiniteDifference : Spectral::Basis::Cartoon,
+          Spectral::Basis::Cartoon};
+      const std::array<Spectral::Quadrature, 3> subcell_quads{
+          Spectral::Quadrature::CellCentered,
+          axial ? Spectral::Quadrature::CellCentered : cartoon_quad,
+          cartoon_quad};
+      const Mesh<3> subcell_mesh{subcell_extents_arr, subcell_bases,
+                                 subcell_quads};
+      const DataVector expected_subcell_values =
+          TestHelpers::evolution::dg::subcell::cell_values(
+              poly_degree, logical_coordinates(subcell_mesh));
+      CHECK_ITERABLE_APPROX(subcell_values, expected_subcell_values);
+    }
+  }
+#ifdef SPECTRE_DEBUG
+  // reconstruction_matrix 3D spherical: cartoon subcell extents must be 1.
+  CHECK_THROWS_WITH(
+      subcell::fd::reconstruction_matrix(
+          Mesh<3>{{3, 1, 1},
+                  {Spectral::Basis::Legendre, Spectral::Basis::Cartoon,
+                   Spectral::Basis::Cartoon},
+                  {QuadratureType, Spectral::Quadrature::SphericalSymmetry,
+                   Spectral::Quadrature::SphericalSymmetry}},
+          Index<3>{{5, 3, 1}}),
+      Catch::Matchers::ContainsSubstring(
+          "The subcell extents are neither isotropic nor a valid cartoon "
+          "pattern"));
+  // reconstruction_matrix 3D axial: non-uniform DG extents in non-cartoon dims.
+  CHECK_THROWS_WITH(
+      subcell::fd::reconstruction_matrix(
+          Mesh<3>{{3, 4, 1},
+                  {Spectral::Basis::Legendre, Spectral::Basis::Legendre,
+                   Spectral::Basis::Cartoon},
+                  {QuadratureType, QuadratureType,
+                   Spectral::Quadrature::AxialSymmetry}},
+          Index<3>{{5, 5, 1}}),
+      Catch::Matchers::ContainsSubstring(
+          "The non-cartoon subcell sub-mesh must have isotropic basis"));
+  // reconstruction_matrix 3D axial: subcell extents not {n,n,1}.
+  CHECK_THROWS_WITH(
+      subcell::fd::reconstruction_matrix(
+          Mesh<3>{{3, 3, 1},
+                  {Spectral::Basis::Legendre, Spectral::Basis::Legendre,
+                   Spectral::Basis::Cartoon},
+                  {QuadratureType, QuadratureType,
+                   Spectral::Quadrature::AxialSymmetry}},
+          Index<3>{{5, 7, 1}}),
+      Catch::Matchers::ContainsSubstring(
+          "The subcell extents are neither isotropic nor a valid cartoon"));
+  // reconstruction_matrix 3D axial: cartoon subcell extent not 1.
+  CHECK_THROWS_WITH(
+      subcell::fd::reconstruction_matrix(
+          Mesh<3>{{3, 3, 1},
+                  {Spectral::Basis::Legendre, Spectral::Basis::Legendre,
+                   Spectral::Basis::Cartoon},
+                  {QuadratureType, QuadratureType,
+                   Spectral::Quadrature::AxialSymmetry}},
+          Index<3>{{5, 5, 3}}),
+      Catch::Matchers::ContainsSubstring(
+          "The subcell mesh must be uniform but is"));
+#endif
+}
+
 SPECTRE_TEST_CASE("Unit.Evolution.Subcell.Fd.ProjectionMatrix",
                   "[Evolution][Unit]") {
   test_projection_matrix<10, 1, Spectral::Basis::Legendre,
@@ -261,6 +450,9 @@ SPECTRE_TEST_CASE("Unit.Evolution.Subcell.Fd.ProjectionMatrix",
                                  Spectral::Quadrature::GaussLobatto>();
   test_projection_matrix_to_face<5, 3, 2, Spectral::Basis::Legendre,
                                  Spectral::Quadrature::Gauss>();
+  test_cartoon_matrices();
+  test_cartoon_mixed_matrices<10, Spectral::Quadrature::GaussLobatto>();
+  test_cartoon_mixed_matrices<10, Spectral::Quadrature::Gauss>();
 }
 
 // [[TimeOut, 10]]

--- a/tests/Unit/Evolution/DgSubcell/Test_Mesh.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_Mesh.cpp
@@ -89,7 +89,7 @@ void test_mesh() {
       Catch::Matchers::ContainsSubstring(
           "The DG quadrature for computing the DG mesh must be Gauss or "
           "GaussLobatto but "));
-#endif // SPECTRE_DEBUG
+#endif  // SPECTRE_DEBUG
 
   for (size_t i = min_num_pts; i < max_num_pts; ++i) {
     CHECK(evolution::dg::subcell::fd::mesh(
@@ -145,6 +145,91 @@ void test_mesh() {
             BasisType,
             QuadratureType) == Mesh<3>({{4, 6, 7}}, BasisType, QuadratureType));
 }
+template <Spectral::Basis BasisType, Spectral::Quadrature QuadratureType>
+void test_cartoon_mesh() {
+  for (size_t i = 2; i < 5; ++i) {
+    // Spherically symmetric: second and third bases are Cartoon.
+    const Mesh<3> dg_spherical{
+        {{i, 1, 1}},
+        {BasisType, Spectral::Basis::Cartoon, Spectral::Basis::Cartoon},
+        {QuadratureType, Spectral::Quadrature::SphericalSymmetry,
+         Spectral::Quadrature::SphericalSymmetry}};
+    const Mesh<3> subcell_spherical{
+        {{2 * i - 1, 1, 1}},
+        {Spectral::Basis::FiniteDifference, Spectral::Basis::Cartoon,
+         Spectral::Basis::Cartoon},
+        {Spectral::Quadrature::CellCentered,
+         Spectral::Quadrature::SphericalSymmetry,
+         Spectral::Quadrature::SphericalSymmetry}};
+    CHECK(evolution::dg::subcell::fd::mesh(dg_spherical) == subcell_spherical);
+    CHECK(evolution::dg::subcell::fd::dg_mesh(subcell_spherical, BasisType,
+                                              QuadratureType) == dg_spherical);
+
+    // Axially symmetric: only third basis is Cartoon.
+    const Mesh<3> dg_axial{
+        {{i, i, 1}},
+        {BasisType, BasisType, Spectral::Basis::Cartoon},
+        {QuadratureType, QuadratureType, Spectral::Quadrature::AxialSymmetry}};
+    const Mesh<3> subcell_axial{
+        {{2 * i - 1, 2 * i - 1, 1}},
+        {Spectral::Basis::FiniteDifference, Spectral::Basis::FiniteDifference,
+         Spectral::Basis::Cartoon},
+        {Spectral::Quadrature::CellCentered, Spectral::Quadrature::CellCentered,
+         Spectral::Quadrature::AxialSymmetry}};
+    CHECK(evolution::dg::subcell::fd::mesh(dg_axial) == subcell_axial);
+    CHECK(evolution::dg::subcell::fd::dg_mesh(subcell_axial, BasisType,
+                                              QuadratureType) == dg_axial);
+  }
+
+#ifdef SPECTRE_DEBUG
+  // mesh() assert: non-Legendre/Chebyshev dimension mixed with Cartoon
+  CHECK_THROWS_WITH(
+      evolution::dg::subcell::fd::mesh(
+          Mesh<3>{{{3, 1, 1}},
+                  {Spectral::Basis::ZernikeB2, Spectral::Basis::Cartoon,
+                   Spectral::Basis::Cartoon},
+                  {Spectral::Quadrature::GaussRadauUpper,
+                   Spectral::Quadrature::SphericalSymmetry,
+                   Spectral::Quadrature::SphericalSymmetry}}),
+      Catch::Matchers::ContainsSubstring(
+          "The DG mesh that is being converted to subcell can only mix "
+          "Legendre or Chebyshev with Cartoon"));
+  CHECK_THROWS_WITH(
+      evolution::dg::subcell::fd::mesh(
+          Mesh<3>{{{3, 3, 1}},
+                  {Spectral::Basis::FiniteDifference, BasisType,
+                   Spectral::Basis::Cartoon},
+                  {Spectral::Quadrature::CellCentered, QuadratureType,
+                   Spectral::Quadrature::AxialSymmetry}}),
+      Catch::Matchers::ContainsSubstring(
+          "The DG mesh that is being converted to subcell can only mix "
+          "Legendre or Chebyshev with Cartoon"));
+
+  // dg_mesh() assert: non-FiniteDifference dimension mixed with Cartoon
+  CHECK_THROWS_WITH(
+      evolution::dg::subcell::fd::dg_mesh(
+          Mesh<3>{
+              {{5, 1, 1}},
+              {BasisType, Spectral::Basis::Cartoon, Spectral::Basis::Cartoon},
+              {QuadratureType, Spectral::Quadrature::SphericalSymmetry,
+               Spectral::Quadrature::SphericalSymmetry}},
+          BasisType, QuadratureType),
+      Catch::Matchers::ContainsSubstring(
+          "The basis for computing the DG mesh can only mix "
+          "FiniteDifference with Cartoon"));
+  CHECK_THROWS_WITH(
+      evolution::dg::subcell::fd::dg_mesh(
+          Mesh<3>{{{5, 3, 1}},
+                  {BasisType, Spectral::Basis::FiniteDifference,
+                   Spectral::Basis::Cartoon},
+                  {QuadratureType, Spectral::Quadrature::CellCentered,
+                   Spectral::Quadrature::AxialSymmetry}},
+          BasisType, QuadratureType),
+      Catch::Matchers::ContainsSubstring(
+          "The basis for computing the DG mesh can only mix "
+          "FiniteDifference with Cartoon"));
+#endif  // SPECTRE_DEBUG
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Evolution.Subcell.FD.Mesh", "[Evolution][Unit]") {
@@ -152,5 +237,11 @@ SPECTRE_TEST_CASE("Unit.Evolution.Subcell.FD.Mesh", "[Evolution][Unit]") {
   test_mesh<Spectral::Basis::Legendre, Spectral::Quadrature::Gauss>();
   test_mesh<Spectral::Basis::Chebyshev, Spectral::Quadrature::GaussLobatto>();
   test_mesh<Spectral::Basis::Chebyshev, Spectral::Quadrature::Gauss>();
+  test_cartoon_mesh<Spectral::Basis::Legendre,
+                    Spectral::Quadrature::GaussLobatto>();
+  test_cartoon_mesh<Spectral::Basis::Legendre, Spectral::Quadrature::Gauss>();
+  test_cartoon_mesh<Spectral::Basis::Chebyshev,
+                    Spectral::Quadrature::GaussLobatto>();
+  test_cartoon_mesh<Spectral::Basis::Chebyshev, Spectral::Quadrature::Gauss>();
   print_comparison_point_computation();
 }

--- a/tests/Unit/Evolution/DgSubcell/Test_NeighborRdmpAndVolumeData.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_NeighborRdmpAndVolumeData.cpp
@@ -469,7 +469,7 @@ void test() {
             non_uniform_mesh, element, subcell_mesh, number_of_ghost_zones,
             neighbor_dg_to_fd_interpolants),
         Catch::Matchers::ContainsSubstring(
-            "The neighbor mesh must be uniform but is"));
+            "The neighbor subcell mesh must have isotropic basis"));
     CHECK_THROWS_WITH(
         evolution::dg::subcell::insert_or_update_neighbor_volume_data<false>(
             make_not_null(&neighbor_data), received_fd_data,
@@ -478,7 +478,25 @@ void test() {
             non_uniform_mesh, element, subcell_mesh, number_of_ghost_zones,
             neighbor_dg_to_fd_interpolants),
         Catch::Matchers::ContainsSubstring(
-            "The neighbor mesh must be uniform but is"));
+            "The neighbor subcell mesh must have isotropic basis"));
+    if constexpr (Dim == 3) {
+      const Mesh<3> non_uniform_cartoon_mesh{
+          {{4, 5, 1}},
+          {Spectral::Basis::FiniteDifference, Spectral::Basis::FiniteDifference,
+           Spectral::Basis::Cartoon},
+          {Spectral::Quadrature::CellCentered,
+           Spectral::Quadrature::CellCentered,
+           Spectral::Quadrature::AxialSymmetry}};
+      CHECK_THROWS_WITH(
+          evolution::dg::subcell::insert_or_update_neighbor_volume_data<false>(
+              make_not_null(&neighbor_data), received_fd_data,
+              number_of_rdmp_vars,
+              DirectionalId<Dim>{Direction<Dim>::upper_xi(), ElementId<Dim>{1}},
+              non_uniform_cartoon_mesh, element, subcell_mesh,
+              number_of_ghost_zones, neighbor_dg_to_fd_interpolants),
+          Catch::Matchers::ContainsSubstring(
+              "The non-cartoon neighbor subcell sub-mesh must have isotropic"));
+    }
   }
 #endif
 }

--- a/tests/Unit/Evolution/DgSubcell/Test_SliceData.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_SliceData.cpp
@@ -182,11 +182,79 @@ void test() {
   }
 }
 
+void test_cartoon() {
+  const size_t num_pts_xy = 5;
+  const size_t additional_buffer_size = 0;
+  const Index<3> extents{num_pts_xy, num_pts_xy, 1};
+
+  Variables<tmpl::list<Tags::Scalar, Tags::Vector<3>>> volume_vars{
+      extents.product()};
+  std::iota(volume_vars.data(), volume_vars.data() + volume_vars.size(), 0.0);
+
+  // Cartoon dimension is not sliced
+  const std::unordered_set<Direction<3>> directions_to_slice{
+      Direction<3>::upper_xi(), Direction<3>::lower_xi(),
+      Direction<3>::upper_eta(), Direction<3>::lower_eta()};
+
+  for (size_t number_of_ghost_points = 1; number_of_ghost_points < 4;
+       ++number_of_ghost_points) {
+    CAPTURE(number_of_ghost_points);
+    const auto sliced_data =
+        subcell::slice_data(volume_vars, extents, number_of_ghost_points,
+                            directions_to_slice, additional_buffer_size, {});
+    // Check that we got data back for the four requested directions.
+    CHECK(sliced_data.size() == 4);
+    for (const auto& direction : directions_to_slice) {
+      CAPTURE(direction);
+      REQUIRE(sliced_data.count(direction) == 1);
+      Index<3> expected_slice_extents = extents;
+      expected_slice_extents[direction.dimension()] = number_of_ghost_points;
+      CHECK(sliced_data.at(direction).size() ==
+            expected_slice_extents.product() *
+                    Variables<tmpl::list<Tags::Scalar, Tags::Vector<3>>>::
+                        number_of_independent_components +
+                additional_buffer_size);
+    }
+    // Zeta directions are absent.
+    CHECK(sliced_data.count(Direction<3>::upper_zeta()) == 0);
+    CHECK(sliced_data.count(Direction<3>::lower_zeta()) == 0);
+  }
+}
+
+#ifdef SPECTRE_DEBUG
+template <size_t Dim>
+void test_assert() {
+  const size_t num_points = 2;
+  const size_t additional_buffer_size = 0;
+  const Index<Dim> extents{num_points};
+
+  Variables<tmpl::list<Tags::Scalar, Tags::Vector<Dim>>> volume_vars{
+      extents.product()};
+  std::iota(volume_vars.data(), volume_vars.data() + volume_vars.size(), 0.0);
+
+  const std::unordered_set<Direction<Dim>> directions_to_slice{
+      Direction<Dim>::upper_xi()};
+
+  const size_t number_of_ghost_points = 3;
+
+  CHECK_THROWS_WITH(
+      subcell::slice_data(volume_vars, extents, number_of_ghost_points,
+                          directions_to_slice, additional_buffer_size, {}),
+      Catch::Matchers::ContainsSubstring("Number of ghost points"));
+}
+#endif  // SPECTRE_DEBUG
+
 // [[TimeOut, 8]]
 SPECTRE_TEST_CASE("Unit.Evolution.Subcell.SliceData", "[Evolution][Unit]") {
   test<1>();
   test<2>();
   test<3>();
+  test_cartoon();
+#ifdef SPECTRE_DEBUG
+  test_assert<1>();
+  test_assert<2>();
+  test_assert<3>();
+#endif  // SPECTRE_DEBUG
 }
 }  // namespace
 }  // namespace evolution::dg::subcell


### PR DESCRIPTION
## Proposed changes

There are many asserts of isotropic FD extents: this modifies them to allow Cartoon bases. In this commit and ones to come, we can often skip cartoon dimensions entirely for certain operations.


<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
