### PR TITLE
Add TensorYlm transform helpers for shell power monitors

### DIFF
--- a/src/NumericalAlgorithms/SphericalHarmonics/CMakeLists.txt
+++ b/src/NumericalAlgorithms/SphericalHarmonics/CMakeLists.txt
@@ -22,6 +22,7 @@ spectre_target_sources(
   TensorYlmFilter.cpp
   TensorYlmHelpers.cpp
   TensorYlmSphereToCart.cpp
+  TensorYlmTransforms.cpp
   WignerThreeJ.cpp
   YlmToStf.cpp
   )
@@ -49,6 +50,7 @@ spectre_target_headers(
   TensorYlmFilter.hpp
   TensorYlmHelpers.hpp
   TensorYlmSphereToCart.hpp
+  TensorYlmTransforms.hpp
   WignerThreeJ.hpp
   YlmToStf.hpp
   )

--- a/src/NumericalAlgorithms/SphericalHarmonics/TensorYlmTransforms.cpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/TensorYlmTransforms.cpp
@@ -1,0 +1,198 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/SphericalHarmonics/TensorYlmTransforms.hpp"
+
+#include <cstddef>
+#include <type_traits>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/SimpleSparseMatrix.hpp"
+#include "DataStructures/Tensor/Structure.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/SpherepackIterator.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/TensorYlmCartToSphere.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/TensorYlmSphereToCart.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
+
+namespace ylm::TensorYlm {
+
+namespace {
+
+template <typename TensorType>
+void check_tensor_ylm_transform_sizes(const TensorType& coefficients,
+                                      const size_t spectral_size,
+                                      const size_t number_of_offsets) {
+  for (size_t component = 0; component < coefficients.size(); ++component) {
+    ASSERT(coefficients[component].size() == spectral_size * number_of_offsets,
+           "Expected each tensor component to have size "
+               << spectral_size * number_of_offsets << ", but component "
+               << component << " has size " << coefficients[component].size()
+               << ".");
+  }
+}
+
+template <typename TensorType>
+void apply_transform_matrix(const gsl::not_null<TensorType*> result,
+                            const TensorType& coefficients, const size_t l_max,
+                            const size_t number_of_offsets,
+                            const SimpleSparseMatrix& transform_matrix) {
+  if constexpr (TensorType::rank() == 0) {
+    *result = coefficients;
+    return;
+  }
+
+  const SpherepackIterator iter{l_max, l_max, 1, false};
+  const size_t spectral_size = iter.spherepack_array_size();
+  check_tensor_ylm_transform_sizes(coefficients, spectral_size,
+                                   number_of_offsets);
+
+  set_number_of_grid_points(result, coefficients);
+
+  DataVector source{coefficients.size() * spectral_size};
+  DataVector destination{result->size() * spectral_size};
+  for (size_t offset = 0; offset < number_of_offsets; ++offset) {
+    for (size_t component = 0; component < coefficients.size(); ++component) {
+      for (size_t coefficient_index = 0; coefficient_index < spectral_size;
+           ++coefficient_index) {
+        source[component * spectral_size + coefficient_index] =
+            coefficients[component]
+                        [coefficient_index * number_of_offsets + offset];
+      }
+    }
+    destination = 0.0;
+    const gsl::span<double> source_span{source.data(), source.size()};
+    gsl::span<double> destination_span{destination.data(), destination.size()};
+    transform_matrix.increment_multiply_on_right(
+        make_not_null(&destination_span), 0, 1, source_span, 0, 1);
+
+    for (size_t component = 0; component < result->size(); ++component) {
+      for (size_t coefficient_index = 0; coefficient_index < spectral_size;
+           ++coefficient_index) {
+        (*result)[component][coefficient_index * number_of_offsets + offset] =
+            destination[component * spectral_size + coefficient_index];
+      }
+    }
+  }
+}
+
+}  // namespace
+
+template <typename TensorType>
+void scalar_to_tensor_ylm_coefficients(
+    const gsl::not_null<TensorType*> result,
+    const TensorType& scalar_ylm_coefficients, const size_t l_max,
+    const size_t number_of_offsets,
+    const CoefficientNormalization coefficient_normalization) {
+  ASSERT(result.get() != &scalar_ylm_coefficients,
+         "The output tensor must not alias the input scalar-Ylm coefficients.");
+  if constexpr (TensorType::rank() == 0) {
+    *result = scalar_ylm_coefficients;
+  } else {
+    SimpleSparseMatrix transform_matrix{};
+    fill_cart_to_sphere<typename TensorType::structure>(
+        make_not_null(&transform_matrix), l_max, coefficient_normalization);
+    apply_transform_matrix(result, scalar_ylm_coefficients, l_max,
+                           number_of_offsets, transform_matrix);
+  }
+}
+
+template <typename TensorType>
+TensorType scalar_to_tensor_ylm_coefficients(
+    const TensorType& scalar_ylm_coefficients, const size_t l_max,
+    const size_t number_of_offsets,
+    const CoefficientNormalization coefficient_normalization) {
+  auto result = TensorType{};
+  set_number_of_grid_points(make_not_null(&result), scalar_ylm_coefficients);
+  scalar_to_tensor_ylm_coefficients(
+      make_not_null(&result), scalar_ylm_coefficients, l_max, number_of_offsets,
+      coefficient_normalization);
+  return result;
+}
+
+template <typename TensorType>
+void tensor_to_scalar_ylm_coefficients(
+    const gsl::not_null<TensorType*> result,
+    const TensorType& tensor_ylm_coefficients, const size_t l_max,
+    const size_t number_of_offsets,
+    const CoefficientNormalization coefficient_normalization) {
+  ASSERT(result.get() != &tensor_ylm_coefficients,
+         "The output tensor must not alias the input tensor-Ylm coefficients.");
+  if constexpr (TensorType::rank() == 0) {
+    *result = tensor_ylm_coefficients;
+  } else {
+    SimpleSparseMatrix transform_matrix{};
+    fill_sphere_to_cart<typename TensorType::structure>(
+        make_not_null(&transform_matrix), l_max, coefficient_normalization);
+    apply_transform_matrix(result, tensor_ylm_coefficients, l_max,
+                           number_of_offsets, transform_matrix);
+  }
+}
+
+template <typename TensorType>
+TensorType tensor_to_scalar_ylm_coefficients(
+    const TensorType& tensor_ylm_coefficients, const size_t l_max,
+    const size_t number_of_offsets,
+    const CoefficientNormalization coefficient_normalization) {
+  auto result = TensorType{};
+  set_number_of_grid_points(make_not_null(&result), tensor_ylm_coefficients);
+  tensor_to_scalar_ylm_coefficients(
+      make_not_null(&result), tensor_ylm_coefficients, l_max, number_of_offsets,
+      coefficient_normalization);
+  return result;
+}
+
+#define TENSOR(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define TENSOR_TYPE(data) TENSOR(data)<DataVector, 3>
+
+#define INSTANTIATE(_, data)                                    \
+  template void scalar_to_tensor_ylm_coefficients(              \
+      gsl::not_null<TENSOR_TYPE(data)*> result,                 \
+      const TENSOR_TYPE(data) & coefficients, size_t l_max,     \
+      size_t number_of_offsets,                                 \
+      CoefficientNormalization coefficient_normalization);      \
+  template TENSOR_TYPE(data) scalar_to_tensor_ylm_coefficients( \
+      const TENSOR_TYPE(data) & coefficients, size_t l_max,     \
+      size_t number_of_offsets,                                 \
+      CoefficientNormalization coefficient_normalization);      \
+  template void tensor_to_scalar_ylm_coefficients(              \
+      gsl::not_null<TENSOR_TYPE(data)*> result,                 \
+      const TENSOR_TYPE(data) & coefficients, size_t l_max,     \
+      size_t number_of_offsets,                                 \
+      CoefficientNormalization coefficient_normalization);      \
+  template TENSOR_TYPE(data) tensor_to_scalar_ylm_coefficients( \
+      const TENSOR_TYPE(data) & coefficients, size_t l_max,     \
+      size_t number_of_offsets,                                 \
+      CoefficientNormalization coefficient_normalization);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE,
+                        (tnsr::i, tnsr::ii, tnsr::ij, tnsr::ijj, tnsr::ijk))
+
+#undef INSTANTIATE
+#undef TENSOR_TYPE
+#undef TENSOR
+
+template void scalar_to_tensor_ylm_coefficients(
+    gsl::not_null<Scalar<DataVector>*> result,
+    const Scalar<DataVector>& coefficients, size_t l_max,
+    size_t number_of_offsets,
+    CoefficientNormalization coefficient_normalization);
+template Scalar<DataVector> scalar_to_tensor_ylm_coefficients(
+    const Scalar<DataVector>& coefficients, size_t l_max,
+    size_t number_of_offsets,
+    CoefficientNormalization coefficient_normalization);
+template void tensor_to_scalar_ylm_coefficients(
+    gsl::not_null<Scalar<DataVector>*> result,
+    const Scalar<DataVector>& coefficients, size_t l_max,
+    size_t number_of_offsets,
+    CoefficientNormalization coefficient_normalization);
+template Scalar<DataVector> tensor_to_scalar_ylm_coefficients(
+    const Scalar<DataVector>& coefficients, size_t l_max,
+    size_t number_of_offsets,
+    CoefficientNormalization coefficient_normalization);
+
+}  // namespace ylm::TensorYlm

