### PR TITLE
Add ZernikeB1 topology

### DIFF
--- a/src/Domain/BlockLogicalCoordinates.cpp
+++ b/src/Domain/BlockLogicalCoordinates.cpp
@@ -114,6 +114,7 @@ block_logical_coordinates_single_point(
   for (size_t d = 0; d < Dim; ++d) {
     const auto topology = gsl::at(block.topologies(), d);
     if (topology == domain::Topology::I1 or
+        topology == domain::Topology::B1Radial or
         topology == domain::Topology::B2Radial or
         topology == domain::Topology::B3Radial) {
       // Map inverses may report logical coordinates outside [-1, 1] due to

--- a/src/Domain/CreateInitialElement.cpp
+++ b/src/Domain/CreateInitialElement.cpp
@@ -9,6 +9,7 @@
 #include "DataStructures/Index.hpp"
 #include "DataStructures/IndexIterator.hpp"
 #include "Domain/Block.hpp"
+#include "Domain/Structure/CreateInitialMesh.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/Element.hpp"
 #include "Domain/Structure/ElementId.hpp"
@@ -228,9 +229,9 @@ Element<VolumeDim> create_initial_element(
           compute_element_neighbor_in_same_block(upper_direction));
     }
   }
+  const auto topologies = refine_Bn_topology(block.topologies(), element_id);
   return Element<VolumeDim>(ElementId<VolumeDim>(element_id),
-                            std::move(neighbors_of_element),
-                            block.topologies());
+                            std::move(neighbors_of_element), topologies);
 }
 }  // namespace domain
 

--- a/src/Domain/Structure/CreateInitialMesh.cpp
+++ b/src/Domain/Structure/CreateInitialMesh.cpp
@@ -11,6 +11,7 @@
 #include "Domain/Structure/Element.hpp"
 #include "Domain/Structure/ElementId.hpp"
 #include "Domain/Structure/OrientationMap.hpp"
+#include "Domain/Structure/Topology.hpp"
 #include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
@@ -52,6 +53,8 @@ std::array<Spectral::Basis, Dim> make_basis(
         [[fallthrough]];
       case (domain::Topology::CartoonCylinder):
         return Spectral::Basis::Cartoon;
+      case (domain::Topology::B1Radial):
+        return Spectral::Basis::ZernikeB1;
       default:
         ERROR("Invalid topology");
     }
@@ -93,6 +96,8 @@ std::array<Spectral::Quadrature, Dim> make_quadrature(
             return Spectral::Quadrature::SphericalSymmetry;
           case (domain::Topology::CartoonCylinder):
             return Spectral::Quadrature::AxialSymmetry;
+          case (domain::Topology::B1Radial):
+            return Spectral::Quadrature::GaussRadauUpper;
           default:
             ERROR("Invalid topology");
         }

--- a/src/Domain/Structure/CreateInitialMesh.cpp
+++ b/src/Domain/Structure/CreateInitialMesh.cpp
@@ -3,6 +3,7 @@
 
 #include "Domain/Structure/CreateInitialMesh.hpp"
 
+#include <algorithm>
 #include <array>
 #include <cstddef>
 #include <vector>
@@ -106,26 +107,62 @@ std::array<Spectral::Quadrature, Dim> make_quadrature(
 }
 
 template <size_t Dim>
