### PR TITLE
Fix Time Precedes Earliest Bug in Ringdown

### DIFF
--- a/src/Evolution/Ringdown/StrahlkorperCoefsAndCenters.cpp
+++ b/src/Evolution/Ringdown/StrahlkorperCoefsAndCenters.cpp
@@ -5,6 +5,7 @@
 #include <array>
 #include <cstddef>
 #include <optional>
+#include <string>
 #include <vector>
 
 #include "DataStructures/Matrix.hpp"
@@ -12,7 +13,6 @@
 #include "Domain/CoordsToDifferentFrame.hpp"
 #include "Domain/Creators/Sphere.hpp"
 #include "Domain/Creators/TimeDependentOptions/ExpansionMap.hpp"
-#include "Domain/Creators/TimeDependentOptions/FromVolumeFile.hpp"
 #include "Domain/Creators/TimeDependentOptions/RotationMap.hpp"
 #include "Domain/Creators/TimeDependentOptions/Sphere.hpp"
 #include "Domain/Creators/TimeDependentOptions/TranslationMap.hpp"
@@ -23,8 +23,59 @@
 #include "NumericalAlgorithms/SphericalHarmonics/ChangeCenterOfStrahlkorper.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/IO/ReadSurfaceYlm.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Serialization/Serialize.hpp"
+
+namespace {
+std::array<double, 3> extract_expansion_outer_boundary_func_and_2_derivs(
+    const domain::FunctionsOfTimeMap& functions_of_time, const double time) {
+  const auto function_of_time =
+      functions_of_time.find("ExpansionOuterBoundary");
+  if (function_of_time == functions_of_time.end()) {
+    ERROR("ExpansionOuterBoundary function of time could not be found at time "
+          << time << "M.");
+  }
+  const auto values = function_of_time->second->func_and_2_derivs(time);
+  return std::array{values[0][0], values[1][0], values[2][0]};
+}
+
+std::vector<std::array<double, 4>> extract_rotation_func_and_2_derivs(
+    const domain::FunctionsOfTimeMap& functions_of_time, const double time) {
+  const auto function_of_time = functions_of_time.find("Rotation");
+  if (function_of_time == functions_of_time.end()) {
+    ERROR("Rotation function of time could not be found at " << "time " << time
+                                                             << "M.");
+  }
+  const auto values = function_of_time->second->func_and_2_derivs(time);
+  std::vector<std::array<double, 4>> result(3);
+  for (size_t deriv = 0; deriv < values.size(); ++deriv) {
+    auto& result_deriv = result[deriv];
+    for (size_t component = 0; component < 4; ++component) {
+      gsl::at(result_deriv, component) = gsl::at(values, deriv)[component];
+    }
+  }
+  return result;
+}
+
+std::array<std::array<double, 3>, 3> extract_translation_func_and_2_derivs(
+    const domain::FunctionsOfTimeMap& functions_of_time, const double time) {
+  const auto function_of_time = functions_of_time.find("Translation");
+  if (function_of_time == functions_of_time.end()) {
+    ERROR("Translation function of time could not be found at "
+          << "time " << time << "M.");
+  }
+  const auto values = function_of_time->second->func_and_2_derivs(time);
+  std::array<std::array<double, 3>, 3> result{};
+  for (size_t deriv = 0; deriv < values.size(); ++deriv) {
+    auto& result_deriv = gsl::at(result, deriv);
+    for (size_t component = 0; component < 3; ++component) {
+      gsl::at(result_deriv, component) = gsl::at(values, deriv)[component];
+    }
+  }
+  return result;
+}
+}  // namespace
 
 namespace evolution::Ringdown {
 std::pair<std::vector<DataVector>, std::vector<std::array<double, 3>>>
@@ -60,80 +111,6 @@ strahlkorper_coefs_and_centers(
     }
   }
 