--- a/src/NumericalAlgorithms/SphericalHarmonics/TensorYlmTransforms.hpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/TensorYlmTransforms.hpp
@@ -1,0 +1,66 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "NumericalAlgorithms/SphericalHarmonics/TensorYlm.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace ylm::TensorYlm {
+
+/// @{
+/*!
+ * \brief Transform scalar-Ylm coefficients into tensor-Ylm coefficients.
+ *
+ * The `scalar_ylm_coefficients` are stored in Spherepack ordering. For each
+ * spectral coefficient, the data for the `number_of_offsets` independent
+ * offsets are interleaved contiguously, matching the `*_all_offsets` layout
+ * used by `ylm::Spherepack`.
+ *
+ * The tensor structure of `TensorType` determines the tensor-Ylm sectors that
+ * are produced, and `coefficient_normalization` selects whether the stored
+ * coefficients use Standard or Spherepack normalization.
+ */
+template <typename TensorType>
+void scalar_to_tensor_ylm_coefficients(
+    gsl::not_null<TensorType*> result,
+    const TensorType& scalar_ylm_coefficients, size_t l_max,
+    size_t number_of_offsets,
+    CoefficientNormalization coefficient_normalization);
+
+template <typename TensorType>
+TensorType scalar_to_tensor_ylm_coefficients(
+    const TensorType& scalar_ylm_coefficients, size_t l_max,
+    size_t number_of_offsets,
+    CoefficientNormalization coefficient_normalization);
+/// @}
+
+/// @{
+/*!
+ * \brief Transform tensor-Ylm coefficients into scalar-Ylm coefficients.
+ *
+ * The `tensor_ylm_coefficients` and the output `result` use Spherepack
+ * coefficient ordering, with `number_of_offsets` interleaved values per
+ * spectral coefficient, matching the `*_all_offsets` layout used by
+ * `ylm::Spherepack`.
+ *
+ * The `coefficient_normalization` selects whether the stored coefficients use
+ * Standard or Spherepack normalization.
+ */
+template <typename TensorType>
+void tensor_to_scalar_ylm_coefficients(
+    gsl::not_null<TensorType*> result,
+    const TensorType& tensor_ylm_coefficients, size_t l_max,
+    size_t number_of_offsets,
+    CoefficientNormalization coefficient_normalization);
+
+template <typename TensorType>
+TensorType tensor_to_scalar_ylm_coefficients(
+    const TensorType& tensor_ylm_coefficients, size_t l_max,
+    size_t number_of_offsets,
+    CoefficientNormalization coefficient_normalization);
+/// @}
+
+}  // namespace ylm::TensorYlm

