### PR TITLE
Update actions versions and use x86-64 arch with Kokkos

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -86,7 +86,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Check commits
@@ -116,7 +116,7 @@ jobs:
       image: ${{ inputs.container || 'sxscollaboration/spectre:dev' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       # Work around https://github.com/actions/checkout/issues/760
@@ -214,7 +214,7 @@ jobs:
         build_type: [Debug, Release]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       # Work around https://github.com/actions/checkout/issues/760
@@ -299,7 +299,7 @@ jobs:
         CCACHE_BASEDIR: $GITHUB_WORKSPACE
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       # Work around https://github.com/actions/checkout/issues/760
       - name: Trust checkout
         run: |
@@ -322,7 +322,7 @@ jobs:
           cat /work/release_notes.md | sed 's/\(\B\@\)/\\\1/g' \
             >> docs/Changelog.md
       - name: Restore ccache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         id: restore-ccache
         env:
           CACHE_KEY_PREFIX: ccache-gcc-11-Debug-pch-ON
@@ -569,7 +569,7 @@ jobs:
         run: |
           echo "time=$(date +%s)" >> "$GITHUB_OUTPUT"
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       # Work around https://github.com/actions/checkout/issues/760
       - name: Trust checkout
         run: |
@@ -678,7 +678,7 @@ jobs:
       # - To restore the most recent cache we provide a partially-matched
       #   "restore key".
       - name: Restore ccache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         id: restore-ccache
         env:
           CACHE_KEY_PREFIX: "ccache-${{ matrix.compiler }}-\
@@ -864,7 +864,7 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
       # cache.
       - name: Save ccache
         if: always() && github.ref == 'refs/heads/develop'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: /work/ccache
           key: ${{ steps.restore-ccache.outputs.cache-primary-key }}
@@ -1042,7 +1042,7 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
           echo "NUM_CORES=$CORES" >> $GITHUB_ENV
           echo "Detect $CORES cores"
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
@@ -1054,7 +1054,7 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
       # We install the remaining dependencies with Spack and cache them.
       # See the `unit_tests` job above for details on the cache configuration.
       - name: Restore dependency cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         id: restore-dependencies
         env:
           CACHE_KEY_PREFIX: "dependencies-${{ matrix.os }}"
@@ -1113,7 +1113,7 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
         continue-on-error: true
       - name: Save dependency cache
         if: github.ref == 'refs/heads/develop'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ~/dependencies
           key: ${{ steps.restore-dependencies.outputs.cache-primary-key }}
@@ -1132,7 +1132,7 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
           rm -rf $CCACHE_DIR
           mkdir -p $CCACHE_DIR
       - name: Restore ccache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         id: restore-ccache
         env:
           CACHE_KEY_PREFIX: "ccache-${{ matrix.os }}"
@@ -1199,7 +1199,7 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
           ccache --evict-older-than "${job_duration}s"
       - name: Save ccache
         if: always() && github.ref == 'refs/heads/develop'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ~/ccache
           key: ${{ steps.restore-ccache.outputs.cache-primary-key }}
@@ -1247,7 +1247,7 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
     env:
       TZ: ${{ github.event.inputs.timezone }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           # Using a personal access token with admin privileges here so this
@@ -1383,7 +1383,7 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
         CXXFLAGS: "-Werror"
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       # Work around https://github.com/actions/checkout/issues/760
       - name: Trust checkout
         run: |

--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -610,7 +610,7 @@ jobs:
             -D Kokkos_ENABLE_SERIAL=ON \
             -D Kokkos_ENABLE_OPENMP=ON \
             -D Kokkos_ENABLE_CUDA=${{ matrix.CUDA || 'OFF' }} \
-            -D Kokkos_ARCH_${{ matrix.KOKKOS_ARCH || 'NATIVE' }}=ON \
+            -D Kokkos_ARCH_${{ matrix.KOKKOS_ARCH || 'X86_64' }}=ON \
             -D Kokkos_ENABLE_CUDA_CONSTEXPR=ON \
             -D Kokkos_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE=ON \
             -D CMAKE_POSITION_INDEPENDENT_CODE=ON


### PR DESCRIPTION
## Proposed changes

We have warnings of upcoming removal of the v4 actions support.

We have intermittent failures in builds about the PCH being built with a different arch flag. I think this is because of the Kokkos build, but since it fails  randomly I'm not completely sure.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