-  // Create a time-dependent domain; only the the time-dependent map options
-  // matter; the domain is just a spherical shell with inner and outer
-  // radii chosen so any conceivable common horizon will fit between them.
-  const auto expansion_map_options =
-      exp_func_and_2_derivs.has_value()
-          ? domain::creators::time_dependent_options::ExpansionMapOptions<
-                true>{exp_func_and_2_derivs.value(), settling_timescale,
-                      exp_outer_bdry_func_and_2_derivs.value(),
-                      settling_timescale}
-          : std::optional<domain::creators::time_dependent_options::
-                              ExpansionMapOptions<true>>{};
-  const auto rotation_map_options =
-      rot_func_and_2_derivs.has_value()
-          ? domain::creators::time_dependent_options::RotationMapOptions<
-                true>{rot_func_and_2_derivs.value(), settling_timescale}
-          : std::optional<domain::creators::time_dependent_options::
-                              RotationMapOptions<true>>{};
-  const auto& translation_fot_from_volume =
-      trans_func_and_2_derivs.has_value()
-          ? domain::creators::time_dependent_options::FromVolumeFile(
-                path_to_volume_data, volume_subfile_name, true)
-          : std::optional<
-                domain::creators::time_dependent_options::FromVolumeFile>{};
-  const domain::creators::sphere::TimeDependentMapOptions
-      time_dependent_map_options{match_time,
-                                 std::nullopt,
-                                 rotation_map_options,
-                                 expansion_map_options,
-                                 translation_fot_from_volume,
-                                 true};
-  // We construct a temporary ringdown domain that will be used to transform the
-  // common horizon from the inspiral inertial frame to the temporary frame
-  // (ringdown intermediate frame in SpEC) for shape coefficients and then from
-  // the temporary frame to the inertial frame for geometric center positions
-  // for the ringdown translation map. We choose an inner radius at machine
-  // precision so that every point on any Strahlkorper transformed to this
-  // temporary ringdown domain will be mapped to a block. It's assumed that the
-  // Strahlkorper has not translated beyond 200M and has a radius < 200M in the
-  // inertial frame. The resolution on this domain does not matter because the
-  // actual grid points in the temporary ringdown domain are never used. We are
-  // only after how the shape coefficients and center changes as you transform
-  // the Strahlkorper to this temporary ringdown domain. The only member
-  // functions of the domain that are used are the coordinate maps (and
-  // associated functions of time) that map the "grid frame" of the temporary
-  // ringdown domain to the inertial frame of the temporary ringdown domain. The
-  // "grid frame" of the temporary ringdown domain is the inertial frame pushed
-  // through the inverse-rotation-expansion-translation map, where "translation"
-  // is the inspiral's translation map, and "rotation" and "expansion" are new
-  // rotation and expansion maps that match the inspiral's rotation and
-  // expansion at the outer boundary at the transition time, have some smooth
-  // falloff in the interior, and have a "settle to constant" time dependence.
-  // Thus the "grid frame" of the temporary domain is almost (except for an
-  // uncorrected translation map) the distorted frame of the ringdown. The
-  // "almost" is because in the "grid frame" of the temporary ringdown domain,
-  // the center of the excision boundary moves, and is not at the origin.
-  const domain::creators::Sphere domain_creator{
-      // Inner radius and outer radius chosen so that every point on a
-      // strahlkorper transformed to this domain will be mapped to a block.
-      std::numeric_limits<double>::epsilon(),
-      200.0,
-      // nullptr because no boundary condition
-      domain::creators::Sphere::Excision{nullptr},
-      static_cast<size_t>(0),
-      static_cast<size_t>(5),
-      false,
-      std::nullopt,
-      // Radial partition used to separate Shell0/1 in the ringdown domain.
-      // This value is what is currently used in the Bbh pipeline
-      {50.0},
-      domain::CoordinateMaps::Distribution::Linear,
-      ShellWedges::All,
-      time_dependent_map_options};
-  const auto temporary_ringdown_domain = domain_creator.create_domain();
-  const auto ringdown_functions_of_time = domain_creator.functions_of_time();
   // Loop over the selected horizons, transforming each to the
   // temporary frame
   std::vector<DataVector> ahc_ringdown_distorted_coefs{};
