### PR TITLE
Add Filters::Filter base class and Hypercube implementation

### DIFF
--- a/src/NumericalAlgorithms/LinearOperators/CMakeLists.txt
+++ b/src/NumericalAlgorithms/LinearOperators/CMakeLists.txt
@@ -55,4 +55,5 @@ target_link_libraries(
   DomainStructure
   )
 
+add_subdirectory(Filters)
 add_subdirectory(Python)

--- a/src/NumericalAlgorithms/LinearOperators/Filters/CMakeLists.txt
+++ b/src/NumericalAlgorithms/LinearOperators/Filters/CMakeLists.txt
@@ -1,0 +1,11 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  Filter.hpp
+  Hypercube.hpp
+  Hypercube.tpp
+  )

--- a/src/NumericalAlgorithms/LinearOperators/Filters/Filter.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/Filters/Filter.hpp
@@ -1,0 +1,164 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <pup.h>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+template <size_t Dim>
+class Mesh;
+template <typename TagsList>
+class Variables;
+/// \endcond
+
+namespace Filters {
+/*!
+ * \ingroup DiscontinuousGalerkinGroup
+ * \brief Abstract base class for spectral filters.
+ *
+ * Derived classes implement spectral filters that suppress high-frequency
+ * modes in the modal expansion of a discontinuous Galerkin solution. Writing
+ * the 1-D modal coefficients of a tensor component as \f$c_i\f$, a spectral
+ * filter rescales them as
+ *
+ * \f{align*}{
+ *  c_i \to \sigma\!\left(\frac{i}{N}\right) c_i,
+ * \f}
+ *
+ * where \f$N\f$ is the basis degree (number of grid points per element per
+ * dimension minus one) and \f$\sigma\f$ is a derived-class-specific damping
+ * factor (for example, an exponential in `Filters::Hypercube`). For a
+ * discussion of filtering see section 5.3 of \cite HesthavenWarburton.
+ *
+ * The interface is organized along two axes:
+ *
+ * - **Volume vs. boundary.** `apply_in_volume` filters the evolved
+ *   `Variables` on the element's `Dim`-dimensional mesh, while
+ *   `apply_on_boundary` filters data on a `Dim - 1` face mesh. The boundary
+ *   hook is intended for filtering the lifted boundary corrections produced
+ *   by the DG numerical flux before they enter the volume right-hand side.
+ *
+ * - **Substep vs. every-N-steps.** The driving action queries
+ *   `apply_volume_filter_on_substep()` (and the boundary analogue) to decide
+ *   whether to filter inside every Runge-Kutta substep, and
+ *   `apply_volume_filter_on_this_step(step_number)` (and the boundary
+ *   analogue) to gate filtering at coarser cadences such as every `N` full
+ *   steps. The two return values are independent so a derived class may pick
+ *   any combination.
+ *
+ * Derived classes additionally declare via `need_jacobians()` whether they
+ * require the grid-to-inertial Jacobian and its inverse in `apply_in_volume`
+ * / `apply_on_boundary`. When `need_jacobians()` returns `false`, the
+ * driving action passes `std::nullopt` for both Jacobian arguments and skips
+ * computing them.
+ *
+ * The set of domain blocks to which the filter applies is reported by
+ * `blocks_to_filter()`; a `std::nullopt` return value means the filter
+ * applies to every block in the domain.
+ */
+template <size_t Dim, typename TagList>
+class Filter : public PUP::able {
+ public:
+  Filter() = default;
+  ~Filter() noexcept override = default;
+
+  WRAPPED_PUPable_abstract(Filter);  // NOLINT
+  explicit Filter(CkMigrateMessage* m) : PUP::able(m) {}
+
+  /// Return a heap-allocated deep copy of this filter.
+  virtual std::unique_ptr<Filter<Dim, TagList>> get_clone() const = 0;
+
+  /// Whether the volume filter should be applied inside every Runge-Kutta
+  /// substep.
+  virtual bool apply_volume_filter_on_substep() const = 0;
+
+  /// Whether the volume filter should be applied at the given `step_number`.
+  virtual bool apply_volume_filter_on_this_step(size_t step_number) const = 0;
+
+  /// Whether the boundary filter should be applied inside every Runge-Kutta
+  /// substep.
+  virtual bool apply_boundary_filter_on_substep() const = 0;
+
+  /// Whether the boundary filter should be applied at the given
+  /// `step_number`.
+  virtual bool apply_boundary_filter_on_this_step(size_t step_number) const = 0;
+
+  /// \brief Whether the filter needs the grid-to-inertial Jacobian and its
+  /// inverse.
+  ///
+  /// When `false`, the driving action passes `std::nullopt` for the Jacobian
+  /// arguments of `apply_in_volume` and `apply_on_boundary` and avoids
+  /// constructing them.
+  virtual bool need_jacobians() const = 0;
+
+  /// \brief Returns `true` if this filter can filter the `mesh`.
+  virtual bool supports_mesh(const Mesh<Dim>& mesh) const = 0;
+
+  /// \brief Returns `true` if `other` is the same concrete filter type and is
+  /// equivalent to `*this`.
+  virtual bool is_equal(const Filter& other) const = 0;
+
+  /// \brief The set of block (or block group) names the filter applies to.
+  ///
+  /// `std::nullopt` means the filter applies to every block in the domain.
+  virtual const std::optional<std::vector<size_t>>& blocks_to_filter()
+      const = 0;
+
+  /// \brief Used after construction to change blocks and groups labeled by
+  /// strings to `size_t`s, which is what is used throughout the code.
+  virtual void set_blocks_to_filter(
+      const std::vector<std::string>& all_block_names,
+      const std::unordered_map<std::string, std::unordered_set<std::string>>&
+          block_groups) = 0;
+
+  /*!
+   * \brief Apply the filter in place to the volume `vars` on the
+   * `Dim`-dimensional `mesh`.
+   *
+   * The grid-to-inertial Jacobian `jac_grid_to_inertial` and its inverse
+   * `inv_jac_grid_to_inertial` are populated only when `need_jacobians()`
+   * returns `true`; otherwise both arguments are `std::nullopt`.
+   */
+  virtual void apply_in_volume(
+      gsl::not_null<Variables<TagList>*> vars, const Mesh<Dim>& mesh,
+      const std::optional<
+          InverseJacobian<DataVector, Dim, Frame::Grid, Frame::Inertial>>&
+          inv_jac_grid_to_inertial,
+      const std::optional<
+          Jacobian<DataVector, Dim, Frame::Grid, Frame::Inertial>>&
+          jac_grid_to_inertial) const = 0;
+
+  /*!
+   * \brief Apply the filter in place to face `vars` on the `Dim - 1` face
+   * `mesh`.
+   *
+   * Used to filter the lifted boundary corrections produced by the DG numerical
+   * flux before they enter the volume right-hand side. The grid-to-inertial
+   * Jacobian `jac_grid_to_inertial` and its inverse `inv_jac_grid_to_inertial`
+   * are populated only when `need_jacobians()` returns `true`; otherwise both
+   * arguments are `std::nullopt`.
+   */
+  virtual void apply_on_boundary(
+      gsl::not_null<Variables<TagList>*> vars, const Mesh<Dim - 1>& mesh,
+      const std::optional<
+          InverseJacobian<DataVector, Dim, Frame::Grid, Frame::Inertial>>&
+          inv_jac_grid_to_inertial,
+      const std::optional<
+          Jacobian<DataVector, Dim, Frame::Grid, Frame::Inertial>>&
+          jac_grid_to_inertial) const = 0;
+};
+}  // namespace Filters

