### PR TITLE
Call CAPTURE_FOR_ERROR from MAKE_GENERATOR

### DIFF
--- a/tests/Unit/Framework/TestHelpers.hpp
+++ b/tests/Unit/Framework/TestHelpers.hpp
@@ -25,6 +25,7 @@
 #include "DataStructures/Variables.hpp"
 #include "Utilities/Algorithm.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/ErrorHandling/CaptureForError.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeArray.hpp"
@@ -326,15 +327,25 @@ inline std::ostream& operator<<(std::ostream& os, const NonCopyable& /*v*/) {
 /// \cond
 #define MAKE_GENERATOR_IMPL_FIRST_ARG(NAME, ...) NAME
 #define MAKE_GENERATOR_IMPL_SECOND_ARG(NAME, SEED, ...) SEED
+#define MAKE_GENERATOR_IMPL_CONCAT2(a, b) a##b
+#define MAKE_GENERATOR_IMPL_CONCAT(a, b) MAKE_GENERATOR_IMPL_CONCAT2(a, b)
+// Because of preprocessor weirdness the name and arguments of this
+// macro get printed in the error message, so make it something
+// understandable and avoid requiring dummy arguments and such.
+#define MAKE_GENERATOR_MESSAGE(...)                            \
+  MAKE_GENERATOR_IMPL_CONCAT(                                  \
+      MAKE_GENERATOR_IMPL_FIRST_ARG(__VA_ARGS__, DUMMY_TOKEN), \
+      _MAKE_GENERATOR_message)
 /// \endcond
 
 /// \ingroup TestingFrameworkGroup
 /// \brief `MAKE_GENERATOR(NAME [, SEED])` declares a variable of name `NAME`
 /// containing a generator of type `std::mt19937`.
 ///
-/// \details As the generator is made, `INFO` is called to make sure failed
-/// tests provide seed information.  `SEED` is chosen randomly if not supplied,
-/// otherwise it must be a constant expression.
+/// \details As the generator is made, `INFO` and `CAPTURE_FOR_ERROR`
+/// are called to make sure failed tests provide seed information.
+/// `SEED` is chosen randomly if not supplied, otherwise it must be a
+/// constant expression.
 // What is going on here:
 //
 // If this is called as MAKE_GENERATOR(NAME):
@@ -366,14 +377,16 @@ inline std::ostream& operator<<(std::ostream& os, const NonCopyable& /*v*/) {
 #define MAKE_GENERATOR(...)                                             \
   std::mt19937 MAKE_GENERATOR_IMPL_FIRST_ARG(__VA_ARGS__, DUMMY_TOKEN); \
   /* Capture everything because we don't know what passed seed uses */  \
-  INFO("Seed is: " << [&]() {                                           \
+  const std::string MAKE_GENERATOR_MESSAGE(__VA_ARGS__) = [&]() {       \
     const auto MAKE_GENERATOR_seed = (MAKE_GENERATOR_IMPL_SECOND_ARG(   \
         __VA_ARGS__, std::random_device{}(), DUMMY_TOKEN));             \
     MAKE_GENERATOR_IMPL_FIRST_ARG(__VA_ARGS__, DUMMY_TOKEN)             \
         .seed(MAKE_GENERATOR_seed);                                     \
-    return MakeString{} << MAKE_GENERATOR_seed << " from " __FILE__ ":" \
-                        << __LINE__;                                    \
-  }());
+    return MakeString{} << "Seed is: " << MAKE_GENERATOR_seed           \
+                        << " from " __FILE__ ":" << __LINE__;           \
+  }();                                                                  \
+  INFO(MAKE_GENERATOR_MESSAGE(__VA_ARGS__));                            \
+  CAPTURE_FOR_ERROR(MAKE_GENERATOR_MESSAGE(__VA_ARGS__))
 
 /*!
  * \ingroup TestingFrameworkGroup

--- a/tests/Unit/Framework/Tests/Test_TestHelpers.cpp
+++ b/tests/Unit/Framework/Tests/Test_TestHelpers.cpp
@@ -16,6 +16,7 @@
 #include <vector>
 
 #include "Framework/TestHelpers.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/StdHelpers.hpp"
 
@@ -150,6 +151,9 @@ void test_make_generator(const gsl::not_null<std::mt19937*> generator) {
 
   MAKE_GENERATOR(seeded_gen, 12345);
   CHECK(seeded_gen() == 3992670690);
+
+  CHECK_THROWS_WITH([]() { ERROR(""); }(),
+                    Catch::Matchers::ContainsSubstring("Seed is: 12345 from "));
 }
 
 void test_random_sample(const gsl::not_null<std::mt19937*> generator) {


### PR DESCRIPTION
The existing INFO prints the seed for Catch macro failures, but not if the code calls ERROR outside a Catch macro.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
