### PR TITLE
Add ZernikeB1 filtering (only for cartoon bases)

### DIFF
--- a/src/NumericalAlgorithms/LinearOperators/ExponentialFilter.cpp
+++ b/src/NumericalAlgorithms/LinearOperators/ExponentialFilter.cpp
@@ -11,6 +11,7 @@
 #include "NumericalAlgorithms/Spectral/Filtering.hpp"
 #include "NumericalAlgorithms/Spectral/MaximumNumberOfPoints.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Parity.hpp"
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
 #include "Options/Options.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
@@ -43,7 +44,7 @@ Exponential<FilterIndex>::Exponential(
 
 template <size_t FilterIndex>
 const Matrix& Exponential<FilterIndex>::filter_matrix(
-    const Mesh<1>& mesh) const {
+    const Mesh<1>& mesh, const Spectral::Parity parity) const {
   const static double cached_alpha = alpha_;
 
   ASSERT(cached_alpha == alpha_, "Filter was cached with alpha = "
@@ -82,10 +83,26 @@ const Matrix& Exponential<FilterIndex>::filter_matrix(
         return compute_filter(extents, Spectral::Basis::Fourier,
                               Spectral::Quadrature::Equiangular);
       });
+  const static auto zernikeb1_cache = make_static_cache<
+      CacheRange<
+          1_st,
+          Spectral::maximum_number_of_points<Spectral::Basis::ZernikeB1> + 1>,
+      CacheEnumeration<Spectral::Parity, Spectral::Parity::Even,
+                       Spectral::Parity::Odd>>(
+      [alpha = alpha_, half_power = half_power_](
+          const size_t extents, const Spectral::Parity local_parity) {
+        return Spectral::filtering::exponential_filter(
+            Mesh<1>{extents, Spectral::Basis::ZernikeB1,
+                    Spectral::Quadrature::GaussRadauUpper},
+            alpha, half_power, local_parity);
+      });
   if (mesh.basis(0) == Spectral::Basis::Fourier) {
     return fourier_cache(mesh.extents(0));
+  } else if (mesh.basis(0) == Spectral::Basis::ZernikeB1) {
+    return zernikeb1_cache(mesh.extents(0), parity);
+  } else {
+    return cache(mesh.extents(0), mesh.basis(0), mesh.quadrature(0));
   }
-  return cache(mesh.extents(0), mesh.basis(0), mesh.quadrature(0));
 }
 
 template <size_t FilterIndex>

--- a/src/NumericalAlgorithms/LinearOperators/ExponentialFilter.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/ExponentialFilter.hpp
@@ -9,6 +9,7 @@
 #include <string>
 #include <unordered_set>
 
+#include "NumericalAlgorithms/Spectral/Parity.hpp"
 #include "Options/Auto.hpp"
 #include "Options/String.hpp"
 #include "Utilities/TMPL.hpp"
@@ -110,7 +111,9 @@ class Exponential {
               const Options::Context& context = {});
 
   /// A cached matrix used to apply the filter to the given mesh
-  const Matrix& filter_matrix(const Mesh<1>& mesh) const;
+  const Matrix& filter_matrix(
+      const Mesh<1>& mesh,
+      Spectral::Parity parity = Spectral::Parity::Uninitialized) const;
 
   bool enable() const { return enable_; }
 

--- a/src/NumericalAlgorithms/Spectral/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Spectral/CMakeLists.txt
@@ -50,6 +50,8 @@ spectre_target_headers(
   CollocationPointsAndWeights.hpp
   DifferentiationMatrix.hpp
   Filtering.hpp
+  FilteringB1.hpp
+  FilteringB1.tpp
   FilteringB2.hpp
   FilteringB2.tpp
   GetSpectralQuantityForMesh.hpp

--- a/src/NumericalAlgorithms/Spectral/Filtering.cpp
+++ b/src/NumericalAlgorithms/Spectral/Filtering.cpp
@@ -19,9 +19,32 @@
 
 namespace Spectral::filtering {
 Matrix exponential_filter(const Mesh<1>& mesh, const double alpha,
-                          const unsigned half_power) {
+                          const unsigned half_power, const Parity parity) {
   if (UNLIKELY(mesh.number_of_grid_points() == 1)) {
     return Matrix(1, 1, 1.0);
+  }
+  if (mesh.basis(0) == Spectral::Basis::ZernikeB1) {
+    ASSERT(parity != Parity::Uninitialized,
+           "Need parity to be set to filter ZernikeB1");
+    const size_t m = parity == Parity::Even ? 0 : 1;
+    const size_t n = mesh.number_of_grid_points();
+    const Matrix& nodal_to_modal =
+        Spectral::nodal_to_modal_matrix<Spectral::Basis::ZernikeB1,
+                                        Spectral::Quadrature::GaussRadauUpper>(
+            n, m, 2 * n - 2);
+    const Matrix& modal_to_nodal =
+        Spectral::modal_to_nodal_matrix<Spectral::Basis::ZernikeB1,
+                                        Spectral::Quadrature::GaussRadauUpper>(
+            n, m, 2 * n - 2);
+    Matrix filter_matrix(n - m, n - m, 0.0);
+    const size_t order = n - 1 - m;
+    filter_matrix(0, 0) = 1.0;
+    for (size_t i = 1; i <= order; ++i) {
+      filter_matrix(i, i) =
+          exp(-alpha * pow(static_cast<double>(i) / static_cast<double>(order),
+                           2 * half_power));
+    }
+    return modal_to_nodal * filter_matrix * nodal_to_modal;
   }
   const Matrix& nodal_to_modal = Spectral::nodal_to_modal_matrix(mesh);
   const Matrix& modal_to_nodal = Spectral::modal_to_nodal_matrix(mesh);

--- a/src/NumericalAlgorithms/Spectral/Filtering.hpp
+++ b/src/NumericalAlgorithms/Spectral/Filtering.hpp
@@ -5,6 +5,8 @@
 
 #include <cstddef>
 
+#include "NumericalAlgorithms/Spectral/Parity.hpp"
+
 /// \cond
 class Matrix;
 template <size_t>
@@ -34,13 +36,17 @@ namespace filtering {
  * more coefficients). Setting \f$\alpha=36\f$ results in setting the highest
  * coefficient to machine precision, effectively zeroing it out.
  *
+ * The Parity argument is only used for ZernikeB1 bases, where the modal space
+ * is parity dependent.
+ *
  * \note The filter matrix is not cached by the function because it depends on a
  * double, an integer, and the mesh, which could make caching very memory
  * intensive. The caller of this function is responsible for determining whether
  * or not the matrix should be cached.
  */
 Matrix exponential_filter(const Mesh<1>& mesh, double alpha,
-                          unsigned half_power);
+                          unsigned half_power,
+                          Parity parity = Parity::Uninitialized);
 
 /*!
  * \brief Zeros the lowest `number_of_modes_to_zero` modal coefficients. Note

--- a/src/NumericalAlgorithms/Spectral/FilteringB1.hpp
+++ b/src/NumericalAlgorithms/Spectral/FilteringB1.hpp
@@ -1,0 +1,33 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "Utilities/Gsl.hpp"
+
+/// \cond
+class Matrix;
+template <size_t>
+class Mesh;
+template <typename TagsList>
+class Variables;
+/// \endcond
+
+namespace Spectral::filtering {
+/*!
+ * \brief Filters the tensors stored within a `Variables` being represented by
+ * ZernikeB1 basis functions in their first dimension.
+ *
+ * \details The Cartoon method with spectral bases can be unstable for small
+ * \f$x\f$, so we use ZernikeB1 bases with GaussRadauUpper quadrature to push
+ * collocation points to higher inertial coordinates. This basis has
+ * parity-dependent spectral space, so we must go to the proper modal space,
+ * apply the exponential filter, and transform back.
+ *
+ * \see exponential_filter()
+ */
+template <typename VariablesTags>
+void zernike_b1_exponential_filter(gsl::not_null<Variables<VariablesTags>*> u,
+                                   const Mesh<3>& mesh, double alpha,
+                                   unsigned half_power);
+}  // namespace Spectral::filtering

--- a/src/NumericalAlgorithms/Spectral/FilteringB1.tpp
+++ b/src/NumericalAlgorithms/Spectral/FilteringB1.tpp
@@ -1,0 +1,111 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "NumericalAlgorithms/Spectral/FilteringB1.hpp"
+
+#include "DataStructures/ApplyMatrices.hpp"
+#include "DataStructures/Matrix.hpp"
+#include "DataStructures/Variables.hpp"
+#include "NumericalAlgorithms/Spectral/Filtering.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/ParityFromSymmetry.hpp"
+#include "Utilities/MemoryHelpers.hpp"
+
+namespace Spectral::filtering {
+template <typename VariablesTags>
+void zernike_b1_exponential_filter(gsl::not_null<Variables<VariablesTags>*> u,
+                                   const Mesh<3>& mesh, const double alpha,
+                                   const unsigned half_power) {
+  const Matrix empty{};
+  std::array<Matrix, 3> filter_even = make_array<3>(empty);
+  std::array<Matrix, 3> filter_odd = make_array<3>(empty);
+
+  for (size_t d = 0; d < 3; d++) {
+    gsl::at(filter_even, d) = Spectral::filtering::exponential_filter(
+        mesh.slice_through(d), alpha, half_power, Spectral::Parity::Even);
+    gsl::at(filter_odd, d) = Spectral::filtering::exponential_filter(
+        mesh.slice_through(d), alpha, half_power, Spectral::Parity::Odd);
+  }
+
+  double* p_data = u->data();
+
+  constexpr auto parity_info = Spectral::compute_parity_list<VariablesTags>();
+  const auto parity_list = std::get<0>(parity_info);
+  const auto num_even_comps = std::get<1>(parity_info);
+  const auto num_odd_comps = std::get<2>(parity_info);
+
+  const size_t num_grid_points = mesh.number_of_grid_points();
+  // NOLINTNEXTLINE(modernize-avoid-c-arrays)
+  const auto buffer = cpp20::make_unique_for_overwrite<double[]>(
+      (num_even_comps + num_odd_comps) * num_grid_points);
+  DataVector even_components{};
+  even_components.set_data_ref(&buffer[0], num_even_comps * num_grid_points);
+  DataVector odd_components{};
+  odd_components.set_data_ref(&buffer[num_even_comps * num_grid_points],
+                              num_odd_comps * num_grid_points);
+  double* p_even_components = even_components.data();
+  double* p_odd_components = odd_components.data();
+
+  bool even = true;
+  for (const auto seg_size : parity_list) {
+    if (UNLIKELY(seg_size == 0)) {
+      if (even) {
+        // Will have leading zero if first element is odd
+        even = false;
+        continue;
+      } else {
+        // Iterated through all non-zero values
+        break;
+      }
+    }
+    if (even) {
+      std::copy(p_data, p_data + seg_size * num_grid_points, p_even_components);
+      p_even_components += seg_size * num_grid_points;
+    } else {
+      std::copy(p_data, p_data + seg_size * num_grid_points, p_odd_components);
+      p_odd_components += seg_size * num_grid_points;
+    }
+    p_data += seg_size * num_grid_points;
+    even = not even;
+  }
+  if (num_even_comps > 0) {
+    even_components =
+        apply_matrices(filter_even, even_components, mesh.extents());
+  }
+  if (num_odd_comps > 0) {
+    odd_components = apply_matrices(filter_odd, odd_components, mesh.extents());
+  }
+  // reset pointers to beginning of buffers
+  p_data = u->data();
+  p_even_components = even_components.data();
+  p_odd_components = odd_components.data();
+  even = true;
+  for (const auto seg_size : parity_list) {
+    if (UNLIKELY(seg_size == 0)) {
+      if (even) {
+        // Will have leading zero if first element is odd
+        even = false;
+        continue;
+      } else {
+        // Iterated through all non-zero values
+        break;
+      }
+    }
+    // Now copy the data from the buffer to the correct location in u
+    if (even) {
+      std::copy(p_even_components,
+                p_even_components + seg_size * num_grid_points, p_data);
+      p_even_components += seg_size * num_grid_points;
+    } else {
+      std::copy(p_odd_components, p_odd_components + seg_size * num_grid_points,
+                p_data);
+      p_odd_components += seg_size * num_grid_points;
+    }
+    p_data += seg_size * num_grid_points;
+    even = not even;
+  }
+}
+
+}  // namespace Spectral::filtering

--- a/src/NumericalAlgorithms/Spectral/FilteringB2.hpp
+++ b/src/NumericalAlgorithms/Spectral/FilteringB2.hpp
@@ -27,7 +27,7 @@ namespace Spectral::filtering {
  * \see exponential_filter()
  */
 template <typename TagsList>
-void ZernikeB2_disk_exponential_filter(gsl::not_null<Variables<TagsList>*> u,
+void zernike_b2_disk_exponential_filter(gsl::not_null<Variables<TagsList>*> u,
                                        const Mesh<2>& mesh, double alpha,
                                        unsigned half_power);
 
@@ -45,7 +45,7 @@ void ZernikeB2_disk_exponential_filter(gsl::not_null<Variables<TagsList>*> u,
  * \see exponential_filter()
  */
 template <typename TagsList>
-void ZernikeB2_cylinder_exponential_filter(
+void zernike_b2_cylinder_exponential_filter(
     gsl::not_null<Variables<TagsList>*> u, const Mesh<3>& mesh, double alpha,
     unsigned half_power);
 }  // namespace Spectral::filtering

--- a/src/NumericalAlgorithms/Spectral/FilteringB2.tpp
+++ b/src/NumericalAlgorithms/Spectral/FilteringB2.tpp
@@ -52,7 +52,7 @@ void check_valid_extents(const size_t n_r, const size_t n_phi,
 }  // namespace
 
 template <typename TagsList>
-void ZernikeB2_disk_exponential_filter(
+void zernike_b2_disk_exponential_filter(
     const gsl::not_null<Variables<TagsList>*> u, const Mesh<2>& mesh,
     const double alpha, const unsigned half_power) {
   const auto [n_r, n_phi] = mesh.extents().indices();
@@ -190,7 +190,7 @@ void ZernikeB2_disk_exponential_filter(
 }
 
 template <typename TagsList>
-void ZernikeB2_cylinder_exponential_filter(
+void zernike_b2_cylinder_exponential_filter(
     const gsl::not_null<Variables<TagsList>*> u, const Mesh<3>& mesh,
     const double alpha, const unsigned half_power) {
   const auto [n_r, n_phi, n_z] = mesh.extents().indices();

--- a/src/NumericalAlgorithms/Spectral/Python/Bindings.cpp
+++ b/src/NumericalAlgorithms/Spectral/Python/Bindings.cpp
@@ -6,6 +6,7 @@
 #include "DataStructures/Matrix.hpp"
 #include "NumericalAlgorithms/Spectral/Filtering.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Parity.hpp"
 #include "NumericalAlgorithms/Spectral/Projection.hpp"
 #include "NumericalAlgorithms/Spectral/Python/LogicalCoordinates.hpp"
 #include "NumericalAlgorithms/Spectral/Python/Mesh.hpp"
@@ -22,8 +23,13 @@ PYBIND11_MODULE(_Pybindings, m) {  // NOLINT
   Spectral::py_bindings::bind_spectral(m);
   py_bindings::bind_mesh(m);
   // Filtering
+  py::enum_<Spectral::Parity>(m, "Parity")
+      .value("Even", Spectral::Parity::Even)
+      .value("Odd", Spectral::Parity::Odd)
+      .value("Uninitialized", Spectral::Parity::Uninitialized);
   m.def("exponential_filter", &Spectral::filtering::exponential_filter,
-        py::arg("mesh"), py::arg("alpha"), py::arg("half_power"));
+        py::arg("mesh"), py::arg("alpha"), py::arg("half_power"),
+        py::arg("parity") = Spectral::Parity::Uninitialized);
   m.def("zero_lowest_modes", &Spectral::filtering::zero_lowest_modes,
         py::arg("mesh"), py::arg("number_of_modes_to_zero"),
         py::return_value_policy::reference);

--- a/tests/Unit/NumericalAlgorithms/Spectral/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Spectral/CMakeLists.txt
@@ -20,6 +20,7 @@ set(LIBRARY_SOURCES
   Test_CollocationPointsAndWeights.cpp
   Test_DifferentiationMatrix.cpp
   Test_Filtering.cpp
+  Test_FilteringB1.cpp
   Test_FilteringB2.cpp
   Test_FiniteDifference.cpp
   Test_IndefiniteIntegral.cpp

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_FilteringB1.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_FilteringB1.cpp
@@ -1,0 +1,223 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <functional>
+
+#include "DataStructures/ApplyMatrices.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Matrix.hpp"
+#include "DataStructures/Tags/TempTensor.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "NumericalAlgorithms/LinearOperators/ExponentialFilter.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/BasisFunctionValue.hpp"
+#include "NumericalAlgorithms/Spectral/CollocationPoints.hpp"
+#include "NumericalAlgorithms/Spectral/FilteringB1.hpp"
+#include "NumericalAlgorithms/Spectral/FilteringB1.tpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Parity.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+using TestTags = tmpl::list<Tags::TempScalar<0>, Tags::TempI<1, 3>>;
+
+// Compute the expected filtered Variables by iterating each tensor component
+// individually. For each component, count the number of x-direction indices to
+// determine parity, then apply_matrices with the corresponding filter directly
+// on that component's DataVector. This is independent of the buffer-copying
+// logic in the implementation.
+template <typename VariableTags>
+Variables<VariableTags> compute_expected(const Variables<VariableTags>& vars,
+                                         const Mesh<3>& mesh,
+                                         const double alpha,
+                                         const unsigned half_power) {
+  const Matrix empty{};
+  std::array<Matrix, 3> filter_even = make_array<3>(empty);
+  std::array<Matrix, 3> filter_odd = make_array<3>(empty);
+
+  for (size_t d = 0; d < 3; d++) {
+    gsl::at(filter_even, d) = Spectral::filtering::exponential_filter(
+        mesh.slice_through(d), alpha, half_power, Spectral::Parity::Even);
+    gsl::at(filter_odd, d) = Spectral::filtering::exponential_filter(
+        mesh.slice_through(d), alpha, half_power, Spectral::Parity::Odd);
+  }
+
+  Variables<VariableTags> expected{mesh.number_of_grid_points()};
+
+  tmpl::for_each<VariableTags>(
+      [&]<typename Tag>(const tmpl::type_<Tag> /*meta*/) {
+        using TensorType = typename Tag::type;
+        constexpr auto index_types = TensorType::index_types();
+        const auto& in_tensor = get<Tag>(vars);
+        auto& out_tensor = get<Tag>(expected);
+
+        for (size_t comp = 0; comp < TensorType::size(); ++comp) {
+          const auto tensor_index = TensorType::get_tensor_index(comp);
+          size_t x_count = 0;
+          for (size_t i = 0; i < index_types.size(); ++i) {
+            const bool is_x_spatial =
+                gsl::at(index_types, i) == IndexType::Spatial and
+                gsl::at(tensor_index, i) == 0;
+            const bool is_x_spacetime =
+                gsl::at(index_types, i) == IndexType::Spacetime and
+                gsl::at(tensor_index, i) == 1;
+            if (is_x_spatial or is_x_spacetime) {
+              ++x_count;
+            }
+          }
+          const auto& filter = (x_count % 2 == 0) ? filter_even : filter_odd;
+          out_tensor[comp] =
+              apply_matrices(filter, in_tensor[comp], mesh.extents());
+        }
+      });
+
+  return expected;
+}
+
+template <typename VariableTags>
+void test_b1_filter(const Mesh<3>& mesh, const double alpha,
+                    const unsigned half_power) {
+  CAPTURE(mesh);
+  CAPTURE(alpha);
+  CAPTURE(half_power);
+
+  const size_t num_pts = mesh.number_of_grid_points();
+
+  Variables<VariableTags> vars{num_pts};
+  double val = 1.0;
+  for (size_t i = 0; i < vars.size(); ++i) {
+    vars.data()[i] = val;
+    val += 1.3;
+  }
+
+  const Variables<VariableTags> expected =
+      compute_expected(vars, mesh, alpha, half_power);
+
+  Spectral::filtering::zernike_b1_exponential_filter(make_not_null(&vars), mesh,
+                                                     alpha, half_power);
+
+  CHECK_VARIABLES_APPROX(vars, expected);
+}
+
+// For a fixed alpha, the filter must damp the highest-order modal coefficient
+// by exactly exp(-alpha). We construct nodal data equal to the highest-order
+// ZernikeB1 basis function for each parity, apply the filter, and check the
+// result is exp(-alpha) times the input. This verifies the magnitude of
+// damping, not just self-consistency between the implementation and
+// compute_expected.
+void test_highest_mode_damping(const size_t n_r, const double alpha,
+                               const unsigned half_power) {
+  CAPTURE(n_r);
+  CAPTURE(alpha);
+  CAPTURE(half_power);
+
+  // Spherical mesh: only radial dimension is non-trivial
+  const Mesh<3> mesh{{{n_r, 1, 1}},
+                     {{Spectral::Basis::ZernikeB1, Spectral::Basis::Cartoon,
+                       Spectral::Basis::Cartoon}},
+                     {{Spectral::Quadrature::GaussRadauUpper,
+                       Spectral::Quadrature::SphericalSymmetry,
+                       Spectral::Quadrature::SphericalSymmetry}}};
+  const size_t num_pts = mesh.number_of_grid_points();
+  const size_t N = 2 * n_r - 2;
+  const DataVector& pts =
+      Spectral::collocation_points<Spectral::Basis::ZernikeB1,
+                                   Spectral::Quadrature::GaussRadauUpper>(n_r);
+  const Approx local_approx = Approx::custom().epsilon(1e-12).scale(1.0);
+
+  // Even parity (m=0): highest mode index is k = N
+  {
+    using ScalarTags = tmpl::list<Tags::TempScalar<0>>;
+    Variables<ScalarTags> vars{num_pts, 0.0};
+    get(get<Tags::TempScalar<0>>(vars)) =
+        Spectral::compute_basis_function_value<Spectral::Basis::ZernikeB1>(N, 0,
+                                                                           pts);
+    const Variables<ScalarTags> vars_copy = vars;
+
+    Spectral::filtering::zernike_b1_exponential_filter(make_not_null(&vars),
+                                                       mesh, alpha, half_power);
+
+    const double expected_factor = std::exp(-alpha);
+    CHECK_ITERABLE_CUSTOM_APPROX(
+        get(get<Tags::TempScalar<0>>(vars)),
+        expected_factor * get(get<Tags::TempScalar<0>>(vars_copy)),
+        local_approx);
+  }
+
+  // Odd parity (m=1): highest mode index is k = N - 1
+  if (n_r > 1) {
+    using VectorTags = tmpl::list<Tags::TempI<0, 3>>;
+    Variables<VectorTags> vars{num_pts, 0.0};
+    get<0>(get<Tags::TempI<0, 3>>(vars)) =
+        Spectral::compute_basis_function_value<Spectral::Basis::ZernikeB1>(
+            N - 1, 1, pts);
+    const Variables<VectorTags> vars_copy = vars;
+
+    Spectral::filtering::zernike_b1_exponential_filter(make_not_null(&vars),
+                                                       mesh, alpha, half_power);
+
+    const double expected_factor = std::exp(-alpha);
+    CHECK_ITERABLE_CUSTOM_APPROX(
+        get<0>(get<Tags::TempI<0, 3>>(vars)),
+        expected_factor * get<0>(get<Tags::TempI<0, 3>>(vars_copy)),
+        local_approx);
+  }
+}
+
+void test_spherical_mesh() {
+  for (const size_t n_r : {2_st, 3_st, 5_st, 7_st, 8_st, 10_st}) {
+    CAPTURE(n_r);
+    const Mesh<3> mesh{{{n_r, 1, 1}},
+                       {{Spectral::Basis::ZernikeB1, Spectral::Basis::Cartoon,
+                         Spectral::Basis::Cartoon}},
+                       {{Spectral::Quadrature::GaussRadauUpper,
+                         Spectral::Quadrature::SphericalSymmetry,
+                         Spectral::Quadrature::SphericalSymmetry}}};
+
+    test_b1_filter<TestTags>(mesh, 10.0, 2u);
+    test_b1_filter<TestTags>(mesh, 10.0, 4u);
+    test_b1_filter<TestTags>(mesh, 36.0, 2u);
+    test_b1_filter<TestTags>(mesh, 36.0, 4u);
+  }
+}
+
+void test_axial_mesh() {
+  for (const size_t n_r : {2_st, 3_st, 5_st, 6_st}) {
+    for (const size_t n_y : {3_st, 4_st}) {
+      CAPTURE(n_r);
+      CAPTURE(n_y);
+      const Mesh<3> mesh{
+          {{n_r, n_y, 1}},
+          {{Spectral::Basis::ZernikeB1, Spectral::Basis::Legendre,
+            Spectral::Basis::Cartoon}},
+          {{Spectral::Quadrature::GaussRadauUpper,
+            Spectral::Quadrature::GaussLobatto,
+            Spectral::Quadrature::AxialSymmetry}}};
+
+      test_b1_filter<TestTags>(mesh, 10.0, 2u);
+      test_b1_filter<TestTags>(mesh, 10.0, 4u);
+      test_b1_filter<TestTags>(mesh, 36.0, 2u);
+      test_b1_filter<TestTags>(mesh, 36.0, 4u);
+    }
+  }
+}
+
+SPECTRE_TEST_CASE("Unit.Numerical.Spectral.B1Filter",
+                  "[NumericalAlgorithms][Spectral][Unit]") {
+  test_spherical_mesh();
+  test_axial_mesh();
+  for (const size_t n_r : {3_st, 5_st, 8_st}) {
+    test_highest_mode_damping(n_r, 36.0, 2u);
+    test_highest_mode_damping(n_r, 10.0, 4u);
+  }
+}
+}  // namespace

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_FilteringB2.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_FilteringB2.cpp
@@ -73,8 +73,8 @@ void test_disk_filter() {
       get<0>(get<::Tags::Tempi<0, 2>>(expected_result)) = f_vals;
       get<1>(get<::Tags::Tempi<0, 2>>(expected_result)) = f_sin_vals;
 
-      Spectral::filtering::ZernikeB2_disk_exponential_filter(make_not_null(&u),
-                                                             mesh, 0.0, 2);
+      Spectral::filtering::zernike_b2_disk_exponential_filter(make_not_null(&u),
+                                                              mesh, 0.0, 2);
 
       CHECK_VARIABLES_APPROX(u, expected_result);
     }
@@ -89,8 +89,8 @@ void test_disk_filter() {
       get<0>(get<::Tags::Tempi<0, 2>>(expected_result)) = 1.0;
       get<1>(get<::Tags::Tempi<0, 2>>(expected_result)) = 1.0;
 
-      Spectral::filtering::ZernikeB2_disk_exponential_filter(make_not_null(&u),
-                                                             mesh, 36.0, 32);
+      Spectral::filtering::zernike_b2_disk_exponential_filter(make_not_null(&u),
+                                                              mesh, 36.0, 32);
 
       CHECK_VARIABLES_APPROX(u, expected_result);
     }
@@ -108,8 +108,8 @@ void test_disk_filter() {
       get<0>(get<::Tags::Tempi<0, 2>>(expected_result)) = 0.;
       get<1>(get<::Tags::Tempi<0, 2>>(expected_result)) = 0.;
 
-      Spectral::filtering::ZernikeB2_disk_exponential_filter(make_not_null(&u),
-                                                             mesh, 36.0, 32);
+      Spectral::filtering::zernike_b2_disk_exponential_filter(make_not_null(&u),
+                                                              mesh, 36.0, 32);
 
       CHECK_VARIABLES_APPROX(u, expected_result);
     }
@@ -125,8 +125,8 @@ void test_disk_filter() {
       get<0>(get<::Tags::Tempi<0, 2>>(expected_result)) = 1.;
       get<1>(get<::Tags::Tempi<0, 2>>(expected_result)) = 1.;
 
-      Spectral::filtering::ZernikeB2_disk_exponential_filter(make_not_null(&u),
-                                                             mesh, 36.0, 32);
+      Spectral::filtering::zernike_b2_disk_exponential_filter(make_not_null(&u),
+                                                              mesh, 36.0, 32);
 
       CHECK_VARIABLES_APPROX(u, expected_result);
     }
@@ -183,7 +183,7 @@ void test_disk_filter_weights() {
         {
           const DataVector f_cos = r_m * cos(static_cast<double>(m) * phi);
           get(get<::Tags::TempScalar<0>>(u)) = f_cos;
-          Spectral::filtering::ZernikeB2_disk_exponential_filter(
+          Spectral::filtering::zernike_b2_disk_exponential_filter(
               make_not_null(&u), mesh, alpha, half_power);
           get(get<::Tags::TempScalar<0>>(expected_result)) =
               expected_factor * f_cos;
@@ -194,7 +194,7 @@ void test_disk_filter_weights() {
         {
           const DataVector f_sin = r_m * sin(static_cast<double>(m) * phi);
           get(get<::Tags::TempScalar<0>>(u)) = f_sin;
-          Spectral::filtering::ZernikeB2_disk_exponential_filter(
+          Spectral::filtering::zernike_b2_disk_exponential_filter(
               make_not_null(&u), mesh, alpha, half_power);
           get(get<::Tags::TempScalar<0>>(expected_result)) =
               expected_factor * f_sin;
@@ -245,7 +245,7 @@ void test_cylinder_filter() {
       get<0>(get<::Tags::Tempi<0, 2>>(expected_result)) = f_vals;
       get<1>(get<::Tags::Tempi<0, 2>>(expected_result)) = f_vals;
 
-      Spectral::filtering::ZernikeB2_cylinder_exponential_filter(
+      Spectral::filtering::zernike_b2_cylinder_exponential_filter(
           make_not_null(&u), mesh, 0.0, 2);
 
       CHECK_VARIABLES_APPROX(u, expected_result);
@@ -261,7 +261,7 @@ void test_cylinder_filter() {
       get<0>(get<::Tags::Tempi<0, 2>>(expected_result)) = 1.0;
       get<1>(get<::Tags::Tempi<0, 2>>(expected_result)) = 1.0;
 
-      Spectral::filtering::ZernikeB2_cylinder_exponential_filter(
+      Spectral::filtering::zernike_b2_cylinder_exponential_filter(
           make_not_null(&u), mesh, 36.0, 32);
 
       CHECK_VARIABLES_APPROX(u, expected_result);
@@ -281,7 +281,7 @@ void test_cylinder_filter() {
       get<0>(get<::Tags::Tempi<0, 2>>(expected_result)) = 0.;
       get<1>(get<::Tags::Tempi<0, 2>>(expected_result)) = 0.;
 
-      Spectral::filtering::ZernikeB2_cylinder_exponential_filter(
+      Spectral::filtering::zernike_b2_cylinder_exponential_filter(
           make_not_null(&u), mesh, 36.0, 32);
 
       CHECK_VARIABLES_APPROX(u, expected_result);
@@ -298,7 +298,7 @@ void test_cylinder_filter() {
       get<0>(get<::Tags::Tempi<0, 2>>(expected_result)) = 1.;
       get<1>(get<::Tags::Tempi<0, 2>>(expected_result)) = 1.;
 
-      Spectral::filtering::ZernikeB2_cylinder_exponential_filter(
+      Spectral::filtering::zernike_b2_cylinder_exponential_filter(
           make_not_null(&u), mesh, 36.0, 32);
 
       CHECK_VARIABLES_APPROX(u, expected_result);
@@ -328,7 +328,7 @@ void test_cylinder_filter() {
     get<0>(get<::Tags::Tempi<0, 2>>(expected_result)) = 0.;
     get<1>(get<::Tags::Tempi<0, 2>>(expected_result)) = 0.;
 
-    Spectral::filtering::ZernikeB2_cylinder_exponential_filter(
+    Spectral::filtering::zernike_b2_cylinder_exponential_filter(
         make_not_null(&u), mesh, 36.0, 32);
 
     CHECK_VARIABLES_APPROX(u, expected_result);
@@ -397,7 +397,7 @@ void test_cylinder_filter_weights() {
         {
           const DataVector f_cos = r_m * cos(static_cast<double>(m) * phi);
           get(get<::Tags::TempScalar<0>>(u)) = f_cos;
-          Spectral::filtering::ZernikeB2_cylinder_exponential_filter(
+          Spectral::filtering::zernike_b2_cylinder_exponential_filter(
               make_not_null(&u), mesh, alpha, half_power);
           get(get<::Tags::TempScalar<0>>(expected_result)) =
               disk_factor * f_cos;
@@ -408,7 +408,7 @@ void test_cylinder_filter_weights() {
         {
           const DataVector f_sin = r_m * sin(static_cast<double>(m) * phi);
           get(get<::Tags::TempScalar<0>>(u)) = f_sin;
-          Spectral::filtering::ZernikeB2_cylinder_exponential_filter(
+          Spectral::filtering::zernike_b2_cylinder_exponential_filter(
               make_not_null(&u), mesh, alpha, half_power);
           get(get<::Tags::TempScalar<0>>(expected_result)) =
               disk_factor * f_sin;
@@ -442,7 +442,7 @@ void test_cylinder_filter_weights() {
         Variables<TagsList> u{num_grid_points};
         Variables<TagsList> expected_result{num_grid_points};
         get(get<::Tags::TempScalar<0>>(u)) = f_z_vals;
-        Spectral::filtering::ZernikeB2_cylinder_exponential_filter(
+        Spectral::filtering::zernike_b2_cylinder_exponential_filter(
             make_not_null(&u), mesh, alpha, half_power);
         get(get<::Tags::TempScalar<0>>(expected_result)) = z_factor * f_z_vals;
         CHECK_VARIABLES_APPROX(u, expected_result);
@@ -463,7 +463,7 @@ void test_asserts() {
                         Spectral::Quadrature::Equiangular}};
     Variables<TagsList> u{mesh.number_of_grid_points()};
     CHECK_THROWS_WITH(
-        Spectral::filtering::ZernikeB2_disk_exponential_filter(
+        Spectral::filtering::zernike_b2_disk_exponential_filter(
             make_not_null(&u), mesh, 1.0, 2),
         Catch::Matchers::ContainsSubstring(
             "At least 2 radial grid points are required to filter ZernikeB2,"));
@@ -476,7 +476,7 @@ void test_asserts() {
                         Spectral::Quadrature::Equiangular}};
     Variables<TagsList> u{mesh.number_of_grid_points()};
     CHECK_THROWS_WITH(
-        Spectral::filtering::ZernikeB2_disk_exponential_filter(
+        Spectral::filtering::zernike_b2_disk_exponential_filter(
             make_not_null(&u), mesh, 1.0, 2),
         Catch::Matchers::ContainsSubstring(
             "Fourier with an even number of grid points can be unstable"));
@@ -489,7 +489,7 @@ void test_asserts() {
                         Spectral::Quadrature::Equiangular}};
     Variables<TagsList> u{mesh.number_of_grid_points()};
     CHECK_THROWS_WITH(
-        Spectral::filtering::ZernikeB2_disk_exponential_filter(
+        Spectral::filtering::zernike_b2_disk_exponential_filter(
             make_not_null(&u), mesh, 1.0, 2),
         Catch::Matchers::ContainsSubstring(
             "We choose to enforce the restriction that the Fourier modal space "
@@ -505,7 +505,7 @@ void test_asserts() {
                         Spectral::Quadrature::GaussLobatto}};
     Variables<TagsList> u{mesh.number_of_grid_points()};
     CHECK_THROWS_WITH(
-        Spectral::filtering::ZernikeB2_cylinder_exponential_filter(
+        Spectral::filtering::zernike_b2_cylinder_exponential_filter(
             make_not_null(&u), mesh, 1.0, 2),
         Catch::Matchers::ContainsSubstring(
             "Fourier with an even number of grid points can be unstable"));
@@ -520,7 +520,7 @@ void test_asserts() {
                         Spectral::Quadrature::GaussLobatto}};
     Variables<TagsList> u{mesh.number_of_grid_points()};
     CHECK_THROWS_WITH(
-        Spectral::filtering::ZernikeB2_cylinder_exponential_filter(
+        Spectral::filtering::zernike_b2_cylinder_exponential_filter(
             make_not_null(&u), mesh, 1.0, 2),
         Catch::Matchers::ContainsSubstring(
             "We choose to enforce the restriction that the Fourier modal space "


### PR DESCRIPTION
## Proposed changes

Add a free function to filter bases using ZernikeB1. This basis is only used with cartoon bases and even then, only on element touching the $y$-axis. Similar to other Zernike things, going to the spectral space has requires extra care.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
