### PR TITLE
Support using an outer spherical shell for CBCO wavezone

### DIFF
--- a/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
+++ b/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
@@ -13,9 +13,11 @@
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.tpp"
 #include "Domain/CoordinateMaps/DiscreteRotation.hpp"
+#include "Domain/CoordinateMaps/Identity.hpp"
 #include "Domain/CoordinateMaps/Interval.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
+#include "Domain/CoordinateMaps/SphericalToCartesianPfaffian.hpp"
 #include "Domain/CoordinateMaps/UniformCylindricalEndcap.hpp"
 #include "Domain/CoordinateMaps/UniformCylindricalFlatEndcap.hpp"
 #include "Domain/CoordinateMaps/UniformCylindricalSide.hpp"
@@ -184,13 +186,15 @@ CylindricalBinaryCompactObject::CylindricalBinaryCompactObject(
                 0.5 * (std::abs(z_cutting_plane_ - center_B_[2]) - radius_B_)
           : radius_B_;
 
-  number_of_blocks_ = 64;
+  number_of_blocks_ = 46;
   if (include_inner_sphere_A) {
     number_of_blocks_ += 14;
   }
   if (include_inner_sphere_B) {
     number_of_blocks_ += 14;
   }
+  // Outer sphere
+  number_of_blocks_ += 1;
 
   // Add SphereE blocks if necessary.  Note that
   // https://arxiv.org/abs/1206.3015 has a mistake just above
@@ -295,27 +299,78 @@ CylindricalBinaryCompactObject::CylindricalBinaryCompactObject(
     add_cylinder_name("InnerSphereEB", "InnerSphereB");
     first_outer_shell_block += 14;
   }
-  // 5 blocks
-  add_filled_cylinder_name("OuterSphereCA", "OuterSphere");
-  // 5 blocks
-  add_filled_cylinder_name("OuterSphereCB", "OuterSphere");
-  // 4 blocks
-  add_cylinder_name("OuterSphereCA", "OuterSphere");
-  // 4 blocks
-  add_cylinder_name("OuterSphereCB", "OuterSphere");
+  const std::string name = "OuterShell0";
+  const std::string group_name = "OuterSphere";
+  block_names_.push_back(name);
+  block_groups_[group_name].insert(name);
 
   // Expand initial refinement over all blocks
   const ExpandOverBlocks<std::array<size_t, 3>> expand_over_blocks{
       block_names_, block_groups_};
   try {
-    initial_refinement_ = std::visit(expand_over_blocks, initial_refinement);
+    initial_refinement_ = std::visit(
+        [this, &expand_over_blocks]<typename V>(
+            const V& v) -> std::vector<std::array<size_t, 3>> {
+          if constexpr (std::is_same_v<V, size_t>) {
+            std::vector<std::array<size_t, 3>> expanded = expand_over_blocks(v);
+
+            // If one size_t was used to globally define refinement throughout
+            // the domain, overwrite the refinement levels to be 0 just for the
+            // angular directions of the outer spherical shell since angular
+            // refinement doesn't make since for blocks with spherical
+            // harmonics. This allows the user to still easily specify a global
+            // refinement level instead of having to manually specify the same
+            // refinement for all directions of all block groups with the same
+            // number except zero for only these two.
+            expanded[first_outer_shell_block][1] = 0;
+            expanded[first_outer_shell_block][2] = 0;
+
+            return expanded;
+          } else {
+            (void)first_outer_shell_block;
+            return expand_over_blocks(v);
+          }
+        },
+        initial_refinement);
+
   } catch (const std::exception& error) {
     PARSE_ERROR(context, "Invalid 'InitialRefinement': " << error.what());
   }
+  if (gsl::at(initial_refinement_, first_outer_shell_block)[1] != 0 or
+      gsl::at(initial_refinement_, first_outer_shell_block)[2] != 0) {
+    PARSE_ERROR(context,
+                "Angular h-refinement is not supported for "
+                "spherical-harmonic outer-shell blocks. Specify refinement "
+                "as [radial_refinement, 0, 0].");
+  }
+
+  size_t outer_sphere_l_max = 0;
+  size_t outer_sphere_m_max = 0;
   try {
     initial_grid_points_ = std::visit(expand_over_blocks, initial_grid_points);
+
+    outer_sphere_l_max =
+        initial_grid_points_[first_outer_shell_block][1];
+    outer_sphere_m_max = initial_grid_points_[first_outer_shell_block][2];
+
+    // For spherical-harmonic outer-shell blocks, initial_number_of_grid_points_
+    // stores {n_radial, l_max, m_max}. Convert (l_max, m_max) to the number of
+    // collocation points the spherical-harmonic basis uses in each angular
+    // direction.
+    initial_grid_points_[first_outer_shell_block][1] =
+        ylm::Spherepack::n_theta_points(outer_sphere_l_max);
+    initial_grid_points_[first_outer_shell_block][2] =
+        ylm::Spherepack::n_phi_points(outer_sphere_m_max);
   } catch (const std::exception& error) {
     PARSE_ERROR(context, "Invalid 'InitialGridPoints': " << error.what());
+  }
+  // A spherical-harmonic shell is fully specified by a single ell, so
+  // l_max must equal m_max.
+  if (outer_sphere_l_max != outer_sphere_m_max) {
+    PARSE_ERROR(
+        context,
+        "Spherical-harmonic outer-shell blocks must have L_max = M_max. "
+        "Specify grid points as [radial_points, L_max, L_max].");
   }
 
   // Now we must change the initial refinement and initial grid points
@@ -379,9 +434,6 @@ CylindricalBinaryCompactObject::CylindricalBinaryCompactObject(
       swap_refinement_and_grid_points_xi_zeta(current_block++);
     }
     current_block += 4;
-  }
-  for (size_t block = 0; block < 10; ++block) {
-    swap_refinement_and_grid_points_xi_zeta(current_block++);
   }
 
   // Build time-dependent maps
@@ -771,37 +823,6 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const {
             -z_cut_EB_upper, -z_cut_EB_lower),
         CoordinateMaps::DiscreteRotation<3>(rotate_to_minus_x_axis));
   }
-  const double z_cut_CA_outer = 0.7 * outer_radius_;
-  const double z_cut_CB_outer = -0.7 * outer_radius_;
-  // OuterCA Filled Cylinder
-  // 5 blocks
-  add_endcap_to_list_of_maps(
-      CoordinateMaps::UniformCylindricalEndcap(
-          make_array<3>(0.0), make_array<3>(0.0), inner_radius_C, outer_radius_,
-          z_cut_CA_upper, z_cut_CA_outer),
-      CoordinateMaps::DiscreteRotation<3>(rotate_to_x_axis));
-  // OuterCB Filled Cylinder
-  // 5 blocks
-  add_endcap_to_list_of_maps(
-      CoordinateMaps::UniformCylindricalEndcap(
-          make_array<3>(0.0), make_array<3>(0.0), inner_radius_C, outer_radius_,
-          -z_cut_CB_upper, -z_cut_CB_outer),
-      CoordinateMaps::DiscreteRotation<3>(rotate_to_minus_x_axis));
-  // OuterCA Cylinder
-  // 4 blocks
-  add_side_to_list_of_maps(
-      CoordinateMaps::UniformCylindricalSide(
-          make_array<3>(0.0), make_array<3>(0.0), inner_radius_C, outer_radius_,
-          z_cut_CA_upper, z_cutting_plane_, z_cut_CA_outer, z_cutting_plane_),
-      CoordinateMaps::DiscreteRotation<3>(rotate_to_x_axis));
-  // OuterCB Cylinder
-  // 4 blocks
-  add_side_to_list_of_maps(
-      CoordinateMaps::UniformCylindricalSide(
-          make_array<3>(0.0), make_array<3>(0.0), inner_radius_C, outer_radius_,
-          -z_cut_CB_upper, -z_cutting_plane_, -z_cut_CB_outer,
-          -z_cutting_plane_),
-      CoordinateMaps::DiscreteRotation<3>(rotate_to_minus_x_axis));
 
   // Excision spheres
   std::unordered_map<std::string, ExcisionSphere<3>> excision_spheres{};
@@ -870,8 +891,173 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const {
           tnsr::I<double, 3, Frame::Grid>(rotate_from_z_to_x_axis(center_B_)),
           abutting_directions_B});
 
