### PR TITLE
Add SpECTRE PR readiness skill

### DIFF
--- a/.claude/skills/spectre-pr-ready/SKILL.md
+++ b/.claude/skills/spectre-pr-ready/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: spectre-pr-ready
+description: >
+  Run a SpECTRE pre-PR readiness check on local changes before opening a PR or
+  marking it ready for review.
+allowed-tools: ["Bash", "Read", "Grep", "Glob"]
+argument-hint: "[clang-tidy] [coverage]"
+---
+
+Read and follow instructions in file
+`$(git rev-parse --show-toplevel)/.skills/spectre-pr-ready/SKILL.md`

--- a/.skills/spectre-fix-ci/SKILL.md
+++ b/.skills/spectre-fix-ci/SKILL.md
@@ -17,7 +17,15 @@ After the script returns:
    and what the error was.
 2. **Identify source locations**: find file paths and line numbers in the
    error output that point to the failing code.
-3. **Suggest next steps**: propose a fix or further investigation.
+3. **Classify the failure**: compile, unit-test assertion, timeout,
+   infrastructure/dependency, formatting, clang-tidy, docs, or unknown.
+4. **Timeouts**: if tests only timed out, rerun each timed-out test serially
+   before changing code.
+5. **Tolerance failures**: investigate numerical stability or real `src` bugs
+   before relaxing tolerances.
+6. **Suggest next steps**: propose a fix or further investigation. If the
+   failure looks unrelated to the PR, say why and identify the component that
+   failed.
 
 If the context window seems too narrow to understand the failure, re-run
 with `--context 150` for more surrounding lines.

--- a/.skills/spectre-fix-pr/SKILL.md
+++ b/.skills/spectre-fix-pr/SKILL.md
@@ -14,7 +14,8 @@ python3 \
 After fetching the PR data:
 
 1. **Summarize the review** before starting work: list the total number of
-   threads, how many are unresolved, and the files affected.
+   threads, how many are unresolved, how many are resolved/outdated if that
+   data is available, and the files affected.
 2. **Prioritize UNRESOLVED threads** -- these are the comments that still need
    to be addressed. Start with unresolved, non-outdated threads first.
 3. **Group by file** -- work through comments file-by-file rather than jumping
@@ -24,4 +25,12 @@ After fetching the PR data:
    to.
 5. **Check OUTDATED threads** -- these refer to code that has since changed.
    Verify whether the concern still applies before making changes.
-6. **Skip resolved threads** unless the user specifically asks about them.
+6. **Learn repeated themes before editing** -- if reviewers repeat the same
+   concern (formatting churn, missing includes, weak tests, loose tolerances,
+   allocations, unclear docs, co-author trailers), check for the same issue
+   elsewhere in the PR before calling the feedback addressed.
+7. **Skip resolved threads** unless the user specifically asks about them. If
+   the user asks for all feedback or a summary, include resolved and outdated
+   threads as well.
+8. **Before final response**, state which comments were addressed, which are
+   obsolete because the code changed, and which remain intentionally unresolved.

