### PR TITLE
More descriptive error message for BBH headon

### DIFF
--- a/support/Pipelines/EccentricityControl/InitialOrbitalParameters.py
+++ b/support/Pipelines/EccentricityControl/InitialOrbitalParameters.py
@@ -86,6 +86,12 @@ def initial_orbital_parameters(
         "Initial orbital parameters can currently only be computed for zero"
         " eccentricity."
     )
+    assert orbital_angular_velocity != 0.0, (
+        "Cannot solve for orbital parameters if 'orbital_angular_velocity' is"
+        " zero. If you want orbital_angular_velocity=0, do not specify"
+        " eccentricity. Instead, specify the separation 'D_0' and radial"
+        " expansion velocity 'adot_0'."
+    )
     assert radial_expansion_velocity is None, (
         "Can't use the 'radial_expansion_velocity' to compute orbital"
         " parameters. Remove it and choose another orbital parameter."


### PR DESCRIPTION
## Proposed changes

The following change addresses issue #6240 with a more clarifying error message in the event someone attempts to start a bbh headon collision with both orbital_angular_velocity=0 and eccentricity=0. 

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
