### PR TITLE
Fix bibliography artifacts in docs

### DIFF
--- a/docs/config/postprocess_docs.py
+++ b/docs/config/postprocess_docs.py
@@ -11,6 +11,35 @@ import pybtex.database
 from bs4 import BeautifulSoup
 
 
+def clean_up_doxygen_bibliography_artifacts(citeref_item, entry):
+    logger = logging.getLogger(__name__)
+    citation_entry = citeref_item.parent
+    removed_empty_lists = False
+    for bibliography_list in citation_entry.find_all(
+        ["ol", "ul"], recursive=False
+    ):
+        list_items = bibliography_list.find_all("li", recursive=False)
+        if list_items and all(
+            list_item.get_text(strip=True) == "" for list_item in list_items
+        ):
+            bibliography_list.decompose()
+            removed_empty_lists = True
+    if not removed_empty_lists or "year" not in entry.fields:
+        return
+    citation_text = citeref_item.get_text().rstrip()
+    year = entry.fields["year"]
+    if citation_text.endswith(","):
+        citeref_item.append(f" {year}.")
+    elif citation_text.endswith(".") and not citation_text.endswith(f"{year}."):
+        citeref_item.append(f" {year}.")
+    elif year not in citation_text:
+        citeref_item.append(f", {year}.")
+    logger.info(
+        "Removed empty bibliography list artifact and restored year for %s.",
+        entry.key,
+    )
+
+
 def append_eprint_links_to_citelist(html_dir, references_files):
     logger = logging.getLogger(__name__)
 
@@ -31,6 +60,8 @@ def append_eprint_links_to_citelist(html_dir, references_files):
     for citeref_anchor in citelist.find_all(id=re.compile("CITEREF_*")):
         key = re.match("CITEREF_(.*)", citeref_anchor.attrs["id"]).groups()[0]
         entry = references.entries[key]