-  Domain<3> domain{std::move(coordinate_maps), std::move(excision_spheres),
-                   block_names_, block_groups_};
+  Domain<3> domain;
+  // `coordinate_maps` at this point contains the inner non-shell maps.
+  // Total =  num_shells + n_interior_cubes entries
+  // We determine auto-topology neighbors for these inner maps
+  std::vector<DirectionMap<3, BlockNeighbors<3>>> inner_neighbors;
+  set_internal_boundaries<3>(make_not_null(&inner_neighbors), coordinate_maps);
+
+  // Connect the 18 CA, CB cylinders to the innermost outer shell
+  const OrientationMap<3> shell_to_cyl_endcap_center{
+      {{Direction<3>::upper_zeta(), Direction<3>::self(),
+        Direction<3>::self()}}};
+  const auto cyl_endcap_center_to_shell =
+      shell_to_cyl_endcap_center.inverse_map();
+  const OrientationMap<3> shell_to_cyl_endcap_wedge{
+      {{Direction<3>::upper_zeta(), Direction<3>::self(),
+        Direction<3>::self()}}};
+  const auto cyl_endcap_wedge_to_shell =
+      shell_to_cyl_endcap_wedge.inverse_map();
+  const OrientationMap<3> shell_to_cyl_side{
+      {{Direction<3>::upper_xi(), Direction<3>::self(), Direction<3>::self()}}};
+  const auto cyl_side_to_shell = shell_to_cyl_side.inverse_map();
+
+  const size_t ca_filled_cyl_center_block = 0;
+  const size_t first_ca_filled_cyl_wedges_block =
+      ca_filled_cyl_center_block + 1;
+  const size_t first_ca_hollow_cyl_block = 5;
+  const size_t cb_filled_cyl_center_block = 37;
+  const size_t first_cb_filled_cyl_wedges_block =
+      cb_filled_cyl_center_block + 1;
+  const size_t first_cb_hollow_cyl_block = 42;
+
+  // CA Filled Cylinder: center
+  // 1 block: 0
+  inner_neighbors[ca_filled_cyl_center_block].emplace(
+      Direction<3>::upper_zeta(),
+      BlockNeighbors<3>{{first_outer_shell_block},
+                        {{first_outer_shell_block, cyl_endcap_center_to_shell}},
+                        /*are_conforming=*/false});
+
+  // CA Filled Cylinder: surrounding wedges
+  // 4 blocks: 1 thru 4
+  for (size_t j = first_ca_filled_cyl_wedges_block;
+       j < first_ca_filled_cyl_wedges_block + 4; ++j) {
+    inner_neighbors[j].emplace(Direction<3>::upper_zeta(),
+                               BlockNeighbors<3>{{first_outer_shell_block},
+                                                 {{first_outer_shell_block,
+                                                   cyl_endcap_wedge_to_shell}},
+                                                 /*are_conforming=*/false});
+  }
+
+  // CA Cylinder
+  // 4 blocks: 5 thru 8
+  for (size_t j = first_ca_hollow_cyl_block; j < first_ca_hollow_cyl_block + 4;
+       ++j) {
+    inner_neighbors[j].emplace(
+        Direction<3>::upper_xi(),
+        BlockNeighbors<3>{{first_outer_shell_block},
+                          {{first_outer_shell_block, cyl_side_to_shell}},
+                          /*are_conforming=*/false});
+  }
+
+  // CB Filled Cylinder: center
+  // 1 block: 37
+  inner_neighbors[cb_filled_cyl_center_block].emplace(
+      Direction<3>::upper_zeta(),
+      BlockNeighbors<3>{{first_outer_shell_block},
+                        {{first_outer_shell_block, cyl_endcap_center_to_shell}},
+                        /*are_conforming=*/false});
+
+  // CB Filled Cylinder: surrounding wedges
+  // 4 blocks: 38 thru 41
+  for (size_t j = first_cb_filled_cyl_wedges_block;
+       j < first_cb_filled_cyl_wedges_block + 4; ++j) {
+    inner_neighbors[j].emplace(Direction<3>::upper_zeta(),
+                               BlockNeighbors<3>{{first_outer_shell_block},
+                                                 {{first_outer_shell_block,
+                                                   cyl_endcap_wedge_to_shell}},
+                                                 /*are_conforming=*/false});
+  }
+
+  // CA Cylinder
+  // 4 blocks: 42 thru 45
+  for (size_t j = first_cb_hollow_cyl_block; j < first_cb_hollow_cyl_block + 4;
+       ++j) {
+    inner_neighbors[j].emplace(
+        Direction<3>::upper_xi(),
+        BlockNeighbors<3>{{first_outer_shell_block},
+                          {{first_outer_shell_block, cyl_side_to_shell}},
+                          /*are_conforming=*/false});
+  }
+
+  // Build blocks in final order.
+  std::vector<Block<3>> blocks;
+  blocks.reserve(number_of_blocks_);
+
+  // (a) Inner blocks before SH shells.
+  for (size_t j = 0; j < first_outer_shell_block; ++j) {
+    blocks.emplace_back(std::move(coordinate_maps[j]), j,
+                        std::move(inner_neighbors[j]), block_names_[j]);
+  }
+
+  // (b) SH outer shell blocks.
+  const size_t block_id = first_outer_shell_block;
+  const double r_in = inner_radius_C;
+  const double r_out = outer_radius_;
+
+  CoordinateMaps::Interval radial_map{
+      -1.0, 1.0, r_in, r_out, ::domain::CoordinateMaps::Distribution::Linear,
+      0.0};
+  auto sh_map = make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
+      CoordinateMaps::ProductOf2Maps<CoordinateMaps::Interval,
+                                     CoordinateMaps::Identity<2>>{
+          std::move(radial_map), CoordinateMaps::Identity<2>{}},
+      CoordinateMaps::SphericalToCartesianPfaffian{});
+  DirectionMap<3, BlockNeighbors<3>> sh_neighbors;
+  // lower_xi → all 18 CA, CB blocks (non-conforming, multi-neighbor).
+  std::unordered_set<size_t> cyl_ids;
+  std::unordered_map<size_t, OrientationMap<3>> cyl_orientations;
+
+  // CA Filled Cylinder: center
+  cyl_ids.insert(ca_filled_cyl_center_block);
+  cyl_orientations.emplace(ca_filled_cyl_center_block,
+                           shell_to_cyl_endcap_center);
+
+  // CA Filled Cylinder: surrounding wedges
+  for (size_t j = first_ca_filled_cyl_wedges_block;
+       j < first_ca_filled_cyl_wedges_block + 4; ++j) {
+    cyl_ids.insert(j);
+    cyl_orientations.emplace(j, shell_to_cyl_endcap_wedge);
+  }
+
+  // CA Cylinder
+  for (size_t j = first_ca_hollow_cyl_block; j < first_ca_hollow_cyl_block + 4;
+       ++j) {
+    cyl_ids.insert(j);
+    cyl_orientations.emplace(j, shell_to_cyl_side);
+  }
+
+  // CB Filled Cylinder: center
+  cyl_ids.insert(cb_filled_cyl_center_block);
+  cyl_orientations.emplace(cb_filled_cyl_center_block,
+                           shell_to_cyl_endcap_center);
+
+  // CB Filled Cylinder: surrounding wedges
+  for (size_t j = first_cb_filled_cyl_wedges_block;
+       j < first_cb_filled_cyl_wedges_block + 4; ++j) {
+    cyl_ids.insert(j);
+    cyl_orientations.emplace(j, shell_to_cyl_endcap_wedge);
+  }
+
+  // CB Cylinder
+  for (size_t j = first_cb_hollow_cyl_block; j < first_cb_hollow_cyl_block + 4;
+       ++j) {
+    cyl_ids.insert(j);
+    cyl_orientations.emplace(j, shell_to_cyl_side);
+  }
+
+  sh_neighbors.emplace(
+      Direction<3>::lower_xi(),
+      BlockNeighbors<3>{std::move(cyl_ids), std::move(cyl_orientations),
+                        /*are_conforming=*/false});
+  blocks.emplace_back(std::move(sh_map), block_id, std::move(sh_neighbors),
+                      block_names_[block_id],
+                      domain::topologies::spherical_shell);
+
+  domain =
+      Domain<3>{std::move(blocks), std::move(excision_spheres), block_groups_};
 
   if (time_dependent_options_.has_value()) {
     ASSERT(include_inner_sphere_A_ and include_inner_sphere_B_,
@@ -1054,22 +1240,9 @@ CylindricalBinaryCompactObject::external_boundary_conditions() const {
     }
     last_block += 14;
   }
-  for (size_t i = 0; i < 5; ++i) {
-    // OuterCA Filled Cylinder
-    boundary_conditions[last_block + i][Direction<3>::upper_zeta()] =
-        outer_boundary_condition_->get_clone();
-    // OuterCB Filled Cylinder
-    boundary_conditions[last_block + i + 5][Direction<3>::upper_zeta()] =
-        outer_boundary_condition_->get_clone();
-  }
-  for (size_t i = 0; i < 4; ++i) {
-    // OuterCA Cylinder
-    boundary_conditions[last_block + i + 10][Direction<3>::upper_xi()] =
-        outer_boundary_condition_->get_clone();
-    // OuterCB Cylinder
-    boundary_conditions[last_block + i + 14][Direction<3>::upper_xi()] =
-        outer_boundary_condition_->get_clone();
-  }
+  boundary_conditions[last_block][Direction<3>::upper_xi()] =
+      outer_boundary_condition_->get_clone();
+
   return boundary_conditions;
 }
 