--- a/src/NumericalAlgorithms/LinearOperators/Filters/Hypercube.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/Filters/Hypercube.hpp
@@ -1,0 +1,221 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <optional>
+#include <pup.h>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "NumericalAlgorithms/LinearOperators/Filters/Filter.hpp"
+#include "Options/Auto.hpp"
+#include "Options/Context.hpp"
+#include "Options/String.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+template <size_t Dim>
+class Mesh;
+class Matrix;
+template <typename TagsList>
+class Variables;
+/// \endcond
+
+namespace Filters {
+/*!
+ * \ingroup DiscontinuousGalerkinGroup
+ * \brief An exponential spectral filter applied in each logical direction of
+ * a tensor-product (line, square, cube, ...) element.
+ *
+ * Concrete implementation of `Filters::Filter` for tensor-product
+ * (hypercube) elements, driven by the DG filtering action. See
+ * `Filters::Filter` for the framing of volume vs. boundary application, the
+ * substep / every-N-steps cadence controls, and the `blocks_to_filter`
+ * semantics.
+ *
+ * For each component of the tensors in `TagList`, the filter rescales the
+ * 1-D modal coefficients \f$c_i\f$ in each logical direction as
+ *
+ * \f{align*}{
+ *  c_i \to c_i \exp\!\left[-36 \left(\frac{i}{N}\right)^{2m}\right],
+ * \f}
+ *
+ * where \f$N\f$ is the basis degree (number of grid points per element per
+ * dimension minus one) and \f$m\f$ is the `HalfPower` option. The same
+ * coefficient and `HalfPower` are used in every logical direction. With the
+ * fixed coefficient 36 the highest mode is rescaled by approximately machine
+ * epsilon, i.e. effectively zeroed. For a discussion of filtering see
+ * section 5.3 of \cite HesthavenWarburton.
+ *
+ * #### Design decision:
+ *
+ * The exponential coefficient is hardcoded to 36 since this is what has
+ * worked well in practice for several decades in SpEC. If we ever use
+ * quad or double-double types, we may want to try 72, but that is unlikely to
+ * be necessary since 36 decreases the highest coefficient by 1e-16. I.e.,
+ * this is not relative to the largest coefficient.
+ */
+template <size_t Dim, typename TagList>
+class Hypercube : public Filter<Dim, TagList> {
+ public:
+  /*!
+   * \brief Half of the exponent in the exponential.
+   *
+   * I.e., this is \f$m\f$ in
+   *
+   * \f{align*}{
+   *  c_i\to c_i \exp\left[-\alpha \left(\frac{i}{N}\right)^{2m}\right]
+   * \f}
+   */
+  struct HalfPower {
+    using type = unsigned;
+    static constexpr Options::String help =
+        "Half of the exponent in the generalized Gaussian";
+    static type lower_bound() { return 1; }
+  };
+
+  /// \brief Enable the filter
+  struct Enable {
+    using type = bool;
+    static constexpr Options::String help = {"Enable the filter"};
+  };
+
+  /// \brief Which blocks and block groups the filter should be applied to.
+  struct BlocksToFilter {
+    using type =
+        Options::Auto<std::vector<std::string>, Options::AutoLabel::All>;
+    static constexpr Options::String help = {
+        "List of blocks or block groups to apply filtering to. All other "
+        "blocks will have no filtering. You can also specify 'All' to do "
+        "filtering in all blocks of the domain that are hypercubes."};
+  };
+
+  /// \brief Apply the volume filter inside every substep instead of only at
+  /// step boundaries.
+  struct VolumeFilterOnSubstep {
+    using type = bool;
+    static constexpr Options::String help = {
+        "Enable the volume filter on every substep."};
+  };
+
+  /// \brief Apply the boundary correction filter inside every substep instead
+  /// of only at step boundaries.
+  struct BoundaryCorrectionFilterOnSubstep {
+    using type = bool;
+    static constexpr Options::String help = {
+        "Enable the boundary filter on every substep."};
+  };
+
+  /// \brief Apply the volume filter once every `N` steps. `None`
+  /// (`std::nullopt`) disables the every-N-steps trigger.
+  struct VolumeFilterEveryNSteps {
+    using type = Options::Auto<size_t, Options::AutoLabel::None>;
+    static constexpr Options::String help = {
+        "Enable the volume filter on every N steps. 'None' to disable."};
+  };
+
+  /// \brief Apply the boundary correction filter once every `N` steps. `None`
+  /// (`std::nullopt`) disables the every-N-steps trigger.
+  struct BoundaryCorrectionFilterEveryNSteps {
+    using type = Options::Auto<size_t, Options::AutoLabel::None>;
+    static constexpr Options::String help = {
+        "Enable the boundary filter on every N steps. 'None' to disable."};
+  };
+
+  using options =
+      tmpl::list<HalfPower, Enable, BlocksToFilter, VolumeFilterOnSubstep,
+                 BoundaryCorrectionFilterOnSubstep, VolumeFilterEveryNSteps,
+                 BoundaryCorrectionFilterEveryNSteps>;
+
+  static constexpr Options::String help = {
+      "An exponential filter applied in each direction of a line, square, or "
+      "cube (hypercube)."};
+
+  Hypercube();
+
+  Hypercube(unsigned half_power, bool enable,
+            const std::optional<std::vector<std::string>>& blocks_to_filter,
+            bool volume_filter_on_substep, bool boundary_filter_on_substep,
+            std::optional<size_t> volume_filter_every_n_steps,
+            std::optional<size_t> boundary_filter_every_n_steps,
+            const Options::Context& context = {});
+
+  WRAPPED_PUPable_decl_base_template(  // NOLINT
+      SINGLE_ARG(Filter<Dim, TagList>), Hypercube);
+  explicit Hypercube(CkMigrateMessage* msg) : Filter<Dim, TagList>(msg) {}
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p) override;
+
+  std::unique_ptr<Filter<Dim, TagList>> get_clone() const override;
+
+  bool apply_volume_filter_on_substep() const override;
+  bool apply_volume_filter_on_this_step(size_t step_number) const override;
+
+  bool apply_boundary_filter_on_substep() const override;
+  bool apply_boundary_filter_on_this_step(size_t step_number) const override;
+
+  bool need_jacobians() const override { return false; }
+
+  bool supports_mesh(const Mesh<Dim>& mesh) const override;
+
+  const std::optional<std::vector<size_t>>& blocks_to_filter() const override;
+
+  void set_blocks_to_filter(
+      const std::vector<std::string>& all_block_names,
+      const std::unordered_map<std::string, std::unordered_set<std::string>>&
+          block_groups) override;
+
+  void apply_in_volume(
+      gsl::not_null<Variables<TagList>*> vars, const Mesh<Dim>& mesh,
+      const std::optional<
+          InverseJacobian<DataVector, Dim, Frame::Grid, Frame::Inertial>>&
+          inv_jac_grid_to_inertial,
+      const std::optional<
+          Jacobian<DataVector, Dim, Frame::Grid, Frame::Inertial>>&
+          jac_grid_to_inertial) const override;
+
+  void apply_on_boundary(
+      gsl::not_null<Variables<TagList>*> vars, const Mesh<Dim - 1>& mesh,
+      const std::optional<
+          InverseJacobian<DataVector, Dim, Frame::Grid, Frame::Inertial>>&
+          inv_jac_grid_to_inertial,
+      const std::optional<
+          Jacobian<DataVector, Dim, Frame::Grid, Frame::Inertial>>&
+          jac_grid_to_inertial) const override;
+
+  bool is_equal(const Filter<Dim, TagList>& other) const override;
+
+ private:
+  const Matrix& filter_matrix(const Mesh<1>& mesh) const;
+
+  template <size_t LocalDim, typename LocalTagList>
+  // NOLINTNEXTLINE(readability-redundant-declaration)
+  friend bool operator==(const Hypercube<LocalDim, LocalTagList>& lhs,
+                         const Hypercube<LocalDim, LocalTagList>& rhs);
+
+  unsigned half_power_{0};
+  bool enable_{true};
+  std::optional<std::vector<std::string>> blocks_and_groups_to_filter_{};
+  std::optional<std::vector<size_t>> blocks_to_filter_{};
+  bool volume_filter_on_substep_{false};
+  bool boundary_filter_on_substep_{false};
+  std::optional<size_t> volume_filter_every_n_steps_{std::nullopt};
+  std::optional<size_t> boundary_filter_every_n_steps_{std::nullopt};
+};
+
+template <size_t Dim, typename TagList>
+bool operator==(const Hypercube<Dim, TagList>& lhs,
+                const Hypercube<Dim, TagList>& rhs);
+
+template <size_t Dim, typename TagList>
+bool operator!=(const Hypercube<Dim, TagList>& lhs,
+                const Hypercube<Dim, TagList>& rhs);
+}  // namespace Filters

