### PR TITLE
Relax Wedge interior inverse-map test tolerance

### DIFF
--- a/tests/Unit/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Test_Wedge.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/TimeDependent/ShapeMapTransitionFunctions/Test_Wedge.cpp
@@ -412,7 +412,8 @@ void test_points_shape_map(
     const std::array<double, 3>& outer_center, const Wedge::Axis axis,
     const double check_time, const std::string& fot_name,
     const FunctionsOfTimeMap& functions_of_time, const std::array<T, 3>& points,
-    const bool reverse = false, const bool check_jacobians = true) {
+    const bool reverse = false, const bool check_jacobians = true,
+    const Approx inverse_map_approx = approx) {
   std::unique_ptr<ShapeMapTransitionFunction> wedge = std::make_unique<Wedge>(
       inner_center, inner_radius, inner_sphericity, outer_center, outer_radius,
       outer_sphericity, static_cast<Wedge::Axis>(axis), reverse);
@@ -430,7 +431,8 @@ void test_points_shape_map(
       test_coordinate_map_argument_types(shape, points, check_time,
                                          functions_of_time);
     }
-    test_inverse_map(shape, points, check_time, functions_of_time);
+    test_inverse_map(shape, points, check_time, functions_of_time,
+                     inverse_map_approx);
   }
 
   test_frame_velocity(shape, points, check_time, functions_of_time);
@@ -514,14 +516,20 @@ void test_in_shape_map_no_offset(const gsl::not_null<Generator*> generator,
   }
 
   const double eps = std::numeric_limits<double>::epsilon();
+  const Approx interior_inverse_map_approx =
+      Approx::custom().margin(1.0e-12).scale(1.0);
   // Check for points within the interior
   for (const auto& point :
        {center, center + std::array{0.0, 2.0 * eps, 0.0},
         center + std::array{0.0, 0.5 * inner_radius, 0.0},
         center + std::array{0.0, (1.0 - 2.0 * eps) * inner_radius, 0.0},
         center + std::array{0.0, inner_radius, 0.0}}) {
+    // The interior inverse solves a cubic analytically, so this check picks up
+    // unavoidable floating-point roundoff when converting the recovered radius
+    // back to Cartesian coordinates.
     test_points_shape_map(1.0, 0.0, center, center, Wedge::Axis::Interior,
-                          check_time, fot_name, functions_of_time, point);
+                          check_time, fot_name, functions_of_time, point, false,
+                          true, interior_inverse_map_approx);
   }
 }
 
@@ -680,6 +688,8 @@ void test_in_shape_map_offset(const gsl::not_null<Generator*> generator,
     }      // for axis
 
     const double eps = std::numeric_limits<double>::epsilon();
+    const Approx interior_inverse_map_approx =
+        Approx::custom().margin(1.0e-12).scale(1.0);
     // Check for points within the interior
     for (const auto& point :
          {inner_center, inner_center + std::array{0.0, 2.0 * eps, 0.0},
@@ -688,7 +698,8 @@ void test_in_shape_map_offset(const gsl::not_null<Generator*> generator,
           inner_center + std::array{0.0, inner_radius, 0.0}}) {
       test_points_shape_map(1.0, outer_sphericity, inner_center, outer_center,
                             Wedge::Axis::Interior, check_time, fot_name,
-                            functions_of_time, point);
+                            functions_of_time, point, false, true,
+                            interior_inverse_map_approx);
     }
   }  // for outer sphericity
 }


### PR DESCRIPTION
## Proposed changes

Fixes #6888 by increasing the tolerance, on the grounds that coverting the radius (found when solving an inverse cubic analytically) back to a Cartesian point leads to roundoff error bigger than the default tolerance.

I used codex and the spectre fix issue skill to generate the code in this PR. I reviewed the code to confirm that the comment is correctly describing the situation, and I reviewed the code that increases the tolerance line by line.

I welcome any feedback you might have.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [x] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