-bool is_radially_refined_b2(const std::array<domain::Topology, Dim>& topologies,
-                            const ElementId<Dim>& element_id) {
-  const auto it = alg::find(topologies, domain::Topology::B2Radial);
-  if (it == topologies.end()) {
-    return false;
-  }
-  return gsl::at(element_id.refinement_levels(),
-                 std::distance(topologies.begin(), it)) != 0;
+bool is_angularly_refined(const std::array<domain::Topology, Dim>& topologies,
+                          const ElementId<Dim>& element_id) {
+  constexpr std::array angular_topologies{
+      domain::Topology::S1,          domain::Topology::B2Angular,
+      domain::Topology::S2Longitude, domain::Topology::S2Colatitude,
+      domain::Topology::B3Longitude, domain::Topology::B3Colatitude};
+
+  return std::ranges::any_of(
+      angular_topologies, [&topologies, &element_id](const auto topology) {
+        const auto it = alg::find(topologies, topology);
+
+        return it != topologies.end() and
+               gsl::at(element_id.refinement_levels(),
+                       std::distance(topologies.begin(), it)) != 0;
+      });
 }
 }  // namespace
 
 namespace domain {
 template <size_t Dim>
+std::array<domain::Topology, Dim> refine_Bn_topology(
+    const std::array<domain::Topology, Dim>& topologies,
+    const ElementId<Dim>& element_id) {
+  if constexpr (Dim == 2) {
+    if (element_id.segment_id(0).index() != 0 and
+        topologies == domain::topologies::disk) {
+      return domain::topologies::annulus;
+    }
+  } else if constexpr (Dim == 3) {
+    if (element_id.segment_id(0).index() != 0) {
+      if (topologies == domain::topologies::cartoon_sphere_inner) {
+        return domain::topologies::cartoon_sphere;
+      } else if (topologies == domain::topologies::cartoon_cylinder_inner) {
+        return domain::topologies::cartoon_cylinder;
+      } else if (topologies == domain::topologies::full_cylinder) {
+        return domain::topologies::cylindrical_shell;
+      } else if (topologies == domain::topologies::full_sphere) {
+        return domain::topologies::spherical_shell;
+      }
+    }
+  }
+  return topologies;
+}
+
+template <size_t Dim>
 Mesh<Dim> create_initial_mesh(
     const std::vector<std::array<size_t, Dim>>& initial_extents,
     const Element<Dim>& element, const Spectral::Basis i1_basis,
     const Spectral::Quadrature i1_quadrature) {
+  const auto topologies =
+      refine_Bn_topology(element.topologies(), element.id());
+  ASSERT(not is_angularly_refined(topologies, element.id()),
+         "Angular dimensions cannot be angularly refined");
   return {initial_extents[element.id().block_id()],
-          make_basis(element.topologies(), i1_basis),
-          make_quadrature(element.topologies(), i1_quadrature)};
+          make_basis(topologies, i1_basis),
+          make_quadrature(topologies, i1_quadrature)};
 }
 
 template <size_t Dim>
@@ -133,24 +170,29 @@ Mesh<Dim> create_initial_mesh(
     const std::vector<std::array<size_t, Dim>>& initial_extents,
     const Block<Dim>& block, [[maybe_unused]] const ElementId<Dim>& element_id,
     const Spectral::Basis i1_basis, const Spectral::Quadrature i1_quadrature) {
-  ASSERT(not is_radially_refined_b2(block.topologies(), element_id),
-         "Splitting Topology::B2Radial is not yet supported");
-  return {initial_extents[block.id()], make_basis(block.topologies(), i1_basis),
-          make_quadrature(block.topologies(), i1_quadrature)};
+  const auto topologies = refine_Bn_topology(block.topologies(), element_id);
+  ASSERT(not is_angularly_refined(topologies, element_id),
+         "Angular dimensions cannot be angularly refined");
+  return {initial_extents[block.id()], make_basis(topologies, i1_basis),
+          make_quadrature(topologies, i1_quadrature)};
 }
 }  // namespace domain
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
-#define INSTANTIATE(_, data)                                                 \
-  template Mesh<DIM(data)> domain::create_initial_mesh<DIM(data)>(           \
-      const std::vector<std::array<size_t, DIM(data)>>& initial_extents,     \
-      const Element<DIM(data)>& element, const Spectral::Basis i1_basis,     \
-      const Spectral::Quadrature i1_quadrature);                             \
-  template Mesh<DIM(data)> domain::create_initial_mesh<DIM(data)>(           \
-      const std::vector<std::array<size_t, DIM(data)>>& initial_extents,     \
-      const Block<DIM(data)>& block, const ElementId<DIM(data)>& element_id, \
-      const Spectral::Basis i1_basis, const Spectral::Quadrature _quadrature);
+#define INSTANTIATE(_, data)                                                   \
+  template Mesh<DIM(data)> domain::create_initial_mesh<DIM(data)>(             \
+      const std::vector<std::array<size_t, DIM(data)>>& initial_extents,       \
+      const Element<DIM(data)>& element, const Spectral::Basis i1_basis,       \
+      const Spectral::Quadrature i1_quadrature);                               \
+  template Mesh<DIM(data)> domain::create_initial_mesh<DIM(data)>(             \
+      const std::vector<std::array<size_t, DIM(data)>>& initial_extents,       \
+      const Block<DIM(data)>& block, const ElementId<DIM(data)>& element_id,   \
+      const Spectral::Basis i1_basis, const Spectral::Quadrature _quadrature); \
+  template std::array<domain::Topology, DIM(data)>                             \
+  domain::refine_Bn_topology<DIM(data)>(                                       \
+      const std::array<domain::Topology, DIM(data)>& topologies,               \
+      const ElementId<DIM(data)>& element_id);
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 

