### PR TITLE
Update IrregularInterpolant to handle FD + Cartoon

### DIFF
--- a/src/NumericalAlgorithms/Interpolation/IrregularInterpolant.cpp
+++ b/src/NumericalAlgorithms/Interpolation/IrregularInterpolant.cpp
@@ -14,6 +14,7 @@
 #include "DataStructures/Tensor/IndexType.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "NumericalAlgorithms/Interpolation/CardinalInterpolator.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "NumericalAlgorithms/Spectral/BasisFunctions/Zernike.hpp"
 #include "NumericalAlgorithms/Spectral/InterpolationMatrix.hpp"
 #include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
@@ -508,10 +509,9 @@ Matrix interpolation_matrix(
           fd_to_fd_interp_order == std::nullopt,
       "fd_to_fd_interp_order only applies to FD meshes. But Mesh is " << mesh);
 
-  if (mesh.basis()[0] == Spectral::Basis::FiniteDifference) {
-    ASSERT(mesh.basis()[1] == Spectral::Basis::FiniteDifference and
-               mesh.basis()[2] == Spectral::Basis::FiniteDifference,
-           "Mixed FD and DG bases are not supported. Mesh = " << mesh);
+  if (mesh.basis() == std::array{Spectral::Basis::FiniteDifference,
+                                 Spectral::Basis::FiniteDifference,
+                                 Spectral::Basis::FiniteDifference}) {
     auto source_xi = logical_coordinates(mesh);
     DataVector xi_source{get<0>(source_xi).data(), mesh.extents(0)};
     DataVector eta_source;
@@ -577,6 +577,35 @@ Matrix interpolation_matrix(
       }
     }
     return result;
+  } else if (mesh.basis() == std::array{Spectral::Basis::FiniteDifference,
+                                        Spectral::Basis::FiniteDifference,
+                                        Spectral::Basis::Cartoon}) {
+    // Axial Symmetry -> call 2D implementation
+    tnsr::I<DataType, 2, Frame::ElementLogical> points_2d{};
+    if constexpr (std::is_same_v<DataType, DataVector>) {
+      get<0>(points_2d).set_data_ref(
+          make_not_null(const_cast<DataType*>(&get<0>(points))));  // NOLINT
+      get<1>(points_2d).set_data_ref(
+          make_not_null(const_cast<DataType*>(&get<1>(points))));  // NOLINT
+    } else {
+      get<0>(points_2d) = get<0>(points);
+      get<1>(points_2d) = get<1>(points);
+    }
+    return interpolation_matrix(mesh.slice_through(0, 1), points_2d,
+                                fd_to_fd_interp_order);
+  } else if (mesh.basis() == std::array{Spectral::Basis::FiniteDifference,
+                                        Spectral::Basis::Cartoon,
+                                        Spectral::Basis::Cartoon}) {
+    // Spherical Symmetry -> call 1D implementation
+    tnsr::I<DataType, 1, Frame::ElementLogical> points_1d{};
+    if constexpr (std::is_same_v<DataType, DataVector>) {
+      get<0>(points_1d).set_data_ref(
+          make_not_null(const_cast<DataType*>(&get<0>(points))));  // NOLINT
+    } else {
+      get<0>(points_1d) = get<0>(points);
+    }
+    return interpolation_matrix(mesh.slice_through(0), points_1d,
+                                fd_to_fd_interp_order);
   } else if (mesh.basis()[1] == Spectral::Basis::SphericalHarmonic) {
     ASSERT(mesh.basis()[2] == Spectral::Basis::SphericalHarmonic,
            "Expected last two dimensions to each have spherical harmonic "
@@ -610,6 +639,10 @@ Matrix interpolation_matrix(
                                        number_of_target_points);
     return result;
   }
+  ASSERT(mesh.basis(0) != Spectral::Basis::FiniteDifference and
+             mesh.basis(1) != Spectral::Basis::FiniteDifference and
+             mesh.basis(2) != Spectral::Basis::FiniteDifference,
+         "Mixed FD and DG bases are not supported. Mesh = " << mesh);
 
   // Not FD or special basis, so use 1D spectral interpolation matrices
   const std::array<Matrix, 3> matrices{

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_IrregularInterpolant.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_IrregularInterpolant.cpp
@@ -734,6 +734,113 @@ void test_3d_hollow_cylinder(const gsl::not_null<std::mt19937*> generator) {
   }
 }
 
+// Test that the Cartoon-basis interpolation in 3D delegates correctly to the
+// lower-dimensional interpolator.  For the FD+Cartoon (axisymmetric) case the
+// 3D result must match an Irregular<2> built from slice_through(0,1).  For the
+// Cartoon+Cartoon (spherically-symmetric) case it must match an Irregular<1>
+// built from slice_through(0).
+void test_cartoon_fd(const gsl::not_null<std::mt19937*> generator) {
+  std::uniform_real_distribution<> dist(-1.0, 1.0);
+  const size_t n_target = 7;
+  {
+    INFO("FD+FD+Cartoon matches Irregular<2> on slice_through(0,1)");
+    for (size_t n0 = 4; n0 <= 6; ++n0) {
+      for (size_t n1 = 4; n1 <= 6; ++n1) {
+        CAPTURE(n0);
+        CAPTURE(n1);
+        const Mesh<3> mesh3{
+            {{n0, n1, 1}},
+            {{Spectral::Basis::FiniteDifference,
+              Spectral::Basis::FiniteDifference, Spectral::Basis::Cartoon}},
+            {{Spectral::Quadrature::CellCentered,
+              Spectral::Quadrature::CellCentered,
+              Spectral::Quadrature::AxialSymmetry}}};
+        const Mesh<2> mesh2 = mesh3.slice_through(0, 1);
+
+        // Target points: xi2 is always zero (guaranteed by cartoon symmetry)
+        tnsr::I<DataVector, 3, Frame::ElementLogical> xi3{n_target};
+        get<0>(xi3) = make_with_random_values<DataVector>(
+            generator, make_not_null(&dist), DataVector(n_target));
+        get<1>(xi3) = make_with_random_values<DataVector>(
+            generator, make_not_null(&dist), DataVector(n_target));
+        get<2>(xi3) = DataVector(n_target, 0.0);
+
+        tnsr::I<DataVector, 2, Frame::ElementLogical> xi2{n_target};
+        get<0>(xi2) = get<0>(xi3);
+        get<1>(xi2) = get<1>(xi3);
+
+        // Source data: f(xi, eta) = (1 + xi) * (2 + eta) on the 2D slice,
+        // tiled trivially into 3D (only one point in dim 2)
+        const auto xi_src3 = logical_coordinates(mesh3);
+        DataVector f3(mesh3.number_of_grid_points());
+        for (size_t s = 0; s < mesh3.number_of_grid_points(); ++s) {
+          f3[s] = (1.0 + get<0>(xi_src3)[s]) * (2.0 + get<1>(xi_src3)[s]);
+        }
+        // The 2D slice has the same data layout (dim2 has only one point)
+        const DataVector f2(f3.data(), mesh2.number_of_grid_points());
+
+        const intrp::Irregular<3> interp3(mesh3, xi3);
+        const intrp::Irregular<2> interp2(mesh2, xi2);
+        CHECK_ITERABLE_APPROX(interp3.interpolate(f3), interp2.interpolate(f2));
+
+        tnsr::I<double, 3, Frame::ElementLogical> xi3_double{1};
+        tnsr::I<double, 2, Frame::ElementLogical> xi2_double{1};
+        get<0>(xi3_double) = get<0>(xi2_double) = get<0>(xi3)[0];
+        get<1>(xi3_double) = get<1>(xi2_double) = get<1>(xi3)[0];
+        get<2>(xi3_double) = get<2>(xi3)[0];
+        const intrp::Irregular<3> interp3_double(mesh3, xi3_double);
+        const intrp::Irregular<2> interp2_double(mesh2, xi2_double);
+        CHECK_ITERABLE_APPROX(interp3_double.interpolate(f3),
+                              interp2_double.interpolate(f2));
+      }
+    }
+  }
+  {
+    INFO("FD+Cartoon+Cartoon matches Irregular<1> on slice_through(0)");
+    for (size_t n0 = 4; n0 <= 6; ++n0) {
+      CAPTURE(n0);
+      const Mesh<3> mesh3{
+          {{n0, 1, 1}},
+          {{Spectral::Basis::FiniteDifference, Spectral::Basis::Cartoon,
+            Spectral::Basis::Cartoon}},
+          {{Spectral::Quadrature::CellCentered,
+            Spectral::Quadrature::SphericalSymmetry,
+            Spectral::Quadrature::SphericalSymmetry}}};
+      const Mesh<1> mesh1 = mesh3.slice_through(0);
+
+      tnsr::I<DataVector, 3, Frame::ElementLogical> xi3{n_target};
+      get<0>(xi3) = make_with_random_values<DataVector>(
+          generator, make_not_null(&dist), DataVector(n_target));
+      get<1>(xi3) = DataVector(n_target, 0.0);
+      get<2>(xi3) = DataVector(n_target, 0.0);
+
+      tnsr::I<DataVector, 1, Frame::ElementLogical> xi1{n_target};
+      get<0>(xi1) = get<0>(xi3);
+
+      const auto xi_src3 = logical_coordinates(mesh3);
+      DataVector f3(mesh3.number_of_grid_points());
+      for (size_t s = 0; s < mesh3.number_of_grid_points(); ++s) {
+        f3[s] = 1.0 + 2.0 * get<0>(xi_src3)[s];
+      }
+      const DataVector f1(f3.data(), mesh1.number_of_grid_points());
+
+      const intrp::Irregular<3> interp3(mesh3, xi3);
+      const intrp::Irregular<1> interp1(mesh1, xi1);
+      CHECK_ITERABLE_APPROX(interp3.interpolate(f3), interp1.interpolate(f1));
+
+      tnsr::I<double, 3, Frame::ElementLogical> xi3_double{1};
+      tnsr::I<double, 1, Frame::ElementLogical> xi1_double{1};
+      get<0>(xi3_double) = get<0>(xi1_double) = get<0>(xi3)[0];
+      get<1>(xi3_double) = get<1>(xi3)[0];
+      get<2>(xi3_double) = get<2>(xi3)[0];
+      const intrp::Irregular<3> interp3_double(mesh3, xi3_double);
+      const intrp::Irregular<1> interp1_double(mesh1, xi1_double);
+      CHECK_ITERABLE_APPROX(interp3_double.interpolate(f3),
+                            interp1_double.interpolate(f1));
+    }
+  }
+}
+
 void test_cartoon_spherical(const gsl::not_null<std::mt19937*> generator) {
   std::uniform_real_distribution<> xi_distribution(-1.0, 1.0);
 
@@ -933,6 +1040,7 @@ SPECTRE_TEST_CASE("Unit.Numerical.Interpolation.IrregularInterpolant",
   test_3d_hollow_cylinder(make_not_null(&generator));
   test_cartoon_spherical(make_not_null(&generator));
   test_cartoon_axial(make_not_null(&generator));
+  test_cartoon_fd(make_not_null(&generator));
 #ifdef SPECTRE_DEBUG
   test_errors();
 #endif


### PR DESCRIPTION
## Proposed changes

DG with Cartoon did not need any edits because the interpolation matrix is just the 1x1 Identity. While that is still true, because the FD is a special case in the code, we need to treat the FD with cartoon as a special case as well. Here we can explicitly just call the lower-dimensional version of the interpolation.

The test was primarily written by Claude code
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