--- a/.skills/spectre-pr-ready/SKILL.md
+++ b/.skills/spectre-pr-ready/SKILL.md
@@ -1,0 +1,80 @@
+# SpECTRE PR Readiness
+
+Prepare local SpECTRE changes for opening or marking a PR ready. This is a
+pre-review workflow, not a substitute for human review.
+
+## Step 1: Collect Scope
+
+- Identify the base branch, normally `develop`.
+- Gather `git diff develop...HEAD`, `git diff`, and `git diff --cached`.
+- List changed files by type: C++, Python, CMake, docs, other.
+- List local commits with subjects and full messages.
+
+## Step 2: Run Mechanical Checks
+
+- Run changed-line C++ formatting with `git clang-format` or the same
+  changed-line procedure used by `spectre-review`.
+- Run `black --check --diff` and `isort --check-only --diff` for changed Python
+  files outside `external/`.
+- Check CMake lists are updated and alphabetized.
+- Check direct includes for newly used symbols.
+- Check for whole-file formatting churn unrelated to the change.
+- Run `git commit --dry-run` before finalizing unless the user asked not to
+  commit or the tree is intentionally not commit-ready.
+
+## Step 3: Review Commit Hygiene
+
+- No `fixup!`, `WIP`, `testing`, `rebase`, or similar temporary commit subjects.
+- Commit subjects should be short, descriptive, and imperative.
+- Commit bodies should include context when behavior changes or dependencies are
+  added.
+- Reference issue numbers or external resources inline when available.
+- Squash commits that introduce a mistake and later fix it, unless the user
+  explicitly wants a multi-commit review history.
+- Co-author trailers must be in commit messages, not only PR descriptions.
+- Keep a blank line before trailer blocks so GitHub recognizes
+  `Co-Authored-by` lines.
+
+## Step 4: Run Recurring Feedback Checklist
+
+Read `.skills/spectre-review/references/reviewer-feedback-checklist.md` and
+apply it to the local diff. Focus on:
+
+- weak tests, loose tolerances, missing failure-path tests
+- unit-test placement in `tests/Unit`, test naming, focused coverage for new
+  functionality, and use of anonymous-namespace helpers
+- allocations, copies, expensive recomputation, expression-template pitfalls
+- numerical robustness near poles, origins, degenerate intervals, and
+  cancellation
+- Doxygen assumptions, data layout, valid domains, equations, and citations
+- reuse of existing SpECTRE helpers and local patterns
+
+## Step 5: Build and Test
+
+- Build targeted targets affected by the change when possible.
+- Run focused `ctest --test-dir /home/vscode/work/builds/build -R <pattern>
+  --output-on-failure`.
+- If parallel tests time out, rerun timed-out tests serially before changing
+  code.
+- If changing docs, build `doc-check` when feasible.
+- If clang-tidy is requested, use the repository clang-tidy hash script from
+  `AGENTS.md` or run targeted clang-tidy against the configured build.
+  To test all commits after, but not including, `HASH_BEFORE_COMMITS_TO_CHECK`,
+  run:
+  ```
+  /home/vscode/work/builds/spectre-container/tools/ClangTidyHash.sh \
+    /home/vscode/work/builds/build \
+    /home/vscode/work/builds/spectre-container \
+    HASH_BEFORE_COMMITS_TO_CHECK 8
+  ```
+  Typically `HASH_BEFORE_COMMITS_TO_CHECK` is the commit synced with
+  `origin/develop`.
+
+## Step 6: Report
+
+Summarize blockers first, then important cleanup, optional polish, and testing
+performed. Include exact commands run and any commands that could not be run.
+For PR descriptions, summarize the motivation, user-visible effects, testing
+performed, and relevant build/test commands. Reference issues or external
+resources when useful, and attach visual artifacts or data files when they
+clarify the change.

--- a/.skills/spectre-review/SKILL.md
+++ b/.skills/spectre-review/SKILL.md
@@ -25,6 +25,9 @@ Save the diff. Extract the list of changed files categorized by type (C++
 
 Create a task list tracking all review steps.
 
+Read `references/reviewer-feedback-checklist.md`. Use it as an additional
+checklist throughout the review and provide it to review agents in Step 4.
+
 ## Step 2: Formatting Checks (run in parallel)
 
 ### C++ (clang-format)
@@ -89,11 +92,14 @@ Verify:
 ### Commit Messages (local mode only)
 Check no commit starts with (case-insensitive): fixup, wip, fixme, deleteme,
 rebaseme, testing, rebase.
+Check co-author trailers are in commit messages, separated from the body by a
+blank line, so GitHub recognizes them.
 
 ## Step 4: Code Review (2 Parallel Agents)
 
 Launch 2 parallel agents. Provide each with the full diff and the
-SpECTRE code rules reference shown above.
+SpECTRE code rules reference shown above, plus
+`references/reviewer-feedback-checklist.md`.
 
 ### Agent A: Style, Patterns & Idioms
 Instructions for the agent:
@@ -104,6 +110,9 @@ Instructions for the agent:
   operation, a loop that looks like it reimplements an existing utility), use
   `grep -r` in `src/DataStructures/Tensor/EagerMath/`, `src/DataStructures/`,
   `src/NumericalAlgorithms/`, or `src/Utilities/` to find an existing utility
+- Check the recurring reviewer-feedback checklist, especially commit hygiene,
+  formatting churn, CMake ordering, includes, existing local helpers, and API
+  naming/documentation
 - Only flag issues in lines that the diff introduces (not pre-existing code)
 - For each finding: `file:line`, severity (`critical`/`important`/`suggestion`),
   explanation
@@ -119,6 +128,9 @@ Instructions for the agent:
 - Check that new source files have corresponding tests (`src/Foo/Bar.hpp` ->
   `tests/Unit/Foo/Test_Bar.cpp`)
 - Check that new `.cpp`/`.hpp` files are listed in their `CMakeLists.txt`
+- Check the recurring reviewer-feedback checklist, especially weak tests,
+  tolerance relaxations, missing ASSERT/ERROR tests, unnecessary allocations,
+  copies, expensive recomputation, NaN handling, and unclear numerical docs
 - Only flag issues introduced by the diff
 - For each finding: `file:line`, severity, explanation
 - Check for potentially problematic floating point math like:

--- a/.skills/spectre-review/references/reviewer-feedback-checklist.md
+++ b/.skills/spectre-review/references/reviewer-feedback-checklist.md
@@ -1,0 +1,91 @@
+# Recurring SpECTRE Reviewer Feedback Checklist
+
+Use this checklist when reviewing local changes, PRs, or PR readiness. Only
+flag issues introduced by the diff, unless the user explicitly asks for a
+broader audit.
+
+## Commit and PR Hygiene
+
+- Co-author trailers belong in commit messages, not only PR descriptions.
+- Commit messages should have a subject, a blank line before any body text, and
+  a blank line before trailers so GitHub recognizes `Co-Authored-by` trailers.
+- Flag obvious `fixup!`, `WIP`, or review-fix commits in PR-ready work.
+- If commits introduce a bad pattern and later fix it, suggest squashing before
+  review.
+
+## Formatting and Includes
+
+- Avoid whole-file formatting churn. Prefer `git clang-format` or changed-line
+  formatting.
+- Watch for stale clang-format output, especially around `requires` clauses.
+- CMake source/header lists must stay alphabetized.
+- New symbol uses should have direct includes, not rely on transitive includes.
+- Keep include blocks in SpECTRE order. For CLI Python modules, delayed imports
+  may be intentional to avoid startup cost.
+
+## Tests
+
+- Unit tests should live in `tests/Unit` alongside the module under test.
+- Keep integration or regression scenarios in dedicated subdirectories.
+- Name tests after the component and behavior being validated.
+- Treat tolerance relaxations as suspicious. Prefer finding the numerical cause
+  before raising tolerances.
+- Tests should verify correctness, not just repeat the implementation or check
+  sizes/counts.
+- New functionality should have focused test coverage.
+- Prefer identity/metamorphic tests when possible, such as Cartoon vs
+  non-Cartoon agreement on axes.
+- Add `CHECK_THROWS_WITH` coverage for new `ASSERT`/`ERROR` paths when
+  practical.
+- Use `signaling_NaN()` for data that should not be used.
+- Avoid multiple active `MAKE_GENERATOR` instances; pass generators to helpers.
+- Prefer one `SPECTRE_TEST_CASE` calling anonymous-namespace helpers over many
+  small `SPECTRE_TEST_CASE`s.
+- Increase test timeouts sparingly and justify long-running cases.
+- Test relevant data types, including `double`, when behavior differs from
+  `DataVector`.
+
+## Performance and Allocations
+
+- In numerical kernels and reusable utilities, look for allocations in loops or
+  repeated calls.
+- Prefer `Variables`, explicit temp buffers, or cached matrices for repeated
+  tensor/data operations.
+- Avoid unnecessary copies; use `const auto&` when a copy is not intended.
+- Do not zero-initialize data that is completely overwritten. Debug NaN
+  initialization is often better for catching errors.
+- Cache expensive transform/filter matrices instead of rebuilding them on each
+  call.
+- Be careful with Blaze/DataVector expression templates: `auto` can bind lazy
+  expressions when a concrete `DataType` is intended.
+
+## Numerical Robustness
+
+- Check for cancellation, especially expressions like `1 - W`.
+- Check denominators near coordinate boundaries, poles, origins, and degenerate
+  intervals.
+- Prefer stable library functions: `atan2`, `log1p`, `expm1`, `hypot`, Horner
+  evaluation or `evaluate_polynomial()`.
+- If a test fails near a singular/degenerate case, consider whether `src` has a
+  real bug before relaxing the test.
+- Use sufficiently resolved test grids so tolerances can detect real errors.
+
+## Documentation and API Shape
+
+- New public APIs need Doxygen that explains assumptions, valid domains,
+  restrictions, data layout, and component interpretation.
+- Mathematical/numerical code should include equations or citations when the
+  implementation is not obvious.
+- For tensor transforms, document whether data is Cartesian, spherical,
+  spin-weighted, nodal, modal, strided, or radially batched.
+- Prefer established local terms such as `stride` or `radial_extents` over vague
+  names like `number_of_offsets`.
+
+## Existing Patterns
+
+- Before accepting a new helper, search for local precedent in
+  `src/DataStructures/Tensor/EagerMath/`, `src/NumericalAlgorithms/`,
+  `src/PointwiseFunctions/`, and `src/Utilities/`.
+- Prefer existing helpers and patterns such as `to_different_frame`,
+  `apply_tensor_ylm_filter`, `ActionTesting::invoke_queued_simple_action`,
+  EagerMath functions, and existing domain creator designs.


### PR DESCRIPTION
Add a PR-readiness workflow and recurring reviewer feedback checklist, and wire the review, PR-comment, and CI skills to catch common feedback before review.

## Proposed changes

I used codex to analyze common reviewer feedback on AI-co-authored PRs. I then went back and forth with Codex to draft edits to skills and a new "prepare pr" skill that specifically tries to avoid the common errors that have been coming up.

Before merging, I'd like to get some experience using them to prepare and review new PRs. But I'm sharing this as a draft PR in case anyone would like to offer feedback on the overall idea or on specific changes.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [x] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
