### PR TITLE
Perform SWSH transforms of all required weights

### DIFF
--- a/src/NumericalAlgorithms/SpinWeightedSphericalHarmonics/SwshTags.hpp
+++ b/src/NumericalAlgorithms/SpinWeightedSphericalHarmonics/SwshTags.hpp
@@ -251,13 +251,17 @@ struct SwshInterpolator : db::SimpleTag, db::PrefixTag {
 }  // namespace Tags
 
 namespace detail {
-// implementation for get_tags_with_spin
 template <typename Tag, typename S>
 struct has_spin : std::bool_constant<Tag::type::type::spin == S::value> {};
 
-template <typename PrefixTag, typename S>
-struct wrapped_has_spin : has_spin<typename PrefixTag::tag, S> {};
+template <typename TagList>
+struct spins_in_tag_list;
 
+template <typename... Tags>
+struct spins_in_tag_list<tmpl::list<Tags...>> {
+  using type = tmpl::sort<tmpl::remove_duplicates<
+      tmpl::list<std::integral_constant<int, Tags::type::type::spin>...>>>;
+};
 }  // namespace detail
 
 /// \ingroup SwshGroup
@@ -272,23 +276,21 @@ using coefficient_buffer_tags_for_derivative_tag = tmpl::list<
     Spectral::Swsh::Tags::SwshTransform<DerivativeTag>>;
 
 /// \ingroup SwshGroup
-/// \brief Extract from `TagList` the subset of those tags that have a static
-/// int member `spin` equal to the template parameter `Spin`.
+/// \brief Get a list of distinct spins appearing in `TagList`.
 ///
-/// \snippet Test_SwshTags.cpp get_tags_with_spin
-template <int Spin, typename TagList>
-using get_tags_with_spin = tmpl::remove_duplicates<tmpl::filter<
-    TagList, detail::has_spin<tmpl::_1, std::integral_constant<int, Spin>>>>;
+/// \snippet Test_SwshTags.cpp spins_in_tag_list
+template <typename TagList>
+using spins_in_tag_list = typename detail::spins_in_tag_list<TagList>::type;
 
 /// \ingroup SwshGroup
-/// \brief Extract from `TagList` the subset of  those tags that wrap a tag
-/// that has a static int member `spin` equal to the template parameter `Spin`.
+/// \brief Partition `TagList` into lists with the same spin.
 ///
-/// \snippet Test_SwshTags.cpp get_prefix_tags_that_wrap_tags_with_spin
-template <int Spin, typename TagList>
-using get_prefix_tags_that_wrap_tags_with_spin =
-    tmpl::filter<TagList, tmpl::bind<detail::wrapped_has_spin, tmpl::_1,
-                                     std::integral_constant<int, Spin>>>;
-
+/// \snippet Test_SwshTags.cpp partition_tags_by_spin
+template <typename TagList>
+using partition_tags_by_spin = tmpl::transform<
+    spins_in_tag_list<TagList>,
+    tmpl::lazy::filter<
+        tmpl::pin<TagList>,
+        tmpl::defer<detail::has_spin<tmpl::_1, tmpl::parent<tmpl::_1>>>>>;
 }  // namespace Swsh
 }  // namespace Spectral

--- a/src/NumericalAlgorithms/SpinWeightedSphericalHarmonics/SwshTransform.hpp
+++ b/src/NumericalAlgorithms/SpinWeightedSphericalHarmonics/SwshTransform.hpp
@@ -684,39 +684,21 @@ void inverse_swsh_transform_impl(
                        l_max, number_of_radial_points);
 }
 
-// A metafunction for binning a provided tag list into `SwshTransform` objects
-// according to spin-weight
-template <int MinSpin, ComplexRepresentation Representation, typename TagList,
-          typename IndexSequence>
+template <ComplexRepresentation Representation, typename PartitionedTagList>
 struct make_transform_list_impl;
 