--- a/src/Domain/Structure/CreateInitialMesh.hpp
+++ b/src/Domain/Structure/CreateInitialMesh.hpp
@@ -17,6 +17,9 @@ template <size_t Dim>
 struct ElementId;
 template <size_t Dim>
 class Mesh;
+namespace domain {
+enum class Topology : uint8_t;
+}  // namespace domain
 namespace Spectral {
 enum class Basis : uint8_t;
 enum class Quadrature : uint8_t;
@@ -55,4 +58,16 @@ Mesh<Dim> create_initial_mesh(
     const std::vector<std::array<size_t, Dim>>& initial_extents,
     const Block<Dim>& block, const ElementId<Dim>& element_id,
     Spectral::Basis i1_basis, Spectral::Quadrature i1_quadrature);
+
+/// \ingroup InitializationGroup
+/// \brief Create a new array of topologies to account for potential radial
+/// refinement of Bn topologies.
+///
+/// \param topologies initial topologies of the Element
+/// \param element_id the ElementId of the Element
+template <size_t Dim>
+std::array<domain::Topology, Dim> refine_Bn_topology(
+    const std::array<domain::Topology, Dim>& topologies,
+    const ElementId<Dim>& element_id);
+
 }  // namespace domain

--- a/src/Domain/Structure/HasBoundary.cpp
+++ b/src/Domain/Structure/HasBoundary.cpp
@@ -8,7 +8,7 @@
 
 namespace domain {
 bool has_boundary(const domain::Topology topology, const Side side) {
-  return topology == Topology::I1 or
+  return topology == Topology::I1 or topology == Topology::B1Radial or
          (side == Side::Upper and
           (topology == Topology::B2Radial or topology == Topology::B3Radial));
 }

--- a/src/Domain/Structure/NeighborIsConforming.cpp
+++ b/src/Domain/Structure/NeighborIsConforming.cpp
@@ -69,9 +69,28 @@ bool neighbor_is_conforming(
           return false;
         }
       }
+      // permute_from_neighbor reorders by dimension index only, never flipping
+      // sides. So the correct direction into the permuted array has the
+      // dimension from searching which self index maps to the neighbor shared
+      // face dimension, and the side directly from the orientation-mapped
+      // shared face direction.
+      const auto neighbor_shared_face =
+          orientation_of_neighbor(direction_to_neighbor.opposite());
+      std::optional<size_t> permuted_dim{};
+      for (size_t i = 0; i < VolumeDim; ++i) {
+        if (orientation_of_neighbor(i) == neighbor_shared_face.dimension()) {
+          permuted_dim = i;
+          break;
+        }
+      }
+      ASSERT(permuted_dim.has_value(),
+             "No dimension found matching neighbor shared face dimension "
+                 << neighbor_shared_face.dimension());
+      const Direction<VolumeDim> permuted_neighbor_direction{
+          permuted_dim.value(), neighbor_shared_face.side()};
       const auto neighbor_boundary_topologies = boundary_topologies(
           orientation_of_neighbor.permute_from_neighbor(neighbor_topologies),
-          direction_to_neighbor);
+          permuted_neighbor_direction);
       return self_boundary_topologies == neighbor_boundary_topologies;
     }
   }

--- a/src/Domain/Structure/Topology.cpp
+++ b/src/Domain/Structure/Topology.cpp
@@ -20,6 +20,8 @@ std::ostream& operator<<(std::ostream& os, const Topology topology) {
       return os << "S2Colatitude";
     case Topology::S2Longitude:
       return os << "S2Longitude";
+    case Topology::B1Radial:
+      return os << "B1Radial";
     case Topology::B2Radial:
       return os << "B2Radial";
     case Topology::B2Angular:

--- a/src/Domain/Structure/Topology.hpp
+++ b/src/Domain/Structure/Topology.hpp
@@ -47,13 +47,14 @@ enum class Topology : uint8_t {
   S1 = 2,
   S2Colatitude = 3,
   S2Longitude = 4,
-  B2Radial = 5,
-  B2Angular = 6,
-  B3Radial = 7,
-  B3Colatitude = 8,
-  B3Longitude = 9,
-  CartoonSphere = 10,
-  CartoonCylinder = 11
+  B1Radial = 5,
+  B2Radial = 6,
+  B2Angular = 7,
+  B3Radial = 8,
+  B3Colatitude = 9,
+  B3Longitude = 10,
+  CartoonSphere = 11,
+  CartoonCylinder = 12
 };
 
 /// Output operator for a Topology.
@@ -83,8 +84,14 @@ static constexpr auto full_sphere = std::array{
 static constexpr auto cartoon_sphere =
     std::array{Topology::I1, Topology::CartoonSphere, Topology::CartoonSphere};
 
+static constexpr auto cartoon_sphere_inner = std::array{
+    Topology::B1Radial, Topology::CartoonSphere, Topology::CartoonSphere};
+
 static constexpr auto cartoon_cylinder =
     std::array{Topology::I1, Topology::I1, Topology::CartoonCylinder};
+
+static constexpr auto cartoon_cylinder_inner =
+    std::array{Topology::B1Radial, Topology::I1, Topology::CartoonCylinder};
 }  // namespace topologies
 
 }  // namespace domain

