### PR TITLE
Enable evolutions using non-conforming Blocks.

### DIFF
--- a/src/Domain/Tags/NeighborMesh.hpp
+++ b/src/Domain/Tags/NeighborMesh.hpp
@@ -19,6 +19,9 @@ namespace domain::Tags {
  * \brief Holds the mesh of each neighboring element, oriented to the
  * host's logical frame.
  *
+ * \warning Does not include the neigbors in Directions in which the element has
+ * domain::FaceType::MultipleNonconforming.
+ *
  * This knowledge can be used to determine the geometry of mortars between
  * elements. It is kept up to date by AMR.
  *

--- a/src/Elliptic/DiscontinuousGalerkin/Initialization.cpp
+++ b/src/Elliptic/DiscontinuousGalerkin/Initialization.cpp
@@ -113,6 +113,9 @@ void InitializeGeometry<Dim>::apply(
                                       i1_quadrature);
   // Neighbor meshes
   for (const auto& [direction, neighbors] : element->neighbors()) {
+    ASSERT(element->face_types().at(direction) !=
+               domain::FaceType::MultipleNonconforming,
+           "This code needs updating to handle nonconforming blocks");
     for (const auto& neighbor_id : neighbors) {
       const auto& neighbor_block = domain.blocks()[neighbor_id.block_id()];
       const auto& orientation = neighbors.orientation(neighbor_id);

--- a/src/Elliptic/DiscontinuousGalerkin/Initialization.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/Initialization.hpp
@@ -464,6 +464,9 @@ struct InitializeFacesAndMortars : tt::ConformsTo<::amr::protocols::Projector> {
     const auto& element_id = element.id();
     for (const auto& [direction, neighbors] : element.neighbors()) {
       const auto face_mesh = mesh.slice_away(direction.dimension());
+      ASSERT(element.face_types().at(direction) !=
+                 domain::FaceType::MultipleNonconforming,
+             "This code needs updating to handle nonconforming blocks.\n");
       for (const auto& neighbor_id : neighbors) {
         const auto& orientation = neighbors.orientation(neighbor_id);
         const ::dg::MortarId<Dim> mortar_id{direction, neighbor_id};

--- a/src/Elliptic/DiscontinuousGalerkin/SubdomainOperator/InitializeSubdomain.cpp
+++ b/src/Elliptic/DiscontinuousGalerkin/SubdomainOperator/InitializeSubdomain.cpp
@@ -39,6 +39,9 @@ void InitializeOverlapGeometry<Dim>::operator()(
   // this setup is a possible optimization. The computational cost and memory
   // usage is probably irrelevant though.
   for (const auto& [direction, neighbors] : element.neighbors()) {
+    ASSERT(element.face_types().at(direction) !=
+               domain::FaceType::MultipleNonconforming,
+           "This code needs updating to handle nonconforming blocks");
     for (const auto& neighbor_id : neighbors) {
       const auto& orientation = neighbors.orientation(neighbor_id);
       const auto direction_from_neighbor = orientation(direction.opposite());

--- a/src/Elliptic/DiscontinuousGalerkin/SubdomainOperator/InitializeSubdomain.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/SubdomainOperator/InitializeSubdomain.hpp
@@ -333,6 +333,9 @@ struct InitializeSubdomain {
         db::get<overlaps_tag<domain::Tags::NeighborMesh<Dim>>>(*box).at(
             overlap_id);
     for (const auto& [direction, neighbors] : element.neighbors()) {
+      ASSERT(element.face_types().at(direction) !=
+                 domain::FaceType::MultipleNonconforming,
+             "This code needs updating to handle nonconforming blocks");
       for (const auto& neighbor_id : neighbors) {
         const auto& orientation = neighbors.orientation(neighbor_id);
         const auto direction_from_neighbor = orientation(direction.opposite());

--- a/src/Evolution/DgSubcell/Actions/ReconstructionCommunication.hpp
+++ b/src/Evolution/DgSubcell/Actions/ReconstructionCommunication.hpp
@@ -746,6 +746,9 @@ struct ReceiveDataForReconstruction {
           // is doing DG.
           for (auto& received_mortar_data : received_data) {
             const auto& mortar_id = received_mortar_data.first;
+            ASSERT(element.face_types().at(mortar_id.direction()) !=
+                       domain::FaceType::MultipleNonconforming,
+                   "This code needs updating to handle nonconforming blocks");
             try {
               mortar_next_time_step_id->at(mortar_id) =
                   received_mortar_data.second.validity_range;

--- a/src/Evolution/DiscontinuousGalerkin/Actions/ApplyBoundaryCorrections.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/ApplyBoundaryCorrections.hpp
@@ -31,6 +31,7 @@
 #include "Evolution/BoundaryCorrectionTags.hpp"
 #include "Evolution/DiscontinuousGalerkin/BoundaryData.hpp"
 #include "Evolution/DiscontinuousGalerkin/InboxTags.hpp"
+#include "Evolution/DiscontinuousGalerkin/InterfaceDataPolicy.hpp"
 #include "Evolution/DiscontinuousGalerkin/MortarData.hpp"
 #include "Evolution/DiscontinuousGalerkin/MortarDataHolder.hpp"
 #include "Evolution/DiscontinuousGalerkin/MortarTags.hpp"
@@ -185,9 +186,21 @@ bool receive_boundary_data(
       return true;
     }
 
-    const auto expected_messages = static_cast<size_t>(alg::count_if(
-        mortar_next_time_step_ids,
-        [&](const auto& entry) { return entry.second == *time_to_process; }));
+    const auto& element = db::get<domain::Tags::Element<volume_dim>>(*box);
+    const auto expected_messages = static_cast<size_t>(alg::accumulate(
+        mortar_next_time_step_ids, 0,
+        [&mortar_infos, &element, &time_to_process](const size_t total,
+                                                    const auto& entry) {
+          if (entry.second != *time_to_process) {
+            return total;
+          } else if (mortar_infos.at(entry.first).interface_data_policy() !=
+                     InterfaceDataPolicy::NonconformingNeighborInterpolates) {
+            return total + 1;
+          } else {
+            return total +
+                   element.neighbors().at(entry.first.direction()).size();
+          }
+        }));
 
     // This is a
     //
@@ -229,13 +242,29 @@ bool receive_boundary_data(
     // chosen.  It is important that the corrected version be what is
     // inserted into the boundary history.
     const TimeStepId processing_time = messages_to_process->first;
+    std::unordered_set<Direction<volume_dim>>
+        directions_with_multiple_non_conforming_neighbors{};
 
     for (auto& mortar_id_and_data : messages_to_process->second) {
-      const auto& mortar_id = mortar_id_and_data.first;
+      const auto& received_mortar_id = mortar_id_and_data.first;
       auto& received_mortar_data = mortar_id_and_data.second;
-      const size_t sliced_away_dim = mortar_id.direction().dimension();
+      const auto& direction = received_mortar_id.direction();
+      const auto& neighbor_mesh = received_mortar_data.volume_mesh;
+      const size_t sliced_away_dim = direction.dimension();
       const Mesh<face_dim> face_mesh = volume_mesh.slice_away(sliced_away_dim);
-      ASSERT(mortar_next_time_step_ids.at(mortar_id) == processing_time,
+      // If there are multiple non-conforming neighbors, there is only a
+      // single mortar labeled by the host ElementId.  This is done
+      // because the data from all neighbors will be combined onto a
+      // single mortar as it makes no sense to have multiple mortars
+      // between non-conforming Elements.
+      const DirectionalId<volume_dim> mortar_id =
+          mortar_infos.contains(received_mortar_id)
+              ? received_mortar_id
+              : DirectionalId<volume_dim>{direction, element.id()};
+
+      ASSERT(mortar_next_time_step_ids.at(mortar_id) == processing_time or
+                 directions_with_multiple_non_conforming_neighbors.contains(
+                     direction),
              "Processing wrong time for mortar "
                  << mortar_id << "\nExpected "
                  << mortar_next_time_step_ids.at(mortar_id)
@@ -274,76 +303,201 @@ bool receive_boundary_data(
                   mortar_next_time_step_ids_mutable,
               const gsl::not_null<
                   DirectionalIdMap<volume_dim, Mesh<volume_dim>>*>
-                  neighbor_mesh) {
-            const Mesh<face_dim> neighbor_face_mesh =
-                received_mortar_data.volume_mesh.slice_away(sliced_away_dim);
-            const Mesh<face_dim> mortar_mesh =
-                ::dg::mortar_mesh(face_mesh, neighbor_face_mesh);
+                  neighbor_meshes) {
+            switch (mortar_infos.at(mortar_id).interface_data_policy()) {
+              case InterfaceDataPolicy::CopyProject:
+                [[fallthrough]];
+              case InterfaceDataPolicy::OrientCopyProject: {
+                neighbor_meshes->insert_or_assign(received_mortar_id,
+                                                  neighbor_mesh);
+                const Mesh<face_dim> neighbor_face_mesh =
+                    received_mortar_data.volume_mesh.slice_away(
+                        sliced_away_dim);
+                const Mesh<face_dim> mortar_mesh =
+                    ::dg::mortar_mesh(face_mesh, neighbor_face_mesh);
 
-            const auto project_boundary_mortar_data =
-                [&mortar_mesh](const TimeStepId& /*id*/,
-                               const gsl::not_null<
-                                   ::evolution::dg::MortarData<volume_dim>*>
-                                   mortar_data) {
-                  return p_project_mortar_data(mortar_data, mortar_mesh);
-                };
+                const auto project_boundary_mortar_data =
+                    [&mortar_mesh](const TimeStepId& /*id*/,
+                                   const gsl::not_null<
+                                       ::evolution::dg::MortarData<volume_dim>*>
+                                       mortar_data) {
+                      return p_project_mortar_data(mortar_data, mortar_mesh);
+                    };
 
-            mortar_meshes->at(mortar_id) = mortar_mesh;
-            switch (time_stepping_policy) {
-              case TimeSteppingPolicy::EqualRate:
-                p_project_mortar_data(
-                    make_not_null(&gts_mortar_data->at(mortar_id).local()),
-                    mortar_mesh);
-                break;
-              case TimeSteppingPolicy::Conservative:
-                boundary_data_history->at(mortar_id).local().for_each(
-                    project_boundary_mortar_data);
-                break;
-              default:
-                ERROR("Unhandled TimeSteppingPolicy: " << time_stepping_policy);
-            }
-
-            neighbor_mesh->insert_or_assign(mortar_id,
-                                            received_mortar_data.volume_mesh);
-            mortar_next_time_step_ids_mutable->at(mortar_id) =
-                received_mortar_data.validity_range;
-
-            ASSERT(
-                using_subcell_v<Metavariables> or
-                    received_mortar_data.boundary_correction_data.has_value(),
-                "Must receive neighbor boundary correction data when "
-                "not using DG-subcell. Mortar ID is: ("
-                    << mortar_id.direction() << "," << mortar_id.id()
-                    << ") and TimeStepId is " << processing_time);
-            MortarData<volume_dim> neighbor_mortar_data{};
-            neighbor_mortar_data.face_mesh = neighbor_face_mesh;
-            neighbor_mortar_data.mortar_mesh =
-                received_mortar_data.boundary_correction_mesh;
-            neighbor_mortar_data.mortar_data =
-                std::move(received_mortar_data.boundary_correction_data);
-            switch (time_stepping_policy) {
-              case TimeSteppingPolicy::EqualRate:
-                if (neighbor_mortar_data.mortar_data.has_value()) {
-                  p_project_mortar_data(make_not_null(&neighbor_mortar_data),
-                                        mortar_mesh);
+                mortar_meshes->at(mortar_id) = mortar_mesh;
+                switch (time_stepping_policy) {
+                  case TimeSteppingPolicy::EqualRate:
+                    p_project_mortar_data(
+                        make_not_null(&gts_mortar_data->at(mortar_id).local()),
+                        mortar_mesh);
+                    break;
+                  case TimeSteppingPolicy::Conservative:
+                    boundary_data_history->at(mortar_id).local().for_each(
+                        project_boundary_mortar_data);
+                    break;
+                  default:
+                    ERROR("Unhandled TimeSteppingPolicy: "
+                          << time_stepping_policy);
                 }
-                gts_mortar_data->at(mortar_id).neighbor() =
-                    std::move(neighbor_mortar_data);
+
+                mortar_next_time_step_ids_mutable->at(mortar_id) =
+                    received_mortar_data.validity_range;
+
+                ASSERT(using_subcell_v<Metavariables> or
+                           received_mortar_data.boundary_correction_data
+                               .has_value(),
+                       "Must receive neighbor boundary correction data when "
+                       "not using DG-subcell. Mortar ID is: ("
+                           << mortar_id.direction() << "," << mortar_id.id()
+                           << ") and TimeStepId is " << processing_time);
+                MortarData<volume_dim> neighbor_mortar_data{};
+                neighbor_mortar_data.face_mesh = neighbor_face_mesh;
+                neighbor_mortar_data.mortar_mesh =
+                    received_mortar_data.boundary_correction_mesh;
+                neighbor_mortar_data.mortar_data =
+                    std::move(received_mortar_data.boundary_correction_data);
+                switch (time_stepping_policy) {
+                  case TimeSteppingPolicy::EqualRate:
+                    if (neighbor_mortar_data.mortar_data.has_value()) {
+                      p_project_mortar_data(
+                          make_not_null(&neighbor_mortar_data), mortar_mesh);
+                    }
+                    gts_mortar_data->at(mortar_id).neighbor() =
+                        std::move(neighbor_mortar_data);
+                    break;
+                  case TimeSteppingPolicy::Conservative:
+                    ASSERT(neighbor_mortar_data.mortar_data.has_value(),
+                           "Did not receive mortar data for " << mortar_id);
+                    boundary_data_history->at(mortar_id).remote().insert(
+                        processing_time, received_mortar_data.integration_order,
+                        std::move(neighbor_mortar_data));
+                    boundary_data_history->at(mortar_id).remote().for_each(
+                        project_boundary_mortar_data);
+                    break;
+                  default:
+                    ERROR("Unhandled TimeSteppingPolicy: "
+                          << time_stepping_policy);
+                }
                 break;
-              case TimeSteppingPolicy::Conservative:
-                ASSERT(neighbor_mortar_data.mortar_data.has_value(),
-                       "Did not receive mortar data for " << mortar_id);
-                boundary_data_history->at(mortar_id).remote().insert(
-                    processing_time, received_mortar_data.integration_order,
-                    std::move(neighbor_mortar_data));
-                boundary_data_history->at(mortar_id).remote().for_each(
-                    project_boundary_mortar_data);
+              }
+              case InterfaceDataPolicy::NonconformingSelfInterpolates: {
+                if constexpr (volume_dim > 1) {
+                  neighbor_meshes->insert_or_assign(received_mortar_id,
+                                                    neighbor_mesh);
+                  mortar_next_time_step_ids_mutable->at(mortar_id) =
+                      received_mortar_data.validity_range;
+                  mortar_meshes->at(mortar_id) = face_mesh;
+                  gts_mortar_data->at(mortar_id).neighbor().face_mesh =
+                      face_mesh;
+                  gts_mortar_data->at(mortar_id).neighbor().mortar_mesh =
+                      face_mesh;
+                  const auto& interpolator =
+                      mortar_infos.at(mortar_id).interpolator().value();
+                  const auto& received_data =
+                      received_mortar_data.boundary_correction_data.value();
+                  DataVector interpolated_data =
+                      interpolator.interpolate_to_host(received_data);
+                  gts_mortar_data->at(mortar_id).neighbor().mortar_data =
+                      std::move(interpolated_data);
+                } else {
+                  ERROR("Cannot have non-conforming neighbors in 1D");
+                }
                 break;
+              }
+              case InterfaceDataPolicy::NonconformingNeighborInterpolates: {
+                if constexpr (volume_dim > 1) {
+                  // We do not insert the neighbor mesh into neighbor_meshes
+                  // as this could overflow the FixedHashMap size
+                  const size_t npts_mortar = face_mesh.number_of_grid_points();
+                  const size_t mortar_data_size = gts_mortar_data->at(mortar_id)
+                                                      .local()
+                                                      .mortar_data.value()
+                                                      .size();
+                  const size_t number_of_components =
+                      mortar_data_size / npts_mortar;
+                  // The data received from each neighbor has been interpolated
+                  // to a subset of points of the single mortar mesh of the host
+                  // If this is the first neighbor processed,
+                  if (not directions_with_multiple_non_conforming_neighbors
+                              .contains(direction)) {
+                    directions_with_multiple_non_conforming_neighbors.emplace(
+                        direction);
+                    mortar_next_time_step_ids_mutable->at(mortar_id) =
+                        received_mortar_data.validity_range;
+                    mortar_meshes->at(mortar_id) = face_mesh;
+                    gts_mortar_data->at(mortar_id).neighbor().face_mesh =
+                        face_mesh;
+                    gts_mortar_data->at(mortar_id).neighbor().mortar_mesh =
+                        face_mesh;
+                    gts_mortar_data->at(mortar_id).neighbor().mortar_data =
+                        DataVector{
+                            mortar_data_size,
+                            std::numeric_limits<double>::signaling_NaN()};
+                  }
+                  ASSERT(
+                      mortar_next_time_step_ids_mutable->at(mortar_id) ==
+                          received_mortar_data.validity_range,
+                      "Inconsistent validity range "
+                          << received_mortar_data.validity_range
+                          << " received from " << received_mortar_id
+                          << "; expected "
+                          << mortar_next_time_step_ids_mutable->at(mortar_id));
+                  const auto& interpolated_boundary_data =
+                      received_mortar_data.interpolated_boundary_data.value();
+                  const auto& interpolated_data =
+                      interpolated_boundary_data.boundary_data();
+                  const size_t interpolated_data_size =
+                      interpolated_data.size();
+                  const auto& offsets = interpolated_boundary_data.offsets();
+                  const size_t npts_interpolated = offsets.size();
+                  ASSERT(npts_interpolated * number_of_components ==
+                             interpolated_data_size,
+                         "Size mismatch!  Number of interpolated points "
+                             << npts_interpolated
+                             << " times number of components "
+                             << number_of_components
+                             << " is not interpolated data size "
+                             << interpolated_data_size);
+                  auto& target_mortar_data = gts_mortar_data->at(mortar_id)
+                                                 .neighbor()
+                                                 .mortar_data.value();
+                  for (size_t c = 0; c < number_of_components; ++c) {
+                    for (size_t i = 0; i < npts_interpolated; ++i) {
+                      target_mortar_data[offsets[i] + c * npts_mortar] =
+                          interpolated_data[i + c * npts_interpolated];
+                    }
+                  }
+                } else {
+                  ERROR("Cannot have non-conforming neighbors in 1D");
+                }
+                break;
+              }
               default:
-                ERROR("Unhandled TimeSteppingPolicy: " << time_stepping_policy);
+                ERROR("InterfaceDataPolicy "
+                      << mortar_infos.at(mortar_id).interface_data_policy()
+                      << " is not handled yet, id = " << mortar_id);
             }
           },
           box);
+    }
+
+    const auto& gts_mortar_data =
+        db::get<evolution::dg::Tags::MortarData<volume_dim>>(*box);
+    for (const auto& direction :
+         directions_with_multiple_non_conforming_neighbors) {
+      const DirectionalId<volume_dim> mortar_id =
+          DirectionalId<volume_dim>{direction, element.id()};
+      const auto& target_mortar_data =
+          gts_mortar_data.at(mortar_id).neighbor().mortar_data.value();
+      ASSERT(std::none_of(target_mortar_data.begin(),
+                          target_mortar_data.begin() +
+                              static_cast<ptrdiff_t>(
+                                  volume_mesh.slice_away(direction.dimension())
+                                      .number_of_grid_points()),
+                          [](const double v) { return std::isnan(v); }),
+             "Not all points were interpolated.  Direction = "
+                 << direction << " ElementId = " << element.id() << "\n"
+                 << "target_mortar_data = " << target_mortar_data);
     }
 
     inbox_data.erase(messages_to_process);
@@ -646,9 +800,9 @@ struct ApplyBoundaryCorrections {
                  &local_data_on_mortar, &mortar_id, &mortar_meshes,
                  &mortar_infos, &neighbor_data_on_mortar, using_points_on_face,
                  &volume_args_tuple, &volume_det_jacobian,
-                 &volume_det_inv_jacobian, &volume_dt_correction, &volume_mesh](
-                    const MortarData<volume_dim>& local_mortar_data,
-                    const MortarData<volume_dim>& neighbor_mortar_data)
+                 &volume_det_inv_jacobian, &volume_dt_correction, &volume_mesh,
+                 &element](const MortarData<volume_dim>& local_mortar_data,
+                           const MortarData<volume_dim>& neighbor_mortar_data)
                 -> DtVariables {
               if (local_time_stepping and not using_points_on_face) {
                 // This needs to be updated every call because the Jacobian
@@ -719,8 +873,10 @@ struct ApplyBoundaryCorrections {
               auto& dt_boundary_correction =
                   [&dt_boundary_correction_on_mortar,
                    &dt_boundary_correction_projected_onto_face, &face_mesh,
-                   &mortar_mesh, &mortar_size]() -> DtVariables& {
-                if (Spectral::needs_projection(face_mesh, mortar_mesh,
+                   &mortar_mesh, &mortar_size, &element,
+                   &direction]() -> DtVariables& {
+                if (element.neighbors().at(direction).are_conforming() and
+                    Spectral::needs_projection(face_mesh, mortar_mesh,
                                                mortar_size)) {
                   dt_boundary_correction_projected_onto_face =
                       ::dg::project_from_mortar(

--- a/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp
@@ -35,8 +35,11 @@
 #include "Evolution/DiscontinuousGalerkin/Actions/VolumeTermsImpl.hpp"
 #include "Evolution/DiscontinuousGalerkin/BoundaryData.hpp"
 #include "Evolution/DiscontinuousGalerkin/InboxTags.hpp"
+#include "Evolution/DiscontinuousGalerkin/InterfaceDataPolicy.hpp"
+#include "Evolution/DiscontinuousGalerkin/InterpolatedBoundaryData.hpp"
 #include "Evolution/DiscontinuousGalerkin/MortarData.hpp"
 #include "Evolution/DiscontinuousGalerkin/MortarDataHolder.hpp"
+#include "Evolution/DiscontinuousGalerkin/MortarInfo.hpp"
 #include "Evolution/DiscontinuousGalerkin/MortarTags.hpp"
 #include "Evolution/DiscontinuousGalerkin/NormalVectorTags.hpp"
 #include "Evolution/DiscontinuousGalerkin/TimeSteppingPolicy.hpp"
@@ -682,6 +685,7 @@ void ComputeTimeDerivative<Dim, EvolutionSystem, DgStepChoosers,
   const auto& all_mortar_data =
       db::get<evolution::dg::Tags::MortarData<Dim>>(*box);
   const auto& mortar_meshes = get<evolution::dg::Tags::MortarMesh<Dim>>(*box);
+  const auto& mortar_info = get<evolution::dg::Tags::MortarInfo<Dim>>(*box);
 
   std::optional<DirectionMap<Dim, DataVector>>
       all_neighbor_data_for_reconstruction = std::nullopt;
@@ -700,7 +704,7 @@ void ComputeTimeDerivative<Dim, EvolutionSystem, DgStepChoosers,
   }
 
   for (const auto& [direction, neighbors] : element.neighbors()) {
-    DataVector ghost_and_subcell_data{};
+    std::optional<DataVector> ghost_and_subcell_data = std::nullopt;
     if constexpr (using_subcell_v<Metavariables>) {
       ASSERT(all_neighbor_data_for_reconstruction.has_value(),
              "Trying to do DG-subcell but the ghost and subcell data for the "
@@ -710,26 +714,63 @@ void ComputeTimeDerivative<Dim, EvolutionSystem, DgStepChoosers,
     }
 
     const size_t total_neighbors = neighbors.size();
+    // If there are multiple non-conforming neighbors, we only create a single
+    // mortar labeled by the host ElementId.  This is done because the data
+    // from all neighbors will be combined onto a single mortar as it makes no
+    // sense to have multiple mortars between non-conforming Elements.
+    const bool has_multiple_non_conforming_neighbors =
+        total_neighbors > 1 and not neighbors.are_conforming();
     size_t neighbor_count = 1;
     for (const auto& neighbor : neighbors) {
       const auto& orientation = neighbors.orientation(neighbor);
       const auto direction_from_neighbor = orientation(direction.opposite());
-      const DirectionalId<Dim> mortar_id{direction, neighbor};
-
+      const DirectionalId<Dim> mortar_id{
+          direction,
+          has_multiple_non_conforming_neighbors ? element.id() : neighbor};
       const Mesh<Dim - 1>& mortar_mesh = mortar_meshes.at(mortar_id);
-      const auto volume_mesh_for_neighbor = orientation(volume_mesh);
-      const auto mortar_mesh_for_neighbor =
-          orient_mesh_on_slice(mortar_mesh, direction.dimension(), orientation);
+      auto volume_mesh_for_neighbor = volume_mesh;
+      auto mortar_mesh_for_neighbor = mortar_mesh;
       DataVector neighbor_boundary_data_on_mortar{};
+      std::optional<InterpolatedBoundaryData<Dim>> interpolated_boundary_data{
+          std::nullopt};
 
-      if (LIKELY(orientation.is_aligned())) {
-        neighbor_boundary_data_on_mortar =
-            *all_mortar_data.at(mortar_id).local().mortar_data.value();
-      } else {
-        const auto& slice_extents = mortar_mesh.extents();
-        neighbor_boundary_data_on_mortar = orient_variables_on_slice(
-            all_mortar_data.at(mortar_id).local().mortar_data.value(),
-            slice_extents, direction.dimension(), orientation);
+      switch (mortar_info.at(mortar_id).interface_data_policy()) {
+        case InterfaceDataPolicy::CopyProject:
+          [[fallthrough]];
+        case InterfaceDataPolicy::NonconformingNeighborInterpolates:
+          neighbor_boundary_data_on_mortar =
+              *all_mortar_data.at(mortar_id).local().mortar_data.value();
+          break;
+        case InterfaceDataPolicy::OrientCopyProject: {
+          volume_mesh_for_neighbor = orientation(volume_mesh);
+          mortar_mesh_for_neighbor = orient_mesh_on_slice(
+              mortar_mesh, direction.dimension(), orientation);
+          const auto& slice_extents = mortar_mesh.extents();
+          neighbor_boundary_data_on_mortar = orient_variables_on_slice(
+              all_mortar_data.at(mortar_id).local().mortar_data.value(),
+              slice_extents, direction.dimension(), orientation);
+          break;
+        }
+        case InterfaceDataPolicy::NonconformingSelfInterpolates: {
+          if constexpr (Dim > 1) {
+            neighbor_boundary_data_on_mortar =
+                *all_mortar_data.at(mortar_id).local().mortar_data.value();
+            const auto& interpolator =
+                mortar_info.at(mortar_id).interpolator().value();
+            interpolated_boundary_data = InterpolatedBoundaryData<Dim>{
+                {.data = interpolator.interpolate_to_neighbor(
+                     neighbor_boundary_data_on_mortar),
+                 .target_mesh = interpolator.neighbor_mortar_mesh(),
+                 .offsets = interpolator.interpolated_neighbor_data_offsets()}};
+          } else {
+            ERROR("Cannot have non-conforming neighbors in 1D");
+          }
+          break;
+        }
+        default:
+          ERROR("InterfaceDataPolicy "
+                << mortar_info.at(mortar_id).interface_data_policy()
+                << " is not handled yet, id = " << mortar_id);
       }
 
       const TimeStepId& next_time_step_id =
@@ -747,7 +788,7 @@ void ComputeTimeDerivative<Dim, EvolutionSystem, DgStepChoosers,
                         next_time_step_id,
                         tci_decision,
                         integration_order,
-                        std::nullopt};
+                        interpolated_boundary_data};
       } else {
         data = SendData{volume_mesh_for_neighbor,
                         ghost_data_mesh,
@@ -757,7 +798,7 @@ void ComputeTimeDerivative<Dim, EvolutionSystem, DgStepChoosers,
                         next_time_step_id,
                         tci_decision,
                         integration_order,
-                        std::nullopt};
+                        interpolated_boundary_data};
       }
 
       // Send mortar data (the `std::tuple` named `data`) to neighbor
@@ -782,7 +823,6 @@ void ComputeTimeDerivative<Dim, EvolutionSystem, DgStepChoosers,
     }
   }
 
-  const auto& mortar_info = db::get<Tags::MortarInfo<Dim>>(*box);
   // We treat this as a set, but use a map because we don't have a
   // non-allocating set type.
   DirectionMap<Dim, bool> mortar_history_directions{};
@@ -848,6 +888,15 @@ void ComputeTimeDerivative<Dim, EvolutionSystem, DgStepChoosers,
             if (not mortar_history_directions.contains(direction)) {
               continue;
             }
+            const size_t total_neighbors = neighbors_in_direction.size();
+            // If there are multiple non-conforming neighbors, we only create a
+            // single mortar labeled by the host ElementId.  This is done
+            // because the data from all neighbors will be combined onto a
+            // single mortar as it makes no sense to have multiple mortars
+            // between non-conforming Elements.
+            const bool has_multiple_non_conforming_neighbors =
+                total_neighbors > 1 and
+                not neighbors_in_direction.are_conforming();
             // We can perform projections once for all neighbors in the
             // direction because we care about the _face_ mesh, not the mortar
             // mesh.
@@ -878,7 +927,10 @@ void ComputeTimeDerivative<Dim, EvolutionSystem, DgStepChoosers,
             }
 
             for (const auto& neighbor : neighbors_in_direction) {
-              const DirectionalId<Dim> mortar_id{direction, neighbor};
+              const DirectionalId<Dim> mortar_id{
+                  direction, has_multiple_non_conforming_neighbors
+                                 ? element.id()
+                                 : neighbor};
               if (mortar_info.at(mortar_id).time_stepping_policy() !=
                   TimeSteppingPolicy::Conservative) {
                 continue;

--- a/src/Evolution/DiscontinuousGalerkin/Actions/InternalMortarDataImpl.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/InternalMortarDataImpl.hpp
@@ -231,19 +231,29 @@ void internal_mortar_data_impl(
         Variables<mortar_tags_list>::number_of_independent_components;
     Variables<mortar_tags_list> packaged_data{};
 
-    // This is the case where we only have one neighbor in this direction, so we
-    // may or may not have to do any projection. If we don't have to do
-    // projection, then we can use the local_mortar_data itself to calculate the
-    // dg_package_data. However, if we need to project, then we hae to use the
-    // packaged_data_buffer that was passed in.
-    if (neighbors_in_direction.size() == 1) {
+    // If there are multiple non-conforming neighbors, we only create a single
+    // mortar labeled by the host ElementId.  This is done because the data
+    // from all neighbors will be combined onto a single mortar as it makes no
+    // sense to have multiple mortars between non-conforming Elements.
+    const bool has_multiple_non_conforming_neighbors =
+        neighbors_in_direction.size() > 1 and
+        not neighbors_in_direction.are_conforming();
+    if (neighbors_in_direction.size() == 1 or
+        not neighbors_in_direction.are_conforming()) {
       const auto& neighbor = *neighbors_in_direction.begin();
-      const auto mortar_id = DirectionalId<Dim>{direction, neighbor};
+      const DirectionalId<Dim> mortar_id{
+          direction,
+          has_multiple_non_conforming_neighbors ? element.id() : neighbor};
       const auto& mortar_mesh = mortar_meshes.at(mortar_id);
       const auto& mortar_size = mortar_infos.at(mortar_id).mortar_size();
 
-      // Have to use packaged_data_buffer
-      if (Spectral::needs_projection(face_mesh, mortar_mesh, mortar_size)) {
+      // If we only have one conforming neighbor in this direction, we may or
+      // may not have to do any projection. If we don't have to do projection,
+      // then we can use the local_mortar_data itself to calculate the
+      // dg_package_data. However, if we need to project, then we have to use
+      // the packaged_data_buffer that was passed in.
+      if (neighbors_in_direction.are_conforming() and
+          Spectral::needs_projection(face_mesh, mortar_mesh, mortar_size)) {
         // The face mesh will be assigned below along with ensuring the size of
         // the mortar data is correct
         packaged_data.set_data_ref(packaged_data_buffer->data(),
@@ -268,8 +278,8 @@ void internal_mortar_data_impl(
                                    local_mortar_data.size());
       }
     } else {
-      // In this case, we have multiple neighbors in this direction so all will
-      // need to project their data which means we use the
+      // In this case, we have multiple conforming neighbors in this direction
+      // so all will need to project their data which means we use the
       // packaged_data_buffer to calculate the dg_package_data
       packaged_data.set_data_ref(packaged_data_buffer->data(), total_face_size);
     }
@@ -282,37 +292,39 @@ void internal_mortar_data_impl(
         package_data_volume_args...);
 
     // Perform step 3
-    // This will only do something if
+    // This will only do something if neighbors are conforming and either
     //  a) we have multiple neighbors in this direction
     // or
     //  b) the one (and only) neighbor in this direction needed projection
-    for (const auto& neighbor : neighbors_in_direction) {
-      const DirectionalId<Dim> mortar_id{direction, neighbor};
-      const auto& mortar_mesh = mortar_meshes.at(mortar_id);
-      const auto& mortar_size = mortar_infos.at(mortar_id).mortar_size();
+    if (neighbors_in_direction.are_conforming()) {
+      for (const auto& neighbor : neighbors_in_direction) {
+        const DirectionalId<Dim> mortar_id{direction, neighbor};
+        const auto& mortar_mesh = mortar_meshes.at(mortar_id);
+        const auto& mortar_size = mortar_infos.at(mortar_id).mortar_size();
 
-      if (Spectral::needs_projection(face_mesh, mortar_mesh, mortar_size)) {
-        auto& local_mortar = mortar_data_ptr->at(mortar_id).local();
-        local_mortar.face_mesh = face_mesh;
-        local_mortar.mortar_mesh = mortar_mesh;
-        // If this is the first time, initialize the data. If we don't do this,
-        // then the DataVector will be non-owning which we don't want
-        if (UNLIKELY(not local_mortar.mortar_data.has_value())) {
-          local_mortar.mortar_data = DataVector{};
+        if (Spectral::needs_projection(face_mesh, mortar_mesh, mortar_size)) {
+          auto& local_mortar = mortar_data_ptr->at(mortar_id).local();
+          local_mortar.face_mesh = face_mesh;
+          local_mortar.mortar_mesh = mortar_mesh;
+          // If this is the first time, initialize the data. If we don't do
+          // this, then the DataVector will be non-owning which we don't want
+          if (UNLIKELY(not local_mortar.mortar_data.has_value())) {
+            local_mortar.mortar_data = DataVector{};
+          }
+
+          DataVector& local_mortar_data = local_mortar.mortar_data.value();
+
+          // Do a destructive resize to account for potential p-refinement
+          local_mortar_data.destructive_resize(
+              mortar_mesh.number_of_grid_points() *
+              Variables<mortar_tags_list>::number_of_independent_components);
+
+          Variables<mortar_tags_list> projected_packaged_data{
+              local_mortar_data.data(), local_mortar_data.size()};
+          ::dg::project_to_mortar(make_not_null(&projected_packaged_data),
+                                  packaged_data, face_mesh, mortar_mesh,
+                                  mortar_size);
         }
-
-        DataVector& local_mortar_data = local_mortar.mortar_data.value();
-
-        // Do a destructive resize to account for potential p-refinement
-        local_mortar_data.destructive_resize(
-            mortar_mesh.number_of_grid_points() *
-            Variables<mortar_tags_list>::number_of_independent_components);
-
-        Variables<mortar_tags_list> projected_packaged_data{
-            local_mortar_data.data(), local_mortar_data.size()};
-        ::dg::project_to_mortar(make_not_null(&projected_packaged_data),
-                                packaged_data, face_mesh, mortar_mesh,
-                                mortar_size);
       }
     }
   }

--- a/src/Evolution/DiscontinuousGalerkin/Initialization/Mortars.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/Initialization/Mortars.cpp
@@ -279,6 +279,9 @@ void h_refine_structure(
   }
 
   for (const auto& [direction, neighbors] : new_element.neighbors()) {
+    ASSERT(new_element.face_types().at(direction) !=
+               domain::FaceType::MultipleNonconforming,
+           "This code needs updating to handle nonconforming blocks");
     const auto sliced_away_dimension = direction.dimension();
     const auto new_face_mesh = new_mesh.slice_away(sliced_away_dimension);
     for (const auto& neighbor : neighbors) {
@@ -380,6 +383,9 @@ void ProjectMortars<Dim, LocalTimeStepping>::apply(
   std::vector<NewMortarEntry> new_mortars{};
 
   for (const auto& [direction, neighbors] : new_element.neighbors()) {
+    ASSERT(new_element.face_types().at(direction) !=
+               domain::FaceType::MultipleNonconforming,
+           "This code needs updating to handle nonconforming blocks");
     const auto sliced_away_dimension = direction.dimension();
     const auto old_face_mesh = old_mesh.slice_away(sliced_away_dimension);
     const auto new_face_mesh = new_mesh.slice_away(sliced_away_dimension);

--- a/src/Evolution/Initialization/DgDomain.hpp
+++ b/src/Evolution/Initialization/DgDomain.hpp
@@ -177,7 +177,11 @@ struct Domain {
               neighbor_orientation.inverse_map()(::domain::create_initial_mesh(
                   initial_extents, neighbor_block, neighbor, i1_basis,
                   i1_quadrature)));
-        } else {
+        } else if (element->face_types().at(direction) ==
+                   ::domain::FaceType::SingleNonconforming) {
+          // We do not insert neighbor meshes into neighbor_mesh for a direction
+          // with domain::FaceType::MultipleNonconforming as this could
+          // overflow the FixedHashMap size
           neighbor_mesh->emplace(
               DirectionalId{direction, neighbor},
               ::domain::create_initial_mesh(initial_extents, neighbor_block,

--- a/tests/InputFiles/ScalarWave/NonconformingSphericalWave.yaml
+++ b/tests/InputFiles/ScalarWave/NonconformingSphericalWave.yaml
@@ -1,0 +1,86 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+Executable: EvolveScalarWave3D
+Testing:
+  Check: parse;execute
+
+---
+
+Parallelization:
+  ElementDistribution: NumGridPoints
+
+ResourceInfo:
+  AvoidGlobalProc0: false
+  Singletons: Auto
+
+InitialData: &InitialData
+  RegularSphericalWave:
+    Profile:
+      Gaussian:
+        Amplitude: 1.0
+        Width: 1.0
+        Center: 2.4
+
+Amr:
+  Criteria:
+  EnableInBlocks: All
+  Policies:
+    AllowCoarsening: true
+    EnforceTwoToOneBalanceInNormalDirection: true
+    Isotropy: Anisotropic
+    Limits:
+      RefinementLevel: Auto
+      NumGridPoints: Auto
+      ErrorBeyondLimits: False
+  Verbosity: Verbose
+
+PhaseChangeAndTriggers:
+
+Evolution:
+  InitialTime: 0.0
+  InitialTimeStep: 0.001
+  MinimumTimeStep: 1e-7
+  TimeStepper:
+    AdamsBashforth:
+      Order: 3
+
+DomainCreator:
+  NonconformingSphericalShells:
+    InnerRadius: 1.9
+    InterfaceRadius: 2.4
+    OuterRadius: 2.9
+    InitialRadialRefinement: 0
+    InitialAngularRefinementOfWedges: 1
+    InitialNumberOfRadialGridPoints: 5
+    InitialSphericalHarmonicL: 4
+    InitialNumberOfAngularGridPointsOfWedges: 5
+    InnerBoundaryCondition:
+      DirichletAnalytic:
+        AnalyticPrescription: *InitialData
+    OuterBoundaryCondition:
+      DirichletAnalytic:
+        AnalyticPrescription: *InitialData
+
+SpatialDiscretization:
+  BoundaryCorrection:
+    UpwindPenalty:
+  DiscontinuousGalerkin:
+    Formulation: StrongInertial
+    Quadrature: GaussLobatto
+
+EventsAndTriggersAtCheckpoints:
+
+EventsAndTriggersAtSlabs:
+  - Trigger:
+      Slabs:
+        Specified:
+          Values: [50]
+    Events:
+      - Completion
+
+EventsAndDenseTriggers:
+
+Observers:
+  VolumeFileName: "Volume"
+  ReductionFileName: "Reductions"

--- a/tests/Unit/Evolution/Initialization/Test_DgDomain.cpp
+++ b/tests/Unit/Evolution/Initialization/Test_DgDomain.cpp
@@ -648,12 +648,7 @@ void test_nonconforming_blocks() {
   const auto& shell_neighbor_mesh =
       ActionTesting::get_databox_tag<component, domain::Tags::NeighborMesh<3>>(
           runner, shell_id);
-  CHECK(shell_neighbor_mesh.size() == 6);
-  for (size_t block_id = 0; block_id < 6; ++block_id) {
-    CHECK(shell_neighbor_mesh.at(
-              {Direction<3>::lower_xi(), ElementId<3>(block_id)}) ==
-          cubed_sphere_mesh);
-  }
+  CHECK(shell_neighbor_mesh.empty());
 }
 
 namespace test_projectors {


### PR DESCRIPTION
## Proposed changes

Enables evolutions with spherical shells next to cubed spheres.  Tested with the input file for scalar wave. 

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

- Updated tests for the evolution actions are in progress; others want to experiment with running before the tests are finished.
- Will fail if the spherical shell dynamically p-refines (will be fixed with PR updating the ApplyBoundaryCorrections test)
- Will fail if LTS chooses different time steps on the two sides of the interface.  Fix is to use the FixedLtsRatio in these Elements.  This ratio needs to be specified in the input file, probably in the Evolution group.
