### PR TITLE
Add Kretschmann scalar to QuadraticCurvatureScalars and Hydro namespace

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -716,6 +716,13 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
             && github.event.inputs.clear_ccache == 'yes'
         run: |
           ccache -C
+      - name: Start memory monitor
+        run: |
+          (while true; do
+            echo "$(date -Iseconds) $(free -m | awk '/^Mem:/{print "used="$3"M free="$4"M avail="$7"M"}')"
+            sleep 15
+          done) >> /tmp/mem_monitor.log 2>&1 &
+          disown $!
       - name: Configure build with cmake
         # Notes on the build configuration:
         # - We don't need debug symbols during CI, so we turn them off to reduce
@@ -828,6 +835,16 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
         # We currently don't require codecov in our guidelines, so don't fail
         # the CI build if codecov fails to upload
         continue-on-error: true
+      - name: Diagnostics on failure
+        if: failure()
+        run: |
+          set +e
+          echo "=== dmesg (tail) ==="
+          dmesg | tail -n 200 || true
+          echo "=== memory ==="
+          free -h || true
+          echo "=== top ==="
+          ps -eo pid,ppid,cmd,%mem,%cpu,rss,vsz --sort=-rss | head -n 40 || true
       # Test only a few unit tests with nvcc for now because compiling the full
       # suite is too slow and exceed the available memory. We should extend this
       # to the full suite once we have a better solution for the memory issue.
@@ -1020,6 +1037,13 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
       - name: Diagnose ccache
         run: |
           ccache -s
+      - name: Upload memory monitor log
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: mem-monitor-${{ matrix.compiler }}-${{ matrix.build_type }}
+          path: /tmp/mem_monitor.log
+          if-no-files-found: ignore
 
   # Build all test executables and run unit tests on macOS
   unit_tests_macos:

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -100,6 +100,7 @@
 #include "Evolution/Systems/GrMhd/GhValenciaDivClean/TimeDerivativeTerms.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/AllSolutions.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/Factory.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/ComovingMagneticFieldMagnitude.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/FixConservatives.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAl.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/NewmanHamlin.hpp"
@@ -200,6 +201,7 @@
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
 #include "PointwiseFunctions/GeneralRelativity/DetAndInverseSpatialMetric.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ExtrinsicCurvature.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/ConstraintGammas.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/ExtrinsicCurvature.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SecondTimeDerivOfSpacetimeMetric.hpp"
@@ -211,13 +213,18 @@
 #include "PointwiseFunctions/GeneralRelativity/Surfaces/Tags.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "PointwiseFunctions/GeneralRelativity/WeylElectric.hpp"
+#include "PointwiseFunctions/GeneralRelativity/WeylMagnetic.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/Factory.hpp"
 #include "PointwiseFunctions/Hydro/LowerSpatialFourVelocity.hpp"
 #include "PointwiseFunctions/Hydro/MassFlux.hpp"
 #include "PointwiseFunctions/Hydro/MassWeightedFluidItems.hpp"
+#include "PointwiseFunctions/Hydro/QuadraticCurvatureScalars.hpp"
+#include "PointwiseFunctions/Hydro/Ricci.hpp"
 #include "PointwiseFunctions/Hydro/SpecificEntropy.hpp"
+#include "PointwiseFunctions/Hydro/StressEnergy.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"
 #include "PointwiseFunctions/Hydro/TransportVelocity.hpp"
+#include "PointwiseFunctions/Hydro/WeylElectric.hpp"
 #include "PointwiseFunctions/InitialDataUtilities/Tags/InitialData.hpp"
 #include "PointwiseFunctions/MathFunctions/Factory.hpp"
 #include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
@@ -459,6 +466,28 @@ struct GhValenciaDivCleanTemplateBase<
                                         ::Frame::Inertial>,
           gr::Tags::SpatialRicciScalarCompute<DataVector, volume_dim,
                                               ::Frame::Inertial>,
+          grmhd::ValenciaDivClean::Tags::ComovingMagneticFieldMagnitudeCompute,
+          hydro::Tags::StressEnergyCompute<DataVector>,
+          gr::Tags::InducedSpatialMetricCompute<DataVector, volume_dim,
+                                                ::Frame::Inertial>,
+          hydro::Tags::GrRicciCompute<DataVector>,
+          hydro::Tags::GrRicciScalarCompute<DataVector>,
+          gr::Tags::WeylElectricCompute<DataVector, volume_dim,
+                                        ::Frame::Inertial>,
+          hydro::Tags::WeylElectricCompute<DataVector>,
+          hydro::Tags::WeylElectricScalarCompute<DataVector>,
+          ::Tags::DerivTensorCompute<
+              gr::Tags::ExtrinsicCurvature<DataVector, volume_dim>,
+              ::Events::Tags::ObserverInverseJacobian<
+                  volume_dim, Frame::ElementLogical, Frame::Inertial>,
+              ::Events::Tags::ObserverMesh<volume_dim>>,
+          gr::Tags::CovariantDerivativeOfExtrinsicCurvatureCompute<
+              volume_dim, ::Frame::Inertial>,
+          gr::Tags::WeylMagneticCompute<DataVector, volume_dim,
+                                        ::Frame::Inertial>,
+          gr::Tags::WeylMagneticScalarCompute<DataVector, volume_dim,
+                                              ::Frame::Inertial>,
+          hydro::Tags::KretschmannScalarCompute<DataVector>,
 
           // Constraints
           gh::Tags::GaugeConstraintCompute<volume_dim, domain_frame>,
@@ -510,12 +539,6 @@ struct GhValenciaDivCleanTemplateBase<
           ::Tags::dt<gh::Tags::Pi<DataVector, volume_dim, Frame::Inertial>>,
           gh::Tags::SecondTimeDerivOfSpacetimeMetricCompute<volume_dim,
                                                             Frame::Inertial>,
-          ::Tags::DerivTensorCompute<
-              gr::Tags::ExtrinsicCurvature<DataVector, 3>,
-              ::Events::Tags::ObserverInverseJacobian<
-                  volume_dim, Frame::ElementLogical, Frame::Inertial>,
-              ::Events::Tags::ObserverMesh<volume_dim>>,
-          gr::Tags::WeylElectricCompute<DataVector, 3, Frame::Inertial>,
           gr::Tags::Psi4RealCompute<Frame::Inertial>,
           ::Events::Tags::ObserverMeshVelocity<3>>,
       tmpl::conditional_t<