+        citeref_item = citeref_anchor.find_next("p")
+        clean_up_doxygen_bibliography_artifacts(citeref_item, entry)
         # We support only arXiv eprints for now. More formats may be added here
         # if necessary.
         if (
@@ -42,13 +73,16 @@ def append_eprint_links_to_citelist(html_dir, references_files):
             arxiv_url = "https://arxiv.org/abs/{}".format(
                 entry.fields["eprint"]
             )
+            if citeref_item.find("a", href=arxiv_url) is not None:
+                logger.debug("ArXiv link already present for {}.".format(key))
+                continue
             eprint_link = citelist.new_tag("a", href=arxiv_url)
             eprint_link.string = "arXiv:{}".format(entry.fields["eprint"])
         else:
             logger.debug("Found no supported eprint data for {}.".format(key))
             continue
         # Append the eprint link to the citation HTML
-        citeref_item = citeref_anchor.find_next("p")
+        citeref_item.append(" ")
         citeref_item.append(eprint_link)
         citeref_item.append(".")
         logger.info("Added eprint link to {}: {}".format(key, eprint_link))

--- a/tests/tools/CMakeLists.txt
+++ b/tests/tools/CMakeLists.txt
@@ -14,6 +14,12 @@ spectre_add_python_bindings_test(
   None)
 
 spectre_add_python_bindings_test(
+  "tools.PostprocessDocs"
+  Test_PostprocessDocs.py
+  "Python"
+  None)
+
+spectre_add_python_bindings_test(
   "tools.Status"
   Test_Status.py
   "Python"

--- a/tests/tools/Test_PostprocessDocs.py
+++ b/tests/tools/Test_PostprocessDocs.py
@@ -1,0 +1,119 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import importlib.util
+import shutil
+import textwrap
+import unittest
+from pathlib import Path
+
+from spectre.Informer import unit_test_build_path, unit_test_src_path
+
+
+def load_postprocess_docs_module():
+    module_path = (
+        Path(unit_test_src_path()).parents[1]
+        / "docs/config/postprocess_docs.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "postprocess_docs", module_path
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+postprocess_docs = load_postprocess_docs_module()
+
+
+class TestPostprocessDocs(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = Path(unit_test_build_path(), "tools/PostprocessDocs")
+        shutil.rmtree(self.test_dir, ignore_errors=True)
+        self.html_dir = self.test_dir / "html"
+        self.html_dir.mkdir(parents=True, exist_ok=True)
+        self.citelist_path = self.html_dir / "citelist.html"
+        self.references_path = self.test_dir / "References.bib"
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir, ignore_errors=True)
+
+    def test_fix_empty_bibliography_list_and_append_eprint(self):
+        self.citelist_path.write_text(
+            textwrap.dedent("""\
+                <html>
+                <body>
+                <dl>
+                <dt><a class="anchor" id="CITEREF_Ayachour2003"></a>[1]</dt>
+                <dd><p class="startdd">E.H. Ayachour. <a href="http://www.sciencedirect.com/science/article/pii/S037704270300534X">A fast implementation for GMRES method</a>. <em>Journal of Computational and Applied Mathematics</em>, 159(2):269 &ndash; 283,</p><ol type="1"><li></li></ol><p class="enddd"></p></dd>
+                <dt>
+                <a class="anchor" id="CITEREF_Alcubierre2003pc"></a>[2]
+                </dt>
+                <dd><p class="startdd">Miguel Alcubierre and others. <a href="https://doi.org/10.1088/0264-9381/21/2/019">Toward standard testbeds for numerical relativity</a>. <em>Class. Quant. Grav.</em>, 21(2):589&ndash;613, 2004.</p><p class="enddd"></p></dd>
+                </dl>
+                </body>
+                </html>
+                """),
+            encoding="utf-8",
+        )
+        self.references_path.write_text(
+            textwrap.dedent("""\
+                @article{Ayachour2003,
+                  author  = "Ayachour, E.H.",
+                  title   = "A fast implementation for {GMRES} method",
+                  journal =
+                    "Journal of Computational and Applied Mathematics",
+                  volume  = "159",
+                  number  = "2",
+                  pages   = "269 - 283",
+                  year    = "2003",
+                  doi     = "10.1016/S0377-0427(03)00534-X",
+                  url     = "http://www.sciencedirect.com/science/article/pii/S037704270300534X"
+                }
+
+                @article{Alcubierre2003pc,
+                  author        = "Alcubierre, Miguel and others",
+                  title         =
+                    "Toward standard testbeds for numerical relativity",
+                  journal       = "Class. Quant. Grav.",
+                  volume        = "21",
+                  number        = "2",
+                  pages         = "589--613",
+                  year          = "2004",
+                  archivePrefix = "arXiv",
+                  eprint        = "gr-qc/0305023",
+                  doi           = "10.1088/0264-9381/21/2/019",
+                  url           = "https://doi.org/10.1088/0264-9381/21/2/019"
+                }
+                """),
+            encoding="utf-8",
+        )
+
+        postprocess_docs.append_eprint_links_to_citelist(
+            str(self.html_dir), [str(self.references_path)]
+        )
+        postprocess_docs.append_eprint_links_to_citelist(
+            str(self.html_dir), [str(self.references_path)]
+        )
+
+        processed_citelist = self.citelist_path.read_text(encoding="utf-8")
+        self.assertNotIn('<ol type="1">', processed_citelist)
+        self.assertIn("159(2):269 – 283, 2003.", processed_citelist)
+        self.assertIn(
+            (
+                '2004. <a href="https://arxiv.org/abs/gr-qc/0305023">'
+                "arXiv:gr-qc/0305023</a>."
+            ),
+            processed_citelist,
+        )
+        self.assertEqual(
+            processed_citelist.count(
+                'href="https://arxiv.org/abs/gr-qc/0305023"'
+            ),
+            1,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Proposed changes

Fixes #7173 ... I used the spectre fix issue skill. It didn't figure out the cause of the empty lists, but it updated the postprocess docs script to remove the empty lists and put in the year that the empty lists were replacing for some reason. It also added a unit test to catch such bugs in the bibliography page in the future.

I reviewed every line and also did a blink test between the old and new bibliography pages, making sure that the empty random lists were fixed correctly but that nothing else in the page had changed.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [x] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
