### PR TITLE
Update inertial coord tag for observing norms with cartoon basis

### DIFF
--- a/src/ParallelAlgorithms/Events/ObserveNorms.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveNorms.hpp
@@ -462,15 +462,14 @@ operator()(const ObservationBox<ComputeTagsList, DataBoxType>& box,
   const auto& mesh = get<::Events::Tags::ObserverMesh<VolumeDim>>(box);
   const auto det_jacobian = [&box, &mesh]() -> DataVector {
     if constexpr (VolumeDim == 3 and
-                  db::tag_is_retrievable_v<
-                      domain::Tags::Coordinates<VolumeDim, Frame::Inertial>,
-                      std::decay_t<decltype(box)>>) {
+                  db::tag_is_retrievable_v<::Events::Tags::ObserverCoordinates<
+                                               VolumeDim, Frame::Inertial>,
+                                           std::decay_t<decltype(box)>>) {
       if (mesh.basis(2) == Spectral::Basis::Cartoon) {
         if (mesh.quadrature(2) == Spectral::Quadrature::SphericalSymmetry) {
           // Spherical Symmetry, needs x^2 cartesian to spherical jacobian
-          return square(get<0>(
-                     get<domain::Tags::Coordinates<VolumeDim, Frame::Inertial>>(
-                         box))) /
+          return square(get<0>(get<::Events::Tags::ObserverCoordinates<
+                                   VolumeDim, Frame::Inertial>>(box))) /
                  get(get<::Events::Tags::ObserverDetInvJacobian<
                          Frame::ElementLogical, Frame::Inertial>>(box));
         } else {
@@ -478,9 +477,8 @@ operator()(const ObservationBox<ComputeTagsList, DataBoxType>& box,
           ASSERT(mesh.quadrature(2) == Spectral::Quadrature::AxialSymmetry,
                  "Unexpected quadrature " << mesh.quadrature(2)
                                           << " (expected AxialSymmetry)");
-          return get<0>(
-                     get<domain::Tags::Coordinates<VolumeDim, Frame::Inertial>>(
-                         box)) /
+          return get<0>(get<::Events::Tags::ObserverCoordinates<
+                            VolumeDim, Frame::Inertial>>(box)) /
                  get(get<::Events::Tags::ObserverDetInvJacobian<
                          Frame::ElementLogical, Frame::Inertial>>(box));
         }

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveNorms.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveNorms.cpp
@@ -416,7 +416,7 @@ void test_cartoon(const std::unique_ptr<ObserveEvent> observe,
                         ::Events::Tags::ObserverMesh<3>,
                         ::Events::Tags::ObserverDetInvJacobian<
                             Frame::ElementLogical, Frame::Inertial>,
-                        domain::Tags::Coordinates<3, Frame::Inertial>,
+                        ::Events::Tags::ObserverCoordinates<3, Frame::Inertial>,
                         Tags::Variables<typename decltype(vars)::tags_list>,
                         observers::Tags::ObservationKey<ArraySectionIdTag>>>(
       metavariables{}, mesh, det_inv_jacobian, inertial_coords, vars, section);


### PR DESCRIPTION
## Proposed changes

We need to get the right mesh when using subcell (still works without subcell)

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