--- a/src/PointwiseFunctions/GeneralRelativity/QuadraticCurvatureScalars.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/QuadraticCurvatureScalars.cpp
@@ -9,42 +9,70 @@
 
 namespace gr {
 
-template <typename Frame>
-void pontryagin_scalar_in_vacuum(
-    const gsl::not_null<Scalar<DataVector>*> pontryagin_scalar,
-    const tnsr::ii<DataVector, 3, Frame>& weyl_electric,
-    const tnsr::ii<DataVector, 3, Frame>& weyl_magnetic,
-    const tnsr::II<DataVector, 3, Frame>& inverse_spatial_metric) {
-  tenex::evaluate(pontryagin_scalar, -16.0 * weyl_electric(ti::i, ti::j) *
+template <typename DataType, typename Frame>
+void pontryagin_scalar(
+    const gsl::not_null<Scalar<DataType>*> pontryagin_scalar,
+    const tnsr::ii<DataType, 3, Frame>& weyl_electric,
+    const tnsr::ii<DataType, 3, Frame>& weyl_magnetic,
+    const tnsr::II<DataType, 3, Frame>& inverse_spatial_metric) {
+  tenex::evaluate(pontryagin_scalar, 16.0 * weyl_electric(ti::i, ti::j) *
                                          inverse_spatial_metric(ti::J, ti::K) *
                                          weyl_magnetic(ti::k, ti::l) *
                                          inverse_spatial_metric(ti::L, ti::I));
 }
 
-template <typename Frame>
-Scalar<DataVector> pontryagin_scalar_in_vacuum(
-    const tnsr::ii<DataVector, 3, Frame>& weyl_electric,
-    const tnsr::ii<DataVector, 3, Frame>& weyl_magnetic,
-    const tnsr::II<DataVector, 3, Frame>& inverse_spatial_metric) {
-  Scalar<DataVector> pontryagin_scalar{get<0, 0>(weyl_electric).size()};
-  pontryagin_scalar_in_vacuum(make_not_null(&pontryagin_scalar), weyl_electric,
-                              weyl_magnetic, inverse_spatial_metric);
-  return pontryagin_scalar;
+template <typename DataType, typename Frame>
+Scalar<DataType> pontryagin_scalar(
+    const tnsr::ii<DataType, 3, Frame>& weyl_electric,
+    const tnsr::ii<DataType, 3, Frame>& weyl_magnetic,
+    const tnsr::II<DataType, 3, Frame>& inverse_spatial_metric) {
+  Scalar<DataType> result{get_size(get<0, 0>(weyl_electric))};
+  pontryagin_scalar(make_not_null(&result), weyl_electric, weyl_magnetic,
+                    inverse_spatial_metric);
+  return result;
 }
 
-void gauss_bonnet_scalar_in_vacuum(
-    const gsl::not_null<Scalar<DataVector>*> gb_scalar,
-    const Scalar<DataVector>& weyl_electric_scalar,
-    const Scalar<DataVector>& weyl_magnetic_scalar) {
-  // Compute the Kretschmann scalar in vacuum
-  gb_scalar->get() =
+template <typename DataType>
+void kretschmann_scalar_in_vacuum(
+    const gsl::not_null<Scalar<DataType>*> kretschmann_scalar,
+    const Scalar<DataType>& weyl_electric_scalar,
+    const Scalar<DataType>& weyl_magnetic_scalar) {
+  // Note: Really this is just computing the parts of the Kretschmann scalar
+  // that depend on the Weyl electric and magnetic scalars. When in vacuum, this
+  // indeed is the pure vacuum contribution to the Kretschmann scalar. When not
+  // in vacuum, the Weyl electric scalar technically includes some non-vacuum
+  // contribution. However, in addition to this contribution, the Kretschmann
+  // scalar has some separate, purely non-vacuum terms which are computed in the
+  // Hydro namespace (see `hydro::kretschmann_scalar`).
+  kretschmann_scalar->get() =
       8.0 * (weyl_electric_scalar.get() - weyl_magnetic_scalar.get());
 }
 
-Scalar<DataVector> gauss_bonnet_scalar_in_vacuum(
-    const Scalar<DataVector>& weyl_electric_scalar,
-    const Scalar<DataVector>& weyl_magnetic_scalar) {
-  Scalar<DataVector> gb_scalar{get(weyl_electric_scalar).size()};
+template <typename DataType>
+Scalar<DataType> kretschmann_scalar_in_vacuum(
+    const Scalar<DataType>& weyl_electric_scalar,
+    const Scalar<DataType>& weyl_magnetic_scalar) {
+  Scalar<DataType> kretschmann_scalar{get_size(get(weyl_electric_scalar))};
+  kretschmann_scalar_in_vacuum(make_not_null(&kretschmann_scalar),
+                               weyl_electric_scalar, weyl_magnetic_scalar);
+  return kretschmann_scalar;
+}
+
+template <typename DataType>
+void gauss_bonnet_scalar_in_vacuum(
+    const gsl::not_null<Scalar<DataType>*> gb_scalar,
+    const Scalar<DataType>& weyl_electric_scalar,
+    const Scalar<DataType>& weyl_magnetic_scalar) {
+  // The Gauss-Bonnet scalar is equivalent to the Kretschmann scalar in vacuum
+  kretschmann_scalar_in_vacuum(gb_scalar, weyl_electric_scalar,
+                               weyl_magnetic_scalar);
+}
+
+template <typename DataType>
+Scalar<DataType> gauss_bonnet_scalar_in_vacuum(
+    const Scalar<DataType>& weyl_electric_scalar,
+    const Scalar<DataType>& weyl_magnetic_scalar) {
+  Scalar<DataType> gb_scalar{get_size(get(weyl_electric_scalar))};
   gauss_bonnet_scalar_in_vacuum(make_not_null(&gb_scalar), weyl_electric_scalar,
                                 weyl_magnetic_scalar);
   return gb_scalar;
@@ -52,20 +80,46 @@ Scalar<DataVector> gauss_bonnet_scalar_in_vacuum(
 
 }  // namespace gr
 
-#define FRAME(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
 
 #define INSTANTIATE(_, data)                                                \
-  template Scalar<DataVector> gr::pontryagin_scalar_in_vacuum(             \
-      const tnsr::ii<DataVector, 3, FRAME(data)>& weyl_electric,           \
-      const tnsr::ii<DataVector, 3, FRAME(data)>& weyl_magnetic,           \
-      const tnsr::II<DataVector, 3, FRAME(data)>& inverse_spatial_metric); \
-  template void gr::pontryagin_scalar_in_vacuum(                            \
-      const gsl::not_null<Scalar<DataVector>*> pontryagin_scalar,          \
-      const tnsr::ii<DataVector, 3, FRAME(data)>& weyl_electric,           \
-      const tnsr::ii<DataVector, 3, FRAME(data)>& weyl_magnetic,           \
-      const tnsr::II<DataVector, 3, FRAME(data)>& inverse_spatial_metric);
+  template Scalar<DTYPE(data)> gr::pontryagin_scalar(                       \
+      const tnsr::ii<DTYPE(data), 3, FRAME(data)>& weyl_electric,           \
+      const tnsr::ii<DTYPE(data), 3, FRAME(data)>& weyl_magnetic,           \
+      const tnsr::II<DTYPE(data), 3, FRAME(data)>& inverse_spatial_metric); \
+  template void gr::pontryagin_scalar(                                      \
+      const gsl::not_null<Scalar<DTYPE(data)>*> pontryagin_scalar,          \
+      const tnsr::ii<DTYPE(data), 3, FRAME(data)>& weyl_electric,           \
+      const tnsr::ii<DTYPE(data), 3, FRAME(data)>& weyl_magnetic,           \
+      const tnsr::II<DTYPE(data), 3, FRAME(data)>& inverse_spatial_metric);
 
-GENERATE_INSTANTIATIONS(INSTANTIATE, (Frame::Grid, Frame::Inertial))
+GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector),
+                        (Frame::Grid, Frame::Inertial))
 
 #undef FRAME
+#undef DTYPE
+#undef INSTANTIATE
+
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                        \
+  template Scalar<DTYPE(data)> gr::kretschmann_scalar_in_vacuum(    \
+      const Scalar<DTYPE(data)>& weyl_electric_scalar,              \
+      const Scalar<DTYPE(data)>& weyl_magnetic_scalar);             \
+  template void gr::kretschmann_scalar_in_vacuum(                   \
+      const gsl::not_null<Scalar<DTYPE(data)>*> kretschmann_scalar, \
+      const Scalar<DTYPE(data)>& weyl_electric_scalar,              \
+      const Scalar<DTYPE(data)>& weyl_magnetic_scalar);             \
+  template Scalar<DTYPE(data)> gr::gauss_bonnet_scalar_in_vacuum(   \
+      const Scalar<DTYPE(data)>& weyl_electric_scalar,              \
+      const Scalar<DTYPE(data)>& weyl_magnetic_scalar);             \
+  template void gr::gauss_bonnet_scalar_in_vacuum(                  \
+      const gsl::not_null<Scalar<DTYPE(data)>*> gb_scalar,          \
+      const Scalar<DTYPE(data)>& weyl_electric_scalar,              \
+      const Scalar<DTYPE(data)>& weyl_magnetic_scalar);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector))
+
+#undef DTYPE
 #undef INSTANTIATE

--- a/src/PointwiseFunctions/GeneralRelativity/QuadraticCurvatureScalars.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/QuadraticCurvatureScalars.hpp
@@ -121,14 +121,10 @@ Scalar<DataType> gauss_bonnet_scalar_in_vacuum(
 namespace gr::Tags {
 /// @{
 /*!
- * \brief Tags for the PontryaginScalar in vacuum.
+ * \brief Compute tag for the PontryaginScalar in vacuum.
  *
  * The tags are tested in Test_CurvatureScalarComputeTags.cpp
  */
-template <typename DataType>
-struct PontryaginScalar : db::SimpleTag {
-  using type = Scalar<DataType>;
-};
 
 template <typename DataType, typename Frame>
 struct PontryaginScalarCompute : PontryaginScalar<DataType>, db::ComputeTag {
@@ -148,14 +144,30 @@ struct PontryaginScalarCompute : PontryaginScalar<DataType>, db::ComputeTag {
 
 /// @{
 /*!
- * \brief Tags for the Gauss Bonnet Scalar in vacuum.
+ * \brief Compute tag for the Kretschmann Scalar in vacuum.
  *
  * The tags are tested in Test_CurvatureScalarComputeTags.cpp
  */
+
 template <typename DataType>
-struct GaussBonnetScalar : db::SimpleTag {
-  using type = Scalar<DataType>;
+struct KretschmannScalarCompute : KretschmannScalar<DataType>, db::ComputeTag {
+  using argument_tags = tmpl::list<gr::Tags::WeylElectricScalar<DataType>,
+                                   gr::Tags::WeylMagneticScalar<DataType>>;
+  using return_type = Scalar<DataType>;
+  static constexpr auto function =
+      static_cast<void (*)(gsl::not_null<Scalar<DataType>*>,
+                           const Scalar<DataType>&, const Scalar<DataType>&)>(
+          &gr::kretschmann_scalar_in_vacuum<DataType>);
+  using base = KretschmannScalar<DataType>;
 };
+/// @}
+
+/// @{
+/*!
+ * \brief Compute tag for the Gauss Bonnet Scalar in vacuum.
+ *
+ * The tags are tested in Test_CurvatureScalarComputeTags.cpp
+ */
 
 template <typename DataType>
 struct GaussBonnetScalarCompute : GaussBonnetScalar<DataType>, db::ComputeTag {

--- a/src/PointwiseFunctions/GeneralRelativity/QuadraticCurvatureScalars.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/QuadraticCurvatureScalars.hpp
@@ -21,33 +21,68 @@ namespace gr {
 
 /// @{
 /*!
- * \brief Computes the Pontryagin scalar in vacuum.
+ * \brief Computes the Pontryagin scalar.
  *
- * \details The Pontryagin scalar in vacuum is given by
- * \begin{align}
- *   \mathcal{P} &\equiv {^{\star} C}_{abcd} C^{abcd} \\
- *    &= - 16 E_{ab} B^{ab} ~,
- * \end{align}
- * where $ C_{abcd} $ it the Weyl tensor (with dual $ {^\star} C}_{abcd} $) in 4
- * spacetime dimensions. Here it is computed in terms of the electric ($
- * E_{ab} $) and magnetic ($ B_{ab} $) parts of the Weyl scalar, with the
- * conventions used here for ($ \{E_{ab}, B_{ab}\} $).
+ * \details The Pontryagin scalar is given by
+ * \f{align}{
+ *   \mathcal{P} &\equiv {}^{\star}R_{abcd} R^{abcd} \\
+ *    &= {}^{\star}C_{abcd} C^{abcd} \\
+ *    &= 16 E_{ab} B^{ab} ~,
+ * \f}
+ * where \f$C_{abcd}\f$ is the Weyl tensor (with dual \f${}^\star C_{abcd}\f$).
+ * Here it is computed in terms of the electric (\f$E_{ab}\f$) and magnetic
+ * (\f$B_{ab}\f$) parts of the Weyl tensor, with the
+ * conventions used here for (\f$\{E_{ab}, B_{ab}\}\f$).
+ * Note that the Pontryagin scalar is insensitive to the Ricci tensor, therefore
+ * is not affected by the presence of matter.
+ *
+ * \see `gr::Tags::WeylMagnetic` and `gr::Tags::WeylElectric`
+ *
+ * \note The spatial dimension is fixed to 3 to be consistent with
+ * `gr::Tags::WeylMagnetic`, which requires the 3D Levi-Civita symbol.
+ */
+template <typename DataType, typename Frame>
+void pontryagin_scalar(
+    gsl::not_null<Scalar<DataType>*> pontryagin_scalar,
+    const tnsr::ii<DataType, 3, Frame>& weyl_electric,
+    const tnsr::ii<DataType, 3, Frame>& weyl_magnetic,
+    const tnsr::II<DataType, 3, Frame>& inverse_spatial_metric);
+
+template <typename DataType, typename Frame>
+Scalar<DataType> pontryagin_scalar(
+    const tnsr::ii<DataType, 3, Frame>& weyl_electric,
+    const tnsr::ii<DataType, 3, Frame>& weyl_magnetic,
+    const tnsr::II<DataType, 3, Frame>& inverse_spatial_metric);
+/// @}
+
+/// @{
+/*!
+ * \brief Computes Kretschmann scalar in vacuum.
+ *
+ * \details The Kretschmann scalar in vacuum is given by
+ * \f{align}{
+ *   \mathcal{K} &\equiv R_{abcd} R^{abcd} \\
+ *    &= C_{abcd} C^{abcd} \\
+ *    &= 8 (E_{ab} E^{ab} - B_{ab} B^{ab}) ~,
+ * \f}
+ * where \f$R_{abcd}\f$, \f$C_{abcd}\f$ are the Riemann tensor and Weyl tensor
+ * in 4 spacetime dimensions. The Kretschmann scalar in vacuum can be computed
+ * in terms of the electric (\f$E_{ab}\f$) and magnetic (\f$B_{ab}\f$) parts of
+ * the Weyl tensor.
  *
  * \see `gr::Tags::WeylMagnetic` and `gr::Tags::WeylElectric`
  *
  */
-template <typename Frame>
-void pontryagin_scalar_in_vacuum(
-    gsl::not_null<Scalar<DataVector>*> pontryagin_scalar,
-    const tnsr::ii<DataVector, 3, Frame>& weyl_electric,
-    const tnsr::ii<DataVector, 3, Frame>& weyl_magnetic,
-    const tnsr::II<DataVector, 3, Frame>& inverse_spatial_metric);
+template <typename DataType>
+void kretschmann_scalar_in_vacuum(
+    gsl::not_null<Scalar<DataType>*> kretschmann_scalar,
+    const Scalar<DataType>& weyl_electric_scalar,
+    const Scalar<DataType>& weyl_magnetic_scalar);
 
-template <typename Frame>
-Scalar<DataVector> pontryagin_scalar_in_vacuum(
-    const tnsr::ii<DataVector, 3, Frame>& weyl_electric,
-    const tnsr::ii<DataVector, 3, Frame>& weyl_magnetic,
-    const tnsr::II<DataVector, 3, Frame>& inverse_spatial_metric);
+template <typename DataType>
+Scalar<DataType> kretschmann_scalar_in_vacuum(
+    const Scalar<DataType>& weyl_electric_scalar,
+    const Scalar<DataType>& weyl_magnetic_scalar);
 /// @}
 
 /// @{
@@ -55,27 +90,30 @@ Scalar<DataVector> pontryagin_scalar_in_vacuum(
  * \brief Computes Gauss-Bonnet scalar in vacuum.
  *
  * \details The Gauss-Bonnet scalar in vacuum is given by
- * \begin{align}
- *   \mathcal{G} &\equiv R_{abcd} R^{abcd} - 4 R_{ab} R^{ab} + R^2
- *    &= C_{abcd} C^{abcd}
+ * \f{align}{
+ *   \mathcal{G} &\equiv R_{abcd} R^{abcd} - 4 R_{ab} R^{ab} + R^2 \\
+ *    &= C_{abcd} C^{abcd} \\
  *    &= 8 (E_{ab} E^{ab} - B_{ab} B^{ab}) ~,
- * \end{align}
- * where $ R_{abcd} $, $ R_{ab} $, $ R $ $ C_{abcd} $ are the Riemann tensor,
- * Ricci tensor, Ricci scalar and Weyl tensor in 4 spacetime dimensions. The
- * Gauss-Bonnet scalar in vacuum can be computed in terms of the electric ($
- * E_{ab} $) and magnetic ($ B_{ab} $) parts of the Weyl tensor.
+ * \f}
+ * where \f$R_{abcd}\f$, \f$R_{ab}\f$, \f$R\f$, \f$C_{abcd}\f$ are the Riemann
+ * tensor, Ricci tensor, Ricci scalar, and Weyl tensor in 4 spacetime
+ * dimensions. The Gauss-Bonnet scalar in vacuum can be computed in terms of
+ * the electric (\f$E_{ab}\f$) and magnetic (\f$B_{ab}\f$) parts of the Weyl
+ * tensor.
  *
  * \see `gr::Tags::WeylMagnetic` and `gr::Tags::WeylElectric`
  *
  */
+template <typename DataType>
 void gauss_bonnet_scalar_in_vacuum(
-    gsl::not_null<Scalar<DataVector>*> gb_scalar,
-    const Scalar<DataVector>& weyl_electric_scalar,
-    const Scalar<DataVector>& weyl_magnetic_scalar);
+    gsl::not_null<Scalar<DataType>*> gb_scalar,
+    const Scalar<DataType>& weyl_electric_scalar,
+    const Scalar<DataType>& weyl_magnetic_scalar);
 
-Scalar<DataVector> gauss_bonnet_scalar_in_vacuum(
-    const Scalar<DataVector>& weyl_electric_scalar,
-    const Scalar<DataVector>& weyl_magnetic_scalar);
+template <typename DataType>
+Scalar<DataType> gauss_bonnet_scalar_in_vacuum(
+    const Scalar<DataType>& weyl_electric_scalar,
+    const Scalar<DataType>& weyl_magnetic_scalar);
 /// @}
 
 }  // namespace gr
@@ -92,21 +130,21 @@ struct PontryaginScalar : db::SimpleTag {
   using type = Scalar<DataType>;
 };
 
-template <typename DataType, size_t Dim, typename Frame>
+template <typename DataType, typename Frame>
 struct PontryaginScalarCompute : PontryaginScalar<DataType>, db::ComputeTag {
   using argument_tags =
-      tmpl::list<gr::Tags::WeylElectric<DataType, Dim, Frame>,
-                 gr::Tags::WeylMagnetic<DataType, Dim, Frame>,
-                 gr::Tags::InverseSpatialMetric<DataType, Dim, Frame>>;
+      tmpl::list<gr::Tags::WeylElectric<DataType, 3, Frame>,
+                 gr::Tags::WeylMagnetic<DataType, 3, Frame>,
+                 gr::Tags::InverseSpatialMetric<DataType, 3, Frame>>;
   using return_type = Scalar<DataType>;
   static constexpr auto function = static_cast<void (*)(
-      gsl::not_null<Scalar<DataType>*>, const tnsr::ii<DataType, Dim, Frame>&,
-      const tnsr::ii<DataType, Dim, Frame>&,
-      const tnsr::II<DataType, Dim, Frame>&)>(
-      &gr::pontryagin_scalar_in_vacuum<Frame>);
+      gsl::not_null<Scalar<DataType>*>, const tnsr::ii<DataType, 3, Frame>&,
+      const tnsr::ii<DataType, 3, Frame>&,
+      const tnsr::II<DataType, 3, Frame>&)>(
+      &gr::pontryagin_scalar<DataType, Frame>);
   using base = PontryaginScalar<DataType>;
 };
-/// @{
+/// @}
 
 /// @{
 /*!
@@ -127,7 +165,7 @@ struct GaussBonnetScalarCompute : GaussBonnetScalar<DataType>, db::ComputeTag {
   static constexpr auto function =
       static_cast<void (*)(gsl::not_null<Scalar<DataType>*>,
                            const Scalar<DataType>&, const Scalar<DataType>&)>(
-          &gr::gauss_bonnet_scalar_in_vacuum);
+          &gr::gauss_bonnet_scalar_in_vacuum<DataType>);
   using base = GaussBonnetScalar<DataType>;
 };
 /// @}

--- a/src/PointwiseFunctions/GeneralRelativity/SpatialMetric.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/SpatialMetric.cpp
@@ -32,6 +32,29 @@ void spatial_metric(
     }
   }
 }
+
+template <typename DataType, size_t SpatialDim, typename Frame>
+tnsr::aa<DataType, SpatialDim, Frame> induced_spatial_metric(
+    const tnsr::aa<DataType, SpatialDim, Frame>& spacetime_metric,
+    const Scalar<DataType>& lapse) {
+  tnsr::aa<DataType, SpatialDim, Frame> result{
+      get_size(get<0, 0>(spacetime_metric))};
+  induced_spatial_metric(make_not_null(&result), spacetime_metric, lapse);
+  return result;
+}
+
+template <typename DataType, size_t SpatialDim, typename Frame>
+void induced_spatial_metric(
+    gsl::not_null<tnsr::aa<DataType, SpatialDim, Frame>*> result,
+    const tnsr::aa<DataType, SpatialDim, Frame>& spacetime_metric,
+    const Scalar<DataType>& lapse) {
+  for (size_t a = 0; a < SpatialDim + 1; a++) {
+    for (size_t b = a; b < SpatialDim + 1; b++) {
+      result->get(a, b) = spacetime_metric.get(a, b);
+    }
+  }
+  result->get(0, 0) += square(get(lapse));
+}
 }  // namespace gr
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
@@ -44,7 +67,16 @@ void spatial_metric(
   template void gr::spatial_metric(                                           \
       const gsl::not_null<tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>*>     \
           spatial_metric,                                                     \
-      const tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>& spacetime_metric);
+      const tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>& spacetime_metric); \
+  template tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>                      \
+  gr::induced_spatial_metric(                                                 \
+      const tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>& spacetime_metric,  \
+      const Scalar<DTYPE(data)>& lapse);                                      \
+  template void gr::induced_spatial_metric(                                   \
+      const gsl::not_null<tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>*>     \
+          result,                                                             \
+      const tnsr::aa<DTYPE(data), DIM(data), FRAME(data)>& spacetime_metric,  \
+      const Scalar<DTYPE(data)>& lapse);
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (double, DataVector),
                         (Frame::Grid, Frame::Inertial))

--- a/src/PointwiseFunctions/GeneralRelativity/SpatialMetric.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/SpatialMetric.hpp
@@ -72,6 +72,28 @@ struct SpatialMetricCompute : SpatialMetric<DataType, SpatialDim, Frame>,
 
   using base = SpatialMetric<DataType, SpatialDim, Frame>;
 };
+/*!
+ * \brief Compute item for the induced spatial metric \f$\gamma_{ab}\f$
+ * from the spacetime metric \f$g_{ab}\f$ and the spacetime normal one-form
+ * \f$n_a\f$.
+ *
+ * \details Can be retrieved using `gr::Tags::InducedSpatialMetric`.
+ */
+template <typename DataType, size_t SpatialDim, typename Frame>
+struct InducedSpatialMetricCompute
+    : InducedSpatialMetric<DataType, SpatialDim, Frame>,
+      db::ComputeTag {
+  using argument_tags =
+      tmpl::list<SpacetimeMetric<DataType, SpatialDim, Frame>, Lapse<DataType>>;
 
+  using return_type = tnsr::aa<DataType, SpatialDim, Frame>;
+
+  static constexpr auto function = static_cast<void (*)(
+      gsl::not_null<tnsr::aa<DataType, SpatialDim, Frame>*>,
+      const tnsr::aa<DataType, SpatialDim, Frame>&, const Scalar<DataType>&)>(
+      &induced_spatial_metric<DataType, SpatialDim, Frame>);
+
+  using base = InducedSpatialMetric<DataType, SpatialDim, Frame>;
+};
 }  // namespace Tags
 }  // namespace gr

--- a/src/PointwiseFunctions/GeneralRelativity/SpatialMetric.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/SpatialMetric.hpp
@@ -30,6 +30,26 @@ void spatial_metric(
     const tnsr::aa<DataType, SpatialDim, Frame>& spacetime_metric);
 /// @}
 
+/// @{
+/*!
+ * \ingroup GeneralRelativityGroup
+ * \brief Compute the induced spatial metric \f$\gamma_{ab}\f$ in spacetime
+ * coordinates.
+ * \details The induced spatial metric is \f$\gamma_{ab}=g_{ab} + n_a n_b\f$.
+ * Since \f$n_a=(-\alpha,0,0,0)\f$, this adds \f$\alpha^2\f$ to \f$g_{tt}\f$.
+ */
+template <typename DataType, size_t SpatialDim, typename Frame>
+tnsr::aa<DataType, SpatialDim, Frame> induced_spatial_metric(
+    const tnsr::aa<DataType, SpatialDim, Frame>& spacetime_metric,
+    const Scalar<DataType>& lapse);
+
+template <typename DataType, size_t SpatialDim, typename Frame>
+void induced_spatial_metric(
+    gsl::not_null<tnsr::aa<DataType, SpatialDim, Frame>*> result,
+    const tnsr::aa<DataType, SpatialDim, Frame>& spacetime_metric,
+    const Scalar<DataType>& lapse);
+/// @}
+
 namespace Tags {
 /*!
  * \brief Compute item for spatial metric \f$\gamma_{ij}\f$ from the
@@ -52,5 +72,6 @@ struct SpatialMetricCompute : SpatialMetric<DataType, SpatialDim, Frame>,
 
   using base = SpatialMetric<DataType, SpatialDim, Frame>;
 };
+
 }  // namespace Tags
 }  // namespace gr

--- a/src/PointwiseFunctions/GeneralRelativity/Tags.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Tags.hpp
@@ -25,6 +25,16 @@ template <typename DataType, size_t Dim, typename Frame>
 struct SpatialMetric : db::SimpleTag {
   using type = tnsr::ii<DataType, Dim, Frame>;
 };
+
+/*!
+ * \brief The induced spatial metric \f$\gamma_{ab} = g_{ab} + n_a n_b\f$
+ * in spacetime coordinates, where \f$n_a\f$ is the unit normal to the spatial
+ * hypersurface.
+ */
+template <typename DataType, size_t Dim, typename Frame>
+struct InducedSpatialMetric : db::SimpleTag {
+  using type = tnsr::aa<DataType, Dim, Frame>;
+};
 /*!
  * \brief Inverse of the spatial metric.
  */

--- a/src/PointwiseFunctions/GeneralRelativity/Tags.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Tags.hpp
@@ -306,6 +306,36 @@ struct WeylTypeD1Scalar : db::SimpleTag {
   using type = Scalar<DataType>;
 };
 
+/*!
+ * \brief The Gauss-Bonnet scalar \f$G = R_{abcd}R^{abcd} - 4R_{ab}R^{ab} +
+ * R^2\f$ in vacuum.
+ */
+template <typename DataType>
+struct GaussBonnetScalar : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
+
+/*!
+ * \brief The Kretschmann scalar \f$K = R_{abcd}R^{abcd}\f$ in vacuum.
+ *
+ * \details This tag computes only the Weyl contribution to the Kretschmann
+ * scalar, which equals \f$R_{abcd}R^{abcd}\f$ in vacuum. In the presence of
+ * matter, additional terms depending on the Ricci tensor are needed: see
+ * `hydro::Tags::KretschmannScalar` for the complete formula.
+ */
+template <typename DataType>
+struct KretschmannScalar : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
+
+/*!
+ * \brief The Pontryagin scalar \f$P = {}^{*}R_{abcd}R^{abcd}\f$.
+ */
+template <typename DataType>
+struct PontryaginScalar : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
+
 }  // namespace Tags
 
 /// GR Tags commonly needed for the evolution of hydro systems

--- a/src/PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp
@@ -18,6 +18,8 @@ struct InverseSpacetimeMetric;
 template <typename DataType, size_t Dim, typename Frame = Frame::Inertial>
 struct SpatialMetric;
 template <typename DataType, size_t Dim, typename Frame = Frame::Inertial>
+struct InducedSpatialMetric;
+template <typename DataType, size_t Dim, typename Frame = Frame::Inertial>
 struct DetAndInverseSpatialMetric;
 template <typename DataType, size_t Dim, typename Frame = Frame::Inertial>
 struct InverseSpatialMetric;

--- a/src/PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp
@@ -93,5 +93,11 @@ template <typename DataType, size_t Dim, typename Frame>
 struct WeylTypeD1;
 template <typename Datatype>
 struct WeylTypeD1Scalar;
+template <typename DataType>
+struct GaussBonnetScalar;
+template <typename DataType>
+struct KretschmannScalar;
+template <typename DataType>
+struct PontryaginScalar;
 }  // namespace Tags
 }  // namespace gr

--- a/src/PointwiseFunctions/GeneralRelativity/WeylElectric.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/WeylElectric.cpp
@@ -5,7 +5,6 @@
 
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/VectorImpl.hpp"
-#include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"

--- a/src/PointwiseFunctions/Hydro/CMakeLists.txt
+++ b/src/PointwiseFunctions/Hydro/CMakeLists.txt
@@ -22,6 +22,7 @@ spectre_target_sources(
   SpecificEntropy.cpp
   StressEnergy.cpp
   TransportVelocity.cpp
+  WeylElectric.cpp
   )
 
 spectre_target_headers(
@@ -46,6 +47,7 @@ spectre_target_headers(
   Temperature.hpp
   TransportVelocity.hpp
   Units.hpp
+  WeylElectric.hpp
   )
 
 target_link_libraries(

--- a/src/PointwiseFunctions/Hydro/CMakeLists.txt
+++ b/src/PointwiseFunctions/Hydro/CMakeLists.txt
@@ -15,6 +15,7 @@ spectre_target_sources(
   MagneticFieldTreatment.cpp
   MassFlux.cpp
   MassWeightedFluidItems.cpp
+  QuadraticCurvatureScalars.cpp
   QuadrupoleFormula.cpp
   Ricci.cpp
   SoundSpeedSquared.cpp
@@ -36,6 +37,7 @@ spectre_target_headers(
   MagneticFieldTreatment.hpp
   MassFlux.hpp
   MassWeightedFluidItems.hpp
+  QuadraticCurvatureScalars.hpp
   QuadrupoleFormula.hpp
   Ricci.hpp
   SoundSpeedSquared.hpp

--- a/src/PointwiseFunctions/Hydro/CMakeLists.txt
+++ b/src/PointwiseFunctions/Hydro/CMakeLists.txt
@@ -16,6 +16,7 @@ spectre_target_sources(
   MassFlux.cpp
   MassWeightedFluidItems.cpp
   QuadrupoleFormula.cpp
+  Ricci.cpp
   SoundSpeedSquared.cpp
   SpecificEnthalpy.cpp
   SpecificEntropy.cpp
@@ -35,6 +36,7 @@ spectre_target_headers(
   MassFlux.hpp
   MassWeightedFluidItems.hpp
   QuadrupoleFormula.hpp
+  Ricci.hpp
   SoundSpeedSquared.hpp
   SpecificEnthalpy.hpp
   SpecificEntropy.hpp

--- a/src/PointwiseFunctions/Hydro/QuadraticCurvatureScalars.cpp
+++ b/src/PointwiseFunctions/Hydro/QuadraticCurvatureScalars.cpp
@@ -1,0 +1,75 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/Hydro/QuadraticCurvatureScalars.hpp"
+
+#include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "PointwiseFunctions/GeneralRelativity/QuadraticCurvatureScalars.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace hydro {
+
+template <typename DataType>
+void kretschmann_scalar(const gsl::not_null<Scalar<DataType>*> result,
+                        const Scalar<DataType>& weyl_electric_scalar,
+                        const Scalar<DataType>& weyl_magnetic_scalar,
+                        const tnsr::AA<DataType, 3>& inverse_spacetime_metric,
+                        const tnsr::aa<DataType, 3>& ricci_tensor,
+                        const Scalar<DataType>& ricci_scalar) {
+  Scalar<DataType> kretschmann_scalar_in_vacuum{
+      get_size(get<0, 0>(inverse_spacetime_metric))};
+  gr::kretschmann_scalar_in_vacuum(make_not_null(&kretschmann_scalar_in_vacuum),
+                                   weyl_electric_scalar, weyl_magnetic_scalar);
+
+  tnsr::AA<DataType, 3> ricci_tensor_upper{
+      get_size(get<0, 0>(inverse_spacetime_metric))};
+  tenex::evaluate<ti::A, ti::B>(make_not_null(&ricci_tensor_upper),
+                                ricci_tensor(ti::c, ti::d) *
+                                    inverse_spacetime_metric(ti::A, ti::C) *
+                                    inverse_spacetime_metric(ti::B, ti::D));
+
+  tenex::evaluate<>(result, kretschmann_scalar_in_vacuum() +
+                                2. * ricci_tensor(ti::a, ti::b) *
+                                    ricci_tensor_upper(ti::A, ti::B) -
+                                square(ricci_scalar()) / 3.);
+}
+
+template <typename DataType>
+Scalar<DataType> kretschmann_scalar(
+    const Scalar<DataType>& weyl_electric_scalar,
+    const Scalar<DataType>& weyl_magnetic_scalar,
+    const tnsr::AA<DataType, 3>& inverse_spacetime_metric,
+    const tnsr::aa<DataType, 3>& ricci_tensor,
+    const Scalar<DataType>& ricci_scalar) {
+  Scalar<DataType> result{get_size(get<0, 0>(inverse_spacetime_metric))};
+  kretschmann_scalar(make_not_null(&result), weyl_electric_scalar,
+                     weyl_magnetic_scalar, inverse_spacetime_metric,
+                     ricci_tensor, ricci_scalar);
+  return result;
+}
+
+}  // namespace hydro
+
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                    \
+  template Scalar<DTYPE(data)> hydro::kretschmann_scalar(       \
+      const Scalar<DTYPE(data)>& weyl_electric_scalar,          \
+      const Scalar<DTYPE(data)>& weyl_magnetic_scalar,          \
+      const tnsr::AA<DTYPE(data), 3>& inverse_spacetime_metric, \
+      const tnsr::aa<DTYPE(data), 3>& ricci_tensor,             \
+      const Scalar<DTYPE(data)>& ricci_scalar);                 \
+  template void hydro::kretschmann_scalar(                      \
+      const gsl::not_null<Scalar<DTYPE(data)>*> result,         \
+      const Scalar<DTYPE(data)>& weyl_electric_scalar,          \
+      const Scalar<DTYPE(data)>& weyl_magnetic_scalar,          \
+      const tnsr::AA<DTYPE(data), 3>& inverse_spacetime_metric, \
+      const tnsr::aa<DTYPE(data), 3>& ricci_tensor,             \
+      const Scalar<DTYPE(data)>& ricci_scalar);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector))
+
+#undef DTYPE
+#undef INSTANTIATE

--- a/src/PointwiseFunctions/Hydro/QuadraticCurvatureScalars.hpp
+++ b/src/PointwiseFunctions/Hydro/QuadraticCurvatureScalars.hpp
@@ -1,0 +1,84 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "PointwiseFunctions/GeneralRelativity/QuadraticCurvatureScalars.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace gsl {
+template <typename>
+struct not_null;
+}  // namespace gsl
+/// \endcond
+
+namespace hydro {
+
+/// @{
+/*!
+ * \brief Computes Kretschmann scalar in hydro.
+ *
+ * \details The Kretschmann scalar is given by
+ * \f{align}{
+ *   \mathcal{K} &\equiv R_{abcd} R^{abcd} \\
+ *    &= C_{abcd} C^{abcd} + 2R_{ab}R^{ab} - R^2/3 \\
+ *    &= 8 (E_{ab} E^{ab} - B_{ab} B^{ab}) + 2R_{ab}R^{ab} - R^2/3 ~,
+ * \f}
+ * where \f$R_{abcd}\f$, \f$C_{abcd}\f$ are the Riemann tensor and Weyl tensor
+ * in 4 spacetime dimensions, \f$R_{ab}\f$ is the Ricci tensor, \f$R\f$ is the
+ * Ricci scalar, and \f$E_{ab}\f$, \f$B_{ab}\f$ are the electric and magnetic
+ * parts of the Weyl tensor.
+ *
+ * \see `gr::Tags::WeylMagnetic` and `gr::Tags::WeylElectric`
+ *
+ */
+template <typename DataType>
+void kretschmann_scalar(gsl::not_null<Scalar<DataType>*> result,
+                        const Scalar<DataType>& weyl_electric_scalar,
+                        const Scalar<DataType>& weyl_magnetic_scalar,
+                        const tnsr::AA<DataType, 3>& inverse_spacetime_metric,
+                        const tnsr::aa<DataType, 3>& ricci_tensor,
+                        const Scalar<DataType>& ricci_scalar);
+
+template <typename DataType>
+Scalar<DataType> kretschmann_scalar(
+    const Scalar<DataType>& weyl_electric_scalar,
+    const Scalar<DataType>& weyl_magnetic_scalar,
+    const tnsr::AA<DataType, 3>& inverse_spacetime_metric,
+    const tnsr::aa<DataType, 3>& ricci_tensor,
+    const Scalar<DataType>& ricci_scalar);
+/// @}
+
+namespace Tags {
+/// Compute item for the Kretschmann scalar in hydro.
+///
+/// Can be retrieved using hydro::Tags::KretschmannScalar
+template <typename DataType>
+struct KretschmannScalarCompute : KretschmannScalar<DataType>, db::ComputeTag {
+  using argument_tags =
+      tmpl::list<hydro::Tags::WeylElectricScalar<DataType>,
+                 gr::Tags::WeylMagneticScalar<DataType>,
+                 gr::Tags::InverseSpacetimeMetric<DataType, 3>,
+                 hydro::Tags::GrRicci<DataType, 3>,
+                 hydro::Tags::GrRicciScalar<DataType>>;
+
+  using return_type = Scalar<DataType>;
+
+  static constexpr auto function = static_cast<void (*)(
+      gsl::not_null<Scalar<DataType>*>, const Scalar<DataType>&,
+      const Scalar<DataType>&, const tnsr::AA<DataType, 3>&,
+      const tnsr::aa<DataType, 3>&, const Scalar<DataType>&)>(
+      &hydro::kretschmann_scalar);
+
+  using base = KretschmannScalar<DataType>;
+};
+
+}  // namespace Tags
+}  // namespace hydro

--- a/src/PointwiseFunctions/Hydro/QuadraticCurvatureScalars.hpp
+++ b/src/PointwiseFunctions/Hydro/QuadraticCurvatureScalars.hpp
@@ -80,5 +80,23 @@ struct KretschmannScalarCompute : KretschmannScalar<DataType>, db::ComputeTag {
   using base = KretschmannScalar<DataType>;
 };
 
+/// Compute item for the Pontryagin scalar in hydro.
+///
+/// Can be retrieved using hydro::Tags::PontryaginScalar
+template <typename DataType>
+struct PontryaginScalarCompute : PontryaginScalar<DataType>, db::ComputeTag {
+  using argument_tags = tmpl::list<hydro::Tags::WeylElectric<DataType, 3>,
+                                   gr::Tags::WeylMagnetic<DataType, 3>,
+                                   gr::Tags::InverseSpatialMetric<DataType, 3>>;
+
+  using return_type = Scalar<DataType>;
+
+  static constexpr auto function = static_cast<void (*)(
+      gsl::not_null<Scalar<DataType>*>, const tnsr::ii<DataType, 3>&,
+      const tnsr::ii<DataType, 3>&, const tnsr::II<DataType, 3>&)>(
+      &gr::pontryagin_scalar);
+
+  using base = PontryaginScalar<DataType>;
+};
 }  // namespace Tags
 }  // namespace hydro

--- a/src/PointwiseFunctions/Hydro/Ricci.cpp
+++ b/src/PointwiseFunctions/Hydro/Ricci.cpp
@@ -1,0 +1,53 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/Hydro/Ricci.hpp"
+
+#include "DataStructures/Tensor/EagerMath/Trace.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
+
+namespace hydro {
+template <typename DataType>
+void ricci_in_gr(const gsl::not_null<tnsr::aa<DataType, 3>*> result,
+                 const tnsr::AA<DataType, 3>& stress_energy,
+                 const tnsr::aa<DataType, 3>& spacetime_metric) {
+  set_number_of_grid_points(result, spacetime_metric);
+  const Scalar<DataType> trace_stress_energy =
+      trace(stress_energy, spacetime_metric);
+  ::tenex::evaluate<ti::a, ti::b>(
+      result,
+      8. * M_PI *
+          (stress_energy(ti::C, ti::D) * spacetime_metric(ti::a, ti::c) *
+               spacetime_metric(ti::b, ti::d) -
+           0.5 * trace_stress_energy() * spacetime_metric(ti::a, ti::b)));
+}
+
+template <typename DataType>
+tnsr::aa<DataType, 3> ricci_in_gr(
+    const tnsr::AA<DataType, 3>& stress_energy,
+    const tnsr::aa<DataType, 3>& spacetime_metric) {
+  tnsr::aa<DataType, 3> result{get_size(get<0, 0>(spacetime_metric))};
+  ricci_in_gr(make_not_null(&result), stress_energy, spacetime_metric);
+  return result;
+}
+}  // namespace hydro
+
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                 \
+  template void hydro::ricci_in_gr(                          \
+      const gsl::not_null<tnsr::aa<DTYPE(data), 3>*> result, \
+      const tnsr::AA<DTYPE(data), 3>& stress_energy,         \
+      const tnsr::aa<DTYPE(data), 3>& spacetime_metric);     \
+  template tnsr::aa<DTYPE(data), 3> hydro::ricci_in_gr(      \
+      const tnsr::AA<DTYPE(data), 3>& stress_energy,         \
+      const tnsr::aa<DTYPE(data), 3>& spacetime_metric);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector))
+
+#undef DTYPE
+#undef INSTANTIATE

--- a/src/PointwiseFunctions/Hydro/Ricci.hpp
+++ b/src/PointwiseFunctions/Hydro/Ricci.hpp
@@ -1,0 +1,83 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Ricci.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+
+/// \cond
+namespace gsl {
+template <typename>
+struct not_null;
+}  // namespace gsl
+/// \endcond
+
+namespace hydro {
+
+/// @{
+/*!
+ * \brief Computes Ricci tensor in GR from the trace-reversed stress-energy
+ * tensor.
+ *
+ * \details From the Einstein Equations, trace-reversal of the stress-energy
+ * tensor yields \f$R_{ab} = 8\pi(T_{ab} - \frac{1}{2}g_{ab}T)\f$ where
+ * \f$T = g^{ab}T_{ab}\f$ is the stress-energy trace.
+ */
+template <typename DataType>
+void ricci_in_gr(gsl::not_null<tnsr::aa<DataType, 3>*> result,
+                 const tnsr::AA<DataType, 3>& stress_energy,
+                 const tnsr::aa<DataType, 3>& spacetime_metric);
+
+template <typename DataType>
+tnsr::aa<DataType, 3> ricci_in_gr(
+    const tnsr::AA<DataType, 3>& stress_energy,
+    const tnsr::aa<DataType, 3>& spacetime_metric);
+/// @}
+
+namespace Tags {
+/// Compute item for the spacetime (4D) Ricci tensor \f$R_{ab}\f$ in hydro,
+/// computed by trace-reversing the stress-energy tensor.
+///
+/// Can be retrieved using `hydro::Tags::GrRicci`
+template <typename DataType>
+struct GrRicciCompute : GrRicci<DataType, 3>, db::ComputeTag {
+  using argument_tags = tmpl::list<hydro::Tags::StressEnergy<DataType, 3>,
+                                   gr::Tags::SpacetimeMetric<DataType, 3>>;
+
+  using return_type = tnsr::aa<DataType, 3>;
+
+  static constexpr auto function = static_cast<void (*)(
+      gsl::not_null<tnsr::aa<DataType, 3>*>, const tnsr::AA<DataType, 3>&,
+      const tnsr::aa<DataType, 3>&)>(&ricci_in_gr);
+
+  using base = GrRicci<DataType, 3>;
+};
+
+/// Computes the spacetime (4D) Ricci scalar using the spacetime Ricci tensor
+/// and the inverse spacetime metric.
+///
+/// Can be retrieved using `hydro::Tags::GrRicciScalar`
+template <typename DataType>
+struct GrRicciScalarCompute : GrRicciScalar<DataType>, db::ComputeTag {
+  using argument_tags =
+      tmpl::list<hydro::Tags::GrRicci<DataType, 3>,
+                 gr::Tags::InverseSpacetimeMetric<DataType, 3>>;
+
+  using return_type = Scalar<DataType>;
+
+  static constexpr auto function = static_cast<void (*)(
+      gsl::not_null<Scalar<DataType>*>, const tnsr::aa<DataType, 3>&,
+      const tnsr::AA<DataType, 3>&)>(&gr::ricci_scalar);
+
+  using base = GrRicciScalar<DataType>;
+};
+}  // namespace Tags
+}  // namespace hydro

--- a/src/PointwiseFunctions/Hydro/StressEnergy.hpp
+++ b/src/PointwiseFunctions/Hydro/StressEnergy.hpp
@@ -3,7 +3,10 @@
 
 #pragma once
 
+#include "DataStructures/Tensor/IndexType.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
 #include "Utilities/Gsl.hpp"
 
 namespace hydro {
@@ -133,7 +136,7 @@ void stress_trace(gsl::not_null<Scalar<DataType>*> result,
                   const Scalar<DataType>& comoving_magnetic_field_squared);
 
 /*!
- * \brief Stress Energy Tesnor, $T^{ab}=
+ * \brief Stress Energy Tensor, $T^{ab}=
  * (\rho h)^{*} u^a u ^b + p^{*} g^{ab} - b^{a} b^{b}$,
  *
  * where $(\rho h)^{*} = \rho h + b^{2}$ and $p^{*} = p + b^{2}/2$
@@ -156,4 +159,35 @@ void stress_energy_tensor(
     const tnsr::I<DataType, 3>& magnetic_field,
     const tnsr::ii<DataType, 3>& spatial_metric,
     const tnsr::II<DataType, 3>& inverse_spatial_metric);
+
+namespace Tags {
+/// Compute item for the stress-energy tensor, \f$T^{ab}\f$.
+///
+/// Can be retrieved using hydro::Tags::StressEnergy
+template <typename DataType>
+struct StressEnergyCompute : StressEnergy<DataType, 3>, db::ComputeTag {
+  using argument_tags = tmpl::list<
+      hydro::Tags::RestMassDensity<DataType>,
+      hydro::Tags::SpecificInternalEnergy<DataType>,
+      hydro::Tags::Pressure<DataType>, hydro::Tags::LorentzFactor<DataType>,
+      gr::Tags::Lapse<DataType>,
+      hydro::Tags::ComovingMagneticFieldMagnitude<DataType>,
+      hydro::Tags::SpatialVelocity<DataType, 3>, gr::Tags::Shift<DataType, 3>,
+      hydro::Tags::MagneticField<DataType, 3>,
+      gr::Tags::SpatialMetric<DataType, 3>,
+      gr::Tags::InverseSpatialMetric<DataType, 3>>;
+
+  using return_type = tnsr::AA<DataType, 3>;
+
+  static constexpr auto function = static_cast<void (*)(
+      gsl::not_null<tnsr::AA<DataType, 3>*>, const Scalar<DataType>&,
+      const Scalar<DataType>&, const Scalar<DataType>&, const Scalar<DataType>&,
+      const Scalar<DataType>&, const Scalar<DataType>&,
+      const tnsr::I<DataType, 3>&, const tnsr::I<DataType, 3>&,
+      const tnsr::I<DataType, 3>&, const tnsr::ii<DataType, 3>&,
+      const tnsr::II<DataType, 3>&)>(&stress_energy_tensor);
+
+  using base = StressEnergy<DataType, 3>;
+};
+}  // namespace Tags
 }  // namespace hydro

--- a/src/PointwiseFunctions/Hydro/Tags.hpp
+++ b/src/PointwiseFunctions/Hydro/Tags.hpp
@@ -236,6 +236,17 @@ struct MagneticPressure : db::SimpleTag {
   using type = Scalar<DataType>;
 };
 
+/// The Pontryagin scalar
+/// \f$P = {}^{*}R_{abcd}R^{abcd} = {}^{*}C_{abcd}C^{abcd} = 16 E_{ab}B^{ab}\f$,
+/// where \f$E_{ab}\f$ and \f$B_{ab}\f$ are the electric and magnetic
+/// decompositions of the Weyl tensor, \f$C_{abcd}\f$. Note that the formula is
+/// the same as in vacuum, but the input Weyl electric component is different in
+/// the hydro system.
+template <typename DataType>
+struct PontryaginScalar : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
+
 /// The fluid pressure \f$p\f$.
 template <typename DataType>
 struct Pressure : db::SimpleTag {

--- a/src/PointwiseFunctions/Hydro/Tags.hpp
+++ b/src/PointwiseFunctions/Hydro/Tags.hpp
@@ -293,6 +293,12 @@ struct SpecificInternalEnergy : db::SimpleTag {
   using type = Scalar<DataType>;
 };
 
+/// The stress-energy tensor \f$T^{ab}\f$.
+template <typename DataType, size_t Dim, typename Fr>
+struct StressEnergy : db::SimpleTag {
+  using type = tnsr::AA<DataType, Dim, Fr>;
+};
+
 /// The temperature \f$T\f$ of the fluid.
 template <typename DataType>
 struct Temperature : db::SimpleTag {

--- a/src/PointwiseFunctions/Hydro/Tags.hpp
+++ b/src/PointwiseFunctions/Hydro/Tags.hpp
@@ -327,6 +327,20 @@ struct TransportVelocity : db::SimpleTag {
   using type = tnsr::I<DataType, Dim, Fr>;
 };
 
+/// The electric part of the Weyl tensor in hydro.
+/// \see hydro::weyl_electric
+template <typename DataType, size_t Dim, typename Fr>
+struct WeylElectric : db::SimpleTag {
+  using type = tnsr::ii<DataType, Dim, Fr>;
+};
+
+/// The Weyl electric scalar \f$E_{ij} E^{ij}\f$.
+/// \see gr::weyl_electric_scalar
+template <typename DataType>
+struct WeylElectricScalar : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
+
 /// The spatial components of the four-velocity one-form \f$u_i\f$.
 template <typename DataType, size_t Dim, typename Fr>
 struct LowerSpatialFourVelocity : db::SimpleTag {

--- a/src/PointwiseFunctions/Hydro/Tags.hpp
+++ b/src/PointwiseFunctions/Hydro/Tags.hpp
@@ -241,6 +241,18 @@ struct RestMassDensity : db::SimpleTag {
   using type = Scalar<DataType>;
 };
 
+/// The spacetime (4D) Ricci tensor \f$R_{ab}\f$.
+template <typename DataType, size_t Dim, typename Fr>
+struct GrRicci : db::SimpleTag {
+  using type = tnsr::aa<DataType, Dim, Fr>;
+};
+
+/// The spacetime (4D) Ricci scalar \f$R\f$.
+template <typename DataType>
+struct GrRicciScalar : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
+
 /// The sound speed squared \f$c_s^2\f$.
 template <typename DataType>
 struct SoundSpeedSquared : db::SimpleTag {

--- a/src/PointwiseFunctions/Hydro/Tags.hpp
+++ b/src/PointwiseFunctions/Hydro/Tags.hpp
@@ -167,6 +167,13 @@ struct EquationOfState : db::SimpleTag {
   }
 };
 
+/// The Kretschmann scalar in hydro.
+/// \see hydro::kretschmann_scalar
+template <typename DataType>
+struct KretschmannScalar : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
+
 /// The inverse plasma beta \f$\beta^{-1} = b^2 / (2 p)\f$, where
 ///// \f$b^2\f$ is the square of the comoving magnetic field amplitude
 ///// and \f$p\f$ is the fluid pressure.

--- a/src/PointwiseFunctions/Hydro/TagsDeclarations.hpp
+++ b/src/PointwiseFunctions/Hydro/TagsDeclarations.hpp
@@ -79,6 +79,10 @@ struct Temperature;
 template <typename DataType, size_t Dim, typename Fr = Frame::Inertial>
 struct TransportVelocity;
 template <typename DataType, size_t Dim, typename Fr = Frame::Inertial>
+struct WeylElectric;
+template <typename DataType>
+struct WeylElectricScalar;
+template <typename DataType, size_t Dim, typename Fr = Frame::Inertial>
 struct LowerSpatialFourVelocity;
 template <typename DataType, size_t Dim, typename Fr = Frame::Inertial>
 struct LorentzFactorTimesSpatialVelocity;

--- a/src/PointwiseFunctions/Hydro/TagsDeclarations.hpp
+++ b/src/PointwiseFunctions/Hydro/TagsDeclarations.hpp
@@ -35,6 +35,8 @@ struct GrmhdEquationOfState;
 template <typename DataType>
 struct InversePlasmaBeta;
 template <typename DataType>
+struct KretschmannScalar;
+template <typename DataType>
 struct LorentzFactor;
 template <typename DataType>
 struct LorentzFactorSquared;

--- a/src/PointwiseFunctions/Hydro/TagsDeclarations.hpp
+++ b/src/PointwiseFunctions/Hydro/TagsDeclarations.hpp
@@ -53,6 +53,8 @@ struct MagneticPressure;
 template <typename DataType, size_t Dim, typename Fr = Frame::Inertial>
 struct MassFlux;
 template <typename DataType>
+struct PontryaginScalar;
+template <typename DataType>
 struct Pressure;
 template <typename DataType>
 struct RestMassDensity;

--- a/src/PointwiseFunctions/Hydro/TagsDeclarations.hpp
+++ b/src/PointwiseFunctions/Hydro/TagsDeclarations.hpp
@@ -54,6 +54,10 @@ template <typename DataType>
 struct Pressure;
 template <typename DataType>
 struct RestMassDensity;
+template <typename DataType, size_t Dim, typename Fr = Frame::Inertial>
+struct GrRicci;
+template <typename DataType>
+struct GrRicciScalar;
 template <typename DataType>
 struct SoundSpeedSquared;
 template <typename DataType, size_t Dim, typename Fr = Frame::Inertial>

--- a/src/PointwiseFunctions/Hydro/TagsDeclarations.hpp
+++ b/src/PointwiseFunctions/Hydro/TagsDeclarations.hpp
@@ -68,6 +68,8 @@ template <typename DataType>
 struct SpecificEnthalpy;
 template <typename DataType>
 struct SpecificInternalEnergy;
+template <typename DataType, size_t Dim, typename Fr = Frame::Inertial>
+struct StressEnergy;
 template <typename DataType>
 struct Temperature;
 template <typename DataType, size_t Dim, typename Fr = Frame::Inertial>

--- a/src/PointwiseFunctions/Hydro/WeylElectric.cpp
+++ b/src/PointwiseFunctions/Hydro/WeylElectric.cpp
@@ -1,0 +1,100 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/Hydro/WeylElectric.hpp"
+
+#include "DataStructures/Tensor/Expressions/TensorExpression.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/VectorImpl.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
+
+namespace hydro {
+template <typename DataType>
+tnsr::ii<DataType, 3> weyl_electric(
+    const tnsr::ii<DataType, 3>& vacuum_weyl_electric,
+    const tnsr::AA<DataType, 3>& stress_energy,
+    const tnsr::aa<DataType, 3>& ricci_tensor,
+    const Scalar<DataType>& ricci_scalar,
+    const tnsr::AA<DataType, 3>& inverse_spacetime_metric,
+    const tnsr::aa<DataType, 3>& induced_spatial_metric) {
+  tnsr::ii<DataType, 3> result{get_size(get<0, 0>(stress_energy))};
+  weyl_electric(make_not_null(&result), vacuum_weyl_electric, stress_energy,
+                ricci_tensor, ricci_scalar, inverse_spacetime_metric,
+                induced_spatial_metric);
+  return result;
+}
+
+template <typename DataType>
+void weyl_electric(const gsl::not_null<tnsr::ii<DataType, 3>*> weyl_electric,
+                   const tnsr::ii<DataType, 3>& vacuum_weyl_electric,
+                   const tnsr::AA<DataType, 3>& stress_energy,
+                   const tnsr::aa<DataType, 3>& ricci_tensor,
+                   const Scalar<DataType>& ricci_scalar,
+                   const tnsr::AA<DataType, 3>& inverse_spacetime_metric,
+                   const tnsr::aa<DataType, 3>& induced_spatial_metric) {
+  set_number_of_grid_points(weyl_electric, stress_energy);
+
+  // gamma_aB(a, B) = γ_a^B = g^{BC} γ_{aC}
+  auto gamma_aB =
+      make_with_value<tnsr::aB<DataType, 3>>(get<0, 0>(stress_energy), 0.0);
+  ::tenex::evaluate<ti::a, ti::B>(make_not_null(&gamma_aB),
+                                  inverse_spacetime_metric(ti::B, ti::C) *
+                                      induced_spatial_metric(ti::a, ti::c));
+
+  // gamma_trace = γ^{ab} R_{ab} = g^{AB} γ_B^C R_{AC}
+  auto gamma_trace =
+      make_with_value<Scalar<DataType>>(get<0, 0>(stress_energy), 0.0);
+  tenex::evaluate<>(make_not_null(&gamma_trace),
+                    inverse_spacetime_metric(ti::A, ti::B) *
+                        gamma_aB(ti::b, ti::C) * ricci_tensor(ti::a, ti::c));
+
+  // Assemble directly into the spatial output components, avoiding the wasted
+  // time-component evaluations of computing the full 4D spacetime tensor.
+  // E_{ij} = E_{ij}^{vac}
+  //        - 1/2 (γ_{i+1}^a γ_{j+1}^b + γ_{(i+1)(j+1)} γ^{ab}) R_{ab}
+  //        + 1/3 γ_{(i+1)(j+1)} R
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = i; j < 3; ++j) {
+      weyl_electric->get(i, j) = vacuum_weyl_electric.get(i, j);
+      for (size_t a = 0; a < 4; ++a) {
+        for (size_t b = 0; b < 4; ++b) {
+          weyl_electric->get(i, j) -= 0.5 * gamma_aB.get(i + 1, a) *
+                                      gamma_aB.get(j + 1, b) *
+                                      ricci_tensor.get(a, b);
+        }
+      }
+      weyl_electric->get(i, j) +=
+          induced_spatial_metric.get(i + 1, j + 1) *
+          ((1.0 / 3.0) * get(ricci_scalar) - 0.5 * get(gamma_trace));
+    }
+  }
+}
+}  // namespace hydro
+
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                        \
+  template tnsr::ii<DTYPE(data), 3> hydro::weyl_electric(           \
+      const tnsr::ii<DTYPE(data), 3>& vacuum_weyl_electric,         \
+      const tnsr::AA<DTYPE(data), 3>& stress_energy,                \
+      const tnsr::aa<DTYPE(data), 3>& ricci_tensor,                 \
+      const Scalar<DTYPE(data)>& ricci_scalar,                      \
+      const tnsr::AA<DTYPE(data), 3>& inverse_spacetime_metric,     \
+      const tnsr::aa<DTYPE(data), 3>& induced_spatial_metric);      \
+  template void hydro::weyl_electric(                               \
+      const gsl::not_null<tnsr::ii<DTYPE(data), 3>*> weyl_electric, \
+      const tnsr::ii<DTYPE(data), 3>& vacuum_weyl_electric,         \
+      const tnsr::AA<DTYPE(data), 3>& stress_energy,                \
+      const tnsr::aa<DTYPE(data), 3>& ricci_tensor,                 \
+      const Scalar<DTYPE(data)>& ricci_scalar,                      \
+      const tnsr::AA<DTYPE(data), 3>& inverse_spacetime_metric,     \
+      const tnsr::aa<DTYPE(data), 3>& induced_spatial_metric);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector))
+
+#undef DTYPE
+#undef INSTANTIATE

--- a/src/PointwiseFunctions/Hydro/WeylElectric.hpp
+++ b/src/PointwiseFunctions/Hydro/WeylElectric.hpp
@@ -1,0 +1,106 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/WeylElectric.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace gsl {
+template <typename>
+struct not_null;
+}  // namespace gsl
+/// \endcond
+
+namespace hydro {
+
+/// @{
+/*!
+ * \brief Computes the electric part of the Weyl tensor in a hydro system.
+ *
+ * \details Computes the electric part of the Weyl tensor \f$E_{ij}\f$ in hydro
+ * as the spatial components of
+ *
+ * \f{align}{
+ *   E_{ab} = E_{ab}^{(\mathrm{vac})} -
+ *   \frac{1}{2}(\gamma_a^{\ c}\gamma_b^{\ d} +
+ *   \gamma_{ab}\gamma^{cd}){}^{(4)}R_{cd} +
+ *   \frac{1}{3}\gamma_{ab}{}^{(4)}R ~,
+ * \f}
+ *
+ * where \f$E_{ab}^{(\mathrm{vac})}\f$ is the vacuum contribution to the
+ * electric part of the Weyl tensor (computed in `GeneralRelativity`),
+ * \f$\gamma_{ab}\f$ is the induced spatial metric, \f${}^{(4)}R_{ab}\f$ is
+ * the Ricci tensor, and \f${}^{(4)}R\f$ is the Ricci scalar.
+ */
+template <typename DataType>
+tnsr::ii<DataType, 3> weyl_electric(
+    const tnsr::ii<DataType, 3>& vacuum_weyl_electric,
+    const tnsr::AA<DataType, 3>& stress_energy,
+    const tnsr::aa<DataType, 3>& ricci_tensor,
+    const Scalar<DataType>& ricci_scalar,
+    const tnsr::AA<DataType, 3>& inverse_spacetime_metric,
+    const tnsr::aa<DataType, 3>& induced_spatial_metric);
+
+template <typename DataType>
+void weyl_electric(gsl::not_null<tnsr::ii<DataType, 3>*> weyl_electric,
+                   const tnsr::ii<DataType, 3>& vacuum_weyl_electric,
+                   const tnsr::AA<DataType, 3>& stress_energy,
+                   const tnsr::aa<DataType, 3>& ricci_tensor,
+                   const Scalar<DataType>& ricci_scalar,
+                   const tnsr::AA<DataType, 3>& inverse_spacetime_metric,
+                   const tnsr::aa<DataType, 3>& induced_spatial_metric);
+/// @}
+
+namespace Tags {
+/// Compute item for the electric part of the weyl tensor in hydro.
+///
+/// Can be retrieved using hydro::Tags::WeylElectric
+template <typename DataType>
+struct WeylElectricCompute : WeylElectric<DataType, 3>, db::ComputeTag {
+  using argument_tags =
+      tmpl::list<gr::Tags::WeylElectric<DataType, 3>,
+                 hydro::Tags::StressEnergy<DataType, 3>,
+                 hydro::Tags::GrRicci<DataType, 3>,
+                 hydro::Tags::GrRicciScalar<DataType>,
+                 gr::Tags::InverseSpacetimeMetric<DataType, 3>,
+                 gr::Tags::InducedSpatialMetric<DataType, 3>>;
+
+  using return_type = tnsr::ii<DataType, 3>;
+
+  static constexpr auto function = static_cast<void (*)(
+      gsl::not_null<tnsr::ii<DataType, 3>*>, const tnsr::ii<DataType, 3>&,
+      const tnsr::AA<DataType, 3>&, const tnsr::aa<DataType, 3>&,
+      const Scalar<DataType>&, const tnsr::AA<DataType, 3>&,
+      const tnsr::aa<DataType, 3>&)>(&weyl_electric);
+
+  using base = WeylElectric<DataType, 3>;
+};
+
+/// Compute item for the Weyl electric scalar in hydro.
+///
+/// Can be retrieved using hydro::Tags::WeylElectricScalar
+template <typename DataType>
+struct WeylElectricScalarCompute : WeylElectricScalar<DataType>,
+                                   db::ComputeTag {
+  using argument_tags = tmpl::list<hydro::Tags::WeylElectric<DataType, 3>,
+                                   gr::Tags::InverseSpatialMetric<DataType, 3>>;
+
+  using return_type = Scalar<DataType>;
+
+  static constexpr auto function = static_cast<void (*)(
+      gsl::not_null<Scalar<DataType>*>, const tnsr::ii<DataType, 3>&,
+      const tnsr::II<DataType, 3>&)>(&gr::weyl_electric_scalar<DataType, 3>);
+
+  using base = WeylElectricScalar<DataType>;
+};
+}  // namespace Tags
+}  // namespace hydro

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.py
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/ComputeSpacetimeQuantities.py
@@ -178,10 +178,8 @@ def deriv_inverse_spatial_metric(inverse_spatial_metric, d_spatial_metric):
     )
 
 
-def pontryagin_scalar_in_vacuum(
-    weyl_electric, weyl_magnetic, inverse_spatial_metric
-):
-    pontryagin_scalar = -16.0 * np.trace(
+def pontryagin_scalar(weyl_electric, weyl_magnetic, inverse_spatial_metric):
+    pontryagin_scalar = 16.0 * np.trace(
         weyl_electric
         @ inverse_spatial_metric
         @ weyl_magnetic
@@ -191,8 +189,17 @@ def pontryagin_scalar_in_vacuum(
     return pontryagin_scalar
 
 
-def gauss_bonnet_scalar_in_vacuum(
+def kretschmann_scalar_in_vacuum(
     weyl_electric_scalar,
     weyl_magnetic_scalar,
 ):
     return 8 * (weyl_electric_scalar - weyl_magnetic_scalar)
+
+
+def gauss_bonnet_scalar_in_vacuum(
+    weyl_electric_scalar,
+    weyl_magnetic_scalar,
+):
+    return kretschmann_scalar_in_vacuum(
+        weyl_electric_scalar, weyl_magnetic_scalar
+    )

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
@@ -302,6 +302,9 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.SpacetimeDecomp",
   TestHelpers::db::test_compute_tag<
       gr::Tags::LapseCompute<DataVector, 3, Frame::Inertial>>("Lapse");
   TestHelpers::db::test_compute_tag<
+      gr::Tags::InducedSpatialMetricCompute<DataVector, 3, Frame::Inertial>>(
+      "InducedSpatialMetric");
+  TestHelpers::db::test_compute_tag<
       gr::Tags::SqrtDetSpatialMetricCompute<DataVector, 3, Frame::Inertial>>(
       "SqrtDetSpatialMetric");
   TestHelpers::db::test_compute_tag<gr::Tags::DetAndInverseSpatialMetricCompute<
@@ -345,6 +348,8 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.SpacetimeDecomp",
                 expected_det_and_inverse_spatial_metric.second);
   const auto expected_lapse =
       gr::lapse(expected_shift, expected_spacetime_metric);
+  const auto expected_induced_spatial_metric =
+      gr::induced_spatial_metric(expected_spacetime_metric, expected_lapse);
   const auto expected_inverse_spacetime_metric = gr::inverse_spacetime_metric(
       expected_lapse, expected_shift,
       expected_det_and_inverse_spatial_metric.second);
@@ -358,6 +363,7 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.SpacetimeDecomp",
           gr::Tags::SqrtDetSpatialMetricCompute<DataVector, 3, Frame::Inertial>,
           gr::Tags::ShiftCompute<DataVector, 3, Frame::Inertial>,
           gr::Tags::LapseCompute<DataVector, 3, Frame::Inertial>,
+          gr::Tags::InducedSpatialMetricCompute<DataVector, 3, Frame::Inertial>,
           gr::Tags::InverseSpacetimeMetricCompute<DataVector, 3,
                                                   Frame::Inertial>,
           gr::Tags::SpacetimeNormalOneFormCompute<DataVector, 3,
@@ -375,6 +381,8 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.SpacetimeDecomp",
         sqrt(get(expected_det_and_inverse_spatial_metric.first)));
   CHECK(db::get<gr::Tags::Shift<DataVector, 3>>(box) == expected_shift);
   CHECK(db::get<gr::Tags::Lapse<DataVector>>(box) == expected_lapse);
+  CHECK(db::get<gr::Tags::InducedSpatialMetric<DataVector, 3, Frame::Inertial>>(
+            box) == expected_induced_spatial_metric);
   CHECK(db::get<gr::Tags::InverseSpacetimeMetric<DataVector, 3>>(box) ==
         expected_inverse_spacetime_metric);
   CHECK(db::get<gr::Tags::SpacetimeNormalOneForm<DataVector, 3>>(box) ==

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
@@ -224,18 +224,25 @@ void test_compute_deriv_inverse_spatial_metric(const DataType& used_for_size) {
       {{{-10., 10.}}}, used_for_size);
 }
 
-void test_compute_pontryagin_scalar_in_vacuum(const DataVector& used_for_size) {
+void test_compute_pontryagin_scalar(const DataVector& used_for_size) {
   pypp::check_with_random_values<1>(
       static_cast<Scalar<DataVector> (*)(
           const tnsr::ii<DataVector, 3, Frame::Inertial>&,
           const tnsr::ii<DataVector, 3, Frame::Inertial>&,
           const tnsr::II<DataVector, 3, Frame::Inertial>&)>(
-          &gr::pontryagin_scalar_in_vacuum),
-      "ComputeSpacetimeQuantities", "pontryagin_scalar_in_vacuum",
-      // The C++ Tenex contraction and the Python matrix-product reference
-      // accumulate roundoff in a different order for this fully algebraic
-      // expression, so allow a slightly looser comparison here.
-      {{{-10., 10.}}}, used_for_size, 2.0e-12);
+          &gr::pontryagin_scalar),
+      "ComputeSpacetimeQuantities", "pontryagin_scalar", {{{-10., 10.}}},
+      used_for_size);
+}
+
+void test_compute_kretschmann_scalar_in_vacuum(
+    const DataVector& used_for_size) {
+  pypp::check_with_random_values<1>(
+      static_cast<Scalar<DataVector> (*)(const Scalar<DataVector>&,
+                                         const Scalar<DataVector>&)>(
+          &gr::kretschmann_scalar_in_vacuum),
+      "ComputeSpacetimeQuantities", "kretschmann_scalar_in_vacuum",
+      {{{-10., 10.}}}, used_for_size);
 }
 
 void test_compute_gauss_bonnet_scalar_in_vacuum(
@@ -277,7 +284,8 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.GeneralRelativity.SpacetimeDecomp",
                                     (1, 2, 3));
   CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_cov_deriv_extrinsic_curvature_adm,
                                     (1, 2, 3));
-  test_compute_pontryagin_scalar_in_vacuum(DataVector{5});
+  test_compute_pontryagin_scalar(DataVector{5});
+  test_compute_kretschmann_scalar_in_vacuum(DataVector{5});
   test_compute_gauss_bonnet_scalar_in_vacuum(DataVector{5});
 
   // Check that compute items work correctly in the DataBox

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_ComputeSpacetimeQuantities.cpp
@@ -205,6 +205,12 @@ void test_compute_spatial_metric_lapse_shift(const T& used_for_size) {
   CHECK_ITERABLE_APPROX(spatial_metric, spatial_metric_test);
   CHECK_ITERABLE_APPROX(shift, shift_test);
   CHECK_ITERABLE_APPROX(lapse, lapse_test);
+
+  // The induced spatial metric should only differ from the spacetime metric
+  // by an $\alpha^2$ term.
+  auto induced_spatial_metric_test = gr::induced_spatial_metric(psi, lapse);
+  induced_spatial_metric_test.get(0, 0) -= square(get(lapse));
+  CHECK_ITERABLE_APPROX(psi, induced_spatial_metric_test);
 }
 
 template <size_t Dim, typename DataType>

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_CurvatureScalarComputeTags.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_CurvatureScalarComputeTags.cpp
@@ -22,8 +22,10 @@ SPECTRE_TEST_CASE(
     "Unit.PointwiseFunctions.GeneralRelativity.CurvatureScalars.ComputeTags",
     "[PointwiseFunctions][Unit]") {
   TestHelpers::db::test_compute_tag<
-      gr::Tags::PontryaginScalarCompute<DataVector, 3, Frame::Inertial>>(
+      gr::Tags::PontryaginScalarCompute<DataVector, Frame::Inertial>>(
       "PontryaginScalar");
+  TestHelpers::db::test_compute_tag<
+      gr::Tags::KretschmannScalarCompute<DataVector>>("KretschmannScalar");
   TestHelpers::db::test_compute_tag<
       gr::Tags::GaussBonnetScalarCompute<DataVector>>("GaussBonnetScalar");
   TestHelpers::db::test_compute_tag<
@@ -62,21 +64,26 @@ SPECTRE_TEST_CASE(
           gr::Tags::WeylElectricScalar<DataVector>,
           gr::Tags::WeylMagneticScalar<DataVector>>,
       db::AddComputeTags<
-          gr::Tags::PontryaginScalarCompute<DataVector, 3, Frame::Inertial>,
+          gr::Tags::PontryaginScalarCompute<DataVector, Frame::Inertial>,
           gr::Tags::GaussBonnetScalarCompute<DataVector>,
+          gr::Tags::KretschmannScalarCompute<DataVector>,
           gr::Tags::CubicInvariantRealCompute<DataVector, 3, Frame::Inertial>,
           gr::Tags::CubicInvariantImagCompute<DataVector, 3, Frame::Inertial>>>(
       E, B, inv_metric, E_scalar, B_scalar);
 
   const auto expected_pontryagin =
-      gr::pontryagin_scalar_in_vacuum<Frame::Inertial>(E, B, inv_metric);
+      gr::pontryagin_scalar<DataVector, Frame::Inertial>(E, B, inv_metric);
+  const auto expected_kretschmann =
+      gr::kretschmann_scalar_in_vacuum<DataVector>(E_scalar, B_scalar);
   const auto expected_gb =
-      gr::gauss_bonnet_scalar_in_vacuum(E_scalar, B_scalar);
+      gr::gauss_bonnet_scalar_in_vacuum<DataVector>(E_scalar, B_scalar);
   const auto expected_cubic_real = gr::cubic_invariant_real(E, B, inv_metric);
   const auto expected_cubic_imag = gr::cubic_invariant_imag(E, B, inv_metric);
 
   CHECK_ITERABLE_APPROX((db::get<gr::Tags::PontryaginScalar<DataVector>>(box)),
                         expected_pontryagin);
+  CHECK_ITERABLE_APPROX((db::get<gr::Tags::KretschmannScalar<DataVector>>(box)),
+                        expected_kretschmann);
   CHECK_ITERABLE_APPROX((db::get<gr::Tags::GaussBonnetScalar<DataVector>>(box)),
                         expected_gb);
   CHECK_ITERABLE_APPROX(

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_CurvatureScalars.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_CurvatureScalars.cpp
@@ -72,11 +72,15 @@ void test_curvature_scalars_schwarzschild() {
       gr::weyl_magnetic_scalar<Frame::Inertial, DataVector>(
           magnetic_weyl, inverse_spatial_metric);
 
-  const auto gauss_bonnet = gr::gauss_bonnet_scalar_in_vacuum(
+  const auto kretschmann = gr::kretschmann_scalar_in_vacuum<DataVector>(
+      electric_weyl_scalar, magnetic_weyl_scalar);
+  CHECK_ITERABLE_APPROX(kretschmann.get(), 48.0 * a * a);
+
+  const auto gauss_bonnet = gr::gauss_bonnet_scalar_in_vacuum<DataVector>(
       electric_weyl_scalar, magnetic_weyl_scalar);
   CHECK_ITERABLE_APPROX(gauss_bonnet.get(), 48.0 * a * a);
 
-  const auto pontryagin = gr::pontryagin_scalar_in_vacuum<Frame::Inertial>(
+  const auto pontryagin = gr::pontryagin_scalar<DataVector, Frame::Inertial>(
       electric_weyl, magnetic_weyl, inverse_spatial_metric);
   CHECK_ITERABLE_APPROX(pontryagin.get(), DataVector(num_points, 0.0));
 

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Tags.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_Tags.cpp
@@ -28,6 +28,8 @@ void test_simple_tags() {
   TestHelpers::db::test_simple_tag<gr::Tags::SpatialMetric<Type, Dim, Frame>>(
       "SpatialMetric");
   TestHelpers::db::test_simple_tag<
+      gr::Tags::InducedSpatialMetric<Type, Dim, Frame>>("InducedSpatialMetric");
+  TestHelpers::db::test_simple_tag<
       gr::Tags::InverseSpatialMetric<Type, Dim, Frame>>("InverseSpatialMetric");
   TestHelpers::db::test_simple_tag<gr::Tags::DetSpatialMetric<Type>>(
       "DetSpatialMetric");

--- a/tests/Unit/PointwiseFunctions/Hydro/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/Hydro/CMakeLists.txt
@@ -9,6 +9,7 @@ set(LIBRARY "Test_Hydro")
 
 set(LIBRARY_SOURCES
   Test_ComovingMagneticField.cpp
+  Test_CurvatureQuantities.cpp
   Test_InversePlasmaBeta.cpp
   Test_LorentzFactor.cpp
   Test_MagneticFieldTreatment.cpp

--- a/tests/Unit/PointwiseFunctions/Hydro/CurvatureQuantities.py
+++ b/tests/Unit/PointwiseFunctions/Hydro/CurvatureQuantities.py
@@ -18,3 +18,35 @@ def ricci_in_gr(stress_energy, spacetime_metric):
 def ricci_scalar(ricci_tensor, inverse_spacetime_metric):
     # R = g^{ab} R_{ab}
     return np.einsum("ab,ab->", inverse_spacetime_metric, ricci_tensor)
+
+
+def weyl_electric(
+    vacuum_weyl_electric,
+    _stress_energy,
+    ricci_tensor,
+    ricci_scalar,
+    inverse_spacetime_metric,
+    induced_spatial_metric,
+):
+    # Mixed-index four-spatial metric: gamma_a^B = g^{BC} gamma_{aC}
+    gamma_mixed = np.einsum(
+        "BC,aC->aB", inverse_spacetime_metric, induced_spatial_metric
+    )
+    # Spatial projection of Ricci: gamma_a^c gamma_b^d R_{cd}
+    proj_R = np.einsum("ac,bd,cd->ab", gamma_mixed, gamma_mixed, ricci_tensor)
+    # Raised four-spatial metric: gamma^{cd} = g^{ca} g^{db} gamma_{ab}
+    gamma_upper = np.einsum(
+        "ca,db,ab->cd",
+        inverse_spacetime_metric,
+        inverse_spacetime_metric,
+        induced_spatial_metric,
+    )
+    # Trace: gamma^{cd} R_{cd}
+    trace_gamma_R = np.einsum("cd,cd->", gamma_upper, ricci_tensor)
+    # Spacetime matter contribution to Weyl electric (4x4)
+    matter_weyl = (
+        -0.5 * (proj_R + induced_spatial_metric * trace_gamma_R)
+        + induced_spatial_metric * ricci_scalar / 3.0
+    )
+    # Extract spatial components and add vacuum contribution
+    return vacuum_weyl_electric + matter_weyl[1:, 1:]

--- a/tests/Unit/PointwiseFunctions/Hydro/CurvatureQuantities.py
+++ b/tests/Unit/PointwiseFunctions/Hydro/CurvatureQuantities.py
@@ -50,3 +50,22 @@ def weyl_electric(
     )
     # Extract spatial components and add vacuum contribution
     return vacuum_weyl_electric + matter_weyl[1:, 1:]
+
+
+def kretschmann_scalar(
+    weyl_electric_scalar,
+    weyl_magnetic_scalar,
+    inverse_spacetime_metric,
+    ricci_tensor,
+    ricci_scalar,
+):
+    # K = 8(E - B) + 2 R_{ab} R^{ab} - R^2/3
+    kretschmann_vacuum = 8.0 * (weyl_electric_scalar - weyl_magnetic_scalar)
+    ricci_sq = np.einsum(
+        "ab,ac,bd,cd->",
+        ricci_tensor,
+        inverse_spacetime_metric,
+        inverse_spacetime_metric,
+        ricci_tensor,
+    )
+    return kretschmann_vacuum + 2.0 * ricci_sq - ricci_scalar**2 / 3.0

--- a/tests/Unit/PointwiseFunctions/Hydro/CurvatureQuantities.py
+++ b/tests/Unit/PointwiseFunctions/Hydro/CurvatureQuantities.py
@@ -1,0 +1,20 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def ricci_in_gr(stress_energy, spacetime_metric):
+    # T_{ab} = g_{ac} g_{bd} T^{cd}
+    stress_energy_lower = np.einsum(
+        "ac,bd,cd->ab", spacetime_metric, spacetime_metric, stress_energy
+    )
+    # T = g_{ab} T^{ab}
+    trace = np.einsum("ab,ab->", spacetime_metric, stress_energy)
+    # R_{ab} = 8pi (T_{ab} - 1/2 g_{ab} T)
+    return 8.0 * np.pi * (stress_energy_lower - 0.5 * spacetime_metric * trace)
+
+
+def ricci_scalar(ricci_tensor, inverse_spacetime_metric):
+    # R = g^{ab} R_{ab}
+    return np.einsum("ab,ab->", inverse_spacetime_metric, ricci_tensor)

--- a/tests/Unit/PointwiseFunctions/Hydro/Test_CurvatureQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/Test_CurvatureQuantities.cpp
@@ -14,11 +14,20 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Framework/CheckWithRandomValues.hpp"
 #include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
+#include "PointwiseFunctions/GeneralRelativity/CubicCurvatureScalars.hpp"
 #include "PointwiseFunctions/GeneralRelativity/ExtrinsicCurvature.hpp"
-#include "PointwiseFunctions/GeneralRelativity/Ricci.hpp"
+#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/CovariantDerivOfExtrinsicCurvature.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Lapse.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Shift.hpp"
+#include "PointwiseFunctions/GeneralRelativity/SpacetimeNormalVector.hpp"
 #include "PointwiseFunctions/GeneralRelativity/SpatialMetric.hpp"
 #include "PointwiseFunctions/GeneralRelativity/WeylElectric.hpp"
+#include "PointwiseFunctions/GeneralRelativity/WeylMagnetic.hpp"
+#include "PointwiseFunctions/Hydro/QuadraticCurvatureScalars.hpp"
 #include "PointwiseFunctions/Hydro/Ricci.hpp"
 #include "PointwiseFunctions/Hydro/StressEnergy.hpp"
 #include "PointwiseFunctions/Hydro/WeylElectric.hpp"
@@ -91,11 +100,39 @@ void test_curvature_quantities_flrw() {
   const tnsr::AA<DataVector, 3, Frame::Inertial> inverse_spacetime_metric =
       determinant_and_inverse(spacetime_metric).second;
 
+  auto compute_deriv_spacetime_metric = [num_points, scale_factor, density]() {
+    // Friedmann equations ->
+    // $d_t g_{ii} = 2 a \dot{a} = 2 a^2 \sqrt{8\pi \rho / 3}
+    // All other components are 0.
+    tnsr::abb<DataVector, 3, Frame::Inertial> deriv_spacetime_metric(num_points,
+                                                                     0.0);
+    tnsr::ii<DataVector, 3, Frame::Inertial> dt_spatial_metric(num_points, 0.0);
+    for (size_t i = 0; i < 3; ++i) {
+      deriv_spacetime_metric.get(0, i + 1, i + 1) =
+          2. * square(scale_factor) * sqrt(8. * M_PI * get(density) / 3.);
+      dt_spatial_metric.get(i, i) =
+          2. * square(scale_factor) * sqrt(8. * M_PI * get(density) / 3.);
+    }
+    return std::make_pair(deriv_spacetime_metric, dt_spatial_metric);
+  };
+  const auto derivs = compute_deriv_spacetime_metric();
+  const tnsr::abb<DataVector, 3, Frame::Inertial> deriv_spacetime_metric =
+      derivs.first;
+  const tnsr::ii<DataVector, 3, Frame::Inertial> dt_spatial_metric =
+      derivs.second;
+  const tnsr::ijj<DataVector, 3, Frame::Inertial> deriv_spatial_metric(
+      num_points, 0.0);
+
   const auto spatial_metric = gr::spatial_metric(spacetime_metric);
+  const Scalar<DataVector> sqrt_det_spatial_metric = Scalar<DataVector>{
+      sqrt(get(determinant_and_inverse(spatial_metric).first))};
   const tnsr::II<DataVector, 3, Frame::Inertial> inverse_spatial_metric =
       determinant_and_inverse(spatial_metric).second;
   const tnsr::I<DataVector, 3, Frame::Inertial> shift(num_points, 0.0);
+  const tnsr::iJ<DataVector, 3, Frame::Inertial> deriv_shift(num_points, 0.0);
   const Scalar<DataVector> lapse(num_points, 1.0);
+  const auto induced_spatial_metric =
+      gr::induced_spatial_metric(spacetime_metric, lapse);
 
   // Hydro quantities for stress energy tensor (cold stationary fluid)
   const Scalar<DataVector> specific_internal_energy(num_points, 0.0);
@@ -104,6 +141,29 @@ void test_curvature_quantities_flrw() {
   const tnsr::I<DataVector, 3, Frame::Inertial> spatial_velocity(num_points,
                                                                  0.0);
   const tnsr::I<DataVector, 3, Frame::Inertial> magnetic_field(num_points, 0.0);
+
+  const tnsr::ii<DataVector, 3, Frame::Inertial> spatial_ricci(num_points, 0.0);
+
+  // GR quantities for stress energy tensor
+  const auto extrinsic_curvature =
+      gr::extrinsic_curvature(lapse, shift, deriv_shift, spatial_metric,
+                              dt_spatial_metric, deriv_spatial_metric);
+  const auto spacetime_unit_normal_vector =
+      gr::spacetime_normal_vector(lapse, shift);
+  const tnsr::Ijj<DataVector, 3, Frame::Inertial>
+      spatial_christoffel_second_kind(num_points, 0.0);
+  const tnsr::iaa<DataVector, 3, Frame::Inertial> phi(num_points, 0.0);
+  const tnsr::iaa<DataVector, 3, Frame::Inertial> d_pi(num_points, 0.0);
+  const tnsr::ijaa<DataVector, 3, Frame::Inertial> d_phi(num_points, 0.0);
+  const auto deriv_extrinsic_curvature =
+      gh::covariant_deriv_of_extrinsic_curvature(
+          extrinsic_curvature, spacetime_unit_normal_vector,
+          spatial_christoffel_second_kind, inverse_spacetime_metric, phi, d_pi,
+          d_phi);
+  const auto grad_extrinsic_curvature =
+      gr::covariant_derivative_of_extrinsic_curvature(
+          deriv_extrinsic_curvature, extrinsic_curvature,
+          spatial_christoffel_second_kind);
 
   // Stress energy tensor
   tnsr::AA<DataVector, 3, Frame::Inertial> stress_energy(num_points, 0.0);
@@ -126,35 +186,6 @@ void test_curvature_quantities_flrw() {
   CHECK_ITERABLE_APPROX(get(ricci_scalar),
                         8. * M_PI * (get(density) - 3. * get(pressure)));
 
-  auto compute_deriv_spacetime_metric = [num_points, scale_factor, density]() {
-    // Friedmann equations ->
-    // $d_t g_{ii} = 2 a \dot{a} = 2 a^2 \sqrt{8\pi \rho / 3}
-    // All other components are 0.
-    tnsr::abb<DataVector, 3, Frame::Inertial> deriv_spacetime_metric(num_points,
-                                                                     0.0);
-    tnsr::ii<DataVector, 3, Frame::Inertial> dt_spatial_metric(num_points, 0.0);
-    for (size_t i = 0; i < 3; ++i) {
-      deriv_spacetime_metric.get(0, i + 1, i + 1) =
-          2. * square(scale_factor) * sqrt(8. * M_PI * get(density) / 3.);
-      dt_spatial_metric.get(i, i) =
-          2. * square(scale_factor) * sqrt(8. * M_PI * get(density) / 3.);
-    }
-    return std::make_pair(deriv_spacetime_metric, dt_spatial_metric);
-  };
-  const auto derivs = compute_deriv_spacetime_metric();
-  const tnsr::ii<DataVector, 3, Frame::Inertial> dt_spatial_metric =
-      derivs.second;
-  const tnsr::ijj<DataVector, 3, Frame::Inertial> deriv_spatial_metric(
-      num_points, 0.0);
-  const tnsr::iJ<DataVector, 3, Frame::Inertial> deriv_shift(num_points, 0.0);
-  const auto induced_spatial_metric =
-      gr::induced_spatial_metric(spacetime_metric, lapse);
-  const tnsr::ii<DataVector, 3, Frame::Inertial> spatial_ricci(num_points, 0.0);
-
-  const auto extrinsic_curvature =
-      gr::extrinsic_curvature(lapse, shift, deriv_shift, spatial_metric,
-                              dt_spatial_metric, deriv_spatial_metric);
-
   // Weyl electric and magnetic components
   const auto electric_weyl =
       hydro::weyl_electric(gr::weyl_electric(spatial_ricci, extrinsic_curvature,
@@ -169,6 +200,29 @@ void test_curvature_quantities_flrw() {
                                    custom_approx);
     }
   }
+  const auto magnetic_weyl = gr::weyl_magnetic(
+      grad_extrinsic_curvature, spatial_metric, sqrt_det_spatial_metric);
+
+  const auto electric_weyl_scalar =
+      gr::weyl_electric_scalar(electric_weyl, inverse_spatial_metric);
+  const auto magnetic_weyl_scalar =
+      gr::weyl_magnetic_scalar<Frame::Inertial, DataVector>(
+          magnetic_weyl, inverse_spatial_metric);
+
+  // Kretschmann computation and tests
+  const auto kretschmann =
+      hydro::kretschmann_scalar(electric_weyl_scalar, magnetic_weyl_scalar,
+                                inverse_spacetime_metric, ricci, ricci_scalar);
+  CHECK_ITERABLE_APPROX(kretschmann.get(),
+                        (64. / 3.) * square(M_PI) *
+                            (4. * square(get(density)) +
+                             square(3. * get(pressure) + get(density))));
+
+  // Check compute items work correctly in DataBox
+  TestHelpers::db::test_compute_tag<
+      hydro::Tags::KretschmannScalarCompute<DataVector>>("KretschmannScalar");
+  TestHelpers::db::test_compute_tag<
+      hydro::Tags::PontryaginScalarCompute<DataVector>>("PontryaginScalar");
   TestHelpers::db::test_compute_tag<
       hydro::Tags::WeylElectricCompute<DataVector>>("WeylElectric");
   TestHelpers::db::test_compute_tag<
@@ -198,6 +252,14 @@ void test_curvature_quantities_random_values(const DataType& used_for_size) {
       &hydro::weyl_electric<DataType>;
   pypp::check_with_random_values<1>(f_weyl_electric, "CurvatureQuantities",
                                     "weyl_electric", {{{-1., 1.}}},
+                                    used_for_size);
+
+  Scalar<DataType> (*f_kretschmann)(
+      const Scalar<DataType>&, const Scalar<DataType>&,
+      const tnsr::AA<DataType, 3>&, const tnsr::aa<DataType, 3>&,
+      const Scalar<DataType>&) = &hydro::kretschmann_scalar<DataType>;
+  pypp::check_with_random_values<1>(f_kretschmann, "CurvatureQuantities",
+                                    "kretschmann_scalar", {{{-1., 1.}}},
                                     used_for_size);
 }
 

--- a/tests/Unit/PointwiseFunctions/Hydro/Test_CurvatureQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/Test_CurvatureQuantities.cpp
@@ -6,7 +6,6 @@
 #include <cmath>
 #include <cstddef>
 #include <random>
-#include <utility>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
@@ -17,16 +16,9 @@
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
-#include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
-#include "PointwiseFunctions/GeneralRelativity/CubicCurvatureScalars.hpp"
 #include "PointwiseFunctions/GeneralRelativity/ExtrinsicCurvature.hpp"
-#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/CovariantDerivOfExtrinsicCurvature.hpp"
-#include "PointwiseFunctions/GeneralRelativity/Lapse.hpp"
-#include "PointwiseFunctions/GeneralRelativity/Shift.hpp"
-#include "PointwiseFunctions/GeneralRelativity/SpacetimeNormalVector.hpp"
 #include "PointwiseFunctions/GeneralRelativity/SpatialMetric.hpp"
 #include "PointwiseFunctions/GeneralRelativity/WeylElectric.hpp"
-#include "PointwiseFunctions/GeneralRelativity/WeylMagnetic.hpp"
 #include "PointwiseFunctions/Hydro/QuadraticCurvatureScalars.hpp"
 #include "PointwiseFunctions/Hydro/Ricci.hpp"
 #include "PointwiseFunctions/Hydro/StressEnergy.hpp"
@@ -66,6 +58,10 @@ void test_curvature_quantities_flrw() {
   // - Ricci scalar: $R = 8\pi (\rho - 3p)$
   // - Kretschmann scalar: $K = (64\pi^2 / 3) * (4\rho^2 + (3p + \rho)^2)$
   //
+  // The magnetic Weyl tensor vanishes in FLRW: the spacetime is conformally
+  // flat and the extrinsic curvature is proportional to the spatial metric, so
+  // the magnetic part B_{ij} = epsilon_{ikl} nabla^k K^l_j = 0.
+  //
   // The metric is constant in space. We test random values for density,
   // pressure, and the scale factor, to represent random instances of the
   // metric, not random points.
@@ -100,32 +96,16 @@ void test_curvature_quantities_flrw() {
   const tnsr::AA<DataVector, 3, Frame::Inertial> inverse_spacetime_metric =
       determinant_and_inverse(spacetime_metric).second;
 
-  auto compute_deriv_spacetime_metric = [num_points, scale_factor, density]() {
-    // Friedmann equations ->
-    // $d_t g_{ii} = 2 a \dot{a} = 2 a^2 \sqrt{8\pi \rho / 3}
-    // All other components are 0.
-    tnsr::abb<DataVector, 3, Frame::Inertial> deriv_spacetime_metric(num_points,
-                                                                     0.0);
-    tnsr::ii<DataVector, 3, Frame::Inertial> dt_spatial_metric(num_points, 0.0);
-    for (size_t i = 0; i < 3; ++i) {
-      deriv_spacetime_metric.get(0, i + 1, i + 1) =
-          2. * square(scale_factor) * sqrt(8. * M_PI * get(density) / 3.);
-      dt_spatial_metric.get(i, i) =
-          2. * square(scale_factor) * sqrt(8. * M_PI * get(density) / 3.);
-    }
-    return std::make_pair(deriv_spacetime_metric, dt_spatial_metric);
-  };
-  const auto derivs = compute_deriv_spacetime_metric();
-  const tnsr::abb<DataVector, 3, Frame::Inertial> deriv_spacetime_metric =
-      derivs.first;
-  const tnsr::ii<DataVector, 3, Frame::Inertial> dt_spatial_metric =
-      derivs.second;
+  // Friedmann equations -> d_t g_{ii} = 2 a adot = 2 a^2 sqrt(8 pi rho / 3)
+  tnsr::ii<DataVector, 3, Frame::Inertial> dt_spatial_metric(num_points, 0.0);
+  for (size_t i = 0; i < 3; ++i) {
+    dt_spatial_metric.get(i, i) =
+        2. * square(scale_factor) * sqrt(8. * M_PI * get(density) / 3.);
+  }
   const tnsr::ijj<DataVector, 3, Frame::Inertial> deriv_spatial_metric(
       num_points, 0.0);
 
   const auto spatial_metric = gr::spatial_metric(spacetime_metric);
-  const Scalar<DataVector> sqrt_det_spatial_metric = Scalar<DataVector>{
-      sqrt(get(determinant_and_inverse(spatial_metric).first))};
   const tnsr::II<DataVector, 3, Frame::Inertial> inverse_spatial_metric =
       determinant_and_inverse(spatial_metric).second;
   const tnsr::I<DataVector, 3, Frame::Inertial> shift(num_points, 0.0);
@@ -144,26 +124,9 @@ void test_curvature_quantities_flrw() {
 
   const tnsr::ii<DataVector, 3, Frame::Inertial> spatial_ricci(num_points, 0.0);
 
-  // GR quantities for stress energy tensor
   const auto extrinsic_curvature =
       gr::extrinsic_curvature(lapse, shift, deriv_shift, spatial_metric,
                               dt_spatial_metric, deriv_spatial_metric);
-  const auto spacetime_unit_normal_vector =
-      gr::spacetime_normal_vector(lapse, shift);
-  const tnsr::Ijj<DataVector, 3, Frame::Inertial>
-      spatial_christoffel_second_kind(num_points, 0.0);
-  const tnsr::iaa<DataVector, 3, Frame::Inertial> phi(num_points, 0.0);
-  const tnsr::iaa<DataVector, 3, Frame::Inertial> d_pi(num_points, 0.0);
-  const tnsr::ijaa<DataVector, 3, Frame::Inertial> d_phi(num_points, 0.0);
-  const auto deriv_extrinsic_curvature =
-      gh::covariant_deriv_of_extrinsic_curvature(
-          extrinsic_curvature, spacetime_unit_normal_vector,
-          spatial_christoffel_second_kind, inverse_spacetime_metric, phi, d_pi,
-          d_phi);
-  const auto grad_extrinsic_curvature =
-      gr::covariant_derivative_of_extrinsic_curvature(
-          deriv_extrinsic_curvature, extrinsic_curvature,
-          spatial_christoffel_second_kind);
 
   // Stress energy tensor
   tnsr::AA<DataVector, 3, Frame::Inertial> stress_energy(num_points, 0.0);
@@ -186,7 +149,7 @@ void test_curvature_quantities_flrw() {
   CHECK_ITERABLE_APPROX(get(ricci_scalar),
                         8. * M_PI * (get(density) - 3. * get(pressure)));
 
-  // Weyl electric and magnetic components
+  // Weyl electric component (vanishes in FLRW by conformally-flat symmetry)
   const auto electric_weyl =
       hydro::weyl_electric(gr::weyl_electric(spatial_ricci, extrinsic_curvature,
                                              inverse_spatial_metric),
@@ -200,14 +163,12 @@ void test_curvature_quantities_flrw() {
                                    custom_approx);
     }
   }
-  const auto magnetic_weyl = gr::weyl_magnetic(
-      grad_extrinsic_curvature, spatial_metric, sqrt_det_spatial_metric);
 
   const auto electric_weyl_scalar =
       gr::weyl_electric_scalar(electric_weyl, inverse_spatial_metric);
-  const auto magnetic_weyl_scalar =
-      gr::weyl_magnetic_scalar<Frame::Inertial, DataVector>(
-          magnetic_weyl, inverse_spatial_metric);
+  // Magnetic Weyl vanishes in FLRW: extrinsic curvature is proportional to
+  // the spatial metric, so its covariant curl is zero.
+  const Scalar<DataVector> magnetic_weyl_scalar(num_points, 0.0);
 
   // Kretschmann computation and tests
   const auto kretschmann =

--- a/tests/Unit/PointwiseFunctions/Hydro/Test_CurvatureQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/Test_CurvatureQuantities.cpp
@@ -1,0 +1,153 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cmath>
+#include <cstddef>
+#include <random>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Ricci.hpp"
+#include "PointwiseFunctions/GeneralRelativity/SpatialMetric.hpp"
+#include "PointwiseFunctions/Hydro/Ricci.hpp"
+#include "PointwiseFunctions/Hydro/StressEnergy.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+namespace {
+
+void test_curvature_quantities_flrw() {
+  // The FLRW metric provides a non-trivial but still analytic spacetime that
+  // depends on a nonzero stress-energy tensor, allowing for a simple test of
+  // the various curvature tensors/scalars (Ricci and Kretschmann) in a hydro
+  // environment.
+  //
+  // We assume zero spatial curvature and zero cosmological constant. Then, the
+  // line element is given by $ds^2 = -dt^2 + a(t)^2 d\|\vec{x}\|^2$, which
+  // yields:
+  // - A diagonal Ricci tensor: $R_{tt} = -3 \ddot{a} / a$, $R_{ii} = (a\ddot{a}
+  //   + 2\dot{a}^2)$
+  // - Ricci scalar: $R = 6 (\ddot{a}/a + (\dot{a} / a)^2 )$
+  // - Kretschmann scalar: $K = (6 / a^8) (2\dot{a}^4 + a^2 (1 + a^4)
+  //   \ddot{a}^2)$
+  //
+  // The stress-energy tensor is given by the usual cold ideal fluid expression:
+  // $T^{ab} = (\rho + p) u^a u^b + p g^{ab}$, where $u^a = (1, 0, 0, 0)$ is a
+  // stationary 4-velocity, $\rho$ is the rest mass density, and $p$ the
+  // pressure. Applying the Einstein Equations yields the Friedmann Equations,
+  // which allows us to relate the density and pressure to the scale factor and
+  // its derivatives:
+  // $(\dot{a} / a)^2 = 8\pi \rho / 3$
+  // $\ddot{a} / a = - (4\pi / 3) (\rho + 3p)$
+  // Substituting these into the above yields the following curvature
+  // quantities:
+  // - Ricci tensor: $R_{tt} = 4\pi (3p + \rho)$, $R_{ii} = 4\pi a^2 (\rho - p)$
+  // - Ricci scalar: $R = 8\pi (\rho - 3p)$
+  // - Kretschmann scalar: $K = (64\pi^2 / 3) * (4\rho^2 + (3p + \rho)^2)$
+  //
+  // The metric is constant in space. We test random values for density,
+  // pressure, and the scale factor, to represent random instances of the
+  // metric, not random points.
+
+  // Random parameters for metric and Friedmann Equations
+  MAKE_GENERATOR(gen);
+  std::uniform_real_distribution<> density_dist(1.0, 2.0);
+  std::uniform_real_distribution<> pressure_dist(0.0, 0.3);
+  std::uniform_real_distribution<> scale_factor_dist(0.3, 2.5);
+  const size_t num_points = 100;
+  Scalar<DataVector> density(num_points, 0.0);
+  get(density) = make_with_random_values<DataVector>(
+      make_not_null(&gen), make_not_null(&density_dist), num_points);
+  Scalar<DataVector> pressure(num_points, 0.0);
+  get(pressure) = make_with_random_values<DataVector>(
+      make_not_null(&gen), make_not_null(&pressure_dist), num_points);
+  const auto scale_factor = make_with_random_values<DataVector>(
+      make_not_null(&gen), make_not_null(&scale_factor_dist), num_points);
+
+  // Compute analytic expressions for metric and its derivatives
+  auto compute_spacetime_metric = [num_points, scale_factor]() {
+    // $ds^2 = -dt^2 + a(t)^2 d\|\vec{x}\|^2$
+    tnsr::aa<DataVector, 3, Frame::Inertial> spacetime_metric(num_points, 0.0);
+    spacetime_metric.get(0, 0) = -1.;
+    for (size_t i = 0; i < 3; ++i) {
+      spacetime_metric.get(i + 1, i + 1) = square(scale_factor);
+    }
+    return spacetime_metric;
+  };
+  const tnsr::aa<DataVector, 3, Frame::Inertial> spacetime_metric =
+      compute_spacetime_metric();
+  const tnsr::AA<DataVector, 3, Frame::Inertial> inverse_spacetime_metric =
+      determinant_and_inverse(spacetime_metric).second;
+
+  const auto spatial_metric = gr::spatial_metric(spacetime_metric);
+  const tnsr::II<DataVector, 3, Frame::Inertial> inverse_spatial_metric =
+      determinant_and_inverse(spatial_metric).second;
+  const tnsr::I<DataVector, 3, Frame::Inertial> shift(num_points, 0.0);
+  const Scalar<DataVector> lapse(num_points, 1.0);
+
+  // Hydro quantities for stress energy tensor (cold stationary fluid)
+  const Scalar<DataVector> specific_internal_energy(num_points, 0.0);
+  const Scalar<DataVector> lorentz_factor(num_points, 1.0);
+  const Scalar<DataVector> comoving_magnetic_field_magnitude(num_points, 0.0);
+  const tnsr::I<DataVector, 3, Frame::Inertial> spatial_velocity(num_points,
+                                                                 0.0);
+  const tnsr::I<DataVector, 3, Frame::Inertial> magnetic_field(num_points, 0.0);
+
+  // Stress energy tensor
+  tnsr::AA<DataVector, 3, Frame::Inertial> stress_energy(num_points, 0.0);
+  hydro::stress_energy_tensor(
+      make_not_null(&stress_energy), density, specific_internal_energy,
+      pressure, lorentz_factor, lapse, comoving_magnetic_field_magnitude,
+      spatial_velocity, shift, magnetic_field, spatial_metric,
+      inverse_spatial_metric);
+
+  // Ricci computation and tests
+  const auto ricci = hydro::ricci_in_gr(stress_energy, spacetime_metric);
+  CHECK_ITERABLE_APPROX(ricci.get(0, 0),
+                        4. * M_PI * (get(density) + 3. * get(pressure)));
+  for (size_t i = 0; i < 3; ++i) {
+    CHECK_ITERABLE_APPROX(
+        ricci.get(i + 1, i + 1),
+        4. * M_PI * square(scale_factor) * (get(density) - get(pressure)));
+  }
+  const auto ricci_scalar = gr::ricci_scalar(ricci, inverse_spacetime_metric);
+  CHECK_ITERABLE_APPROX(get(ricci_scalar),
+                        8. * M_PI * (get(density) - 3. * get(pressure)));
+}
+
+template <typename DataType>
+void test_curvature_quantities_random_values(const DataType& used_for_size) {
+  tnsr::aa<DataType, 3> (*f_ricci_tensor)(const tnsr::AA<DataType, 3>&,
+                                          const tnsr::aa<DataType, 3>&) =
+      &hydro::ricci_in_gr<DataType>;
+  pypp::check_with_random_values<1>(f_ricci_tensor, "CurvatureQuantities",
+                                    "ricci_in_gr", {{{-1., 1.}}},
+                                    used_for_size);
+
+  Scalar<DataType> (*f_ricci_scalar)(const tnsr::aa<DataType, 3>&,
+                                     const tnsr::AA<DataType, 3>&) =
+      &gr::ricci_scalar<3, Frame::Inertial, IndexType::Spacetime, DataType>;
+  pypp::check_with_random_values<1>(f_ricci_scalar, "CurvatureQuantities",
+                                    "ricci_scalar", {{{-1., 1.}}},
+                                    used_for_size);
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.Hydro.CurvatureQuantities",
+                  "[PointwiseFunctions][Unit]") {
+  const pypp::SetupLocalPythonEnvironment local_python_env(
+      "PointwiseFunctions/Hydro/");
+  test_curvature_quantities_flrw();
+  GENERATE_UNINITIALIZED_DOUBLE_AND_DATAVECTOR;
+  CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_curvature_quantities_random_values,
+                                    ());
+}

--- a/tests/Unit/PointwiseFunctions/Hydro/Test_CurvatureQuantities.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/Test_CurvatureQuantities.cpp
@@ -6,6 +6,7 @@
 #include <cmath>
 #include <cstddef>
 #include <random>
+#include <utility>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
@@ -14,10 +15,13 @@
 #include "Framework/CheckWithRandomValues.hpp"
 #include "Framework/SetupLocalPythonEnvironment.hpp"
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "PointwiseFunctions/GeneralRelativity/ExtrinsicCurvature.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Ricci.hpp"
 #include "PointwiseFunctions/GeneralRelativity/SpatialMetric.hpp"
+#include "PointwiseFunctions/GeneralRelativity/WeylElectric.hpp"
 #include "PointwiseFunctions/Hydro/Ricci.hpp"
 #include "PointwiseFunctions/Hydro/StressEnergy.hpp"
+#include "PointwiseFunctions/Hydro/WeylElectric.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
@@ -121,6 +125,54 @@ void test_curvature_quantities_flrw() {
   const auto ricci_scalar = gr::ricci_scalar(ricci, inverse_spacetime_metric);
   CHECK_ITERABLE_APPROX(get(ricci_scalar),
                         8. * M_PI * (get(density) - 3. * get(pressure)));
+
+  auto compute_deriv_spacetime_metric = [num_points, scale_factor, density]() {
+    // Friedmann equations ->
+    // $d_t g_{ii} = 2 a \dot{a} = 2 a^2 \sqrt{8\pi \rho / 3}
+    // All other components are 0.
+    tnsr::abb<DataVector, 3, Frame::Inertial> deriv_spacetime_metric(num_points,
+                                                                     0.0);
+    tnsr::ii<DataVector, 3, Frame::Inertial> dt_spatial_metric(num_points, 0.0);
+    for (size_t i = 0; i < 3; ++i) {
+      deriv_spacetime_metric.get(0, i + 1, i + 1) =
+          2. * square(scale_factor) * sqrt(8. * M_PI * get(density) / 3.);
+      dt_spatial_metric.get(i, i) =
+          2. * square(scale_factor) * sqrt(8. * M_PI * get(density) / 3.);
+    }
+    return std::make_pair(deriv_spacetime_metric, dt_spatial_metric);
+  };
+  const auto derivs = compute_deriv_spacetime_metric();
+  const tnsr::ii<DataVector, 3, Frame::Inertial> dt_spatial_metric =
+      derivs.second;
+  const tnsr::ijj<DataVector, 3, Frame::Inertial> deriv_spatial_metric(
+      num_points, 0.0);
+  const tnsr::iJ<DataVector, 3, Frame::Inertial> deriv_shift(num_points, 0.0);
+  const auto induced_spatial_metric =
+      gr::induced_spatial_metric(spacetime_metric, lapse);
+  const tnsr::ii<DataVector, 3, Frame::Inertial> spatial_ricci(num_points, 0.0);
+
+  const auto extrinsic_curvature =
+      gr::extrinsic_curvature(lapse, shift, deriv_shift, spatial_metric,
+                              dt_spatial_metric, deriv_spatial_metric);
+
+  // Weyl electric and magnetic components
+  const auto electric_weyl =
+      hydro::weyl_electric(gr::weyl_electric(spatial_ricci, extrinsic_curvature,
+                                             inverse_spatial_metric),
+                           stress_energy, ricci, ricci_scalar,
+                           inverse_spacetime_metric, induced_spatial_metric);
+  const Approx custom_approx = Approx::custom().epsilon(2.e-13).scale(1.0);
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = 0; j < 3; ++j) {
+      CHECK_ITERABLE_CUSTOM_APPROX(electric_weyl.get(i, j),
+                                   (DataVector{num_points, 0.0}),
+                                   custom_approx);
+    }
+  }
+  TestHelpers::db::test_compute_tag<
+      hydro::Tags::WeylElectricCompute<DataVector>>("WeylElectric");
+  TestHelpers::db::test_compute_tag<
+      hydro::Tags::WeylElectricScalarCompute<DataVector>>("WeylElectricScalar");
 }
 
 template <typename DataType>
@@ -137,6 +189,15 @@ void test_curvature_quantities_random_values(const DataType& used_for_size) {
       &gr::ricci_scalar<3, Frame::Inertial, IndexType::Spacetime, DataType>;
   pypp::check_with_random_values<1>(f_ricci_scalar, "CurvatureQuantities",
                                     "ricci_scalar", {{{-1., 1.}}},
+                                    used_for_size);
+
+  tnsr::ii<DataType, 3> (*f_weyl_electric)(
+      const tnsr::ii<DataType, 3>&, const tnsr::AA<DataType, 3>&,
+      const tnsr::aa<DataType, 3>&, const Scalar<DataType>&,
+      const tnsr::AA<DataType, 3>&, const tnsr::aa<DataType, 3>&) =
+      &hydro::weyl_electric<DataType>;
+  pypp::check_with_random_values<1>(f_weyl_electric, "CurvatureQuantities",
+                                    "weyl_electric", {{{-1., 1.}}},
                                     used_for_size);
 }
 

--- a/tests/Unit/PointwiseFunctions/Hydro/Test_StressEnergy.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/Test_StressEnergy.cpp
@@ -15,6 +15,7 @@
 #include "Evolution/Systems/GrMhd/GhValenciaDivClean/StressEnergy.hpp"
 #include "Framework/CheckWithRandomValues.hpp"
 #include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
 #include "Helpers/PointwiseFunctions/GeneralRelativity/TestHelpers.hpp"
 #include "PointwiseFunctions/GeneralRelativity/InverseSpacetimeMetric.hpp"
@@ -200,6 +201,8 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.Hydro.StressEnergy",
       {"stress_energy_tensor"}, {{{0.0, 1.0}}}, used_for_size, tolerance);
 
   consistency_check(used_for_size);
+  TestHelpers::db::test_compute_tag<
+      hydro::Tags::StressEnergyCompute<DataVector>>("StressEnergy");
 }
 
 }  // namespace hydro

--- a/tests/Unit/PointwiseFunctions/Hydro/Test_Tags.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/Test_Tags.cpp
@@ -31,6 +31,8 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.Hydro.Tags", "[Unit][Hydro]") {
       "EquationOfState");
   TestHelpers::db::test_simple_tag<hydro::Tags::LorentzFactor<DataVector>>(
       "LorentzFactor");
+  TestHelpers::db::test_simple_tag<hydro::Tags::KretschmannScalar<DataVector>>(
+      "KretschmannScalar");
   TestHelpers::db::test_simple_tag<
       hydro::Tags::InversePlasmaBeta<DataVector>>("InversePlasmaBeta");
   TestHelpers::db::test_simple_tag<

--- a/tests/Unit/PointwiseFunctions/Hydro/Test_Tags.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/Test_Tags.cpp
@@ -52,6 +52,10 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.Hydro.Tags", "[Unit][Hydro]") {
       "Pressure");
   TestHelpers::db::test_simple_tag<hydro::Tags::RestMassDensity<DataVector>>(
       "RestMassDensity");
+  TestHelpers::db::test_simple_tag<
+      hydro::Tags::GrRicci<DataVector, 3, Frame::ElementLogical>>("GrRicci");
+  TestHelpers::db::test_simple_tag<hydro::Tags::GrRicciScalar<DataVector>>(
+      "GrRicciScalar");
   TestHelpers::db::test_simple_tag<hydro::Tags::SoundSpeedSquared<DataVector>>(
       "SoundSpeedSquared");
   // [prefix_example]

--- a/tests/Unit/PointwiseFunctions/Hydro/Test_Tags.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/Test_Tags.cpp
@@ -50,6 +50,8 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.Hydro.Tags", "[Unit][Hydro]") {
       hydro::Tags::MagneticFieldSquared<DataVector>>("MagneticFieldSquared");
   TestHelpers::db::test_simple_tag<hydro::Tags::MagneticPressure<DataVector>>(
       "MagneticPressure");
+  TestHelpers::db::test_simple_tag<hydro::Tags::PontryaginScalar<DataVector>>(
+      "PontryaginScalar");
   TestHelpers::db::test_simple_tag<hydro::Tags::Pressure<DataVector>>(
       "Pressure");
   TestHelpers::db::test_simple_tag<hydro::Tags::RestMassDensity<DataVector>>(

--- a/tests/Unit/PointwiseFunctions/Hydro/Test_Tags.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/Test_Tags.cpp
@@ -76,6 +76,9 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.Hydro.Tags", "[Unit][Hydro]") {
   TestHelpers::db::test_simple_tag<
       hydro::Tags::SpecificInternalEnergy<DataVector>>(
       "SpecificInternalEnergy");
+  TestHelpers::db::test_simple_tag<
+      hydro::Tags::StressEnergy<DataVector, 3, Frame::ElementLogical>>(
+      "StressEnergy");
   TestHelpers::db::test_simple_tag<hydro::Tags::Temperature<DataVector>>(
       "Temperature");
   TestHelpers::db::test_simple_tag<

--- a/tests/Unit/PointwiseFunctions/Hydro/Test_Tags.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/Test_Tags.cpp
@@ -88,6 +88,11 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.Hydro.Tags", "[Unit][Hydro]") {
   TestHelpers::db::test_simple_tag<
       hydro::Tags::TransportVelocity<DataVector, 3, Frame::Inertial>>(
       "TransportVelocity");
+  TestHelpers::db::test_simple_tag<
+      hydro::Tags::WeylElectric<DataVector, 3, Frame::ElementLogical>>(
+      "WeylElectric");
+  TestHelpers::db::test_simple_tag<hydro::Tags::WeylElectricScalar<DataVector>>(
+      "WeylElectricScalar");
   TestHelpers::db::test_simple_tag<hydro::Tags::LowerSpatialFourVelocity<
       DataVector, 3, Frame::ElementLogical>>("LowerSpatialFourVelocity");
   TestHelpers::db::test_simple_tag<


### PR DESCRIPTION
## Proposed changes

The main objective of this PR is to add the Kretschmann scalar to `GeneralRelativity` and `Hydro` namespaces, especially to the latter to be observable.

Along the way, it added tags for intermediary steps, such as (in `GeneralRelativity`) the induced spatial metric (i.e. 4D version of spatial metric), and (in `Hydro`) the 4D Ricci tensor/scalar and the Weyl Electric component (the magnetic component is the same in vacuum). Compute tags are also added for existing functions, namely including the Stress Energy Tensor in `Hydro`.

Lastly, the Pontryagin scalar previously had the wrong sign, so this is fixed.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
