### PR TITLE
Fix warnings stemming from namespace and included files in hydro

### DIFF
--- a/src/PointwiseFunctions/Hydro/LowerSpatialFourVelocity.hpp
+++ b/src/PointwiseFunctions/Hydro/LowerSpatialFourVelocity.hpp
@@ -22,14 +22,13 @@ namespace hydro::Tags {
  *
  */
 struct LowerSpatialFourVelocityCompute
-    : hydro::Tags::LowerSpatialFourVelocity<DataVector, 3, Frame::Inertial>,
+    : LowerSpatialFourVelocity<DataVector, 3, Frame::Inertial>,
       db::ComputeTag {
-  using base =
-      hydro::Tags::LowerSpatialFourVelocity<DataVector, 3, Frame::Inertial>;
+  using base = LowerSpatialFourVelocity<DataVector, 3, Frame::Inertial>;
   using argument_tags =
-      tmpl::list<hydro::Tags::SpatialVelocity<DataVector, 3, Frame::Inertial>,
+      tmpl::list<SpatialVelocity<DataVector, 3, Frame::Inertial>,
                  gr::Tags::SpatialMetric<DataVector, 3>,
-                 hydro::Tags::LorentzFactor<DataVector>>;
+                 LorentzFactor<DataVector>>;
   static void function(const gsl::not_null<tnsr::i<DataVector, 3>*> result,
                        const tnsr::I<DataVector, 3>& spatial_velocity,
                        const tnsr::ii<DataVector, 3>& spatial_metric,

--- a/src/PointwiseFunctions/Hydro/Tags.hpp
+++ b/src/PointwiseFunctions/Hydro/Tags.hpp
@@ -304,7 +304,7 @@ struct Temperature : db::SimpleTag {
 /// The transport velocity is defined as \f$v_t^i=\alpha v^i-\beta^i\f$,
 /// with $v^i$ being the spatial velocity, $\alpha$ the lapse, and
 /// $\beta^i$ the shift.
-template <typename DataType, size_t Dim, typename Fr = Frame::Inertial>
+template <typename DataType, size_t Dim, typename Fr>
 struct TransportVelocity : db::SimpleTag {
   using type = tnsr::I<DataType, Dim, Fr>;
 };

--- a/src/PointwiseFunctions/Hydro/TagsDeclarations.hpp
+++ b/src/PointwiseFunctions/Hydro/TagsDeclarations.hpp
@@ -71,6 +71,8 @@ struct SpecificInternalEnergy;
 template <typename DataType>
 struct Temperature;
 template <typename DataType, size_t Dim, typename Fr = Frame::Inertial>
+struct TransportVelocity;
+template <typename DataType, size_t Dim, typename Fr = Frame::Inertial>
 struct LowerSpatialFourVelocity;
 template <typename DataType, size_t Dim, typename Fr = Frame::Inertial>
 struct LorentzFactorTimesSpatialVelocity;

--- a/src/PointwiseFunctions/Hydro/TransportVelocity.hpp
+++ b/src/PointwiseFunctions/Hydro/TransportVelocity.hpp
@@ -9,7 +9,7 @@
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"
-#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"
 
 /// \cond
 namespace gsl {
@@ -48,7 +48,7 @@ struct TransportVelocityCompute
                  ::gr::Tags::Lapse<DataType>,
                  ::gr::Tags::Shift<DataType, Dim, Fr>>;
 
-  using base = hydro::Tags::TransportVelocity<DataType, Dim, Fr>;
+  using base = TransportVelocity<DataType, Dim, Fr>;
   using return_type = typename base::type;
 
   static constexpr auto function = static_cast<void (*)(

--- a/tests/Unit/PointwiseFunctions/Hydro/Test_TransportVelocity.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/Test_TransportVelocity.cpp
@@ -11,6 +11,7 @@
 #include "Framework/CheckWithRandomValues.hpp"
 #include "Framework/SetupLocalPythonEnvironment.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
 #include "PointwiseFunctions/Hydro/TransportVelocity.hpp"
 
 namespace hydro {


### PR DESCRIPTION
## Proposed changes

A small syntax/formatting fix to the `TransportVelocity` tag, with a few edits to the `LowerSpatialFourVelocity` compute tag as well.

Issues had been stemming from the fact that `TransportVelocity` was not included in `TagsDeclarations.hpp`. Fixing this led to some other stylistic fixes.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
