### PR TITLE
Disable -Og by default

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -347,6 +347,7 @@ jobs:
           -D OVERRIDE_ARCH=x86-64
           -D CHARM_ROOT=${CHARM_ROOT}
           -D CMAKE_BUILD_TYPE=Debug
+          -D SPECTRE_DEBUG_Og=ON
           -D DEBUG_SYMBOLS=OFF
           -D USE_PCH=ON
           -D USE_XSIMD=ON
@@ -742,6 +743,7 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
           -D ENABLE_WARNINGS=${ENABLE_WARNINGS:-'ON'}
           -D CHARM_ROOT=${MATRIX_CHARM_ROOT:-$CHARM_ROOT}
           -D CMAKE_BUILD_TYPE=${{ matrix.build_type }}
+          -D SPECTRE_DEBUG_Og=ON
           -D DEBUG_SYMBOLS=OFF
           -D BACKTRACE_LIB=/usr/local/lib/libbacktrace.a
           -D BACKTRACE_HEADER_DIR=/usr/local/include
@@ -961,6 +963,7 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
           -D BUILD_SHARED_LIBS=ON
           -D CHARM_ROOT=${MATRIX_CHARM_ROOT:-$CHARM_ROOT}
           -D CMAKE_BUILD_TYPE=${{ matrix.build_type }}
+          -D SPECTRE_DEBUG_Og=ON
           -D DEBUG_SYMBOLS=OFF
           -D UNIT_TESTS_IN_TEST_EXECUTABLES=OFF
           -D STRIP_SYMBOLS=ON
@@ -1172,6 +1175,7 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
             -D BLAS_ROOT=$(brew --prefix openblas) \
             -D LAPACK_ROOT=$(brew --prefix openblas) \
             -D CMAKE_BUILD_TYPE=Debug \
+            -D SPECTRE_DEBUG_Og=ON \
             -D DEBUG_SYMBOLS=OFF \
             -D UNIT_TESTS_IN_TEST_EXECUTABLES=OFF \
             -D STUB_EXECUTABLE_OBJECT_FILES=ON \
@@ -1432,6 +1436,7 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
             -D OVERRIDE_ARCH=${OVERRIDE_ARCH}\
             -D CHARM_ROOT=${CHARM_ROOT}\
             -D CMAKE_BUILD_TYPE=Debug\
+            -D SPECTRE_DEBUG_Og=ON\
             -D DEBUG_SYMBOLS=OFF\
             -D STRIP_SYMBOLS=ON\
             -D STUB_EXECUTABLE_OBJECT_FILES=ON\

--- a/cmake/SetupCxxFlags.cmake
+++ b/cmake/SetupCxxFlags.cmake
@@ -18,7 +18,7 @@ endif()
 option(SPECTRE_OPTIMIZE_SIZE "Optimize for executable size instead of speed"
   ${_SPECTRE_OPTIMIZE_SIZE_DEFAULT})
 
-option(SPECTRE_DEBUG_Og "Compile Debug builds with -Og instead of -O0" ON)
+option(SPECTRE_DEBUG_Og "Compile Debug builds with -Og instead of -O0" OFF)
 
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
   set(SPECTRE_DEBUG ON)


### PR DESCRIPTION
Turns out -Og causes a large slowdown with clang, particularly when debug symbols are enabled, so disable it for developers.  Enable it explicitly in CI.

Timing results for building EvolveGhBinaryBlackHole.cpp.o with various settings at some arbitrary commit on my local branch are below.  (With PCH enabled.)

Compiler      | opt | build time (s) | object size (bytes)
--------------|-----|---------------:|--------------------:
gcc           | O0  |  380           |  666563600
gcc           | O1  |  763           |  258895032
gcc           | O2  | 1076          |   237605192
gcc           | O3  | 1333          |   243907896
gcc           | Og  |  673           |  482773776
gcc           | Oz  |  729           |  253410208
clang         | O0  |  268           |  491724704
clang         | O1  |  514           |  283036696
clang         | O2  |  575           |  283744728
clang         | O3  |  583           |  283762736
clang         | Og  |  523           |  284986424
clang         | Oz  |  406           |  383962648
clang symbols | O0  |  288           | 1054000424
clang symbols | O1  |  678           | 1032174680
clang symbols | O2  |  745           | 1047236088
clang symbols | O3  |  766           | 1061041656
clang symbols | Og  |  686           | 1031521088
clang symbols | Oz  |  485           |  947809256

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