--- a/tests/Unit/Domain/Structure/Test_CreateInitialMesh.cpp
+++ b/tests/Unit/Domain/Structure/Test_CreateInitialMesh.cpp
@@ -118,12 +118,22 @@ SPECTRE_TEST_CASE("Unit.Domain.Structure.CreateInitialMesh", "[Domain][Unit]") {
          {Spectral::Basis::Legendre, Spectral::Basis::Chebyshev}) {
       for (const auto& i1_quadrature :
            {Spectral::Quadrature::GaussLobatto, Spectral::Quadrature::Gauss}) {
-        CHECK(create_initial_mesh({{{3, 4}}}, disk, element_id_2d, i1_basis,
-                                  i1_quadrature) ==
+        CHECK(create_initial_mesh(
+                  {{{3, 4}}}, disk,
+                  ElementId<2>{0, {{SegmentId{1, 0}, SegmentId{0, 0}}}},
+                  i1_basis, i1_quadrature) ==
               Mesh<2>{{{3, 4}},
                       std::array{Spectral::Basis::ZernikeB2,
                                  Spectral::Basis::ZernikeB2},
                       std::array{Spectral::Quadrature::GaussRadauUpper,
+                                 Spectral::Quadrature::Equiangular}});
+        CHECK(create_initial_mesh(
+                  {{{3, 4}}}, disk,
+                  ElementId<2>{0, {{SegmentId{1, 1}, SegmentId{0, 0}}}},
+                  i1_basis, i1_quadrature) ==
+              Mesh<2>{{{3, 4}},
+                      std::array{i1_basis, Spectral::Basis::Fourier},
+                      std::array{i1_quadrature,
                                  Spectral::Quadrature::Equiangular}});
       }
     }
@@ -154,19 +164,32 @@ SPECTRE_TEST_CASE("Unit.Domain.Structure.CreateInitialMesh", "[Domain][Unit]") {
          {Spectral::Basis::Legendre, Spectral::Basis::Chebyshev}) {
       for (const auto& i1_quadrature :
            {Spectral::Quadrature::GaussLobatto, Spectral::Quadrature::Gauss}) {
-        CHECK(create_initial_mesh({{{3, 2, 4}}}, full_cylinder, element_id_3d,
-                                  i1_basis, i1_quadrature) ==
+        CHECK(create_initial_mesh(
+                  {{{3, 2, 4}}}, full_cylinder,
+                  ElementId<3>{
+                      0, {{SegmentId{1, 0}, SegmentId{0, 0}, SegmentId{0, 0}}}},
+                  i1_basis, i1_quadrature) ==
               Mesh<3>{{{3, 2, 4}},
                       std::array{Spectral::Basis::ZernikeB2,
                                  Spectral::Basis::ZernikeB2, i1_basis},
                       std::array{Spectral::Quadrature::GaussRadauUpper,
                                  Spectral::Quadrature::Equiangular,
                                  i1_quadrature}});
+        CHECK(
+            create_initial_mesh(
+                {{{3, 2, 4}}}, full_cylinder,
+                ElementId<3>{
+                    0, {{SegmentId{1, 1}, SegmentId{0, 0}, SegmentId{0, 0}}}},
+                i1_basis, i1_quadrature) ==
+            Mesh<3>{{{3, 2, 4}},
+                    std::array{i1_basis, Spectral::Basis::Fourier, i1_basis},
+                    std::array{i1_quadrature, Spectral::Quadrature::Equiangular,
+                               i1_quadrature}});
       }
     }
   }
   {
-    INFO("spheriical_shell");
+    INFO("spherical_shell");
     const Element<3> spherical_shell(element_id_3d, {},
                                      domain::topologies::spherical_shell);
     for (const auto& i1_basis :
@@ -191,14 +214,27 @@ SPECTRE_TEST_CASE("Unit.Domain.Structure.CreateInitialMesh", "[Domain][Unit]") {
          {Spectral::Basis::Legendre, Spectral::Basis::Chebyshev}) {
       for (const auto& i1_quadrature :
            {Spectral::Quadrature::GaussLobatto, Spectral::Quadrature::Gauss}) {
-        CHECK(create_initial_mesh({{{3, 2, 4}}}, full_sphere, element_id_3d,
-                                  i1_basis, i1_quadrature) ==
+        CHECK(create_initial_mesh(
+                  {{{3, 2, 4}}}, full_sphere,
+                  ElementId<3>{
+                      0, {{SegmentId{1, 0}, SegmentId{0, 0}, SegmentId{0, 0}}}},
+                  i1_basis, i1_quadrature) ==
               Mesh<3>{{{3, 2, 4}},
                       std::array{Spectral::Basis::ZernikeB3,
                                  Spectral::Basis::ZernikeB3,
                                  Spectral::Basis::ZernikeB3},
                       std::array{Spectral::Quadrature::GaussRadauUpper,
                                  Spectral::Quadrature::Gauss,
+                                 Spectral::Quadrature::Equiangular}});
+        CHECK(create_initial_mesh(
+                  {{{3, 2, 4}}}, full_sphere,
+                  ElementId<3>{
+                      0, {{SegmentId{1, 1}, SegmentId{0, 0}, SegmentId{0, 0}}}},
+                  i1_basis, i1_quadrature) ==
+              Mesh<3>{{{3, 2, 4}},
+                      std::array{i1_basis, Spectral::Basis::SphericalHarmonic,
+                                 Spectral::Basis::SphericalHarmonic},
+                      std::array{i1_quadrature, Spectral::Quadrature::Gauss,
                                  Spectral::Quadrature::Equiangular}});
       }
     }
@@ -239,14 +275,113 @@ SPECTRE_TEST_CASE("Unit.Domain.Structure.CreateInitialMesh", "[Domain][Unit]") {
       }
     }
   }
+  {
+    const ElementId<3> element_id_on_axis{
+        0, std::array{SegmentId{1, 0}, SegmentId{0, 0}, SegmentId{0, 0}}};
+    const ElementId<3> element_id_off_axis{
+        0, std::array{SegmentId{1, 1}, SegmentId{0, 0}, SegmentId{0, 0}}};
+    {
+      INFO("cartoon_sphere_inner");
+      const Element<3> cartoon_sphere_on_axis(
+          element_id_on_axis, {}, domain::topologies::cartoon_sphere_inner);
+      const Element<3> cartoon_sphere_off_axis(
+          element_id_off_axis, {}, domain::topologies::cartoon_sphere_inner);
+      for (const auto& i1_basis :
+           {Spectral::Basis::Legendre, Spectral::Basis::Chebyshev}) {
+        for (const auto& i1_quadrature : {Spectral::Quadrature::GaussLobatto,
+                                          Spectral::Quadrature::Gauss}) {
+          CHECK(create_initial_mesh({{{3, 1, 1}}}, cartoon_sphere_on_axis,
+                                    i1_basis, i1_quadrature) ==
+                Mesh<3>{{{3, 1, 1}},
+                        std::array{Spectral::Basis::ZernikeB1,
+                                   Spectral::Basis::Cartoon,
+                                   Spectral::Basis::Cartoon},
+                        std::array{Spectral::Quadrature::GaussRadauUpper,
+                                   Spectral::Quadrature::SphericalSymmetry,
+                                   Spectral::Quadrature::SphericalSymmetry}});
+          CHECK(create_initial_mesh({{{3, 1, 1}}}, cartoon_sphere_off_axis,
+                                    i1_basis, i1_quadrature) ==
+                Mesh<3>{{{3, 1, 1}},
+                        std::array{i1_basis, Spectral::Basis::Cartoon,
+                                   Spectral::Basis::Cartoon},
+                        std::array{i1_quadrature,
+                                   Spectral::Quadrature::SphericalSymmetry,
+                                   Spectral::Quadrature::SphericalSymmetry}});
+        }
+      }
+    }
+    {
+      INFO("cartoon_cylinder_inner");
+      const Block<3> cartoon_cylinder_block(
+          nullptr, 0, {}, "", domain::topologies::cartoon_cylinder_inner);
+      for (const auto& i1_basis :
+           {Spectral::Basis::Legendre, Spectral::Basis::Chebyshev}) {
+        for (const auto& i1_quadrature : {Spectral::Quadrature::GaussLobatto,
+                                          Spectral::Quadrature::Gauss}) {
+          CHECK(create_initial_mesh({{{3, 2, 1}}}, cartoon_cylinder_block,
+                                    element_id_on_axis, i1_basis,
+                                    i1_quadrature) ==
+                Mesh<3>{{{3, 2, 1}},
+                        std::array{Spectral::Basis::ZernikeB1, i1_basis,
+                                   Spectral::Basis::Cartoon},
+                        std::array{Spectral::Quadrature::GaussRadauUpper,
+                                   i1_quadrature,
+                                   Spectral::Quadrature::AxialSymmetry}});
+          CHECK(
+              create_initial_mesh({{{3, 2, 1}}}, cartoon_cylinder_block,
+                                  element_id_off_axis, i1_basis,
+                                  i1_quadrature) ==
+              Mesh<3>{{{3, 2, 1}},
+                      std::array{i1_basis, i1_basis, Spectral::Basis::Cartoon},
+                      std::array{i1_quadrature, i1_quadrature,
+                                 Spectral::Quadrature::AxialSymmetry}});
+        }
+      }
+    }
+  }
+
 #ifdef SPECTRE_DEBUG
   CHECK_THROWS_WITH(
       create_initial_mesh(
           {{{3, 4}}}, Block<2>{nullptr, 0, {}, "", domain::topologies::disk},
-          ElementId<2>{0, {{SegmentId{1, 0}, SegmentId{0, 0}}}},
+          ElementId<2>{0, {{SegmentId{1, 0}, SegmentId{1, 0}}}},
           Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto),
       Catch::Matchers::ContainsSubstring(
-          "Splitting Topology::B2Radial is not yet supported"));
+          "Angular dimensions cannot be angularly refined"));
+  CHECK_THROWS_WITH(
+      create_initial_mesh(
+          {{{3, 4}}}, Block<2>{nullptr, 0, {}, "", domain::topologies::disk},
+          ElementId<2>{0, {{SegmentId{1, 0}, SegmentId{1, 1}}}},
+          Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto),
+      Catch::Matchers::ContainsSubstring(
+          "Angular dimensions cannot be angularly refined"));
+  CHECK_THROWS_WITH(
+      create_initial_mesh(
+          {{{3, 4, 5}}},
+          Block<3>{nullptr, 0, {}, "", domain::topologies::full_cylinder},
+          ElementId<3>{0,
+                       {{SegmentId{0, 0}, SegmentId{1, 1}, SegmentId{0, 0}}}},
+          Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto),
+      Catch::Matchers::ContainsSubstring(
+          "Angular dimensions cannot be angularly refined"));
+  CHECK_THROWS_WITH(
+      create_initial_mesh(
+          {{{3, 4, 5}}},
+          Block<3>{nullptr, 0, {}, "", domain::topologies::full_sphere},
+          ElementId<3>{0,
+                       {{SegmentId{1, 0}, SegmentId{1, 1}, SegmentId{0, 0}}}},
+          Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto),
+      Catch::Matchers::ContainsSubstring(
+          "Angular dimensions cannot be angularly refined"));
+  CHECK_THROWS_WITH(
+      create_initial_mesh(
+          {{{3, 4, 5}}},
+          Block<3>{nullptr, 0, {}, "", domain::topologies::spherical_shell},
+          ElementId<3>{0,
+                       {{SegmentId{1, 0}, SegmentId{0, 0}, SegmentId{1, 1}}}},
+          Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto),
+      Catch::Matchers::ContainsSubstring(
+          "Angular dimensions cannot be angularly refined"));
 #endif  // SPECTRE_DEBUG
 }
 }  // namespace domain