-template <int MinSpin, ComplexRepresentation Representation, typename TagList,
-          int... Is>
-struct make_transform_list_impl<MinSpin, Representation, TagList,
-                                std::integer_sequence<int, Is...>> {
-  using type = tmpl::flatten<tmpl::list<tmpl::conditional_t<
-      not std::is_same_v<get_tags_with_spin<Is + MinSpin, TagList>,
-                         tmpl::list<>>,
-      SwshTransform<get_tags_with_spin<Is + MinSpin, TagList>, Representation>,
-      tmpl::list<>>...>>;
+template <ComplexRepresentation Representation, typename... Partition>
+struct make_transform_list_impl<Representation, tmpl::list<Partition...>> {
+  using type = tmpl::list<SwshTransform<Partition, Representation>...>;
 };
 
-// A metafunction for binning a provided tag list into `InverseSwshTransform`
-// objects according to spin-weight
-template <int MinSpin, ComplexRepresentation Representation, typename TagList,
-          typename IndexSequence>
+template <ComplexRepresentation Representation, typename PartitionedTagList>
 struct make_inverse_transform_list_impl;
 
-template <int MinSpin, ComplexRepresentation Representation, typename TagList,
-          int... Is>
-struct make_inverse_transform_list_impl<MinSpin, Representation, TagList,
-                                        std::integer_sequence<int, Is...>> {
-  using type = tmpl::flatten<tmpl::list<tmpl::conditional_t<
-      not std::is_same_v<get_tags_with_spin<Is + MinSpin, TagList>,
-                         tmpl::list<>>,
-      InverseSwshTransform<get_tags_with_spin<Is + MinSpin, TagList>,
-                           Representation>,
-      tmpl::list<>>...>>;
+template <ComplexRepresentation Representation, typename... Partition>
+struct make_inverse_transform_list_impl<Representation,
+                                        tmpl::list<Partition...>> {
+  using type = tmpl::list<InverseSwshTransform<Partition, Representation>...>;
 };
 }  // namespace detail
 
@@ -727,24 +709,15 @@ struct make_inverse_transform_list_impl<MinSpin, Representation, TagList,
 /// transformed. The `Representation` is the
 /// `Spectral::Swsh::ComplexRepresentation` to use for the transformations.
 ///
-/// \details Up to five `SwshTransform`s or `InverseSwshTransform`s will be
-/// returned, corresponding to the possible spin values. Any number of
-/// transformations are aggregated into that set of `SwshTransform`s (or
-/// `InverseSwshTransform`s). The number of transforms is up to five because the
-/// libsharp utility only has capability to perform spin-weighted spherical
-/// harmonic transforms for integer spin-weights from -2 to 2.
-///
 /// \snippet Test_SwshTransform.cpp make_transform_list
 template <ComplexRepresentation Representation, typename TagList>
 using make_transform_list = typename detail::make_transform_list_impl<
-    -2, Representation, TagList,
-    decltype(std::make_integer_sequence<int, 5>{})>::type;
+    Representation, partition_tags_by_spin<TagList>>::type;
 
 template <ComplexRepresentation Representation, typename TagList>
 using make_inverse_transform_list =
     typename detail::make_inverse_transform_list_impl<
-        -2, Representation, TagList,
-        decltype(std::make_integer_sequence<int, 5>{})>::type;
+        Representation, partition_tags_by_spin<TagList>>::type;
 /// @}
 
 /// \ingroup SwshGroup
@@ -759,12 +732,10 @@ using make_inverse_transform_list =
 ///
 /// \snippet Test_SwshTransform.cpp make_transform_from_derivative_tags
 template <ComplexRepresentation Representation, typename DerivativeTagList>
-using make_transform_list_from_derivative_tags =
-    typename detail::make_transform_list_impl<
-        -2, Representation,
-        tmpl::transform<DerivativeTagList,
-                        tmpl::bind<db::remove_tag_prefix, tmpl::_1>>,
-        decltype(std::make_integer_sequence<int, 5>{})>::type;
+using make_transform_list_from_derivative_tags = make_transform_list<
+    Representation,
+    tmpl::remove_duplicates<tmpl::transform<
+        DerivativeTagList, tmpl::bind<db::remove_tag_prefix, tmpl::_1>>>>;
 
 /// \ingroup SwshGroup
 /// \brief Convert spin-weighted spherical harmonic data to a new set of

--- a/tests/Unit/NumericalAlgorithms/SpinWeightedSphericalHarmonics/Test_SwshTags.cpp
+++ b/tests/Unit/NumericalAlgorithms/SpinWeightedSphericalHarmonics/Test_SwshTags.cpp
@@ -56,14 +56,38 @@ static_assert(
         Derivative<Spin2TestTag, EthEthbar>>,
     "failed testing SwshTransform");
 
-// [get_tags_with_spin]
+namespace test_spins_in_tag_list {
+// [spins_in_tag_list]
 using TestVarTagList = tmpl::list<SpinMinus1TestTag, SpinMinus1TestTag,
-                                  AnotherSpinMinus1TestTag, Spin2TestTag>;
+                                  Spin2TestTag, AnotherSpinMinus1TestTag>;
+
+static_assert(std::is_same_v<spins_in_tag_list<TestVarTagList>,
+                             tmpl::list<std::integral_constant<int, -1>,
+                                        std::integral_constant<int, 2>>>);
+
+using TestDerivativeTagList =
+    tmpl::list<Derivative<SpinMinus1TestTag, Eth>,
+               Derivative<SpinMinus1TestTag, EthEthbar>,
+               Derivative<AnotherSpinMinus1TestTag, EthEth>,
+               Derivative<Spin2TestTag, Ethbar>>;
+
+static_assert(std::is_same_v<spins_in_tag_list<TestDerivativeTagList>,
+                             tmpl::list<std::integral_constant<int, -1>,
+                                        std::integral_constant<int, 0>,
+                                        std::integral_constant<int, 1>>>);
+// [spins_in_tag_list]
+}  // namespace test_spins_in_tag_list
+
+namespace test_partition_tags_by_spin {
+// [partition_tags_by_spin]
+using TestVarTagList = tmpl::list<SpinMinus1TestTag, SpinMinus1TestTag,
+                                  Spin2TestTag, AnotherSpinMinus1TestTag>;
 
 static_assert(
-    std::is_same_v<get_tags_with_spin<-1, TestVarTagList>,
-                   tmpl::list<SpinMinus1TestTag, AnotherSpinMinus1TestTag>>,
-    "failed testing get_tags_with_spin");
+    std::is_same_v<partition_tags_by_spin<TestVarTagList>,
+                   tmpl::list<tmpl::list<SpinMinus1TestTag, SpinMinus1TestTag,
+                                         AnotherSpinMinus1TestTag>,
+                              tmpl::list<Spin2TestTag>>>);
 
 using TestDerivativeTagList =
     tmpl::list<Derivative<SpinMinus1TestTag, Eth>,
@@ -72,24 +96,14 @@ using TestDerivativeTagList =
                Derivative<Spin2TestTag, Ethbar>>;
 
 static_assert(
-    std::is_same_v<get_tags_with_spin<1, TestDerivativeTagList>,
+    std::is_same_v<
+        partition_tags_by_spin<TestDerivativeTagList>,
+        tmpl::list<tmpl::list<Derivative<SpinMinus1TestTag, EthEthbar>>,
+                   tmpl::list<Derivative<SpinMinus1TestTag, Eth>>,
                    tmpl::list<Derivative<AnotherSpinMinus1TestTag, EthEth>,
-                              Derivative<Spin2TestTag, Ethbar>>>,
-    "failed testing get_tags_with_spin");
-// [get_tags_with_spin]
-
-// [get_prefix_tags_that_wrap_tags_with_spin]
-using WrappedTagList = tmpl::list<Derivative<SpinMinus1TestTag, Eth>,
-                                  Derivative<SpinMinus1TestTag, EthEthbar>,
-                                  Derivative<AnotherSpinMinus1TestTag, EthEth>,
-                                  Derivative<Spin2TestTag, Ethbar>>;
-static_assert(
-    std::is_same_v<get_prefix_tags_that_wrap_tags_with_spin<-1, WrappedTagList>,
-                   tmpl::list<Derivative<SpinMinus1TestTag, Eth>,
-                              Derivative<SpinMinus1TestTag, EthEthbar>,
-                              Derivative<AnotherSpinMinus1TestTag, EthEth>>>,
-    "failed testing get_wrapped_tags_with_spin_from_prefix_tag_list");
-// [get_prefix_tags_that_wrap_tags_with_spin]
+                              Derivative<Spin2TestTag, Ethbar>>>>);
+// [partition_tags_by_spin]
+}  // namespace test_partition_tags_by_spin
 
 SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Spectral.Tags",
                   "[Unit][NumericalAlgorithms]") {

--- a/tests/Unit/NumericalAlgorithms/SpinWeightedSphericalHarmonics/Test_SwshTransform.cpp
+++ b/tests/Unit/NumericalAlgorithms/SpinWeightedSphericalHarmonics/Test_SwshTransform.cpp
@@ -42,17 +42,17 @@ using TestDerivativeTagList =
     tmpl::list<Tags::Derivative<TestTag<0, -1>, Tags::Eth>,
                Tags::Derivative<TestTag<0, -1>, Tags::EthEthbar>,
                Tags::Derivative<TestTag<1, -1>, Tags::EthEthbar>,
-               Tags::Derivative<TestTag<0, 2>, Tags::EthbarEthbar>>;
+               Tags::Derivative<TestTag<0, 2>, Tags::EthEth>>;
 
 // [make_transform_list]
 using ExpectedInverseTransforms = tmpl::list<
     SwshTransform<tmpl::list<Tags::Derivative<TestTag<0, -1>, Tags::EthEthbar>,
                              Tags::Derivative<TestTag<1, -1>, Tags::EthEthbar>>,
                   ComplexRepresentation::RealsThenImags>,
-    SwshTransform<
-        tmpl::list<Tags::Derivative<TestTag<0, -1>, Tags::Eth>,
-                   Tags::Derivative<TestTag<0, 2>, Tags::EthbarEthbar>>,
-        ComplexRepresentation::RealsThenImags>>;
+    SwshTransform<tmpl::list<Tags::Derivative<TestTag<0, -1>, Tags::Eth>>,
+                  ComplexRepresentation::RealsThenImags>,
+    SwshTransform<tmpl::list<Tags::Derivative<TestTag<0, 2>, Tags::EthEth>>,
+                  ComplexRepresentation::RealsThenImags>>;
 
 static_assert(
     std::is_same_v<make_transform_list<ComplexRepresentation::RealsThenImags,


### PR DESCRIPTION
This previously had a bug where fields of weight larger than 2 in magnitude would be ignored.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