@@ -152,10 +129,112 @@ strahlkorper_coefs_and_centers(
   ylm::Strahlkorper<Frame::Grid> distorted_ahc;
   for (size_t i = 0; i < requested_number_of_times_from_end; ++i) {
     if (gsl::at(ahc_times, i) <= match_time) {
+      const h5::H5File<h5::AccessType::ReadOnly> volume_file{
+          path_to_volume_data};
+      const auto& volume_data =
+          volume_file.get<h5::VolumeData>(volume_subfile_name);
+
+      const size_t obs_id_at_ahc_time =
+          volume_data.find_observation_id(gsl::at(ahc_times, i), 1e-12);
+
+      const auto serialized_inspiral_functions_of_time =
+          volume_data.get_functions_of_time(obs_id_at_ahc_time);
+      if (not serialized_inspiral_functions_of_time.has_value()) {
+        ERROR(
+            "No functions of time found in volume files at the specified "
+            "time "
+            << gsl::at(ahc_times, i) << "M.");
+      }
+      const auto inspiral_functions_of_time =
+          deserialize<domain::FunctionsOfTimeMap>(
+              serialized_inspiral_functions_of_time->data());
+
+      const auto expansion_map_options_from_volume =
+          exp_outer_bdry_func_and_2_derivs.has_value()
+              ? domain::creators::time_dependent_options::ExpansionMapOptions<
+                    true>{exp_func_and_2_derivs.value(), settling_timescale,
+                          extract_expansion_outer_boundary_func_and_2_derivs(
+                              inspiral_functions_of_time,
+                              gsl::at(ahc_times, i)),
+                          settling_timescale}
+              : std::optional<domain::creators::time_dependent_options::
+                                  ExpansionMapOptions<true>>{};
+      const auto rotation_map_options_from_volume =
+          rot_func_and_2_derivs.has_value()
+              ? domain::creators::time_dependent_options::RotationMapOptions<
+                    true>{extract_rotation_func_and_2_derivs(
+                              inspiral_functions_of_time,
+                              gsl::at(ahc_times, i)),
+                          settling_timescale}
+              : std::optional<domain::creators::time_dependent_options::
+                                  RotationMapOptions<true>>{};
+      const auto translation_map_options_from_volume =
+          trans_func_and_2_derivs.has_value()
+              ? domain::creators::time_dependent_options::TranslationMapOptions<
+                    3>{extract_translation_func_and_2_derivs(
+                    inspiral_functions_of_time, gsl::at(ahc_times, i))}
+              : std::optional<domain::creators::time_dependent_options::
+                                  TranslationMapOptions<3>>{};
+
+      const domain::creators::sphere::TimeDependentMapOptions
+          time_dependent_map_options{gsl::at(ahc_times, i),
+                                     std::nullopt,
+                                     rotation_map_options_from_volume,
+                                     expansion_map_options_from_volume,
+                                     translation_map_options_from_volume,
+                                     true};
+      // We construct a temporary ringdown domain that will be used to transform
+      // the common horizon from the inspiral inertial frame to the temporary
+      // frame (ringdown intermediate frame in SpEC) for shape coefficients and
+      // then from the temporary frame to the inertial frame for geometric
+      // center positions for the ringdown translation map. We choose an inner
+      // radius at machine precision so that every point on any Strahlkorper
+      // transformed to this temporary ringdown domain will be mapped to a
+      // block. It's assumed that the Strahlkorper has not translated beyond
+      // 200M and has a radius < 200M in the inertial frame. The resolution on
+      // this domain does not matter because the actual grid points in the
+      // temporary ringdown domain are never used. We are only after how the
+      // shape coefficients and center changes as you transform the Strahlkorper
+      // to this temporary ringdown domain. The only member functions of the
+      // domain that are used are the coordinate maps (and associated functions
+      // of time) that map the "grid frame" of the temporary ringdown domain to
+      // the inertial frame of the temporary ringdown domain. The "grid frame"
+      // of the temporary ringdown domain is the inertial frame pushed through
+      // the inverse-rotation-expansion-translation map, where "translation" is
+      // the inspiral's translation map, and "rotation" and "expansion" are new
+      // rotation and expansion maps that match the inspiral's rotation and
+      // expansion at the outer boundary at the transition time, have some
+      // smooth falloff in the interior, and have a "settle to constant" time
+      // dependence. Thus the "grid frame" of the temporary domain is almost
+      // (except for an uncorrected translation map) the distorted frame of the
+      // ringdown. The "almost" is because in the "grid frame" of the temporary
+      // ringdown domain, the center of the excision boundary moves, and is not
+      // at the origin.
+      const domain::creators::Sphere domain_creator_non_replay{
+          // Inner radius and outer radius chosen so that every point on a
+          // strahlkorper transformed to this domain will be mapped to a block.
+          std::numeric_limits<double>::epsilon(),
+          200.0,
+          // nullptr because no boundary condition
+          domain::creators::Sphere::Excision{nullptr},
+          static_cast<size_t>(0),
+          static_cast<size_t>(5),
+          false,
+          std::nullopt,
+          // Radial partition used to separate Shell0/1 in the ringdown domain.
+          // This value is what is currently used in the Bbh pipeline
+          {50.0},
+          domain::CoordinateMaps::Distribution::Linear,
+          ShellWedges::All,
+          time_dependent_map_options};
+      const auto temporary_ringdown_domain_non_replay =
+          domain_creator_non_replay.create_domain();
+      const auto ringdown_functions_of_time_non_replay =
+          domain_creator_non_replay.functions_of_time();
       strahlkorper_in_different_frame(
           make_not_null(&distorted_ahc), gsl::at(ahc_inertial_h5, i),
-          temporary_ringdown_domain, ringdown_functions_of_time,
-          gsl::at(ahc_times, i));
+          temporary_ringdown_domain_non_replay,
+          ringdown_functions_of_time_non_replay, gsl::at(ahc_times, i));
       // Relative tolerance is set to the value used in SpEC
       ylm::change_expansion_center_of_strahlkorper_to_physical(
           make_not_null(&distorted_ahc), expansion_center_tolerance);
@@ -172,10 +251,10 @@ strahlkorper_coefs_and_centers(
       // center of AhC accounts for the inspiral's rotation, scaling and
       // translation. This ensures that the center of the excision is at the
       // correct location at the match time
-      coords_to_different_frame(make_not_null(&inertial_center_point),
-                                grid_center_point, temporary_ringdown_domain,
-                                ringdown_functions_of_time,
-                                gsl::at(ahc_times, i));
+      coords_to_different_frame(
+          make_not_null(&inertial_center_point), grid_center_point,
+          temporary_ringdown_domain_non_replay,
+          ringdown_functions_of_time_non_replay, gsl::at(ahc_times, i));
 
       ahc_inertial_centers.push_back(std::array<double, 3>{
           get<0>(inertial_center_point)[0], get<1>(inertial_center_point)[0],

--- a/tests/Unit/Evolution/Ringdown/Test_StrahlkorperCoefsAndCenters.cpp
+++ b/tests/Unit/Evolution/Ringdown/Test_StrahlkorperCoefsAndCenters.cpp
@@ -54,6 +54,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Ringdown.StrahlkorperCoefsAndCenters",
   // First, if the temporary file exists, remove it
   const std::string horizons_file_name{"Unit.Evolution.Ringdown.SCoefsRDis.h5"};
   const std::string horizons_subfile_name{"/ObservationAhC__Ylm.dat"};
+  const std::string volume_file_name{"BbhVolume1.h5"};
+  const std::string volume_file_subfile_name{"ForContinuation"};
   if (file_system::check_if_file_exists(horizons_file_name)) {
     file_system::rm(horizons_file_name, true);
   }
@@ -214,11 +216,11 @@ SPECTRE_TEST_CASE("Unit.Evolution.Ringdown.StrahlkorperCoefsAndCenters",
   auto serialized_fots_bco = serialize(functions_of_time_bco);
   auto serialized_domain_bco = serialize(domain_bco);
 
-  if (file_system::check_if_file_exists("BbhVolume0.h5")) {
-    file_system::rm("BbhVolume0.h5", true);
+  if (file_system::check_if_file_exists(volume_file_name)) {
+    file_system::rm(volume_file_name, true);
   }
-  h5::H5File<h5::AccessType::ReadWrite> h5_file{"BbhVolume0.h5", true};
-  auto& vol_file = h5_file.insert<h5::VolumeData>("ForContinuation");
+  h5::H5File<h5::AccessType::ReadWrite> h5_file{volume_file_name, true};
+  auto& vol_file = h5_file.insert<h5::VolumeData>(volume_file_subfile_name);
 
   for (size_t i = 0; i < times.size(); i++) {
     vol_file.write_volume_data(
@@ -238,7 +240,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Ringdown.StrahlkorperCoefsAndCenters",
   const std::pair<std::vector<DataVector>, std::vector<std::array<double, 3>>>
       distorted_and_translation_coefs =
           evolution::Ringdown::strahlkorper_coefs_and_centers(
-              "BbhVolume0.h5", "ForContinuation", horizons_file_name,
+              volume_file_name, volume_file_subfile_name, horizons_file_name,
               horizons_subfile_name, times_to_retrieve, match_time,
               settling_timescale, exp_func_and_2_derivs,
               exp_outer_bdry_func_and_2_derivs, rot_func_and_2_derivs);
@@ -260,5 +262,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Ringdown.StrahlkorperCoefsAndCenters",
 
   if (file_system::check_if_file_exists(horizons_file_name)) {
     file_system::rm(horizons_file_name, true);
+  }
+  if (file_system::check_if_file_exists(volume_file_name)) {
+    file_system::rm(volume_file_name, true);
   }
 }


### PR DESCRIPTION
## Proposed changes

This changes the StrahlkorperCoefsAndCenters to find the functions of time at each observation AhC time and creates a new domain each time instead of replaying functions of time. This fixes the time precedes earliest problem I was running into with the ringdown. This change has been tested and works for q=1, q=2, q=3 ringdowns.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
-->