--- a/tests/Unit/Domain/Structure/Test_HasBoundary.cpp
+++ b/tests/Unit/Domain/Structure/Test_HasBoundary.cpp
@@ -11,6 +11,7 @@ namespace {
 void test() {
   for (const auto side : std::array{Side::Lower, Side::Upper}) {
     CHECK(domain::has_boundary(domain::Topology::I1, side));
+    CHECK(domain::has_boundary(domain::Topology::B1Radial, side));
     CHECK_FALSE(domain::has_boundary(domain::Topology::S1, side));
     CHECK_FALSE(domain::has_boundary(domain::Topology::S2Colatitude, side));
     CHECK_FALSE(domain::has_boundary(domain::Topology::S2Longitude, side));

--- a/tests/Unit/Domain/Structure/Test_NeighborIsConforming.cpp
+++ b/tests/Unit/Domain/Structure/Test_NeighborIsConforming.cpp
@@ -224,6 +224,35 @@ void test_3d() {
   CHECK(neighbor_is_conforming(domain::topologies::cylindrical_shell,
                                domain::topologies::full_cylinder,
                                Direction<3>::upper_zeta(), shell_to_full));
+
+  // Configurations of blocks in CartoonSphere2D domain
+  const OrientationMap<3> cartoonsphere2d_map(std::array<Direction<3>, 3>{
+      Direction<3>::lower_eta(), Direction<3>::upper_xi(),
+      Direction<3>::upper_zeta()});
+  const OrientationMap<3> cartoonsphere2d_map2(std::array<Direction<3>, 3>{
+      Direction<3>::upper_eta(), Direction<3>::lower_xi(),
+      Direction<3>::upper_zeta()});
+  const OrientationMap<3> cartoonsphere2d_map3(std::array<Direction<3>, 3>{
+      Direction<3>::lower_xi(), Direction<3>::lower_eta(),
+      Direction<3>::upper_zeta()});
+  CHECK(neighbor_is_conforming(domain::topologies::cartoon_cylinder_inner,
+                               domain::topologies::cartoon_cylinder,
+                               Direction<3>::upper_xi(), aligned));
+  CHECK(neighbor_is_conforming(domain::topologies::cartoon_cylinder,
+                               domain::topologies::cartoon_cylinder_inner,
+                               Direction<3>::lower_xi(), aligned));
+  CHECK(neighbor_is_conforming(domain::topologies::cartoon_cylinder_inner,
+                               domain::topologies::cartoon_cylinder,
+                               Direction<3>::upper_xi(), cartoonsphere2d_map2));
+  CHECK(neighbor_is_conforming(domain::topologies::cartoon_cylinder,
+                               domain::topologies::cartoon_cylinder_inner,
+                               Direction<3>::lower_eta(), cartoonsphere2d_map));
+  CHECK(neighbor_is_conforming(domain::topologies::cartoon_cylinder_inner,
+                               domain::topologies::cartoon_cylinder,
+                               Direction<3>::upper_xi(), cartoonsphere2d_map3));
+  CHECK(neighbor_is_conforming(domain::topologies::cartoon_cylinder,
+                               domain::topologies::cartoon_cylinder_inner,
+                               Direction<3>::upper_xi(), cartoonsphere2d_map3));
 }
 }  // namespace
 

--- a/tests/Unit/Domain/Structure/Test_Topology.cpp
+++ b/tests/Unit/Domain/Structure/Test_Topology.cpp
@@ -12,6 +12,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Structure.Topology", "[Domain][Unit]") {
   CHECK(get_output(domain::Topology::S1) == "S1");
   CHECK(get_output(domain::Topology::S2Colatitude) == "S2Colatitude");
   CHECK(get_output(domain::Topology::S2Longitude) == "S2Longitude");
+  CHECK(get_output(domain::Topology::B1Radial) == "B1Radial");
   CHECK(get_output(domain::Topology::B2Radial) == "B2Radial");
   CHECK(get_output(domain::Topology::B2Angular) == "B2Angular");
   CHECK(get_output(domain::Topology::B3Radial) == "B3Radial");

--- a/tests/Unit/Domain/Test_CreateInitialElement.cpp
+++ b/tests/Unit/Domain/Test_CreateInitialElement.cpp
@@ -599,6 +599,121 @@ SPECTRE_TEST_CASE("Unit.Domain.CreateInitialElement", "[Domain][Unit]") {
               aligned}}});
   }
 