--- a/src/NumericalAlgorithms/LinearOperators/Filters/Hypercube.tpp
+++ b/src/NumericalAlgorithms/LinearOperators/Filters/Hypercube.tpp
@@ -1,0 +1,281 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "NumericalAlgorithms/LinearOperators/Filters/Hypercube.hpp"
+
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <pup_stl.h>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "DataStructures/ApplyMatrices.hpp"
+#include "DataStructures/Matrix.hpp"
+#include "Domain/Structure/BlockGroups.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/Filtering.hpp"
+#include "NumericalAlgorithms/Spectral/MaximumNumberOfPoints.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "Options/Context.hpp"
+#include "Options/ParseError.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
+#include "Utilities/Serialization/PupStlCpp17.hpp"
+#include "Utilities/StaticCache.hpp"
+
+namespace Filters {
+template <size_t Dim, typename TagList>
+Hypercube<Dim, TagList>::Hypercube() = default;
+
+template <size_t Dim, typename TagList>
+Hypercube<Dim, TagList>::Hypercube(
+    const unsigned half_power, const bool enable,
+    const std::optional<std::vector<std::string>>& blocks_to_filter,
+    const bool volume_filter_on_substep, const bool boundary_filter_on_substep,
+    const std::optional<size_t> volume_filter_every_n_steps,
+    const std::optional<size_t> boundary_filter_every_n_steps,
+    const Options::Context& context)
+    : half_power_(half_power),
+      enable_(enable),
+      volume_filter_on_substep_(volume_filter_on_substep),
+      boundary_filter_on_substep_(boundary_filter_on_substep),
+      volume_filter_every_n_steps_(volume_filter_every_n_steps),
+      boundary_filter_every_n_steps_(boundary_filter_every_n_steps) {
+  if (blocks_to_filter.has_value()) {
+    blocks_and_groups_to_filter_ = std::vector<std::string>{};
+    std::unordered_set<std::string> seen{};
+    for (const std::string& block_name : blocks_to_filter.value()) {
+      if (not seen.emplace(block_name).second) {
+        PARSE_ERROR(context,
+                    "Duplicate block name '"
+                        << block_name
+                        << "' found when creating an Exponential filter.");
+      }
+      blocks_and_groups_to_filter_->push_back(block_name);
+    }
+  }
+}
+
+template <size_t Dim, typename TagList>
+void Hypercube<Dim, TagList>::pup(PUP::er& p) {
+  Filter<Dim, TagList>::pup(p);
+  p | half_power_;
+  p | enable_;
+  p | blocks_and_groups_to_filter_;
+  p | blocks_to_filter_;
+  p | volume_filter_on_substep_;
+  p | boundary_filter_on_substep_;
+  p | volume_filter_every_n_steps_;
+  p | boundary_filter_every_n_steps_;
+}
+
+template <size_t Dim, typename TagList>
+std::unique_ptr<Filter<Dim, TagList>> Hypercube<Dim, TagList>::get_clone()
+    const {
+  return std::make_unique<Hypercube>(*this);
+}
+
+template <size_t Dim, typename TagList>
+bool Hypercube<Dim, TagList>::apply_volume_filter_on_substep() const {
+  return enable_ and volume_filter_on_substep_;
+}
+
+template <size_t Dim, typename TagList>
+bool Hypercube<Dim, TagList>::apply_volume_filter_on_this_step(
+    const size_t step_number) const {
+  if (not enable_ or not volume_filter_every_n_steps_.has_value()) {
+    return false;
+  }
+  return step_number % volume_filter_every_n_steps_.value() == 0;
+}
+
+template <size_t Dim, typename TagList>
+bool Hypercube<Dim, TagList>::apply_boundary_filter_on_substep() const {
+  return enable_ and boundary_filter_on_substep_;
+}
+
+template <size_t Dim, typename TagList>
+bool Hypercube<Dim, TagList>::apply_boundary_filter_on_this_step(
+    const size_t step_number) const {
+  if (not enable_ or not boundary_filter_every_n_steps_.has_value()) {
+    return false;
+  }
+  return step_number % boundary_filter_every_n_steps_.value() == 0;
+}
+
+template <size_t Dim, typename TagList>
+bool Hypercube<Dim, TagList>::supports_mesh(const Mesh<Dim>& mesh) const {
+  for (size_t d = 0; d < Dim; ++d) {
+    const auto basis = mesh.basis(d);
+    const auto quadrature = mesh.quadrature(d);
+    const bool supported =
+        (basis == Spectral::Basis::Legendre and
+         (quadrature == Spectral::Quadrature::Gauss or
+          quadrature == Spectral::Quadrature::GaussLobatto)) or
+        (basis == Spectral::Basis::Chebyshev and
+         (quadrature == Spectral::Quadrature::Gauss or
+          quadrature == Spectral::Quadrature::GaussLobatto)) or
+        (basis == Spectral::Basis::Fourier and
+         quadrature == Spectral::Quadrature::Equiangular) or
+        (basis == Spectral::Basis::Cartoon and
+         (quadrature == Spectral::Quadrature::AxialSymmetry or
+          quadrature == Spectral::Quadrature::SphericalSymmetry));
+    if (not supported) {
+      return false;
+    }
+  }
+  return true;
+}
+
+template <size_t Dim, typename TagList>
+const std::optional<std::vector<size_t>>&
+Hypercube<Dim, TagList>::blocks_to_filter() const {
+  return blocks_to_filter_;
+}
+
+template <size_t Dim, typename TagList>
+void Hypercube<Dim, TagList>::set_blocks_to_filter(
+    const std::vector<std::string>& all_block_names,
+    const std::unordered_map<std::string, std::unordered_set<std::string>>&
+        block_groups) {
+  if (not blocks_and_groups_to_filter_.has_value()) {
+    blocks_to_filter_ = std::nullopt;
+    return;
+  }
+  if (all_block_names.empty()) {
+    ERROR(
+        "The domain chosen doesn't use block names, but the filter has "
+        "specified block names to use.");
+  }
+  blocks_to_filter_ = domain::block_ids_from_names(
+      blocks_and_groups_to_filter_.value(), all_block_names, block_groups);
+}
+
+template <size_t Dim, typename TagList>
+void Hypercube<Dim, TagList>::apply_in_volume(
+    const gsl::not_null<Variables<TagList>*> vars, const Mesh<Dim>& mesh,
+    const std::optional<
+        InverseJacobian<DataVector, Dim, Frame::Grid, Frame::Inertial>>&
+    /*inv_jac_grid_to_inertial*/,
+    const std::optional<
+        Jacobian<DataVector, Dim, Frame::Grid, Frame::Inertial>>&
+    /*jac_grid_to_inertial*/) const {
+  const Matrix empty{};
+  std::array<std::reference_wrapper<const Matrix>, Dim> filter =
+      make_array<Dim>(std::cref(empty));
+  for (size_t d = 0; d < Dim; d++) {
+    gsl::at(filter, d) = std::cref(filter_matrix(mesh.slice_through(d)));
+  }
+  *vars = apply_matrices(filter, *vars, mesh.extents());
+}
+
+template <size_t Dim, typename TagList>
+void Hypercube<Dim, TagList>::apply_on_boundary(
+    const gsl::not_null<Variables<TagList>*> vars, const Mesh<Dim - 1>& mesh,
+    const std::optional<
+        InverseJacobian<DataVector, Dim, Frame::Grid, Frame::Inertial>>&
+    /*inv_jac_grid_to_inertial*/,
+    const std::optional<
+        Jacobian<DataVector, Dim, Frame::Grid, Frame::Inertial>>&
+    /*jac_grid_to_inertial*/) const {
+  if constexpr (Dim > 1) {
+    const Matrix empty{};
+    std::array<std::reference_wrapper<const Matrix>, Dim - 1> filter =
+        make_array<Dim - 1>(std::cref(empty));
+    for (size_t d = 0; d < Dim - 1; d++) {
+      gsl::at(filter, d) = std::cref(filter_matrix(mesh.slice_through(d)));
+    }
+    *vars = apply_matrices(filter, *vars, mesh.extents());
+  } else {
+    (void)vars;
+    (void)mesh;
+  }
+}
+
+template <size_t Dim, typename TagList>
+const Matrix& Hypercube<Dim, TagList>::filter_matrix(
+    const Mesh<1>& mesh) const {
+  const auto compute_filter = [half_power = half_power_](
+                                  const size_t extents,
+                                  const Spectral::Basis basis,
+                                  const Spectral::Quadrature quadrature) {
+    return Spectral::filtering::exponential_filter(
+        Mesh<1>{extents, basis, quadrature}, 36.0, half_power);
+  };
+  const static auto cache = std::make_tuple(
+      half_power_,
+      make_static_cache<
+          CacheRange<1_st, Spectral::maximum_number_of_points<
+                               Spectral::Basis::Legendre> +
+                               1>,
+          CacheEnumeration<Spectral::Basis, Spectral::Basis::Legendre,
+                           Spectral::Basis::Chebyshev,
+                           Spectral::Basis::Cartoon>,
+          CacheEnumeration<Spectral::Quadrature, Spectral::Quadrature::Gauss,
+                           Spectral::Quadrature::GaussLobatto,
+                           Spectral::Quadrature::AxialSymmetry,
+                           Spectral::Quadrature::SphericalSymmetry>>(
+          compute_filter),
+      make_static_cache<CacheRange<
+          1_st, Spectral::maximum_number_of_points<Spectral::Basis::Fourier> +
+                    1>>([compute_filter](const size_t extents) {
+        return compute_filter(extents, Spectral::Basis::Fourier,
+                              Spectral::Quadrature::Equiangular);
+      }));
+  if (std::get<0>(cache) != half_power_) {
+    ERROR("Filter was cached with half power = "
+          << std::get<0>(cache) << ", but half power is now " << half_power_
+          << ".\nWe currently only support 1 half power per executable per "
+             "TagList in the Hypercube filter.");
+  }
+  if (mesh.basis(0) == Spectral::Basis::Fourier) {
+    return std::get<2>(cache)(mesh.extents(0));
+  }
+  return std::get<1>(cache)(mesh.extents(0), mesh.basis(0), mesh.quadrature(0));
+}
+
+template <size_t Dim, typename TagList>
+bool operator==(const Hypercube<Dim, TagList>& lhs,
+                const Hypercube<Dim, TagList>& rhs) {
+  return lhs.half_power_ == rhs.half_power_ and
+         lhs.enable_ == rhs.enable_ and
+         lhs.blocks_and_groups_to_filter_ ==
+             rhs.blocks_and_groups_to_filter_ and
+         lhs.blocks_to_filter_ == rhs.blocks_to_filter_ and
+         lhs.volume_filter_on_substep_ == rhs.volume_filter_on_substep_ and
+         lhs.boundary_filter_on_substep_ == rhs.boundary_filter_on_substep_ and
+         lhs.volume_filter_every_n_steps_ ==
+             rhs.volume_filter_every_n_steps_ and
+         lhs.boundary_filter_every_n_steps_ ==
+             rhs.boundary_filter_every_n_steps_;
+}
+
+template <size_t Dim, typename TagList>
+bool operator!=(const Hypercube<Dim, TagList>& lhs,
+                const Hypercube<Dim, TagList>& rhs) {
+  return not(lhs == rhs);
+}
+
+template <size_t Dim, typename TagList>
+bool Hypercube<Dim, TagList>::is_equal(
+    const Filter<Dim, TagList>& other) const {
+  const auto* const other_hypercube =
+      dynamic_cast<const Hypercube<Dim, TagList>*>(&other);
+  if (other_hypercube == nullptr) {
+    return false;
+  }
+  return *this == *other_hypercube;
+}
+
+template <size_t Dim, typename TagList>
+PUP::able::PUP_ID Hypercube<Dim, TagList>::my_PUP_ID = 0;  // NOLINT
+}  // namespace Filters

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY "Test_LinearOperators")
 
 set(LIBRARY_SOURCES
+  Filters/Test_Hypercube.cpp
   Test_CoefficientTransforms.cpp
   Test_DefiniteIntegral.cpp
   Test_Divergence.cpp

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Filters/Test_Hypercube.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Filters/Test_Hypercube.cpp
@@ -1,0 +1,673 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "DataStructures/ApplyMatrices.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Matrix.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/Identity.hpp"
+#include "Domain/Creators/DomainCreator.hpp"
+#include "Domain/Creators/OptionTags.hpp"
+#include "Domain/Creators/Tags/Domain.hpp"
+#include "Domain/Domain.hpp"
+#include "Evolution/Tags/Filter.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "NumericalAlgorithms/LinearOperators/Filters/Filter.hpp"
+#include "NumericalAlgorithms/LinearOperators/Filters/Hypercube.hpp"
+#include "NumericalAlgorithms/LinearOperators/Filters/Hypercube.tpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/Filtering.hpp"
+#include "NumericalAlgorithms/Spectral/MaximumNumberOfPoints.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/MinimumNumberOfPoints.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "Utilities/GetOutput.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
+#include "Utilities/StdArrayHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+using namespace std::string_literals;
+
+// Blocks 0-2 do filtering (if enabled). Block 3 doesn't
+constexpr size_t num_blocks = 4;
+
+namespace Tags {
+struct ScalarVar : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+template <size_t Dim>
+struct VectorVar : db::SimpleTag {
+  using type = tnsr::I<DataVector, Dim>;
+};
+}  // namespace Tags
+
+template <size_t Dim>
+using TagList = tmpl::list<Tags::ScalarVar, Tags::VectorVar<Dim>>;
+
+template <size_t Dim>
+using HypercubeFilter = Filters::Hypercube<Dim, TagList<Dim>>;
+
+std::vector<std::string> domain_block_names() {
+  std::vector<std::string> block_names(num_blocks);
+  for (size_t i = 0; i < num_blocks; ++i) {
+    block_names[i] = "Block" + get_output(i);
+  }
+  return block_names;
+}
+
+std::unordered_map<std::string, std::unordered_set<std::string>>
+domain_block_groups() {
+  std::unordered_map<std::string, std::unordered_set<std::string>> groups{};
+  groups["Group1"] = std::unordered_set<std::string>{{"Block1"s}};
+  groups["Group2"] = std::unordered_set<std::string>{{"Block1"s}, {"Block2"s}};
+  return groups;
+}
+
+template <size_t Dim>
+Domain<Dim> make_domain() {
+  using Identity = domain::CoordinateMaps::Identity<Dim>;
+  using Map =
+      domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial, Identity>;
+  register_classes_with_charm(tmpl::list<Map>{});
+  std::vector<std::unique_ptr<
+      domain::CoordinateMapBase<Frame::BlockLogical, Frame::Inertial, Dim>>>
+      maps{num_blocks};
+  for (size_t i = 0; i < num_blocks; ++i) {
+    maps[i] = std::make_unique<Map>(Identity{});
+  }
+  return Domain<Dim>{
+      std::move(maps), {}, domain_block_names(), domain_block_groups()};
+}
+
+template <size_t Dim>
+class TestCreator : public DomainCreator<Dim> {
+ public:
+  explicit TestCreator(const bool use_block_names = true)
+      : use_block_names_(use_block_names) {}
+
+  Domain<Dim> create_domain() const override { return make_domain<Dim>(); }
+  std::vector<std::string> block_names() const override {
+    return use_block_names_ ? domain_block_names() : std::vector<std::string>{};
+  }
+  std::unordered_map<std::string, std::unordered_set<std::string>>
+  block_groups() const override {
+    return use_block_names_
+               ? domain_block_groups()
+               : std::unordered_map<std::string,
+                                    std::unordered_set<std::string>>{};
+  }
+  std::vector<DirectionMap<
+      Dim, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
+  external_boundary_conditions() const override {
+    ERROR("");
+  }
+  std::vector<std::array<size_t, Dim>> initial_extents() const override {
+    ERROR("");
+  }
+  std::vector<std::array<size_t, Dim>> initial_refinement_levels()
+      const override {
+    ERROR("");
+  }
+  auto functions_of_time(const std::unordered_map<std::string, double>&
+                         /*initial_expiration_times*/
+                         = {}) const
+      -> std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>> override {
+    ERROR("");
+  }
+
+ private:
+  bool use_block_names_;
+};
+
+template <size_t Dim>
+struct Metavars {
+  static constexpr size_t volume_dim = Dim;
+  struct factory_creation {
+    using factory_classes = tmpl::map<
+        tmpl::pair<::DomainCreator<Dim>, tmpl::list<TestCreator<Dim>>>>;
+  };
+};
+
+template <size_t Dim>
+void test_construction_and_accessors() {
+  INFO("Construction and accessors");
+  CAPTURE(Dim);
+  const std::vector<std::string> blocks{"Block0", "Group1"};
+  const std::optional<std::vector<std::string>> blocks_opt{blocks};
+
+  const auto filter =
+      HypercubeFilter<Dim>(16, true, blocks_opt, false, true, std::nullopt, 3);
+
+  CHECK_FALSE(filter.need_jacobians());
+  // Before set_blocks_to_filter the resolved IDs are not available.
+  CHECK_FALSE(filter.blocks_to_filter().has_value());
+
+  // After resolution: Block0->0, Group1 expands to Block1->1 -> sorted {0,1}.
+  auto filter_resolved = filter;
+  filter_resolved.set_blocks_to_filter(domain_block_names(),
+                                       domain_block_groups());
+  REQUIRE(filter_resolved.blocks_to_filter().has_value());
+  // NOLINTBEGIN(bugprone-unchecked-optional-access)
+  CHECK(filter_resolved.blocks_to_filter().value() ==
+        std::vector<size_t>{0, 1});
+  // NOLINTEND(bugprone-unchecked-optional-access)
+
+  CHECK_FALSE(filter.apply_volume_filter_on_substep());
+  CHECK(filter.apply_boundary_filter_on_substep());
+
+  // volume_filter_every_n_steps is nullopt -> always false
+  for (const size_t step : {size_t{0}, size_t{1}, size_t{7}, size_t{42}}) {
+    CHECK_FALSE(filter.apply_volume_filter_on_this_step(step));
+  }
+  // boundary_filter_every_n_steps == 3 -> step % 3 == 0
+  CHECK(filter.apply_boundary_filter_on_this_step(0));
+  CHECK_FALSE(filter.apply_boundary_filter_on_this_step(1));
+  CHECK_FALSE(filter.apply_boundary_filter_on_this_step(2));
+  CHECK(filter.apply_boundary_filter_on_this_step(3));
+  CHECK(filter.apply_boundary_filter_on_this_step(6));
+
+  // Filter without any blocks restriction
+  const auto unrestricted =
+      HypercubeFilter<Dim>(8, true, std::nullopt, true, false, 1, std::nullopt);
+  CHECK_FALSE(unrestricted.blocks_to_filter().has_value());
+  CHECK(unrestricted.apply_volume_filter_on_substep());
+  CHECK_FALSE(unrestricted.apply_boundary_filter_on_substep());
+  // every_n_steps == 1 -> always true
+  CHECK(unrestricted.apply_volume_filter_on_this_step(0));
+  CHECK(unrestricted.apply_volume_filter_on_this_step(1));
+  CHECK(unrestricted.apply_volume_filter_on_this_step(99));
+
+  // Filter disabled
+  const auto disabled =
+      HypercubeFilter<Dim>(8, false, std::nullopt, true, true, 1, 1);
+  CHECK_FALSE(disabled.apply_volume_filter_on_substep());
+  CHECK_FALSE(disabled.apply_boundary_filter_on_substep());
+  CHECK_FALSE(disabled.apply_volume_filter_on_this_step(0));
+  CHECK_FALSE(disabled.apply_volume_filter_on_this_step(1));
+  CHECK_FALSE(disabled.apply_volume_filter_on_this_step(99));
+
+  // Equality / inequality: each constructor parameter independently flips.
+  const auto base =
+      HypercubeFilter<Dim>(4, true, blocks_opt, false, false, 2, 5);
+  CHECK(base == HypercubeFilter<Dim>(4, true, blocks_opt, false, false, 2, 5));
+  CHECK_FALSE(base !=
+              HypercubeFilter<Dim>(4, true, blocks_opt, false, false, 2, 5));
+  CHECK(base != HypercubeFilter<Dim>(5, true, blocks_opt, false, false, 2, 5));
+  CHECK(base != HypercubeFilter<Dim>(4, false, blocks_opt, false, false, 2, 5));
+  CHECK(base !=
+        HypercubeFilter<Dim>(4, true, std::nullopt, false, false, 2, 5));
+  CHECK(base != HypercubeFilter<Dim>(4, true, blocks_opt, true, false, 2, 5));
+  CHECK(base != HypercubeFilter<Dim>(4, true, blocks_opt, false, true, 2, 5));
+  CHECK(base != HypercubeFilter<Dim>(4, true, blocks_opt, false, false,
+                                     std::nullopt, 5));
+  CHECK(base != HypercubeFilter<Dim>(4, true, blocks_opt, false, false, 2,
+                                     std::nullopt));
+
+  // Duplicate block names rejected at construction time.
+  CHECK_THROWS_WITH(
+      (HypercubeFilter<Dim>{
+          16, true,
+          std::optional<std::vector<std::string>>{{"Block0", "Block0"}}, false,
+          false, std::nullopt, std::nullopt}),
+      Catch::Matchers::ContainsSubstring("Duplicate block name"));
+}
+
+template <size_t Dim>
+void test_pup_round_trip() {
+  INFO("Serialization");
+  CAPTURE(Dim);
+  const auto filter = HypercubeFilter<Dim>(
+      8, true, std::optional<std::vector<std::string>>{{"Block0", "Group2"}},
+      true, false, 4, std::nullopt);
+  ::test_serialization(filter);
+
+  // Round-trip through the abstract base pointer.
+  using Base = Filters::Filter<Dim, TagList<Dim>>;
+  using Derived = HypercubeFilter<Dim>;
+  register_classes_with_charm<Derived>();
+  const std::unique_ptr<Base> base = std::make_unique<Derived>(filter);
+  const std::unique_ptr<Base> pupped_base = serialize_and_deserialize(base);
+  REQUIRE(dynamic_cast<const Derived*>(pupped_base.get()) != nullptr);
+  CHECK(dynamic_cast<const Derived&>(*pupped_base) == filter);
+}
+
+// Build the analytic post-filter expectation by directly invoking
+// Spectral::filtering::exponential_filter with the same alpha (36) and
+// half_power that Hypercube uses internally.
+template <size_t Dim, size_t MatrixDim>
+Variables<TagList<Dim>> expected_filtered(
+    const Mesh<MatrixDim>& mesh, const Variables<TagList<Dim>>& initial,
+    const unsigned half_power) {
+  std::array<Matrix, MatrixDim> filter_matrices{};
+  for (size_t d = 0; d < MatrixDim; ++d) {
+    gsl::at(filter_matrices, d) = Spectral::filtering::exponential_filter(
+        mesh.slice_through(d), 36.0, half_power);
+  }
+  return apply_matrices(filter_matrices, initial, mesh.extents());
+}
+
+template <size_t Dim>
+Variables<TagList<Dim>> deterministic_vars(const Mesh<Dim>& mesh) {
+  Variables<TagList<Dim>> vars(mesh.number_of_grid_points());
+  for (size_t i = 0; i < mesh.number_of_grid_points(); ++i) {
+    get(get<Tags::ScalarVar>(vars))[i] = (pow(i, 3) * 0.5) + 1.25;
+    for (size_t d = 0; d < Dim; ++d) {
+      get<Tags::VectorVar<Dim>>(vars).get(d)[i] =
+          static_cast<double>(d) + (pow(i, 3) * 0.75);
+    }
+  }
+  return vars;
+}
+
+template <size_t FaceDim, size_t Dim>
+Variables<TagList<Dim>> deterministic_vars(const Mesh<FaceDim>& mesh) {
+  Variables<TagList<Dim>> vars(mesh.number_of_grid_points());
+  for (size_t i = 0; i < mesh.number_of_grid_points(); ++i) {
+    get(get<Tags::ScalarVar>(vars))[i] = (pow(i, 2) * 0.25) + 0.5;
+    for (size_t d = 0; d < Dim; ++d) {
+      get<Tags::VectorVar<Dim>>(vars).get(d)[i] =
+          static_cast<double>(d) + 1.0 + (pow(i, 2) * 0.4);
+    }
+  }
+  return vars;
+}
+
+// All apply_* tests for a given `Hypercube<Dim, TagList>` instantiation must
+// share a single `half_power_` because `Hypercube::filter_matrix` caches
+// matrices in a per-instantiation static cache that is keyed by the first
+// observed `half_power_`. Mixing half_power values across calls in the same
+// process aborts with "Filter was cached with half power = ...". Each Dim
+// gets its own static cache, but for cleanliness we use the same value
+// throughout the suite.
+constexpr unsigned kFilterHalfPower = 4u;
+
+template <size_t Dim, Spectral::Basis BasisType,
+          Spectral::Quadrature QuadratureType>
+void test_apply_in_volume() {
+  INFO("apply_in_volume");
+  CAPTURE(Dim);
+  CAPTURE(BasisType);
+  CAPTURE(QuadratureType);
+  const Approx custom_approx = Approx::custom().epsilon(5.0e-13);
+
+  const size_t max_pts =
+      BasisType == Spectral::Basis::Fourier
+          ? Spectral::maximum_number_of_points<BasisType> / (3 * Dim)
+          : Spectral::maximum_number_of_points<BasisType> / Dim;
+  for (size_t num_pts =
+           Spectral::minimum_number_of_points<BasisType, QuadratureType>;
+       num_pts < max_pts; ++num_pts) {
+    CAPTURE(num_pts);
+    const Mesh<Dim> mesh(num_pts, BasisType, QuadratureType);
+    const auto initial_vars = deterministic_vars<Dim>(mesh);
+
+    // The Hypercube class itself is unconditional in apply_in_volume —
+    // the cadence/enable gating lives in the driving action. Verify
+    // that calling apply_in_volume always rescales the modes,
+    // regardless of how `enable` is set.
+    for (const bool enable : {true, false}) {
+      CAPTURE(enable);
+      const auto filter =
+          HypercubeFilter<Dim>(kFilterHalfPower, enable, std::nullopt, false,
+                               false, std::nullopt, std::nullopt);
+      auto vars = initial_vars;
+      filter.apply_in_volume(make_not_null(&vars), mesh, std::nullopt,
+                             std::nullopt);
+      const auto expected =
+          expected_filtered<Dim, Dim>(mesh, initial_vars, kFilterHalfPower);
+      CHECK_VARIABLES_CUSTOM_APPROX(vars, expected, custom_approx);
+    }
+  }
+}
+
+template <size_t Dim, Spectral::Basis BasisType,
+          Spectral::Quadrature QuadratureType>
+void test_apply_on_boundary() {
+  static_assert(Dim >= 2,
+                "Boundary filtering requires a non-degenerate face mesh.");
+  INFO("apply_on_boundary");
+  CAPTURE(Dim);
+  CAPTURE(BasisType);
+  CAPTURE(QuadratureType);
+  const Approx custom_approx = Approx::custom().epsilon(5.0e-13);
+
+  const size_t max_pts =
+      BasisType == Spectral::Basis::Fourier
+          ? Spectral::maximum_number_of_points<BasisType> / (3 * Dim)
+          : Spectral::maximum_number_of_points<BasisType> / Dim;
+  for (size_t num_pts =
+           Spectral::minimum_number_of_points<BasisType, QuadratureType>;
+       num_pts < max_pts; ++num_pts) {
+    CAPTURE(num_pts);
+    const Mesh<Dim> volume_mesh(num_pts, BasisType, QuadratureType);
+    const Mesh<Dim - 1> face_mesh = volume_mesh.slice_away(0);
+    const auto initial_face_vars = deterministic_vars<Dim - 1, Dim>(face_mesh);
+
+    const auto filter =
+        HypercubeFilter<Dim>(kFilterHalfPower, true, std::nullopt, false, false,
+                             std::nullopt, std::nullopt);
+    auto face_vars = initial_face_vars;
+    filter.apply_on_boundary(make_not_null(&face_vars), face_mesh, std::nullopt,
+                             std::nullopt);
+    const auto expected = expected_filtered<Dim, Dim - 1>(
+        face_mesh, initial_face_vars, kFilterHalfPower);
+    CHECK_VARIABLES_CUSTOM_APPROX(face_vars, expected, custom_approx);
+  }
+}
+
+template <size_t Dim>
+void test_invoke_apply() {
+  test_apply_in_volume<Dim, Spectral::Basis::Legendre,
+                       Spectral::Quadrature::Gauss>();
+  test_apply_in_volume<Dim, Spectral::Basis::Legendre,
+                       Spectral::Quadrature::GaussLobatto>();
+  test_apply_in_volume<Dim, Spectral::Basis::Chebyshev,
+                       Spectral::Quadrature::Gauss>();
+  test_apply_in_volume<Dim, Spectral::Basis::Chebyshev,
+                       Spectral::Quadrature::GaussLobatto>();
+  test_apply_in_volume<Dim, Spectral::Basis::Fourier,
+                       Spectral::Quadrature::Equiangular>();
+
+  if constexpr (Dim >= 2) {
+    test_apply_on_boundary<Dim, Spectral::Basis::Legendre,
+                           Spectral::Quadrature::Gauss>();
+    test_apply_on_boundary<Dim, Spectral::Basis::Legendre,
+                           Spectral::Quadrature::GaussLobatto>();
+    test_apply_on_boundary<Dim, Spectral::Basis::Chebyshev,
+                           Spectral::Quadrature::Gauss>();
+    test_apply_on_boundary<Dim, Spectral::Basis::Chebyshev,
+                           Spectral::Quadrature::GaussLobatto>();
+    test_apply_on_boundary<Dim, Spectral::Basis::Fourier,
+                           Spectral::Quadrature::Equiangular>();
+  }
+}
+
+template <size_t Dim>
+void test_option_parsing() {
+  INFO("Option parsing");
+  CAPTURE(Dim);
+  using Filter = HypercubeFilter<Dim>;
+  using tags = tmpl::list<OptionTags::Filter<Filter>,
+                          domain::OptionTags::DomainCreator<Dim>>;
+
+  // Full option set with explicit blocks.
+  Options::Parser<tags> parser("");
+  parser.parse(
+      "DomainCreator:\n"
+      "  TestCreator\n"
+      "Filtering:\n"
+      "  Hypercube:\n"
+      "    HalfPower: 16\n"
+      "    Enable: True\n"
+      "    BlocksToFilter:\n"
+      "      - Block0\n"
+      "      - Group1\n"
+      "    VolumeFilterOnSubstep: False\n"
+      "    BoundaryCorrectionFilterOnSubstep: True\n"
+      "    VolumeFilterEveryNSteps: 5\n"
+      "    BoundaryCorrectionFilterEveryNSteps: None\n");
+
+  const auto parsed =
+      parser.template get<OptionTags::Filter<Filter>, Metavars<Dim>>();
+  const auto expected = HypercubeFilter<Dim>(
+      16, true, std::optional<std::vector<std::string>>{{"Block0", "Group1"}},
+      false, true, 5, std::nullopt);
+  CHECK(parsed == expected);
+  CHECK_FALSE(parsed != expected);
+
+  // BlocksToFilter: All -> nullopt.
+  Options::Parser<tags> all_parser("");
+  all_parser.parse(
+      "DomainCreator:\n"
+      "  TestCreator\n"
+      "Filtering:\n"
+      "  Hypercube:\n"
+      "    HalfPower: 4\n"
+      "    Enable: False\n"
+      "    BlocksToFilter: All\n"
+      "    VolumeFilterOnSubstep: True\n"
+      "    BoundaryCorrectionFilterOnSubstep: False\n"
+      "    VolumeFilterEveryNSteps: None\n"
+      "    BoundaryCorrectionFilterEveryNSteps: 7\n");
+  const auto all_parsed =
+      all_parser.template get<OptionTags::Filter<Filter>, Metavars<Dim>>();
+  CHECK_FALSE(all_parsed.blocks_to_filter().has_value());
+  // Enable: false disables scheduling regardless of other settings
+  CHECK_FALSE(all_parsed.apply_volume_filter_on_substep());
+  CHECK_FALSE(all_parsed.apply_boundary_filter_on_substep());
+  CHECK_FALSE(all_parsed.apply_volume_filter_on_this_step(0));
+  CHECK_FALSE(all_parsed.apply_boundary_filter_on_this_step(0));
+  CHECK_FALSE(all_parsed.apply_boundary_filter_on_this_step(7));
+  CHECK_FALSE(all_parsed.apply_boundary_filter_on_this_step(8));
+
+  // Duplicate block names parsed via the Options framework -> PARSE_ERROR.
+  Options::Parser<tags> dup_parser("");
+  dup_parser.parse(
+      "DomainCreator:\n"
+      "  TestCreator\n"
+      "Filtering:\n"
+      "  Hypercube:\n"
+      "    HalfPower: 4\n"
+      "    Enable: True\n"
+      "    BlocksToFilter:\n"
+      "      - Block0\n"
+      "      - Block0\n"
+      "    VolumeFilterOnSubstep: False\n"
+      "    BoundaryCorrectionFilterOnSubstep: False\n"
+      "    VolumeFilterEveryNSteps: None\n"
+      "    BoundaryCorrectionFilterEveryNSteps: None\n");
+  CHECK_THROWS_WITH(
+      (dup_parser.template get<OptionTags::Filter<Filter>, Metavars<Dim>>()),
+      Catch::Matchers::ContainsSubstring("Duplicate block name"));
+
+  // Invalid block name caught by set_blocks_to_filter.
+  auto invalid_filter = HypercubeFilter<Dim>(
+      4, true, std::optional<std::vector<std::string>>{{"NotABlock"}}, false,
+      false, std::nullopt, std::nullopt);
+  CHECK_THROWS_AS(invalid_filter.set_blocks_to_filter(domain_block_names(),
+                                                      domain_block_groups()),
+                  std::invalid_argument);
+
+  // Domain that doesn't expose block names but a filter does -> ERROR.
+  CHECK_THROWS_WITH(
+      HypercubeFilter<Dim>(4, true,
+                           std::optional<std::vector<std::string>>{{"Block0"}},
+                           false, false, std::nullopt, std::nullopt)
+          .set_blocks_to_filter({}, {}),
+      Catch::Matchers::ContainsSubstring("doesn't use block names"));
+
+  // Block-only and group-only specifications resolve without throwing.
+  CHECK_NOTHROW(
+      HypercubeFilter<Dim>(4, true,
+                           std::optional<std::vector<std::string>>{{"Block0"}},
+                           false, false, std::nullopt, std::nullopt)
+          .set_blocks_to_filter(domain_block_names(), domain_block_groups()));
+  CHECK_NOTHROW(
+      HypercubeFilter<Dim>(4, true,
+                           std::optional<std::vector<std::string>>{{"Group1"}},
+                           false, false, std::nullopt, std::nullopt)
+          .set_blocks_to_filter(domain_block_names(), domain_block_groups()));
+}
+
+void test_supports_mesh() {
+  INFO("supports_mesh");
+  // Reuse kFilterHalfPower so the static cache stays consistent across tests.
+  const auto f1 = HypercubeFilter<1>(kFilterHalfPower, true, std::nullopt,
+                                     false, false, std::nullopt, std::nullopt);
+  const auto f2 = HypercubeFilter<2>(kFilterHalfPower, true, std::nullopt,
+                                     false, false, std::nullopt, std::nullopt);
+  const auto f3 = HypercubeFilter<3>(kFilterHalfPower, true, std::nullopt,
+                                     false, false, std::nullopt, std::nullopt);
+
+  // All valid (Basis, Quadrature) pairs.
+  CHECK(f1.supports_mesh(
+      Mesh<1>{3, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss}));
+  CHECK(f1.supports_mesh(Mesh<1>{3, Spectral::Basis::Legendre,
+                                 Spectral::Quadrature::GaussLobatto}));
+  CHECK(f1.supports_mesh(
+      Mesh<1>{3, Spectral::Basis::Chebyshev, Spectral::Quadrature::Gauss}));
+  CHECK(f1.supports_mesh(Mesh<1>{3, Spectral::Basis::Chebyshev,
+                                 Spectral::Quadrature::GaussLobatto}));
+  CHECK(f1.supports_mesh(
+      Mesh<1>{4, Spectral::Basis::Fourier, Spectral::Quadrature::Equiangular}));
+  CHECK(f1.supports_mesh(Mesh<1>{1, Spectral::Basis::Cartoon,
+                                 Spectral::Quadrature::AxialSymmetry}));
+  CHECK(f1.supports_mesh(Mesh<1>{1, Spectral::Basis::Cartoon,
+                                 Spectral::Quadrature::SphericalSymmetry}));
+
+  // Invalid cross-combos: wrong quadrature for the basis.
+  CHECK_FALSE(f1.supports_mesh(Mesh<1>{3, Spectral::Basis::Legendre,
+                                       Spectral::Quadrature::AxialSymmetry}));
+  CHECK_FALSE(f1.supports_mesh(Mesh<1>{
+      3, Spectral::Basis::Legendre, Spectral::Quadrature::SphericalSymmetry}));
+  CHECK_FALSE(f1.supports_mesh(Mesh<1>{3, Spectral::Basis::Chebyshev,
+                                       Spectral::Quadrature::AxialSymmetry}));
+  CHECK_FALSE(f1.supports_mesh(Mesh<1>{
+      3, Spectral::Basis::Chebyshev, Spectral::Quadrature::SphericalSymmetry}));
+  CHECK_FALSE(f1.supports_mesh(
+      Mesh<1>{1, Spectral::Basis::Cartoon, Spectral::Quadrature::Gauss}));
+  CHECK_FALSE(f1.supports_mesh(Mesh<1>{1, Spectral::Basis::Cartoon,
+                                       Spectral::Quadrature::GaussLobatto}));
+  CHECK_FALSE(f1.supports_mesh(
+      Mesh<1>{4, Spectral::Basis::Fourier, Spectral::Quadrature::Gauss}));
+
+  // Unsupported basis entirely.
+  CHECK_FALSE(f1.supports_mesh(Mesh<1>{3, Spectral::Basis::FiniteDifference,
+                                       Spectral::Quadrature::CellCentered}));
+  CHECK_FALSE(f1.supports_mesh(Mesh<1>{3, Spectral::Basis::SphericalHarmonic,
+                                       Spectral::Quadrature::Gauss}));
+  CHECK_FALSE(f1.supports_mesh(Mesh<1>{4, Spectral::Basis::SphericalHarmonic,
+                                       Spectral::Quadrature::Equiangular}));
+  CHECK_FALSE(f1.supports_mesh(Mesh<1>{3, Spectral::Basis::ZernikeB1,
+                                       Spectral::Quadrature::GaussRadauUpper}));
+  CHECK_FALSE(f1.supports_mesh(Mesh<1>{3, Spectral::Basis::ZernikeB2,
+                                       Spectral::Quadrature::GaussRadauUpper}));
+  CHECK_FALSE(f1.supports_mesh(Mesh<1>{3, Spectral::Basis::ZernikeB3,
+                                       Spectral::Quadrature::GaussRadauUpper}));
+
+  // Multi-dim: all dims valid -> true.
+  CHECK(f2.supports_mesh(
+      Mesh<2>{3, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss}));
+  CHECK(f3.supports_mesh(Mesh<3>{3, Spectral::Basis::Chebyshev,
+                                 Spectral::Quadrature::GaussLobatto}));
+
+  // Multi-dim: one unsupported dim -> false.
+  CHECK_FALSE(f2.supports_mesh(Mesh<2>{
+      std::array<size_t, 2>{3, 3},
+      std::array<Spectral::Basis, 2>{Spectral::Basis::Legendre,
+                                     Spectral::Basis::FiniteDifference},
+      std::array<Spectral::Quadrature, 2>{
+          Spectral::Quadrature::Gauss, Spectral::Quadrature::CellCentered}}));
+  CHECK_FALSE(f3.supports_mesh(Mesh<3>{
+      std::array<size_t, 3>{3, 3, 3},
+      std::array<Spectral::Basis, 3>{Spectral::Basis::Legendre,
+                                     Spectral::Basis::Chebyshev,
+                                     Spectral::Basis::Legendre},
+      std::array<Spectral::Quadrature, 3>{
+          Spectral::Quadrature::Gauss, Spectral::Quadrature::GaussLobatto,
+          Spectral::Quadrature::AxialSymmetry}}));
+}
+
+template <size_t Dim>
+void test_is_equal() {
+  INFO("is_equal");
+  CAPTURE(Dim);
+  using Base = Filters::Filter<Dim, TagList<Dim>>;
+  const std::optional<std::vector<std::string>> blocks{
+      std::vector<std::string>{"Block0", "Group1"}};
+
+  const auto a =
+      HypercubeFilter<Dim>(8, true, blocks, false, false, 2, std::nullopt);
+  const auto b =
+      HypercubeFilter<Dim>(8, true, blocks, false, false, 2, std::nullopt);
+  const auto c =
+      HypercubeFilter<Dim>(16, true, blocks, false, false, 2, std::nullopt);
+
+  CHECK(a.is_equal(b));
+  CHECK(b.is_equal(a));
+  CHECK_FALSE(a.is_equal(c));
+
+  // Via abstract base pointer (the primary AMR use case).
+  const std::unique_ptr<Base> pa = std::make_unique<HypercubeFilter<Dim>>(a);
+  const std::unique_ptr<Base> pb = std::make_unique<HypercubeFilter<Dim>>(b);
+  const std::unique_ptr<Base> pc = std::make_unique<HypercubeFilter<Dim>>(c);
+  CHECK(pa->is_equal(*pb));
+  CHECK_FALSE(pa->is_equal(*pc));
+}
+
+void test_cartoon() {
+  INFO("Cartoon basis");
+  // Cartoon meshes are 1-point and the resulting 1x1 filter matrix is the
+  // identity, so the data should pass through unchanged regardless of
+  // half_power. Reuse `kFilterHalfPower` so `Hypercube<1, ...>::filter_matrix`
+  // shares its static cache with `test_apply_in_volume<1, ...>`.
+  const auto filter =
+      HypercubeFilter<1>(kFilterHalfPower, true, std::nullopt, false, false,
+                         std::nullopt, std::nullopt);
+  for (const auto quadrature : {Spectral::Quadrature::AxialSymmetry,
+                                Spectral::Quadrature::SphericalSymmetry}) {
+    CAPTURE(quadrature);
+    const Mesh<1> mesh{1, Spectral::Basis::Cartoon, quadrature};
+    Variables<TagList<1>> vars(mesh.number_of_grid_points());
+    get(get<Tags::ScalarVar>(vars))[0] = 3.14;
+    get<Tags::VectorVar<1>>(vars).get(0)[0] = -2.71;
+    const auto initial = vars;
+    filter.apply_in_volume(make_not_null(&vars), mesh, std::nullopt,
+                           std::nullopt);
+    CHECK(get(get<Tags::ScalarVar>(vars))[0] ==
+          approx(get(get<Tags::ScalarVar>(initial))[0]));
+    CHECK(get<Tags::VectorVar<1>>(vars).get(0)[0] ==
+          approx(get<Tags::VectorVar<1>>(initial).get(0)[0]));
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.Filter.Cube",
+                  "[NumericalAlgorithms][LinearOperators][Unit]") {
+  test_construction_and_accessors<1>();
+  test_construction_and_accessors<2>();
+  test_construction_and_accessors<3>();
+
+  test_pup_round_trip<1>();
+  test_pup_round_trip<2>();
+  test_pup_round_trip<3>();
+
+  test_is_equal<1>();
+  test_is_equal<2>();
+  test_is_equal<3>();
+
+  tmpl::for_each<tmpl::make_sequence<tmpl::size_t<1>, 3>>([](auto dim_v) {
+    constexpr size_t Dim = tmpl::type_from<decltype(dim_v)>::value;
+    test_invoke_apply<Dim>();
+  });
+
+  test_option_parsing<1>();
+  test_option_parsing<2>();
+  test_option_parsing<3>();
+
+  test_supports_mesh();
+  test_cartoon();
+}


### PR DESCRIPTION
Introduce a runtime-polymorphic spectral filter interface for DG evolutions. `Filters::Filter` is an abstract base templated on `Dim` and `TagList` exposing:

- `apply_in_volume` on the `Dim`-mesh and `apply_on_boundary` on a `Dim - 1` face mesh, so the same filter object can damp both the volume solution and the lifted boundary corrections.
- independent substep / every-N-steps cadence hooks for volume and boundary application, letting the driving action gate filtering inside RK substeps or only at coarser whole-step intervals.
- a `blocks_to_filter()` selector (with `std::nullopt` meaning every block) and a `need_jacobians()` flag so the action can skip constructing the grid-to-inertial Jacobian when the filter does not use it.

`Filters::Hypercube` is a concrete derived class implementing the exponential filter `c_i -> c_i exp[-36 (i/N)^{2m}]` in each logical direction of a line, square, or cube element. The coefficient is hardcoded to 36 (machine-epsilon attenuation of the highest mode); `HalfPower`, per-block selection, and the substep / every-N-steps cadences are exposed as input-file options. This is the filter that plugs into the new `Filter`-based action and complements the legacy `Filters::Exponential` used by the older filtering action.

Add unit tests covering option parsing, serialization, equality, cadence predicates, and the matrix-based volume/boundary application for `Hypercube` in 1D, 2D, and 3D.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
