### PR TITLE
Add time-dependent map argument-type coverage

### DIFF
--- a/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_ProductMaps.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_ProductMaps.cpp
@@ -20,6 +20,7 @@
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
 #include "Domain/FunctionsOfTime/PiecewisePolynomial.hpp"
 #include "Framework/TestHelpers.hpp"
+#include "Helpers/Domain/CoordinateMaps/TestMapHelpers.hpp"
 #include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
@@ -154,6 +155,10 @@ void test_product_of_2_maps_time_dep(
 
   CHECK(map2d.frame_velocity(logical_coords, time, functions_of_time) ==
         expected_frame_velocity_datavector);
+
+  test_coordinate_map_argument_types(map2d, point_source_a, time,
+                                     functions_of_time);
+  test_coordinate_map_argument_types(map2d, point_xi, time, functions_of_time);
 
   CHECK(map2d == map2d);
   CHECK_FALSE(map2d != map2d);
@@ -447,6 +452,10 @@ void test_product_of_3_maps_time_dep(
 
   CHECK(map3d.frame_velocity(logical_coords, time, functions_of_time) ==
         expected_frame_velocity_datavector);
+
+  test_coordinate_map_argument_types(map3d, point_source_a, time,
+                                     functions_of_time);
+  test_coordinate_map_argument_types(map3d, point_xi, time, functions_of_time);
 
   CHECK(map3d == map3d);
   CHECK_FALSE(map3d != map3d);

--- a/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_RotScaleTrans.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/TimeDependent/Test_RotScaleTrans.cpp
@@ -468,12 +468,54 @@ void test_RotScaleTrans() {
       test_inv_jacobian(rot_scale_trans_map_outer, point_to_check, t,
                         f_of_t_list);
     };
+    const auto check_all_maps_argument_types =
+        [&](const std::array<double, Dim>& point_to_check) {
+          test_coordinate_map_argument_types(rot_map, point_to_check, t,
+                                             f_of_t_list);
+          test_coordinate_map_argument_types(scale_map_inner, point_to_check, t,
+                                             f_of_t_list);
+          test_coordinate_map_argument_types(scale_map_transition,
+                                             point_to_check, t, f_of_t_list);
+          test_coordinate_map_argument_types(scale_map_outer, point_to_check, t,
+                                             f_of_t_list);
+          test_coordinate_map_argument_types(trans_map_inner, point_to_check, t,
+                                             f_of_t_list);
+          test_coordinate_map_argument_types(trans_map_transition,
+                                             point_to_check, t, f_of_t_list);
+          test_coordinate_map_argument_types(trans_map_outer, point_to_check, t,
+                                             f_of_t_list);
+          test_coordinate_map_argument_types(rot_scale_map_inner,
+                                             point_to_check, t, f_of_t_list);
+          test_coordinate_map_argument_types(rot_scale_map_transition,
+                                             point_to_check, t, f_of_t_list);
+          test_coordinate_map_argument_types(rot_scale_map_outer,
+                                             point_to_check, t, f_of_t_list);
+          test_coordinate_map_argument_types(rot_trans_map_inner,
+                                             point_to_check, t, f_of_t_list);
+          test_coordinate_map_argument_types(rot_trans_map_transition,
+                                             point_to_check, t, f_of_t_list);
+          test_coordinate_map_argument_types(rot_trans_map_outer,
+                                             point_to_check, t, f_of_t_list);
+          test_coordinate_map_argument_types(scale_trans_map_inner,
+                                             point_to_check, t, f_of_t_list);
+          test_coordinate_map_argument_types(scale_trans_map_transition,
+                                             point_to_check, t, f_of_t_list);
+          test_coordinate_map_argument_types(scale_trans_map_outer,
+                                             point_to_check, t, f_of_t_list);
+          test_coordinate_map_argument_types(rot_scale_trans_map_inner,
+                                             point_to_check, t, f_of_t_list);
+          test_coordinate_map_argument_types(rot_scale_trans_map_transition,
+                                             point_to_check, t, f_of_t_list);
+          test_coordinate_map_argument_types(rot_scale_trans_map_outer,
+                                             point_to_check, t, f_of_t_list);
+        };
 
     if (radius <= inner_radius) {
       check_inner_maps_inverse(point_xi);
     } else {
       check_transition_maps_inverse(point_xi);
     }
+    check_all_maps_argument_types(point_xi);
     check_all_maps_frame_velocity(point_xi);
     check_all_maps_jacobian(point_xi);
     check_all_maps_jacobian(point_xi_dv);
@@ -483,6 +525,7 @@ void test_RotScaleTrans() {
     } else {
       check_outer_maps_inverse(far_point_xi);
     }
+    check_all_maps_argument_types(far_point_xi);
     check_all_maps_frame_velocity(far_point_xi);
     check_all_maps_jacobian(far_point_xi);
 


### PR DESCRIPTION
## Proposed changes

Fixes #2060, by extending the ProductMaps and RotScaleTrans unit tests to test DataVector, not just double. The other time dependent maps look like they do test DataVector as well as double.

@nilsdeppe I wasn't completly sure if I understood what you wanted in #2060. This was codex's and my stab at it, but happy to revise if you had something else in mind, or close if it turns out this old issue should just be closed.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [x] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