--- a/tests/Unit/NumericalAlgorithms/SphericalHarmonics/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/SphericalHarmonics/CMakeLists.txt
@@ -16,6 +16,7 @@ set(LIBRARY_SOURCES
   Test_TensorYlmCartToSphere.cpp
   Test_TensorYlmFilter.cpp
   Test_TensorYlmSphereToCart.cpp
+  Test_TensorYlmTransforms.cpp
   Test_WignerThreeJ.cpp
   Test_YlmToStf.cpp
   )

--- a/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Test_TensorYlmTransforms.cpp
+++ b/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Test_TensorYlmTransforms.cpp
@@ -1,0 +1,170 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <random>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/SpherepackIterator.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/TensorYlmTransforms.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+namespace {
+
+template <typename TensorType>
+void fill_random_coefficients(const gsl::not_null<TensorType*> coefficients,
+                              const size_t ell_max,
+                              const size_t number_of_offsets,
+                              const gsl::not_null<std::mt19937*> generator) {
+  const ylm::SpherepackIterator it{ell_max, ell_max, 1, false};
+  const size_t spectral_size = it.spherepack_array_size();
+  *coefficients = make_with_value<TensorType>(*coefficients, 0.0);
+
+  std::uniform_real_distribution<> dist{-1.0, 1.0};
+  for (auto& component : *coefficients) {
+    component.destructive_resize(spectral_size * number_of_offsets);
+    for (ylm::SpherepackIterator coeff_it{ell_max, ell_max, 1, false}; coeff_it;
+         ++coeff_it) {
+      const bool keep_mode =
+          coeff_it.l() < ell_max + 1 - TensorType::rank() and
+          (coeff_it.coefficient_array() !=
+               ylm::SpherepackIterator::CoefficientArray::b or
+           coeff_it.m() != 0);
+      for (size_t offset = 0; offset < number_of_offsets; ++offset) {
+        component[coeff_it() * number_of_offsets + offset] =
+            keep_mode ? dist(*generator) : 0.0;
+      }
+    }
+  }
+}
+
+template <typename TensorType>
+void check_transform_roundtrip(
+    const size_t ell_max, const size_t number_of_offsets,
+    const ylm::TensorYlm::CoefficientNormalization normalization,
+    const gsl::not_null<std::mt19937*> generator) {
+  const ylm::SpherepackIterator it{ell_max, ell_max, 1, false};
+  const size_t total_size = it.spherepack_array_size() * number_of_offsets;
+  auto coefficients = TensorType{total_size};
+  fill_random_coefficients(make_not_null(&coefficients), ell_max,
+                           number_of_offsets, generator);
+  const auto transformed = ylm::TensorYlm::scalar_to_tensor_ylm_coefficients(
+      coefficients, ell_max, number_of_offsets, normalization);
+  const auto recovered = ylm::TensorYlm::tensor_to_scalar_ylm_coefficients(
+      transformed, ell_max, number_of_offsets, normalization);
+
+  for (size_t component = 0; component < coefficients.size(); ++component) {
+    CHECK_ITERABLE_CUSTOM_APPROX(recovered[component], coefficients[component],
+                                 approx);
+  }
+}
+
+template <typename TensorType>
+void check_multi_offset_matches_single_offset(
+    const size_t ell_max,
+    const ylm::TensorYlm::CoefficientNormalization normalization,
+    const gsl::not_null<std::mt19937*> generator) {
+  const size_t number_of_offsets = 3;
+  const ylm::SpherepackIterator it{ell_max, ell_max, 1, false};
+  const size_t total_size = it.spherepack_array_size() * number_of_offsets;
+  auto coefficients = TensorType{total_size};
+  fill_random_coefficients(make_not_null(&coefficients), ell_max,
+                           number_of_offsets, generator);
+
+  const auto multi = ylm::TensorYlm::scalar_to_tensor_ylm_coefficients(
+      coefficients, ell_max, number_of_offsets, normalization);
+  for (size_t offset = 0; offset < number_of_offsets; ++offset) {
+    auto single_input = TensorType{it.spherepack_array_size()};
+    for (size_t component = 0; component < coefficients.size(); ++component) {
+      for (size_t i = 0; i < it.spherepack_array_size(); ++i) {
+        single_input[component][i] =
+            coefficients[component][i * number_of_offsets + offset];
+      }
+    }
+
+    const auto single = ylm::TensorYlm::scalar_to_tensor_ylm_coefficients(
+        single_input, ell_max, 1, normalization);
+    for (size_t component = 0; component < coefficients.size(); ++component) {
+      for (size_t i = 0; i < it.spherepack_array_size(); ++i) {
+        CHECK(multi[component][i * number_of_offsets + offset] ==
+              approx(single[component][i]));
+      }
+    }
+  }
+}
+
+template <typename TensorType>
+void check_disallow_aliasing(
+    const size_t ell_max,
+    const ylm::TensorYlm::CoefficientNormalization normalization,
+    const gsl::not_null<std::mt19937*> generator) {
+#ifdef SPECTRE_DEBUG
+  const size_t number_of_offsets = 2;
+  const ylm::SpherepackIterator it{ell_max, ell_max, 1, false};
+  auto coefficients =
+      TensorType{it.spherepack_array_size() * number_of_offsets};
+  fill_random_coefficients(make_not_null(&coefficients), ell_max,
+                           number_of_offsets, generator);
+
+  CHECK_THROWS_WITH(ylm::TensorYlm::scalar_to_tensor_ylm_coefficients(
+                        make_not_null(&coefficients), coefficients, ell_max,
+                        number_of_offsets, normalization),
+                    Catch::Matchers::ContainsSubstring(
+                        "must not alias the input scalar-Ylm coefficients"));
+
+  CHECK_THROWS_WITH(ylm::TensorYlm::tensor_to_scalar_ylm_coefficients(
+                        make_not_null(&coefficients), coefficients, ell_max,
+                        number_of_offsets, normalization),
+                    Catch::Matchers::ContainsSubstring(
+                        "must not alias the input tensor-Ylm coefficients"));
+#else
+  (void)ell_max;
+  (void)normalization;
+  (void)generator;
+#endif
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.SphericalHarmonics.TensorYlmTransforms",
+                  "[Unit][NumericalAlgorithms]") {
+  MAKE_GENERATOR(generator);
+  const auto generator_ptr = make_not_null(&generator);
+
+  check_transform_roundtrip<Scalar<DataVector>>(
+      5, 2, ylm::TensorYlm::CoefficientNormalization::Spherepack,
+      generator_ptr);
+  check_transform_roundtrip<tnsr::i<DataVector, 3>>(
+      5, 2, ylm::TensorYlm::CoefficientNormalization::Spherepack,
+      generator_ptr);
+  check_transform_roundtrip<tnsr::ii<DataVector, 3>>(
+      5, 2, ylm::TensorYlm::CoefficientNormalization::Spherepack,
+      generator_ptr);
+  check_transform_roundtrip<tnsr::ij<DataVector, 3>>(
+      4, 2, ylm::TensorYlm::CoefficientNormalization::Standard, generator_ptr);
+  check_transform_roundtrip<tnsr::ijj<DataVector, 3>>(
+      5, 2, ylm::TensorYlm::CoefficientNormalization::Standard, generator_ptr);
+  check_transform_roundtrip<tnsr::ijk<DataVector, 3>>(
+      4, 2, ylm::TensorYlm::CoefficientNormalization::Spherepack,
+      generator_ptr);
+
+  check_multi_offset_matches_single_offset<Scalar<DataVector>>(
+      4, ylm::TensorYlm::CoefficientNormalization::Standard, generator_ptr);
+  check_multi_offset_matches_single_offset<tnsr::i<DataVector, 3>>(
+      4, ylm::TensorYlm::CoefficientNormalization::Spherepack, generator_ptr);
+  check_multi_offset_matches_single_offset<tnsr::ii<DataVector, 3>>(
+      4, ylm::TensorYlm::CoefficientNormalization::Standard, generator_ptr);
+  check_multi_offset_matches_single_offset<tnsr::ij<DataVector, 3>>(
+      3, ylm::TensorYlm::CoefficientNormalization::Spherepack, generator_ptr);
+  check_multi_offset_matches_single_offset<tnsr::ijj<DataVector, 3>>(
+      3, ylm::TensorYlm::CoefficientNormalization::Standard, generator_ptr);
+  check_multi_offset_matches_single_offset<tnsr::ijk<DataVector, 3>>(
+      3, ylm::TensorYlm::CoefficientNormalization::Spherepack, generator_ptr);
+
+  check_disallow_aliasing<tnsr::i<DataVector, 3>>(
+      4, ylm::TensorYlm::CoefficientNormalization::Spherepack, generator_ptr);
+}


### PR DESCRIPTION
## Proposed changes

This is the first in a series of pull requests to add support for power monitors on spherical shells. This PR uses `fill_cart_to_sphere` and `fill_sphere_to_cart` to create the matrix to transform scalar <-> tensor coefficients and then applies the matrix to a tensor with spatial indices. 

The power monitor needs to be able to apply transformations like this to compute the tensor spherical harmonic power, so that e.g. when the top 4 modes are filtered, the power monitor shows those modes have negligible power.

A future PR will contain the actual code to compute the angular and radial power for a spherical shell.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [x] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