--- a/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
+++ b/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
@@ -60,8 +60,7 @@ namespace domain::creators {
 CylindricalBinaryCompactObject::CylindricalBinaryCompactObject(
     std::array<double, 3> center_A, std::array<double, 3> center_B,
     double radius_A, double radius_B, bool include_inner_sphere_A,
-    bool include_inner_sphere_B, bool include_outer_sphere, double outer_radius,
-    bool use_equiangular_map,
+    bool include_inner_sphere_B, double outer_radius, bool use_equiangular_map,
     const typename InitialRefinement::type& initial_refinement,
     const typename InitialGridPoints::type& initial_grid_points,
     std::optional<bco::TimeDependentMapOptions<true>> time_dependent_options,
@@ -76,7 +75,6 @@ CylindricalBinaryCompactObject::CylindricalBinaryCompactObject(
       radius_B_(radius_B),
       include_inner_sphere_A_(include_inner_sphere_A),
       include_inner_sphere_B_(include_inner_sphere_B),
-      include_outer_sphere_(include_outer_sphere),
       outer_radius_(outer_radius),
       use_equiangular_map_(use_equiangular_map),
       inner_boundary_condition_(std::move(inner_boundary_condition)),
@@ -186,15 +184,12 @@ CylindricalBinaryCompactObject::CylindricalBinaryCompactObject(
                 0.5 * (std::abs(z_cutting_plane_ - center_B_[2]) - radius_B_)
           : radius_B_;
 
-  number_of_blocks_ = 46;
+  number_of_blocks_ = 64;
   if (include_inner_sphere_A) {
     number_of_blocks_ += 14;
   }
   if (include_inner_sphere_B) {
     number_of_blocks_ += 14;
-  }
-  if (include_outer_sphere) {
-    number_of_blocks_ += 18;
   }
 
   // Add SphereE blocks if necessary.  Note that
@@ -300,16 +295,14 @@ CylindricalBinaryCompactObject::CylindricalBinaryCompactObject(
     add_cylinder_name("InnerSphereEB", "InnerSphereB");
     first_outer_shell_block += 14;
   }
-  if (include_outer_sphere) {
-    // 5 blocks
-    add_filled_cylinder_name("OuterSphereCA", "OuterSphere");
-    // 5 blocks
-    add_filled_cylinder_name("OuterSphereCB", "OuterSphere");
-    // 4 blocks
-    add_cylinder_name("OuterSphereCA", "OuterSphere");
-    // 4 blocks
-    add_cylinder_name("OuterSphereCB", "OuterSphere");
-  }
+  // 5 blocks
+  add_filled_cylinder_name("OuterSphereCA", "OuterSphere");
+  // 5 blocks
+  add_filled_cylinder_name("OuterSphereCB", "OuterSphere");
+  // 4 blocks
+  add_cylinder_name("OuterSphereCA", "OuterSphere");
+  // 4 blocks
+  add_cylinder_name("OuterSphereCB", "OuterSphere");
 
   // Expand initial refinement over all blocks
   const ExpandOverBlocks<std::array<size_t, 3>> expand_over_blocks{
@@ -372,8 +365,8 @@ CylindricalBinaryCompactObject::CylindricalBinaryCompactObject(
     swap_refinement_and_grid_points_xi_zeta(block);
   }
 
-  // Now do the filled cylinders for the inner and outer shells,
-  // if they are present.
+  // Now do the filled cylinders for the outer shells and any inner shells, if
+  // they are present.
   size_t current_block = 46;
   if (include_inner_sphere_A) {
     for (size_t block = 0; block < 10; ++block) {
@@ -387,10 +380,8 @@ CylindricalBinaryCompactObject::CylindricalBinaryCompactObject(
     }
     current_block += 4;
   }
-  if (include_outer_sphere) {
-    for (size_t block = 0; block < 10; ++block) {
-      swap_refinement_and_grid_points_xi_zeta(current_block++);
-    }
+  for (size_t block = 0; block < 10; ++block) {
+    swap_refinement_and_grid_points_xi_zeta(current_block++);
   }
 
   // Build time-dependent maps
@@ -398,18 +389,13 @@ CylindricalBinaryCompactObject::CylindricalBinaryCompactObject(
   // needs to start and stop at certain radii around each excision. If the inner
   // spheres aren't included, the outer radii would have to be in the middle of
   // a block. With the inner spheres, the outer radii can be at block
-  // boundaries. The outer sphere must be specified because the time-dependent
-  // maps use piecewise functions for `Expansion` and `Translation`. This means
-  // an inner common radius must be specified for the piecewise bounds.
+  // boundaries.
   if (time_dependent_options_.has_value() and
-      not(include_inner_sphere_A and include_inner_sphere_B and
-          include_outer_sphere)) {
+      not(include_inner_sphere_A and include_inner_sphere_B)) {
     PARSE_ERROR(context,
                 "To use the CylindricalBBH domain with time-dependent maps, "
-                "you must include the inner spheres for both objects and "
-                "the outer sphere. "
-                "Currently, one or both objects is missing the inner spheres or"
-                " the outer sphere is missing.");
+                "you must include the inner spheres for both objects. "
+                "Currently, one or both objects is missing the inner sphere.");
   }
 
   if (time_dependent_options_.has_value()) {
@@ -583,11 +569,8 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const {
                 new_logical_to_cylindrical_shell_maps.end()));
       };
 
-  // Inner radius of the outer C shell, if it exists.
-  // If it doesn't exist, then it is the same as the outer_radius_.
-  const double inner_radius_C = include_outer_sphere_
-                                    ? 3.0 * (center_A_[2] - center_B_[2])
-                                    : outer_radius_;
+  // Inner radius of the outer C shell.
+  const double inner_radius_C = 3.0 * (center_A_[2] - center_B_[2]);
 
   // z_cut_CA_lower is the lower z_plane position for the CA endcap,
   // defined by https://arxiv.org/abs/1206.3015 in the bulleted list
@@ -788,40 +771,37 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const {
             -z_cut_EB_upper, -z_cut_EB_lower),
         CoordinateMaps::DiscreteRotation<3>(rotate_to_minus_x_axis));
   }
-  if (include_outer_sphere_) {
-    const double z_cut_CA_outer = 0.7 * outer_radius_;
-    const double z_cut_CB_outer = -0.7 * outer_radius_;
-    // OuterCA Filled Cylinder
-    // 5 blocks
-    add_endcap_to_list_of_maps(
-        CoordinateMaps::UniformCylindricalEndcap(
-            make_array<3>(0.0), make_array<3>(0.0), inner_radius_C,
-            outer_radius_, z_cut_CA_upper, z_cut_CA_outer),
-        CoordinateMaps::DiscreteRotation<3>(rotate_to_x_axis));
-    // OuterCB Filled Cylinder
-    // 5 blocks
-    add_endcap_to_list_of_maps(
-        CoordinateMaps::UniformCylindricalEndcap(
-            make_array<3>(0.0), make_array<3>(0.0), inner_radius_C,
-            outer_radius_, -z_cut_CB_upper, -z_cut_CB_outer),
-        CoordinateMaps::DiscreteRotation<3>(rotate_to_minus_x_axis));
-    // OuterCA Cylinder
-    // 4 blocks
-    add_side_to_list_of_maps(
-        CoordinateMaps::UniformCylindricalSide(
-            make_array<3>(0.0), make_array<3>(0.0), inner_radius_C,
-            outer_radius_, z_cut_CA_upper, z_cutting_plane_, z_cut_CA_outer,
-            z_cutting_plane_),
-        CoordinateMaps::DiscreteRotation<3>(rotate_to_x_axis));
-    // OuterCB Cylinder
-    // 4 blocks
-    add_side_to_list_of_maps(
-        CoordinateMaps::UniformCylindricalSide(
-            make_array<3>(0.0), make_array<3>(0.0), inner_radius_C,
-            outer_radius_, -z_cut_CB_upper, -z_cutting_plane_, -z_cut_CB_outer,
-            -z_cutting_plane_),
-        CoordinateMaps::DiscreteRotation<3>(rotate_to_minus_x_axis));
-  }
+  const double z_cut_CA_outer = 0.7 * outer_radius_;
+  const double z_cut_CB_outer = -0.7 * outer_radius_;
+  // OuterCA Filled Cylinder
+  // 5 blocks
+  add_endcap_to_list_of_maps(
+      CoordinateMaps::UniformCylindricalEndcap(
+          make_array<3>(0.0), make_array<3>(0.0), inner_radius_C, outer_radius_,
+          z_cut_CA_upper, z_cut_CA_outer),
+      CoordinateMaps::DiscreteRotation<3>(rotate_to_x_axis));
+  // OuterCB Filled Cylinder
+  // 5 blocks
+  add_endcap_to_list_of_maps(
+      CoordinateMaps::UniformCylindricalEndcap(
+          make_array<3>(0.0), make_array<3>(0.0), inner_radius_C, outer_radius_,
+          -z_cut_CB_upper, -z_cut_CB_outer),
+      CoordinateMaps::DiscreteRotation<3>(rotate_to_minus_x_axis));
+  // OuterCA Cylinder
+  // 4 blocks
+  add_side_to_list_of_maps(
+      CoordinateMaps::UniformCylindricalSide(
+          make_array<3>(0.0), make_array<3>(0.0), inner_radius_C, outer_radius_,
+          z_cut_CA_upper, z_cutting_plane_, z_cut_CA_outer, z_cutting_plane_),
+      CoordinateMaps::DiscreteRotation<3>(rotate_to_x_axis));
+  // OuterCB Cylinder
+  // 4 blocks
+  add_side_to_list_of_maps(
+      CoordinateMaps::UniformCylindricalSide(
+          make_array<3>(0.0), make_array<3>(0.0), inner_radius_C, outer_radius_,
+          -z_cut_CB_upper, -z_cutting_plane_, -z_cut_CB_outer,
+          -z_cutting_plane_),
+      CoordinateMaps::DiscreteRotation<3>(rotate_to_minus_x_axis));
 
   // Excision spheres
   std::unordered_map<std::string, ExcisionSphere<3>> excision_spheres{};
@@ -937,10 +917,9 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const {
 
     // Because we require that both objects have inner shells, object A
     // corresponds to blocks 46-59 and object B corresponds to blocks 60-73.
-    // If we have extra outer shells, those will have the same maps as block
-    // 0, and will start at block 74. The `true` being passed to the functions
-    // specifies that the size map *should* be included in the distorted
-    // frame.
+    // Outer shells will have the same maps as block 0, and will start at block
+    // 74. The `true` being passed to the functions specifies that the size map
+    // *should* be included in the distorted frame.
     grid_to_inertial_block_maps[46] =
         time_dependent_options_->grid_to_inertial_map<domain::ObjectLabel::A>(
             true, true);
@@ -1012,14 +991,6 @@ CylindricalBinaryCompactObject::external_boundary_conditions() const {
       3, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
       boundary_conditions{number_of_blocks_};
   for (size_t i = 0; i < 5; ++i) {
-    if (not include_outer_sphere_) {
-      // CA Filled Cylinder
-      boundary_conditions[i][Direction<3>::upper_zeta()] =
-          outer_boundary_condition_->get_clone();
-      // CB Filled Cylinder
-      boundary_conditions[i + 37][Direction<3>::upper_zeta()] =
-          outer_boundary_condition_->get_clone();
-    }
     if (not include_inner_sphere_A_) {
       // EA Filled Cylinder
       boundary_conditions[i + 9][Direction<3>::lower_zeta()] =
@@ -1038,14 +1009,6 @@ CylindricalBinaryCompactObject::external_boundary_conditions() const {
     }
   }
   for (size_t i = 0; i < 4; ++i) {
-    if (not include_outer_sphere_) {
-      // CA Cylinder
-      boundary_conditions[i + 5][Direction<3>::upper_xi()] =
-          outer_boundary_condition_->get_clone();
-      // CB Cylinder
-      boundary_conditions[i + 42][Direction<3>::upper_xi()] =
-          outer_boundary_condition_->get_clone();
-    }
     if (not include_inner_sphere_A_) {
       // EA Cylinder
       boundary_conditions[i + 14][Direction<3>::lower_xi()] =
@@ -1091,23 +1054,21 @@ CylindricalBinaryCompactObject::external_boundary_conditions() const {
     }
     last_block += 14;
   }
-  if (include_outer_sphere_) {
-    for (size_t i = 0; i < 5; ++i) {
-      // OuterCA Filled Cylinder
-      boundary_conditions[last_block + i][Direction<3>::upper_zeta()] =
-          outer_boundary_condition_->get_clone();
-      // OuterCB Filled Cylinder
-      boundary_conditions[last_block + i + 5][Direction<3>::upper_zeta()] =
-          outer_boundary_condition_->get_clone();
-    }
-    for (size_t i = 0; i < 4; ++i) {
-      // OuterCA Cylinder
-      boundary_conditions[last_block + i + 10][Direction<3>::upper_xi()] =
-          outer_boundary_condition_->get_clone();
-      // OuterCB Cylinder
-      boundary_conditions[last_block + i + 14][Direction<3>::upper_xi()] =
-          outer_boundary_condition_->get_clone();
-    }
+  for (size_t i = 0; i < 5; ++i) {
+    // OuterCA Filled Cylinder
+    boundary_conditions[last_block + i][Direction<3>::upper_zeta()] =
+        outer_boundary_condition_->get_clone();
+    // OuterCB Filled Cylinder
+    boundary_conditions[last_block + i + 5][Direction<3>::upper_zeta()] =
+        outer_boundary_condition_->get_clone();
+  }
+  for (size_t i = 0; i < 4; ++i) {
+    // OuterCA Cylinder
+    boundary_conditions[last_block + i + 10][Direction<3>::upper_xi()] =
+        outer_boundary_condition_->get_clone();
+    // OuterCB Cylinder
+    boundary_conditions[last_block + i + 14][Direction<3>::upper_xi()] =
+        outer_boundary_condition_->get_clone();
   }
   return boundary_conditions;
 }

--- a/src/Domain/Creators/CylindricalBinaryCompactObject.hpp
+++ b/src/Domain/Creators/CylindricalBinaryCompactObject.hpp
@@ -16,6 +16,7 @@
 #include "Domain/BoundaryConditions/BoundaryCondition.hpp"
 #include "Domain/BoundaryConditions/GetBoundaryConditionsBase.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/Identity.hpp"
 #include "Domain/Creators/DomainCreator.hpp"
 #include "Domain/Creators/TimeDependentOptions/BinaryCompactObject.hpp"
 #include "Domain/Domain.hpp"
@@ -35,6 +36,7 @@ template <typename Map1, typename Map2>
 class ProductOf2Maps;
 template <typename Map1, typename Map2, typename Map3>
 class ProductOf3Maps;
+class SphericalToCartesianPfaffian;
 template <size_t VolumeDim>
 class Wedge;
 template <size_t VolumeDim>
@@ -103,9 +105,8 @@ namespace domain::creators {
  *   consists of 4 blocks, named 'East', 'North', 'West', and 'South',
  *   so an example of a valid block name is 'CACylinderEast'.
  * - The Block group called "Outer" consists of all the CA and CB blocks.
- * - OuterSphereCAFilledCylinder, OuterSphereCBFilledCylinder,
- *   OuterSphereCACylinder, and OuterSphereCBCylinder are in a Block group
- *   called "OuterSphere" and all of these border the outer boundary.
+ * - OuterShell0 is the single shell in a Block group called "OuterSphere" and
+ *   it borders the outer boundary.
  * - The Block group called "InnerA" consists of all the EA, and MA
  *   blocks. They all border the inner boundary "A" if
  *   `IncludeInnerSphereA` is false.
@@ -179,6 +180,11 @@ class CylindricalBinaryCompactObject : public DomainCreator<3> {
                                                     CoordinateMaps::Interval>,
                      CoordinateMaps::UniformCylindricalSide,
                      CoordinateMaps::DiscreteRotation<3>>,
+                 domain::CoordinateMap<
+                     Frame::BlockLogical, Frame::Inertial,
+                     domain::CoordinateMaps::ProductOf2Maps<
+                         CoordinateMaps::Interval, CoordinateMaps::Identity<2>>,
+                     domain::CoordinateMaps::SphericalToCartesianPfaffian>,
                  bco::TimeDependentMapOptions<true>::maps_list>>;
 
   struct CenterA {
@@ -233,7 +239,10 @@ class CylindricalBinaryCompactObject : public DomainCreator<3> {
         "representing [r, theta, perp], or such a list for every block in the "
         "domain. Here 'r' is the radial direction normal to the inner and "
         "outer boundaries, 'theta' is the periodic direction, and 'perp' is "
-        "the third direction."};
+        "the third direction. Note that for blocks in 'OuterSphere', the "
+        "angular refinement levels must be specified as zero. The exception is "
+        "if a single number is specified for global refinement, the angular "
+        "refinement for 'OuterSphere' blocks will be set to 0 for you."};
   };
   struct InitialGridPoints {
     using type =
@@ -245,7 +254,9 @@ class CylindricalBinaryCompactObject : public DomainCreator<3> {
         "list representing [r, theta, perp], or such a list for every block in "
         "the domain. Here 'r' is the radial direction normal to the inner and "
         "outer boundaries, 'theta' is the periodic direction, and 'perp' is "
-        "the third direction."};
+        "the third direction. The exception to this is that for blocks in "
+        "'OuterSphere', the list represents [r, l_max, m_max]. Note that for "
+        "these blocks, l_max must be equal to m_max."};
   };
 
   struct BoundaryConditions {

--- a/src/Domain/Creators/CylindricalBinaryCompactObject.hpp
+++ b/src/Domain/Creators/CylindricalBinaryCompactObject.hpp
@@ -89,12 +89,9 @@ namespace domain::creators {
  * of Figure 20 indicates that there are additional spherical shells
  * outside the "CA" and "CB" blocks; `CylindricalBinaryCompactObject`
  * has these extra shells inside "EA" only if the option `IncludeInnerSphereA`
- * is true, it has the extra shells inside "EB" only if the option
- * `IncludeInnerSphereB` is true, and it has the extra shells outside
- * "CA" and "CB" only if `IncludeOuterSphere` is true.
- * If the shells are absent, then the "EA" and "EB"
- * blocks extend to the excision boundaries and the "CA" and "CB" blocks
- * extend to the outer boundary.
+ * is true, and it has the extra shells inside "EB" only if the option
+ * `IncludeInnerSphereB` is true. If the shells are absent, then the "EA" and
+ * "EB" blocks extend to the excision boundaries.
  *
  * The Blocks are named as follows:
  * - Each of CAFilledCylinder, EAFilledCylinder, EBFilledCylinder,
@@ -105,13 +102,10 @@ namespace domain::creators {
  * - Each of CACylinder, EACylinder, EBCylinder, and CBCylinder
  *   consists of 4 blocks, named 'East', 'North', 'West', and 'South',
  *   so an example of a valid block name is 'CACylinderEast'.
- * - The Block group called "Outer" consists of all the CA and CB blocks. They
- *   all border the outer boundary if `IncludeOuterSphere` is false.
- * - If `IncludeOuterSphere` is true, then there are more blocks named
- *   OuterSphereCAFilledCylinder, OuterSphereCBFilledCylinder,
- *   OuterSphereCACylinder, and OuterSphereCBCylinder.
- *   These are in a Block group called "OuterSphere",
- *   and all of these border the outer boundary.
+ * - The Block group called "Outer" consists of all the CA and CB blocks.
+ * - OuterSphereCAFilledCylinder, OuterSphereCBFilledCylinder,
+ *   OuterSphereCACylinder, and OuterSphereCBCylinder are in a Block group
+ *   called "OuterSphere" and all of these border the outer boundary.
  * - The Block group called "InnerA" consists of all the EA, and MA
  *   blocks. They all border the inner boundary "A" if
  *   `IncludeInnerSphereA` is false.
@@ -217,11 +211,6 @@ class CylindricalBinaryCompactObject : public DomainCreator<3> {
     static constexpr Options::String help = {
         "Add an extra spherical layer of Blocks around Object B."};
   };
-  struct IncludeOuterSphere {
-    using type = bool;
-    static constexpr Options::String help = {
-        "Add an extra spherical layer of Blocks inside the outer boundary."};
-  };
   struct OuterRadius {
     using type = double;
     static constexpr Options::String help = {
@@ -290,9 +279,8 @@ class CylindricalBinaryCompactObject : public DomainCreator<3> {
   template <typename Metavariables>
   using options = tmpl::append<
       tmpl::list<CenterA, CenterB, RadiusA, RadiusB, IncludeInnerSphereA,
-                 IncludeInnerSphereB, IncludeOuterSphere, OuterRadius,
-                 UseEquiangularMap, InitialRefinement, InitialGridPoints,
-                 TimeDependentMaps>,
+                 IncludeInnerSphereB, OuterRadius, UseEquiangularMap,
+                 InitialRefinement, InitialGridPoints, TimeDependentMaps>,
       tmpl::conditional_t<
           domain::BoundaryConditions::has_boundary_conditions_base_v<
               typename Metavariables::system>,
@@ -314,8 +302,8 @@ class CylindricalBinaryCompactObject : public DomainCreator<3> {
   CylindricalBinaryCompactObject(
       std::array<double, 3> center_A, std::array<double, 3> center_B,
       double radius_A, double radius_B, bool include_inner_sphere_A,
-      bool include_inner_sphere_B, bool include_outer_sphere,
-      double outer_radius, bool use_equiangular_map,
+      bool include_inner_sphere_B, double outer_radius,
+      bool use_equiangular_map,
       const typename InitialRefinement::type& initial_refinement,
       const typename InitialGridPoints::type& initial_grid_points,
       std::optional<bco::TimeDependentMapOptions<true>> time_dependent_options =
@@ -378,7 +366,6 @@ class CylindricalBinaryCompactObject : public DomainCreator<3> {
   double outer_radius_B_{};
   bool include_inner_sphere_A_{};
   bool include_inner_sphere_B_{};
-  bool include_outer_sphere_{};
   double outer_radius_{};
   bool use_equiangular_map_{false};
   typename std::vector<std::array<size_t, 3>> initial_refinement_{};

--- a/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
@@ -47,7 +47,6 @@ DomainCreator:
     RadiusB: &RadiusB 0.45825
     IncludeInnerSphereA: true
     IncludeInnerSphereB: true
-    IncludeOuterSphere: true
     UseEquiangularMap: true
     OuterRadius: 300.0
     InitialRefinement: 2

--- a/tests/Unit/Domain/Creators/Test_CylindricalBinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_CylindricalBinaryCompactObject.cpp
@@ -176,28 +176,8 @@ block_names_and_groups(const bool include_inner_sphere_A,
           "InnerSphereEBCylinderEast", "InnerSphereEBCylinderNorth",
           "InnerSphereEBCylinderWest", "InnerSphereEBCylinderSouth"}});
   }
-  block_names.insert(
-      block_names.end(),
-      {"OuterSphereCAFilledCylinderCenter", "OuterSphereCAFilledCylinderEast",
-       "OuterSphereCAFilledCylinderNorth", "OuterSphereCAFilledCylinderWest",
-       "OuterSphereCAFilledCylinderSouth", "OuterSphereCBFilledCylinderCenter",
-       "OuterSphereCBFilledCylinderEast", "OuterSphereCBFilledCylinderNorth",
-       "OuterSphereCBFilledCylinderWest", "OuterSphereCBFilledCylinderSouth",
-       "OuterSphereCACylinderEast", "OuterSphereCACylinderNorth",
-       "OuterSphereCACylinderWest", "OuterSphereCACylinderSouth",
-       "OuterSphereCBCylinderEast", "OuterSphereCBCylinderNorth",
-       "OuterSphereCBCylinderWest", "OuterSphereCBCylinderSouth"});
-  block_groups.insert(
-      {"OuterSphere",
-       {"OuterSphereCAFilledCylinderCenter", "OuterSphereCAFilledCylinderEast",
-        "OuterSphereCAFilledCylinderNorth", "OuterSphereCAFilledCylinderWest",
-        "OuterSphereCAFilledCylinderSouth", "OuterSphereCBFilledCylinderCenter",
-        "OuterSphereCBFilledCylinderEast", "OuterSphereCBFilledCylinderNorth",
-        "OuterSphereCBFilledCylinderWest", "OuterSphereCBFilledCylinderSouth",
-        "OuterSphereCACylinderEast", "OuterSphereCACylinderNorth",
-        "OuterSphereCACylinderWest", "OuterSphereCACylinderSouth",
-        "OuterSphereCBCylinderEast", "OuterSphereCBCylinderNorth",
-        "OuterSphereCBCylinderWest", "OuterSphereCBCylinderSouth"}});
+  block_names.insert(block_names.end(), {"OuterShell0"});
+  block_groups.insert({"OuterSphere", {"OuterShell0"}});
 
   return std::make_pair(block_names, block_groups);
 }
@@ -274,15 +254,21 @@ std::string create_option_string(
                                            "        BlockId: 314\n"}
                              : ""};
 
+  // is_h_refinement = true: we're constructing h-refinement
+  // is_h_refinement = false: we're constructing p-refinement (grid points)
   const auto initial_structure =
       [&include_inner_sphere_A, &include_inner_sphere_B](
-          const bool include_extra, const size_t value) {
+          const bool is_h_refinement, const bool include_extra,
+          const size_t value) {
         const std::string same = "[" + get_output(value) + "," +
                                  get_output(value) + "," + get_output(value) +
                                  "]";
         const std::string one_more = "[" + get_output(value + 1) + "," +
                                      get_output(value) + "," +
                                      get_output(value) + "]";
+        const std::string outer_shell = is_h_refinement ?
+                                    ("[" + get_output(value + 1) + ", 0, 0]") :
+                                    one_more;
         std::string result{};
         if (include_extra) {
           result += "\n    Outer: " + one_more;
@@ -294,7 +280,7 @@ std::string create_option_string(
           if (include_inner_sphere_B) {
             result += "\n    InnerSphereB: " + same;
           }
-          result += "\n    OuterSphere: " + one_more;
+          result += "\n    OuterSphere: " + outer_shell;
         } else {
           result = " " + get_output(value);
         }
@@ -312,9 +298,9 @@ std::string create_option_string(
          "\n  IncludeInnerSphereA: " + stringize(include_inner_sphere_A) +
          "\n  IncludeInnerSphereB: " + stringize(include_inner_sphere_B) +
          "\n  InitialRefinement:" +
-         initial_structure(with_additional_outer_radial_refinement, 1) +
+         initial_structure(true, with_additional_outer_radial_refinement, 1) +
          "\n  InitialGridPoints:" +
-         initial_structure(with_additional_grid_points, 3) + "\n" +
+         initial_structure(false, with_additional_grid_points, 3) + "\n" +
          time_dependence + boundary_conditions;
 }
 
@@ -631,16 +617,34 @@ void test_parse_errors() {
       Catch::Matchers::ContainsSubstring(
           "Must specify either both inner and outer boundary "
           "conditions or neither."));
+  // InitialRefinement and InitialGridPoints
+  CHECK_THROWS_WITH(
+      domain::creators::CylindricalBinaryCompactObject(
+          {{2.0, 0.05, 0.0}}, {-3.0, 0.05, 0.0}, 1.0, 0.4, false, false, 25.0,
+          false, std::array<size_t, 3>{1_st, 1_st, 1_st}, 3_st, std::nullopt,
+          create_inner_boundary_condition(), create_outer_boundary_condition(),
+          Options::Context{false, {}, 1, 1}),
+      Catch::Matchers::ContainsSubstring("Angular h-refinement"));
+  CHECK_THROWS_WITH(
+      domain::creators::CylindricalBinaryCompactObject(
+          {{2.0, 0.05, 0.0}}, {-3.0, 0.05, 0.0}, 1.0, 0.4, false, false, 25.0,
+          false, 1_st, std::array<size_t, 3>{{3_st, 4_st, 5_st}}, std::nullopt,
+          create_inner_boundary_condition(), create_outer_boundary_condition(),
+          Options::Context{false, {}, 1, 1}),
+      Catch::Matchers::ContainsSubstring("must have L_max = M_max"));
 }
 
 // This matches the structure in the option string
 std::unordered_map<std::string, std::array<size_t, 3>> make_initial_structure(
-    const size_t initial_value, const bool include_inner_sphere_A,
-    const bool include_inner_sphere_B) {
+    const bool is_h_refinement, const size_t initial_value,
+    const bool include_inner_sphere_A, const bool include_inner_sphere_B) {
   std::unordered_map<std::string, std::array<size_t, 3>> initial_map;
   const std::array<size_t, 3> same{initial_value, initial_value, initial_value};
   const std::array<size_t, 3> one_more{initial_value + 1, initial_value,
                                        initial_value};
+  const std::array<size_t, 3> outer_sphere =
+      is_h_refinement ? std::array<size_t, 3>{initial_value + 1, 0, 0}
+                      : one_more;
   initial_map["Outer"] = one_more;
   initial_map["InnerA"] = same;
   initial_map["InnerB"] = one_more;
@@ -650,7 +654,7 @@ std::unordered_map<std::string, std::array<size_t, 3>> make_initial_structure(
   if (include_inner_sphere_B) {
     initial_map["InnerSphereB"] = same;
   }
-  initial_map["OuterSphere"] = one_more;
+  initial_map["OuterSphere"] = outer_sphere;
 
   return initial_map;
 }
@@ -715,13 +719,13 @@ void test_cylindrical_bbh() {
 
     if (with_additional_outer_radial_refinement) {
       initial_refinement = make_initial_structure(
-          refinement, include_inner_sphere_A, include_inner_sphere_B);
+          true, refinement, include_inner_sphere_A, include_inner_sphere_B);
     } else {
       initial_refinement = refinement;
     }
     if (with_additional_grid_points) {
       initial_grid_points = make_initial_structure(
-          grid_points, include_inner_sphere_A, include_inner_sphere_B);
+          false, grid_points, include_inner_sphere_A, include_inner_sphere_B);
     } else {
       initial_grid_points = grid_points;
     }

--- a/tests/Unit/Domain/Creators/Test_CylindricalBinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_CylindricalBinaryCompactObject.cpp
@@ -84,8 +84,7 @@ create_outer_boundary_condition() {
 std::pair<std::vector<std::string>,
           std::unordered_map<std::string, std::unordered_set<std::string>>>
 block_names_and_groups(const bool include_inner_sphere_A,
-                       const bool include_inner_sphere_B,
-                       const bool include_outer_sphere) {
+                       const bool include_inner_sphere_B) {
   std::vector<std::string> block_names{
       "CAFilledCylinderCenter", "CAFilledCylinderEast",
       "CAFilledCylinderNorth",  "CAFilledCylinderWest",
@@ -177,32 +176,28 @@ block_names_and_groups(const bool include_inner_sphere_A,
           "InnerSphereEBCylinderEast", "InnerSphereEBCylinderNorth",
           "InnerSphereEBCylinderWest", "InnerSphereEBCylinderSouth"}});
   }
-  if (include_outer_sphere) {
-    block_names.insert(
-        block_names.end(),
-        {"OuterSphereCAFilledCylinderCenter", "OuterSphereCAFilledCylinderEast",
-         "OuterSphereCAFilledCylinderNorth", "OuterSphereCAFilledCylinderWest",
-         "OuterSphereCAFilledCylinderSouth",
-         "OuterSphereCBFilledCylinderCenter", "OuterSphereCBFilledCylinderEast",
-         "OuterSphereCBFilledCylinderNorth", "OuterSphereCBFilledCylinderWest",
-         "OuterSphereCBFilledCylinderSouth", "OuterSphereCACylinderEast",
-         "OuterSphereCACylinderNorth", "OuterSphereCACylinderWest",
-         "OuterSphereCACylinderSouth", "OuterSphereCBCylinderEast",
-         "OuterSphereCBCylinderNorth", "OuterSphereCBCylinderWest",
-         "OuterSphereCBCylinderSouth"});
-    block_groups.insert(
-        {"OuterSphere",
-         {"OuterSphereCAFilledCylinderCenter",
-          "OuterSphereCAFilledCylinderEast", "OuterSphereCAFilledCylinderNorth",
-          "OuterSphereCAFilledCylinderWest", "OuterSphereCAFilledCylinderSouth",
-          "OuterSphereCBFilledCylinderCenter",
-          "OuterSphereCBFilledCylinderEast", "OuterSphereCBFilledCylinderNorth",
-          "OuterSphereCBFilledCylinderWest", "OuterSphereCBFilledCylinderSouth",
-          "OuterSphereCACylinderEast", "OuterSphereCACylinderNorth",
-          "OuterSphereCACylinderWest", "OuterSphereCACylinderSouth",
-          "OuterSphereCBCylinderEast", "OuterSphereCBCylinderNorth",
-          "OuterSphereCBCylinderWest", "OuterSphereCBCylinderSouth"}});
-  }
+  block_names.insert(
+      block_names.end(),
+      {"OuterSphereCAFilledCylinderCenter", "OuterSphereCAFilledCylinderEast",
+       "OuterSphereCAFilledCylinderNorth", "OuterSphereCAFilledCylinderWest",
+       "OuterSphereCAFilledCylinderSouth", "OuterSphereCBFilledCylinderCenter",
+       "OuterSphereCBFilledCylinderEast", "OuterSphereCBFilledCylinderNorth",
+       "OuterSphereCBFilledCylinderWest", "OuterSphereCBFilledCylinderSouth",
+       "OuterSphereCACylinderEast", "OuterSphereCACylinderNorth",
+       "OuterSphereCACylinderWest", "OuterSphereCACylinderSouth",
+       "OuterSphereCBCylinderEast", "OuterSphereCBCylinderNorth",
+       "OuterSphereCBCylinderWest", "OuterSphereCBCylinderSouth"});
+  block_groups.insert(
+      {"OuterSphere",
+       {"OuterSphereCAFilledCylinderCenter", "OuterSphereCAFilledCylinderEast",
+        "OuterSphereCAFilledCylinderNorth", "OuterSphereCAFilledCylinderWest",
+        "OuterSphereCAFilledCylinderSouth", "OuterSphereCBFilledCylinderCenter",
+        "OuterSphereCBFilledCylinderEast", "OuterSphereCBFilledCylinderNorth",
+        "OuterSphereCBFilledCylinderWest", "OuterSphereCBFilledCylinderSouth",
+        "OuterSphereCACylinderEast", "OuterSphereCACylinderNorth",
+        "OuterSphereCACylinderWest", "OuterSphereCACylinderSouth",
+        "OuterSphereCBCylinderEast", "OuterSphereCBCylinderNorth",
+        "OuterSphereCBCylinderWest", "OuterSphereCBCylinderSouth"}});
 
   return std::make_pair(block_names, block_groups);
 }
@@ -235,10 +230,9 @@ std::string stringize(const std::array<double, 3>& t) {
 std::string create_option_string(
     const bool add_time_dependence,
     const bool with_additional_outer_radial_refinement,
-    const bool with_additional_grid_points, const bool include_outer_sphere,
-    const bool include_inner_sphere_A, const bool include_inner_sphere_B,
-    const bool add_boundary_condition, const bool use_equiangular_map,
-    const std::array<double, 3>& center_objectA,
+    const bool with_additional_grid_points, const bool include_inner_sphere_A,
+    const bool include_inner_sphere_B, const bool add_boundary_condition,
+    const bool use_equiangular_map, const std::array<double, 3>& center_objectA,
     const std::array<double, 3>& center_objectB,
     const double inner_radius_objectA, const double inner_radius_objectB,
     const double outer_radius) {
@@ -281,7 +275,7 @@ std::string create_option_string(
                              : ""};
 
   const auto initial_structure =
-      [&include_outer_sphere, &include_inner_sphere_A, &include_inner_sphere_B](
+      [&include_inner_sphere_A, &include_inner_sphere_B](
           const bool include_extra, const size_t value) {
         const std::string same = "[" + get_output(value) + "," +
                                  get_output(value) + "," + get_output(value) +
@@ -294,15 +288,13 @@ std::string create_option_string(
           result += "\n    Outer: " + one_more;
           result += "\n    InnerA: " + same;
           result += "\n    InnerB: " + one_more;
-          if (include_outer_sphere) {
-            result += "\n    OuterSphere: " + one_more;
-          }
           if (include_inner_sphere_A) {
             result += "\n    InnerSphereA: " + same;
           }
           if (include_inner_sphere_B) {
             result += "\n    InnerSphereB: " + same;
           }
+          result += "\n    OuterSphere: " + one_more;
         } else {
           result = " " + get_output(value);
         }
@@ -319,7 +311,6 @@ std::string create_option_string(
          "\n  UseEquiangularMap: " + stringize(use_equiangular_map) +
          "\n  IncludeInnerSphereA: " + stringize(include_inner_sphere_A) +
          "\n  IncludeInnerSphereB: " + stringize(include_inner_sphere_B) +
-         "\n  IncludeOuterSphere: " + stringize(include_outer_sphere) +
          "\n  InitialRefinement:" +
          initial_structure(with_additional_outer_radial_refinement, 1) +
          "\n  InitialGridPoints:" +
@@ -370,16 +361,15 @@ TimeDepOptions construct_time_dependent_options() {
 void test_construction(
     const CylBCO& creator, const bool with_boundary_conditions,
     const bool include_inner_sphere_A, const bool include_inner_sphere_B,
-    const bool include_outer_sphere, const double inner_radius_objectA,
-    const double inner_radius_objectB, const double outer_radius,
-    const std::array<double, 3>& center_objectA,
+    const double inner_radius_objectA, const double inner_radius_objectB,
+    const double outer_radius, const std::array<double, 3>& center_objectA,
     const std::array<double, 3>& center_objectB,
     const std::vector<double>& times_to_check) {
   const auto domain = TestHelpers::domain::creators::test_domain_creator(
       creator, with_boundary_conditions, false, times_to_check);
 
-  const auto& [block_names, block_groups] = block_names_and_groups(
-      include_inner_sphere_A, include_inner_sphere_B, include_outer_sphere);
+  const auto& [block_names, block_groups] =
+      block_names_and_groups(include_inner_sphere_A, include_inner_sphere_B);
 
   CHECK(creator.block_names() == block_names);
   CHECK(creator.block_groups() == block_groups);
@@ -547,62 +537,55 @@ void test_construction(
 void test_parse_errors() {
   CHECK_THROWS_WITH(
       domain::creators::CylindricalBinaryCompactObject(
-          {{2.0, 0.05, 0.0}}, {-5.0, 0.05, 0.0}, 1.0, 0.4, false, false, false,
-          1.0, false, 1_st, 3_st, std::nullopt,
-          create_inner_boundary_condition(), create_outer_boundary_condition(),
-          Options::Context{false, {}, 1, 1}),
+          {{2.0, 0.05, 0.0}}, {-5.0, 0.05, 0.0}, 1.0, 0.4, false, false, 1.0,
+          false, 1_st, 3_st, std::nullopt, create_inner_boundary_condition(),
+          create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring("OuterRadius is too small"));
   CHECK_THROWS_WITH(
       domain::creators::CylindricalBinaryCompactObject(
-          {{-2.0, 0.05, 0.0}}, {-5.0, 0.05, 0.0}, 1.0, 0.4, false, false, false,
-          25.0, false, 1_st, 3_st, std::nullopt,
-          create_inner_boundary_condition(), create_outer_boundary_condition(),
-          Options::Context{false, {}, 1, 1}),
+          {{-2.0, 0.05, 0.0}}, {-5.0, 0.05, 0.0}, 1.0, 0.4, false, false, 25.0,
+          false, 1_st, 3_st, std::nullopt, create_inner_boundary_condition(),
+          create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "The x-coordinate of the input CenterA is expected to be positive"));
   CHECK_THROWS_WITH(
       domain::creators::CylindricalBinaryCompactObject(
-          {{2.0, 0.05, 0.0}}, {5.0, 0.05, 0.0}, 1.0, 0.4, false, false, false,
-          25.0, false, 1_st, 3_st, std::nullopt,
-          create_inner_boundary_condition(), create_outer_boundary_condition(),
-          Options::Context{false, {}, 1, 1}),
+          {{2.0, 0.05, 0.0}}, {5.0, 0.05, 0.0}, 1.0, 0.4, false, false, 25.0,
+          false, 1_st, 3_st, std::nullopt, create_inner_boundary_condition(),
+          create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "The x-coordinate of the input CenterB is expected to be negative"));
   CHECK_THROWS_WITH(
       domain::creators::CylindricalBinaryCompactObject(
-          {{2.0, 0.05, 0.0}}, {-5.0, 0.05, 0.0}, -1.0, 0.4, false, false, false,
-          25.0, false, 1_st, 3_st, std::nullopt,
-          create_inner_boundary_condition(), create_outer_boundary_condition(),
-          Options::Context{false, {}, 1, 1}),
+          {{2.0, 0.05, 0.0}}, {-5.0, 0.05, 0.0}, -1.0, 0.4, false, false, 25.0,
+          false, 1_st, 3_st, std::nullopt, create_inner_boundary_condition(),
+          create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring("RadiusA and RadiusB are expected "
                                          "to be positive"));
   CHECK_THROWS_WITH(
       domain::creators::CylindricalBinaryCompactObject(
-          {{2.0, 0.05, 0.0}}, {-5.0, 0.05, 0.0}, 1.0, -0.4, false, false, false,
-          25.0, false, 1_st, 3_st, std::nullopt,
-          create_inner_boundary_condition(), create_outer_boundary_condition(),
-          Options::Context{false, {}, 1, 1}),
+          {{2.0, 0.05, 0.0}}, {-5.0, 0.05, 0.0}, 1.0, -0.4, false, false, 25.0,
+          false, 1_st, 3_st, std::nullopt, create_inner_boundary_condition(),
+          create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring("RadiusA and RadiusB are expected "
                                          "to be positive"));
   CHECK_THROWS_WITH(
       domain::creators::CylindricalBinaryCompactObject(
-          {{2.0, 0.05, 0.0}}, {-5.0, 0.05, 0.0}, 0.15, 0.4, false, false, false,
-          25.0, false, 1_st, 3_st, std::nullopt,
-          create_inner_boundary_condition(), create_outer_boundary_condition(),
-          Options::Context{false, {}, 1, 1}),
+          {{2.0, 0.05, 0.0}}, {-5.0, 0.05, 0.0}, 0.15, 0.4, false, false, 25.0,
+          false, 1_st, 3_st, std::nullopt, create_inner_boundary_condition(),
+          create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "RadiusA should not be smaller than RadiusB"));
   CHECK_THROWS_WITH(
       domain::creators::CylindricalBinaryCompactObject(
-          {{2.0, 0.05, 0.0}}, {-1.0, 0.05, 0.0}, 1.0, 0.4, false, false, false,
-          25.0, false, 1_st, 3_st, std::nullopt,
-          create_inner_boundary_condition(), create_outer_boundary_condition(),
-          Options::Context{false, {}, 1, 1}),
+          {{2.0, 0.05, 0.0}}, {-1.0, 0.05, 0.0}, 1.0, 0.4, false, false, 25.0,
+          false, 1_st, 3_st, std::nullopt, create_inner_boundary_condition(),
+          create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring("We expect |x_A| <= |x_B|"));
   CHECK_THROWS_WITH(
       domain::creators::CylindricalBinaryCompactObject(
-          {{4.0, 0.0, 0.0}}, {-4.0, 0.0, 0.0}, 1.0, 1.0, false, false, false,
-          25.0, false, 1_st, 3_st,
+          {{4.0, 0.0, 0.0}}, {-4.0, 0.0, 0.0}, 1.0, 1.0, false, false, 25.0,
+          false, 1_st, 3_st,
           TimeDepOptions{
               0.0, std::nullopt,
               domain::creators::time_dependent_options::RotationMapOptions<
@@ -616,9 +599,8 @@ void test_parse_errors() {
   // Boundary condition errors
   CHECK_THROWS_WITH(
       domain::creators::CylindricalBinaryCompactObject(
-          {{2.0, 0.05, 0.0}}, {-5.0, 0.05, 0.0}, 1.0, 0.4, false, false, false,
-          25.0, false, 1_st, 3_st, std::nullopt,
-          create_inner_boundary_condition(),
+          {{2.0, 0.05, 0.0}}, {-5.0, 0.05, 0.0}, 1.0, 0.4, false, false, 25.0,
+          false, 1_st, 3_st, std::nullopt, create_inner_boundary_condition(),
           std::make_unique<TestHelpers::domain::BoundaryConditions::
                                TestPeriodicBoundaryCondition<3>>(),
           Options::Context{false, {}, 1, 1}),
@@ -626,8 +608,8 @@ void test_parse_errors() {
                                          "conditions with a binary domain"));
   CHECK_THROWS_WITH(
       domain::creators::CylindricalBinaryCompactObject(
-          {{2.0, 0.05, 0.0}}, {-5.0, 0.05, 0.0}, 1.0, 0.4, false, false, false,
-          25.0, false, 1_st, 3_st, std::nullopt,
+          {{2.0, 0.05, 0.0}}, {-5.0, 0.05, 0.0}, 1.0, 0.4, false, false, 25.0,
+          false, 1_st, 3_st, std::nullopt,
           std::make_unique<TestHelpers::domain::BoundaryConditions::
                                TestPeriodicBoundaryCondition<3>>(),
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
@@ -635,26 +617,26 @@ void test_parse_errors() {
                                          "conditions with a binary domain"));
   CHECK_THROWS_WITH(
       domain::creators::CylindricalBinaryCompactObject(
-          {{2.0, 0.05, 0.0}}, {-5.0, 0.05, 0.0}, 1.0, 0.4, false, false, false,
-          25.0, false, 1_st, 3_st, std::nullopt, nullptr,
+          {{2.0, 0.05, 0.0}}, {-5.0, 0.05, 0.0}, 1.0, 0.4, false, false, 25.0,
+          false, 1_st, 3_st, std::nullopt, nullptr,
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "Must specify either both inner and outer boundary "
           "conditions or neither."));
-  CHECK_THROWS_WITH(domain::creators::CylindricalBinaryCompactObject(
-                        {{2.0, 0.05, 0.0}}, {-5.0, 0.05, 0.0}, 1.0, 0.4, false,
-                        false, false, 25.0, false, 1_st, 3_st, std::nullopt,
-                        create_inner_boundary_condition(), nullptr,
-                        Options::Context{false, {}, 1, 1}),
-                    Catch::Matchers::ContainsSubstring(
-                        "Must specify either both inner and outer boundary "
-                        "conditions or neither."));
+  CHECK_THROWS_WITH(
+      domain::creators::CylindricalBinaryCompactObject(
+          {{2.0, 0.05, 0.0}}, {-5.0, 0.05, 0.0}, 1.0, 0.4, false, false, 25.0,
+          false, 1_st, 3_st, std::nullopt, create_inner_boundary_condition(),
+          nullptr, Options::Context{false, {}, 1, 1}),
+      Catch::Matchers::ContainsSubstring(
+          "Must specify either both inner and outer boundary "
+          "conditions or neither."));
 }
 
 // This matches the structure in the option string
 std::unordered_map<std::string, std::array<size_t, 3>> make_initial_structure(
     const size_t initial_value, const bool include_inner_sphere_A,
-    const bool include_inner_sphere_B, const bool include_outer_sphere) {
+    const bool include_inner_sphere_B) {
   std::unordered_map<std::string, std::array<size_t, 3>> initial_map;
   const std::array<size_t, 3> same{initial_value, initial_value, initial_value};
   const std::array<size_t, 3> one_more{initial_value + 1, initial_value,
@@ -668,9 +650,7 @@ std::unordered_map<std::string, std::array<size_t, 3>> make_initial_structure(
   if (include_inner_sphere_B) {
     initial_map["InnerSphereB"] = same;
   }
-  if (include_outer_sphere) {
-    initial_map["OuterSphere"] = one_more;
-  }
+  initial_map["OuterSphere"] = one_more;
 
   return initial_map;
 }
@@ -689,20 +669,17 @@ void test_cylindrical_bbh() {
   // When we add sphere_e support we will make the following
   // loop go over {true, false}
   const bool with_sphere_e = false;
-  for (auto [include_outer_sphere, include_inner_sphere_A,
-             include_inner_sphere_B, use_equiangular_map,
-             with_additional_outer_radial_refinement,
+  for (auto [include_inner_sphere_A, include_inner_sphere_B,
+             use_equiangular_map, with_additional_outer_radial_refinement,
              with_additional_grid_points, with_time_dependence,
              with_control_systems, with_boundary_conditions] :
        random_sample<5>(
            cartesian_product(make_array(true, false), make_array(true, false),
                              make_array(true, false), make_array(true, false),
                              make_array(true, false), make_array(true, false),
-                             make_array(true, false), make_array(true, false),
-                             make_array(true, false)),
+                             make_array(true, false), make_array(true, false)),
            make_not_null(&gen))) {
     CAPTURE(with_sphere_e);
-    CAPTURE(include_outer_sphere);
     CAPTURE(use_equiangular_map);
     CAPTURE(with_boundary_conditions);
     CAPTURE(with_additional_outer_radial_refinement);
@@ -711,7 +688,6 @@ void test_cylindrical_bbh() {
     if (with_time_dependence) {
       include_inner_sphere_A = true;
       include_inner_sphere_B = true;
-      include_outer_sphere = true;
     } else {
       // With no time dependence, can't have control systems
       with_control_systems = false;
@@ -720,7 +696,7 @@ void test_cylindrical_bbh() {
     CAPTURE(include_inner_sphere_B);
     CAPTURE(with_control_systems);
 
-    const double outer_radius = include_outer_sphere ? 100.0 : 30.0;
+    const double outer_radius = 100.0;
     const double mass_ratio = with_sphere_e ? 4 : 1.2;
     // Set centers so that the Newtonian COM is at the origin,
     // except offset slightly in the y direction.
@@ -738,16 +714,14 @@ void test_cylindrical_bbh() {
     CylBCO::InitialGridPoints::type initial_grid_points{};
 
     if (with_additional_outer_radial_refinement) {
-      initial_refinement =
-          make_initial_structure(refinement, include_inner_sphere_A,
-                                 include_inner_sphere_B, include_outer_sphere);
+      initial_refinement = make_initial_structure(
+          refinement, include_inner_sphere_A, include_inner_sphere_B);
     } else {
       initial_refinement = refinement;
     }
     if (with_additional_grid_points) {
-      initial_grid_points =
-          make_initial_structure(grid_points, include_inner_sphere_A,
-                                 include_inner_sphere_B, include_outer_sphere);
+      initial_grid_points = make_initial_structure(
+          grid_points, include_inner_sphere_A, include_inner_sphere_B);
     } else {
       initial_grid_points = grid_points;
     }
@@ -764,7 +738,6 @@ void test_cylindrical_bbh() {
         inner_radius_objectB,
         include_inner_sphere_A,
         include_inner_sphere_B,
-        include_outer_sphere,
         outer_radius,
         use_equiangular_map,
         initial_refinement,
@@ -775,17 +748,15 @@ void test_cylindrical_bbh() {
 
     test_construction(cyl_binary_compact_object, with_boundary_conditions,
                       include_inner_sphere_A, include_inner_sphere_B,
-                      include_outer_sphere, inner_radius_objectA,
-                      inner_radius_objectB, outer_radius, center_objectA,
-                      center_objectB, times_to_check);
+                      inner_radius_objectA, inner_radius_objectB, outer_radius,
+                      center_objectA, center_objectB, times_to_check);
     TestHelpers::domain::creators::test_creation(
         create_option_string(
             with_time_dependence, with_additional_outer_radial_refinement,
-            with_additional_grid_points, include_outer_sphere,
-            include_inner_sphere_A, include_inner_sphere_B,
-            with_boundary_conditions, use_equiangular_map, center_objectA,
-            center_objectB, inner_radius_objectA, inner_radius_objectB,
-            outer_radius),
+            with_additional_grid_points, include_inner_sphere_A,
+            include_inner_sphere_B, with_boundary_conditions,
+            use_equiangular_map, center_objectA, center_objectB,
+            inner_radius_objectA, inner_radius_objectB, outer_radius),
         cyl_binary_compact_object, with_boundary_conditions);
   }
 }


### PR DESCRIPTION
## Proposed changes

This enables the user to toggle between using a spherical shell (new) and deformed cylinders (current) for `CylindricalBinaryCompactObject`. It mirrors the changes to BCO in #7205.

Dependent on #7202 and #7205 

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
