### PR TITLE
Soft cancel jobs at 5:45 so that the ccache can be saved

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -410,6 +410,7 @@ jobs:
   unit_tests:
     name: Unit tests
     runs-on: ubuntu-latest
+    timeout-minutes: 345
     strategy:
       fail-fast: false
       matrix:
@@ -1004,6 +1005,7 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
   # Build all test executables and run unit tests on macOS
   unit_tests_macos:
     name: Unit tests on macOS
+    timeout-minutes: 345
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Proposed changes

This allows us to save caches incrementally when we need to do a full rebuild. Currently CI is getting hard-cancelled because of hitting the 6-hour limit and therefore not saving the caches.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
