### PR TITLE
Relax Pontryagin scalar random-test tolerance

### DIFF
--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
@@ -226,7 +226,10 @@ void test_compute_pontryagin_scalar_in_vacuum(const DataVector& used_for_size) {
           const tnsr::II<DataVector, 3, Frame::Inertial>&)>(
           &gr::pontryagin_scalar_in_vacuum),
       "ComputeSpacetimeQuantities", "pontryagin_scalar_in_vacuum",
-      {{{-10., 10.}}}, used_for_size);
+      // The C++ Tenex contraction and the Python matrix-product reference
+      // accumulate roundoff in a different order for this fully algebraic
+      // expression, so allow a slightly looser comparison here.
+      {{{-10., 10.}}}, used_for_size, 2.0e-12);
 }
 
 void test_compute_gauss_bonnet_scalar_in_vacuum(


### PR DESCRIPTION
## Proposed changes

Fixes #6868 by increasing the tolerance of the test that led to a random failure, on the grounds that the test is comparing tensor expresion and numpy matrix math, which do the corresponding mathematical operations in different orders. 

Codex used the spectre fix issue skill to i) reproduce the random failure, and ii) suggest the proposed fix. I verified that codex did in fact reproduce the random failure, an I verified that the test is comparing tensor expression math with python math. I agree with increasing the tolerance.

This is an experiement using the "random test failure" path of the skill. I welcome any suggestions or feedback—especially if you don't agree with the justification for just raising the tolerance.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [x] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
