### PR TITLE
Find different git-clang-format versions in formatting hook

### DIFF
--- a/.claude/hooks/PostFormat.sh
+++ b/.claude/hooks/PostFormat.sh
@@ -6,10 +6,31 @@
 # Claude Code PostToolUse hook: auto-format files after Edit/Write.
 #
 # - C++ (.cpp, .hpp, .tpp):
-#     Edit  -> git clang-format -f (diff-only formatting)
+#     Edit  -> git-clang-format -f (diff-only formatting)
 #     Write -> clang-format -i    (whole-file formatting)
 # - Python (.py):
 #     black -q && isort -q        (single-file formatting)
+
+# Returns the path to the best available git-clang-format binary.
+# Prefers the unversioned `git-clang-format`, then falls back to the
+# highest-versioned `git-clang-format-N` found in PATH.
+find_git_clang_format() {
+  if command -v git-clang-format &>/dev/null; then
+    echo "git-clang-format"
+    return
+  fi
+  local best_ver=0 best_bin=""
+  IFS=: read -ra dirs <<< "$PATH"
+  for dir in "${dirs[@]}"; do
+    for bin in "$dir"/git-clang-format-*; do
+      [[ -x "$bin" ]] || continue
+      local ver="${bin##*-}"
+      [[ "$ver" =~ ^[0-9]+$ ]] || continue
+      (( ver > best_ver )) && { best_ver=$ver; best_bin=$bin; }
+    done
+  done
+  echo "$best_bin"
+}
 
 INPUT=$(cat)
 FILE=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
@@ -24,7 +45,12 @@ case "$FILE" in
     if [[ "$TOOL" == "Write" ]]; then
       clang-format -i "$FILE" 2>/dev/null
     else
-      git clang-format -f -- "$FILE" 2>/dev/null
+      gcf=$(find_git_clang_format)
+      if [[ -n "$gcf" ]]; then
+        "$gcf" -f -- "$FILE" 2>/dev/null
+      else
+        clang-format -i "$FILE" 2>/dev/null
+      fi
     fi
     ;;
   *.py)


### PR DESCRIPTION
## Proposed changes

Previously it always tried to do `git clang-format -f`. If git-clang-format wasn't installed but say git-clang-format-21 was, then it would silently fail. The hook intentionally silently fails, but we do need to find different clang-format versions.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
