### PR TITLE
Harden Affine against degenerate intervals

### DIFF
--- a/src/Domain/CoordinateMaps/Affine.cpp
+++ b/src/Domain/CoordinateMaps/Affine.cpp
@@ -10,6 +10,7 @@
 #include "Domain/CoordinateMaps/AutodiffInstantiationTypes.hpp"
 #include "Utilities/Autodiff/Autodiff.hpp"
 #include "Utilities/DereferenceWrapper.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/MakeWithValue.hpp"
 
@@ -22,7 +23,13 @@ Affine::Affine(const double A, const double B, const double a, const double b)
       b_(b),
       length_of_domain_(B - A),
       length_of_range_(b - a),
-      jacobian_(length_of_range_ / length_of_domain_),
+      jacobian_([A, B, a, b]() {
+        ASSERT(A != B and a != b,
+               "The left and right boundaries for both source and target "
+               "interval must differ, but are; ["
+                   << A << ", " << B << "] -> [" << a << ", " << b << "]");
+        return (b - a) / (B - A);
+      }()),
       inverse_jacobian_(length_of_domain_ / length_of_range_),
       is_identity_(A == a and B == b) {}
 
@@ -95,10 +102,9 @@ bool operator==(const CoordinateMaps::Affine& lhs,
   template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 1, Frame::NoFrame> \
   Affine::inv_jacobian(const std::array<DTYPE(data), 1>& source_coords) const;
 
-GENERATE_INSTANTIATIONS(
-    INSTANTIATE, (double, DataVector,
-                  std::reference_wrapper<const double>,
-                  std::reference_wrapper<const DataVector>))
+GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
+                                      std::reference_wrapper<const double>,
+                                      std::reference_wrapper<const DataVector>))
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, MAP_AUTODIFF_TYPES)
 

--- a/tests/Unit/Domain/CoordinateMaps/Test_Affine.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_Affine.cpp
@@ -58,5 +58,18 @@ SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.Affine", "[Domain][Unit]") {
   test_coordinate_map_argument_types(affine_map, point_xi);
 
   check_if_map_is_identity(CoordinateMaps::Affine{-1.0, 1.0, -1.0, 1.0});
+
+#ifdef SPECTRE_DEBUG
+  CHECK_THROWS_WITH(
+      (CoordinateMaps::Affine{-1.0, -1.0, -2.0, 2.0}),
+      Catch::Matchers::ContainsSubstring(
+          "The left and right boundaries for both source and target "
+          "interval must differ"));
+  CHECK_THROWS_WITH(
+      (CoordinateMaps::Affine{-1.0, 1.0, 2.0, 2.0}),
+      Catch::Matchers::ContainsSubstring(
+          "The left and right boundaries for both source and target "
+          "interval must differ"));
+#endif
 }
 }  // namespace domain

--- a/tests/Unit/Domain/Creators/Test_Rectangle.cpp
+++ b/tests/Unit/Domain/Creators/Test_Rectangle.cpp
@@ -418,11 +418,30 @@ void test_rectangle_factory() {
             Translation2D{f_of_t_name}),
         true, initial_expiration_times);
   }
-}  // namespace domain
+}
+
+void test_rectangle_factory_parse_errors() {
+  CHECK_THROWS_WITH(
+      (TestHelpers::test_option_tag<domain::OptionTags::DomainCreator<2>,
+                                    TestHelpers::domain::BoundaryConditions::
+                                        MetavariablesWithoutBoundaryConditions<
+                                            2, domain::creators::Rectangle>>(
+          "Rectangle:\n"
+          "  LowerBound: [-0.5,-1.0]\n"
+          "  UpperBound: [-0.5,1.0]\n"
+          "  Distribution: [Linear, Linear]\n"
+          "  IsPeriodicIn: [False,False]\n"
+          "  InitialGridPoints: [4,4]\n"
+          "  InitialRefinement: [1,1]\n"
+          "  TimeDependence: None\n")),
+      Catch::Matchers::ContainsSubstring(
+          "must be strictly smaller than upper bound (-0.5) in dimension 0"));
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Domain.Creators.Rectangle", "[Domain][Unit]") {
   test_rectangle();
   test_rectangle_factory();
+  test_rectangle_factory_parse_errors();
 }
 }  // namespace domain


### PR DESCRIPTION
## Proposed changes

Add checks and regression tests so zero-length Affine intervals fail cleanly, including coverage for the Rectangle parse-error path.

When I looked into issue #2934, I found that the failure mode (FPE instead of `ASSERT` when lower and upper bounds are equal, giving a zero-length side had been indirectly fixed by PR #5898, which consolidated interval, rectangle, and brick into `Rectilinear`, although the fix for rectangle specifically was not unit tested. 

But the underlying `affine` map used by these domains currently does not `ASSERT` that source and destination intervals are nonzero. Some callers do not check this, e.g. [src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/TrumpetSchwarzschild.cpp line 272 ](https://github.com/sxs-collaboration/spectre/blob/0feafe9ce27222ed77d5e30f1b7a08a0417c78a3/src/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/TrumpetSchwarzschild.cpp#L272) and [src/Domain/Creators/AngularDisk.cpp line 161](https://github.com/sxs-collaboration/spectre/blob/0feafe9ce27222ed77d5e30f1b7a08a0417c78a3/src/Domain/Creators/AngularDisk.cpp#L161) .

So I thought it might be worthwhile to i) add the `ASSERT` to `affine`, and ii) to add a unit test the explicitly catches any regression that would make original faiure in #2934 fail once again. 

Happy to edit or close this if one or both of these aren't necessary in the reviewer's opinion.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [x] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
