### PR TITLE
Increase tolerance in np.einsum test

### DIFF
--- a/tests/Unit/Framework/Tests/Test_Pypp.cpp
+++ b/tests/Unit/Framework/Tests/Test_Pypp.cpp
@@ -492,7 +492,7 @@ void test_einsum(const T& used_for_size) {
       "PyppPyTests", "test_einsum", scalar, vector, tnsr_ia, tnsr_AA, tnsr_iaa);
   // [einsum_example]
   CHECK_ITERABLE_CUSTOM_APPROX(expected, tensor_from_python,
-                               Approx::custom().epsilon(2.0e-13));
+                               Approx::custom().epsilon(1.0e-12));
 }
 
 void test_function_of_time() {


### PR DESCRIPTION
## Proposed changes

Fixes #3210

The seed in #3210 failed with relative error ~2.59e-13

It was failing at the 3e-13 level and rather than bumping it a bit, 1e-12 relative tolerance is fine. This appears to just be an ordered-of-operations issue.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