+  {
+    // Test refine_Bn_topology: elements at xi_index=0 retain the inner
+    // topology, while elements at xi_index!=0 get the refined topology.
+    const OrientationMap<2> aligned_2d = OrientationMap<2>::create_aligned();
+    const OrientationMap<3> aligned_3d = OrientationMap<3>::create_aligned();
+
+    // Helper: one 2D block, no neighbors. Refinement {2, 0} gives two element
+    // ids to check (xi_index=0 and xi_index=1).
+    const auto test_topology_refinement_2d = [&aligned_2d](
+                                                 const std::array<
+                                                     domain::Topology, 2>&
+                                                     block_topologies,
+                                                 const std::array<
+                                                     domain::Topology, 2>&
+                                                     expected_outer) {
+      const std::array<domain::Topology, 2>& expected_inner = block_topologies;
+      const ElementId<2> element_id_0{0, {{SegmentId{2, 0}, SegmentId{0, 0}}}};
+      const ElementId<2> element_id_1{0, {{SegmentId{2, 1}, SegmentId{0, 0}}}};
+      std::vector<Block<2>> local_blocks;
+      local_blocks.emplace_back(nullptr, 0,
+                                DirectionMap<2, BlockNeighbors<2>>{}, "",
+                                block_topologies);
+      const std::vector<std::array<size_t, 2>> refinement_levels{{2, 0}};
+
+      CHECK(domain::create_initial_element(element_id_0, local_blocks,
+                                           refinement_levels) ==
+            Element<2>{
+                element_id_0,
+                {{Direction<2>::upper_xi(),
+                  Neighbors<2>{ElementId<2>{0, std::array{SegmentId{2, 1},
+                                                          SegmentId{0, 0}}},
+                               aligned_2d}}},
+                expected_inner});
+
+      CHECK(domain::create_initial_element(element_id_1, local_blocks,
+                                           refinement_levels) ==
+            Element<2>{
+                element_id_1,
+                {{Direction<2>::lower_xi(),
+                  Neighbors<2>{ElementId<2>{0, std::array{SegmentId{2, 0},
+                                                          SegmentId{0, 0}}},
+                               aligned_2d}},
+                 {Direction<2>::upper_xi(),
+                  Neighbors<2>{ElementId<2>{0, std::array{SegmentId{2, 2},
+                                                          SegmentId{0, 0}}},
+                               aligned_2d}}},
+                expected_outer});
+    };
+
+    // Helper: one 3D block, no neighbors. Refinement {2, 1, 0} gives two
+    // element ids to check (xi_index=0 and xi_index=1).
+    const auto test_topology_refinement_3d =
+        [&aligned_3d](const std::array<domain::Topology, 3>& block_topologies,
+                      const std::array<domain::Topology, 3>& expected_outer) {
+          const std::array<domain::Topology, 3>& expected_inner =
+              block_topologies;
+          const ElementId<3> element_id_0{
+              0, {{SegmentId{2, 0}, SegmentId{0, 0}, SegmentId{0, 0}}}};
+          const ElementId<3> element_id_1{
+              0, {{SegmentId{2, 1}, SegmentId{0, 0}, SegmentId{0, 0}}}};
+          std::vector<Block<3>> local_blocks;
+          local_blocks.emplace_back(nullptr, 0,
+                                    DirectionMap<3, BlockNeighbors<3>>{}, "",
+                                    block_topologies);
+          const std::vector<std::array<size_t, 3>> refinement_levels{{2, 1, 0}};
+
+          CHECK(domain::create_initial_element(element_id_0, local_blocks,
+                                               refinement_levels) ==
+                Element<3>{
+                    element_id_0,
+                    {{Direction<3>::upper_xi(),
+                      Neighbors<3>{ElementId<3>{0, std::array{SegmentId{2, 1},
+                                                              SegmentId{0, 0},
+                                                              SegmentId{0, 0}}},
+                                   aligned_3d}}},
+                    expected_inner});
+
+          CHECK(domain::create_initial_element(element_id_1, local_blocks,
+                                               refinement_levels) ==
+                Element<3>{
+                    element_id_1,
+                    {{Direction<3>::lower_xi(),
+                      Neighbors<3>{ElementId<3>{0, std::array{SegmentId{2, 0},
+                                                              SegmentId{0, 0},
+                                                              SegmentId{0, 0}}},
+                                   aligned_3d}},
+                     {Direction<3>::upper_xi(),
+                      Neighbors<3>{ElementId<3>{0, std::array{SegmentId{2, 2},
+                                                              SegmentId{0, 0},
+                                                              SegmentId{0, 0}}},
+                                   aligned_3d}}},
+                    expected_outer});
+        };
+
+    // 2D: disk center stays disk; off-axis becomes annulus.
+    test_topology_refinement_2d(domain::topologies::disk,
+                                domain::topologies::annulus);
+
+    // 3D: cartoon cylinder inner stays when on-axis; becomes cartoon cylinder.
+    test_topology_refinement_3d(domain::topologies::cartoon_cylinder_inner,
+                                domain::topologies::cartoon_cylinder);
+
+    // 3D: cartoon sphere inner stays when on-axis; becomes cartoon sphere.
+    test_topology_refinement_3d(domain::topologies::cartoon_sphere_inner,
+                                domain::topologies::cartoon_sphere);
+
+    // 3D: full cylinder stays when on-axis; becomes cylindrical shell.
+    test_topology_refinement_3d(domain::topologies::full_cylinder,
+                                domain::topologies::cylindrical_shell);
+
+    // 3D: full sphere stays when on-axis; becomes spherical shell.
+    test_topology_refinement_3d(domain::topologies::full_sphere,
+                                domain::topologies::spherical_shell);
+  }
+
   test_h_refinement();
   test_nonconforming_blocks();
 }


### PR DESCRIPTION
## Proposed changes

Add a topology case for using ZernikeB1, which is only used with Cartoon bases and used at the element touching the $y$ axis, so there is some manipulation within CreateInitialMesh to get blocks to be non-uniform topologies.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
