### PR TITLE
Fix bug from deriving 3D EoS from initial data in GrmhdEquationOfState.

### DIFF
--- a/src/PointwiseFunctions/Hydro/Tags.hpp
+++ b/src/PointwiseFunctions/Hydro/Tags.hpp
@@ -368,8 +368,8 @@ struct GrmhdEquationOfState : db::SimpleTag {
           tmpl::at<typename Metavariables::factory_creation::factory_classes,
                    ::evolution::initial_data::InitialData>>(
           initial_data.get(), [](const auto* const derived_initial_data) {
-            if constexpr (::evolution::is_numeric_initial_data_v<
-                              std::decay_t<decltype(*derived_initial_data)>>) {
+            using id_type = std::decay_t<decltype(*derived_initial_data)>;
+            if constexpr (::evolution::is_numeric_initial_data_v<id_type>) {
               ERROR(
                   "Equation of State cannot currently be parsed from numeric"
                   "initial data, please explicitly specify the equation of "
@@ -378,8 +378,16 @@ struct GrmhdEquationOfState : db::SimpleTag {
                   EquationsOfState::PolytropicFluid<true>>>(
                   EquationsOfState::PolytropicFluid<true>(100.0, 2.0));
             } else {
-              return (derived_initial_data->equation_of_state()
-                          .promote_to_3d_eos());
+              using eos_type = std::decay_t<decltype(
+                  std::declval<id_type>().equation_of_state())>;
+              const auto& derived_eos =
+                  derived_initial_data->equation_of_state();
+              if constexpr (eos_type::thermodynamic_dim < 3) {
+                return (derived_eos.promote_to_3d_eos());
+              }
+              else {
+                return derived_eos.get_clone();
+              }
             }
           });
     }


### PR DESCRIPTION
## Proposed changes

In the `create_from_options()` function in `GrmhdEquationOfState`, if no equation of state is supplied directly, it will be inferred from initial data. Previously, this step would apply `promote_to_3d_eos()` to the EoS regardless of its dimensionality. If the initial data's EoS happened to already be 3D, this step would break.

This PR checks the dimensionality of the EoS and only runs `promote_to_3d_eos()` if the EoS is 1D or 2D. Otherwise, it simply takes a clone of the EoS. There are otherwise syntax improvements.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

