### PR TITLE
Zernikeb1 subcell projection

### DIFF
--- a/src/Evolution/DgSubcell/Actions/ReconstructionCommunication.hpp
+++ b/src/Evolution/DgSubcell/Actions/ReconstructionCommunication.hpp
@@ -806,7 +806,9 @@ struct ReceiveDataForReconstruction {
                 *boundary_data.ghost_cell_data, number_of_rdmp_vars,
                 directional_element_id,
                 mesh_for_ghost_data->at(directional_element_id), element,
-                subcell_mesh, ghost_zone_size, neighbor_dg_to_fd_interpolants);
+                subcell_mesh, ghost_zone_size, neighbor_dg_to_fd_interpolants,
+                typename Metavariables::SubcellOptions::GhostVariables::
+                    ghost_variables_tag_list{});
             ASSERT(neighbor_tci_decisions->contains(directional_element_id),
                    "The NeighorTciDecisions should contain the neighbor ("
                        << directional_element_id.direction() << ", "

--- a/src/Evolution/DgSubcell/Actions/TciAndRollback.hpp
+++ b/src/Evolution/DgSubcell/Actions/TciAndRollback.hpp
@@ -252,7 +252,9 @@ struct TciAndRollback {
                            .neighbor_ghost_data_for_reconstruction(),
                        0, directional_element_id, mesh_for_ghost_data, element,
                        subcell_mesh, ghost_zone_size,
-                       neighbor_dg_to_fd_interpolants);
+                       neighbor_dg_to_fd_interpolants,
+                       typename Metavariables::SubcellOptions::GhostVariables::
+                           ghost_variables_tag_list{});
           }
 
           // Note: We do _not_ project the boundary history here because

--- a/src/Evolution/DgSubcell/CellCenteredFlux.hpp
+++ b/src/Evolution/DgSubcell/CellCenteredFlux.hpp
@@ -18,6 +18,7 @@
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
 #include "Evolution/DgSubcell/Tags/SubcellOptions.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Parity.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -74,7 +75,8 @@ struct CellCenteredFlux {
             const DataVector& cell_centered_mesh_velocity =
                 evolution::dg::subcell::fd::project(
                     dg_mesh_velocity.value().get(i), dg_mesh,
-                    subcell_mesh.extents());
+                    subcell_mesh.extents(),
+                    i == 0 ? Spectral::Parity::Odd : Spectral::Parity::Even);
 
             tmpl::for_each<flux_variables>(
                 [&cell_centered_flux_vars, &cell_centered_mesh_velocity,

--- a/src/Evolution/DgSubcell/CorrectPackagedData.hpp
+++ b/src/Evolution/DgSubcell/CorrectPackagedData.hpp
@@ -122,7 +122,8 @@ void correct_package_data(
           projected_data = DataVector{
               Variables<DgPackageFieldTags>::number_of_independent_components *
               subcell_face_mesh.number_of_grid_points()};
-          evolution::dg::subcell::fd::detail::project_impl(
+          evolution::dg::subcell::fd::detail::project_impl_with_tag_list<
+              DgPackageFieldTags>(
               gsl::make_span(projected_data.data(), projected_data.size()),
               gsl::make_span(
                   slice_data,

--- a/src/Evolution/DgSubcell/Matrices.cpp
+++ b/src/Evolution/DgSubcell/Matrices.cpp
@@ -19,6 +19,7 @@
 #include "NumericalAlgorithms/Spectral/MaximumNumberOfPoints.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/MinimumNumberOfPoints.hpp"
+#include "NumericalAlgorithms/Spectral/Parity.hpp"
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
 #include "NumericalAlgorithms/Spectral/QuadratureWeights.hpp"
 #include "Utilities/Algorithm.hpp"
@@ -31,12 +32,15 @@
 #include "Utilities/StaticCache.hpp"
 
 namespace evolution::dg::subcell::fd {
-const Matrix& projection_matrix(
-    const Mesh<1>& dg_mesh, const size_t subcell_extents,
-    const Spectral::Quadrature& subcell_quadrature) {
+const Matrix& projection_matrix(const Mesh<1>& dg_mesh,
+                                const size_t subcell_extents,
+                                const Spectral::Quadrature& subcell_quadrature,
+                                const Spectral::Parity parity) {
   ASSERT(dg_mesh.basis(0) == Spectral::Basis::Legendre or
-             dg_mesh.basis(0) == Spectral::Basis::Cartoon,
-         "FD Subcell projection only supports Legendre or Cartoon bases right "
+             dg_mesh.basis(0) == Spectral::Basis::Cartoon or
+             dg_mesh.basis(0) == Spectral::Basis::ZernikeB1,
+         "FD Subcell projection only supports Legendre, Cartoon, or ZernikeB1 "
+         "bases right "
          "now but got basis "
              << dg_mesh.basis(0));
   ASSERT(subcell_quadrature == Spectral::Quadrature::FaceCentered or
@@ -46,7 +50,39 @@ const Matrix& projection_matrix(
          "subcell_quadrature option in projection_matrix should be "
          "FaceCentered, CellCentered, or a Cartoon quadrature, but got "
              << subcell_quadrature);
-  static const auto cache = make_static_cache<
+  ASSERT(dg_mesh.basis(0) != Spectral::Basis::ZernikeB1 or
+             parity != Spectral::Parity::Uninitialized,
+         "Parity must be set when using ZernikeB1");
+
+  const static auto zernike_b1_cache = make_static_cache<
+      CacheRange<
+          Spectral::minimum_number_of_points<
+              Spectral::Basis::ZernikeB1,
+              Spectral::Quadrature::GaussRadauUpper>,
+          Spectral::maximum_number_of_points<Spectral::Basis::ZernikeB1> + 1>,
+      CacheRange<Spectral::minimum_number_of_points<
+                     Spectral::Basis::FiniteDifference,
+                     Spectral::Quadrature::CellCentered>,
+                 Spectral::maximum_number_of_points<
+                     Spectral::Basis::FiniteDifference> +
+                     1>,
+      CacheEnumeration<Spectral::Quadrature, Spectral::Quadrature::CellCentered,
+                       Spectral::Quadrature::FaceCentered>,
+      CacheEnumeration<Spectral::Parity, Spectral::Parity::Even,
+                       Spectral::Parity::Odd>>(
+      [](const size_t local_num_dg_points, const size_t local_num_fd_points,
+         const Spectral::Quadrature local_subcell_quadrature,
+         const Spectral::Parity local_parity) {
+        return Spectral::interpolation_matrix<
+            Spectral::Basis::ZernikeB1, Spectral::Quadrature::GaussRadauUpper>(
+            local_num_dg_points,
+            Spectral::collocation_points(
+                Mesh<1>{local_num_fd_points, Spectral::Basis::FiniteDifference,
+                        local_subcell_quadrature}),
+            local_parity);
+      });
+
+  const static auto legendre_cache = make_static_cache<
       CacheRange<
           Spectral::minimum_number_of_points<
               Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto>,
@@ -74,9 +110,13 @@ const Matrix& projection_matrix(
   if (dg_mesh.basis(0) == Spectral::Basis::Cartoon) {
     static const Matrix cartoon_matrix{1, 1, 1.0};
     return cartoon_matrix;
+  } else if (dg_mesh.basis(0) == Spectral::Basis::ZernikeB1) {
+    return zernike_b1_cache(dg_mesh.extents(0), subcell_extents,
+                            subcell_quadrature, parity);
+  } else {
+    return legendre_cache(dg_mesh.extents(0), subcell_extents,
+                          dg_mesh.quadrature(0), subcell_quadrature);
   }
-  return cache(dg_mesh.extents(0), subcell_extents, dg_mesh.quadrature(0),
-               subcell_quadrature);
 }
 
 namespace {

--- a/src/Evolution/DgSubcell/Matrices.hpp
+++ b/src/Evolution/DgSubcell/Matrices.hpp
@@ -14,6 +14,7 @@ template <size_t Dim>
 class Mesh;
 enum class Side : uint8_t;
 namespace Spectral {
+enum class Parity : uint8_t;
 enum class Quadrature : uint8_t;
 }  // namespace Spectral
 /// \endcond
@@ -23,9 +24,13 @@ namespace evolution::dg::subcell::fd {
  * \ingroup DgSubcellGroup
  * \brief Computes the projection matrix in 1 dimension going from a DG
  * mesh to a conservative finite difference subcell mesh.
+ *
+ * The parity parameter is required for ZernikeB1 bases, and is ignored for
+ * others.
  */
 const Matrix& projection_matrix(const Mesh<1>& dg_mesh, size_t subcell_extents,
-                                const Spectral::Quadrature& subcell_quadrature);
+                                const Spectral::Quadrature& subcell_quadrature,
+                                Spectral::Parity parity);
 
 /*!
  * \ingroup DgSubcellGroup
@@ -95,4 +100,4 @@ const Matrix& reconstruction_matrix(const Mesh<Dim>& dg_mesh,
  */
 const Matrix& projection_matrix(const Mesh<1>& dg_mesh, size_t subcell_extents,
                                 size_t ghost_zone_size, Side side);
-}  // namespace evolution::dg::subcellfd
+}  // namespace evolution::dg::subcell::fd

--- a/src/Evolution/DgSubcell/Mesh.cpp
+++ b/src/Evolution/DgSubcell/Mesh.cpp
@@ -88,9 +88,10 @@ Mesh<Dim> mesh(const Mesh<Dim>& dg_mesh) {
     if (dg_mesh.basis(1) == Spectral::Basis::Cartoon and
         dg_mesh.basis(2) == Spectral::Basis::Cartoon) {
       ASSERT(dg_mesh.basis(0) == Spectral::Basis::Legendre or
-                 dg_mesh.basis(0) == Spectral::Basis::Chebyshev,
+                 dg_mesh.basis(0) == Spectral::Basis::Chebyshev or
+                 dg_mesh.basis(0) == Spectral::Basis::ZernikeB1,
              "The DG mesh that is being converted to subcell can only mix "
-             "Legendre or Chebyshev with Cartoon, but got "
+             "Legendre, Chebyshev, or ZernikeB1 with Cartoon, but got "
                  << dg_mesh);
       ASSERT(dg_mesh.slice_away(0).quadrature() ==
                  make_array<2>(Spectral::Quadrature::SphericalSymmetry),
@@ -102,20 +103,33 @@ Mesh<Dim> mesh(const Mesh<Dim>& dg_mesh) {
                       Spectral::Quadrature::SphericalSymmetry,
                       Spectral::Quadrature::SphericalSymmetry}};
     } else if (dg_mesh.basis(2) == Spectral::Basis::Cartoon) {
-      ASSERT(dg_mesh.slice_away(2).basis() ==
-                     make_array<2>(Spectral::Basis::Legendre) or
-                 dg_mesh.slice_away(2).basis() ==
-                     make_array<2>(Spectral::Basis::Chebyshev),
+      ASSERT((dg_mesh.slice_away(2).basis() ==
+                  make_array<2>(Spectral::Basis::Legendre) or
+              dg_mesh.slice_away(2).basis() ==
+                  make_array<2>(Spectral::Basis::Chebyshev) or
+              dg_mesh.slice_away(2).basis() ==
+                  std::array{Spectral::Basis::ZernikeB1,
+                             Spectral::Basis::Legendre} or
+              dg_mesh.slice_away(2).basis() ==
+                  std::array{Spectral::Basis::ZernikeB1,
+                             Spectral::Basis::Chebyshev}),
              "The DG mesh that is being converted to subcell can only mix "
-             "Legendre or Chebyshev with Cartoon, but got "
+             "Legendre, Chebyshev, or ZernikeB1 with Cartoon, but got "
                  << dg_mesh);
       ASSERT(
-          dg_mesh.slice_away(2).quadrature() ==
-                  make_array<2>(Spectral::Quadrature::Gauss) or
-              dg_mesh.slice_away(2).quadrature() ==
-                  make_array<2>(Spectral::Quadrature::GaussLobatto),
+          (dg_mesh.slice_away(2).quadrature() ==
+               make_array<2>(Spectral::Quadrature::Gauss) or
+           dg_mesh.slice_away(2).quadrature() ==
+               make_array<2>(Spectral::Quadrature::GaussLobatto) or
+           dg_mesh.slice_away(2).quadrature() ==
+               std::array{Spectral::Quadrature::GaussRadauUpper,
+                          Spectral::Quadrature::Gauss} or
+           dg_mesh.slice_away(2).quadrature() ==
+               std::array{Spectral::Quadrature::GaussRadauUpper,
+                          Spectral::Quadrature::GaussLobatto}),
           "The DG quadrature for computing the subcell mesh must be Gauss or "
-          "GaussLobatto with a Cartoon quadrature but got DG mesh"
+          "GaussLobatto (can have ZernikeB1 in first dimension) with a Cartoon "
+          "quadrature but got DG mesh"
               << dg_mesh);
       return Mesh<3>{
           extents,

--- a/src/Evolution/DgSubcell/NeighborRdmpAndVolumeData.cpp
+++ b/src/Evolution/DgSubcell/NeighborRdmpAndVolumeData.cpp
@@ -4,8 +4,10 @@
 #include "Evolution/DgSubcell/NeighborRdmpAndVolumeData.hpp"
 
 #include <algorithm>
+#include <cstddef>
 #include <functional>
 #include <iterator>
+#include <optional>
 #include <utility>
 
 #include "DataStructures/ApplyMatrices.hpp"
@@ -15,21 +17,156 @@
 #include "Domain/Structure/DirectionalId.hpp"
 #include "Domain/Structure/DirectionalIdMap.hpp"
 #include "Domain/Structure/Element.hpp"
-#include "Domain/Structure/ElementId.hpp"
-#include "Domain/Structure/OrientationMapHelpers.hpp"
 #include "Evolution/DgSubcell/GhostData.hpp"
 #include "Evolution/DgSubcell/Matrices.hpp"
 #include "Evolution/DgSubcell/Mesh.hpp"
 #include "NumericalAlgorithms/Interpolation/IrregularInterpolant.hpp"
 #include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Parity.hpp"
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/MakeArray.hpp"
+#include "Utilities/MemoryHelpers.hpp"
 
-namespace evolution::dg::subcell {
+namespace evolution::dg::subcell::detail {
+namespace {
+// Projects ghost data for a ZernikeB1 neighbor using parity-split projection
+// matrices
+void project_zernike_b1_ghost_data(
+    const gsl::not_null<DataVector*> computed_ghost_data,
+    const DataVector& neighbor_data_without_rdmp_vars,
+    const size_t number_of_vars, const Mesh<3>& neighbor_mesh,
+    const Mesh<3>& subcell_mesh, const size_t number_of_ghost_zones,
+    const Direction<3>& direction, const gsl::span<const size_t> parity_list,
+    const size_t num_even, const size_t num_odd) {
+  ASSERT(neighbor_mesh.basis(0) == Spectral::Basis::ZernikeB1 and
+             direction.dimension() != 0,
+         "Neighbor setup is not appropriate to call ZernikeB1-specific "
+         "projection, got neighbor mesh = "
+             << neighbor_mesh << ", direction = " << direction);
+  const size_t num_dg_pts = neighbor_mesh.number_of_grid_points();
+  const size_t num_ghost_pts_per_var =
+      number_of_ghost_zones *
+      subcell_mesh.extents().slice_away(direction.dimension()).product();
+  if (UNLIKELY(computed_ghost_data->size() !=
+               num_ghost_pts_per_var * number_of_vars)) {
+    computed_ghost_data->destructive_resize(num_ghost_pts_per_var *
+                                            number_of_vars);
+  }
+
+  auto buffer =
+      // NOLINTNEXTLINE(modernize-avoid-c-arrays)
+      cpp20::make_unique_for_overwrite<double[]>(
+          (num_even + num_odd) * (num_dg_pts + num_ghost_pts_per_var));
+  DataVector even_input{};
+  even_input.set_data_ref(&buffer[0], num_even * num_dg_pts);
+  DataVector odd_input{};
+  odd_input.set_data_ref(&buffer[num_even * num_dg_pts], num_odd * num_dg_pts);
+  DataVector even_output{};
+  even_input.set_data_ref(&buffer[(num_even + num_odd) * num_dg_pts],
+                          num_even * num_ghost_pts_per_var);
+  DataVector odd_output{};
+  odd_input.set_data_ref(&buffer[(num_even + num_odd) * num_dg_pts +
+                                 num_even * num_ghost_pts_per_var],
+                         num_odd * num_ghost_pts_per_var);
+
+  // Sort input components into even/odd parity buffers
+  const double* p_in = neighbor_data_without_rdmp_vars.data();
+  double* p_even_in = even_input.data();
+  double* p_odd_in = odd_input.data();
+  bool is_even = true;
+  for (const size_t seg_size : parity_list) {
+    if (seg_size == 0) {
+      if (is_even) {
+        is_even = false;
+        continue;
+      } else {
+        break;
+      }
+    }
+    if (is_even) {
+      std::copy(p_in, p_in + seg_size * num_dg_pts, p_even_in);  // NOLINT
+      p_even_in += seg_size * num_dg_pts;                        // NOLINT
+    } else {
+      std::copy(p_in, p_in + seg_size * num_dg_pts, p_odd_in);  // NOLINT
+      p_odd_in += seg_size * num_dg_pts;                        // NOLINT
+    }
+    p_in += seg_size * num_dg_pts;  // NOLINT
+    is_even = not is_even;
+  }
+
+  // Build matrix arrays: dim 0 gets parity-dependent ZernikeB1 matrices;
+  // other dims are shared between even and odd batches.
+  const Matrix empty{};
+  auto even_ghost_mat = make_array<3>(std::cref(empty));
+  auto odd_ghost_mat = make_array<3>(std::cref(empty));
+  even_ghost_mat[0] = std::cref(fd::projection_matrix(
+      neighbor_mesh.slice_through(0), subcell_mesh.extents(0),
+      Spectral::Quadrature::CellCentered, Spectral::Parity::Even));
+  odd_ghost_mat[0] = std::cref(fd::projection_matrix(
+      neighbor_mesh.slice_through(0), subcell_mesh.extents(0),
+      Spectral::Quadrature::CellCentered, Spectral::Parity::Odd));
+  for (size_t i = 1; i < 3; ++i) {
+    if (i == direction.dimension()) {
+      const auto& ghost_mat = fd::projection_matrix(
+          neighbor_mesh.slice_through(i), subcell_mesh.extents(i),
+          number_of_ghost_zones, direction.opposite().side());
+      gsl::at(even_ghost_mat, i) = std::cref(ghost_mat);
+      gsl::at(odd_ghost_mat, i) = std::cref(ghost_mat);
+    } else {
+      const auto& other_mat = fd::projection_matrix(
+          neighbor_mesh.slice_through(i), subcell_mesh.extents(i),
+          Spectral::Quadrature::CellCentered, Spectral::Parity::Uninitialized);
+      gsl::at(even_ghost_mat, i) = std::cref(other_mat);
+      gsl::at(odd_ghost_mat, i) = std::cref(other_mat);
+    }
+  }
+
+  if (num_even > 0) {
+    apply_matrices(make_not_null(&even_output), even_ghost_mat, even_input,
+                   neighbor_mesh.extents());
+  }
+  if (num_odd > 0) {
+    apply_matrices(make_not_null(&odd_output), odd_ghost_mat, odd_input,
+                   neighbor_mesh.extents());
+  }
+
+  // Reassemble output in original component order
+  double* p_out = computed_ghost_data->data();
+  const double* p_even_out = even_output.data();
+  const double* p_odd_out = odd_output.data();
+  is_even = true;
+  for (const size_t seg_size : parity_list) {
+    if (seg_size == 0) {
+      if (is_even) {
+        is_even = false;
+        continue;
+      } else {
+        break;
+      }
+    }
+    if (is_even) {
+      std::copy(p_even_out,
+                p_even_out + seg_size * num_ghost_pts_per_var,  // NOLINT
+                p_out);
+      p_even_out += seg_size * num_ghost_pts_per_var;  // NOLINT
+    } else {
+      std::copy(p_odd_out,
+                p_odd_out + seg_size * num_ghost_pts_per_var,  // NOLINT
+                p_out);
+      p_odd_out += seg_size * num_ghost_pts_per_var;  // NOLINT
+    }
+    p_out += seg_size * num_ghost_pts_per_var;  // NOLINT
+    is_even = not is_even;
+  }
+}
+}  // namespace
+
 template <bool InsertIntoMap, size_t Dim>
-void insert_or_update_neighbor_volume_data(
+void insert_or_update_neighbor_volume_data_impl(
     const gsl::not_null<DirectionalIdMap<Dim, GhostData>*> ghost_data_ptr,
     const DataVector& neighbor_subcell_data,
     const size_t number_of_rdmp_vars_in_buffer,
@@ -37,7 +174,9 @@ void insert_or_update_neighbor_volume_data(
     const Mesh<Dim>& neighbor_mesh, const Element<Dim>& element,
     const Mesh<Dim>& subcell_mesh, const size_t number_of_ghost_zones,
     const DirectionalIdMap<Dim, std::optional<intrp::Irregular<Dim>>>&
-        neighbor_dg_to_fd_interpolants) {
+        neighbor_dg_to_fd_interpolants,
+    const gsl::span<const size_t> parity_list, const size_t num_even,
+    const size_t num_odd) {
   fd::verify_subcell_mesh(neighbor_mesh, true);
   ASSERT(neighbor_subcell_data.size() != 0,
          "neighbor_subcell_data must be non-empty");
@@ -73,10 +212,10 @@ void insert_or_update_neighbor_volume_data(
                           number_of_rdmp_vars_in_buffer)),
         computed_ghost_data.begin());
   } else {
-    ASSERT(evolution::dg::subcell::fd::mesh(neighbor_mesh) == subcell_mesh,
+    ASSERT(fd::mesh(neighbor_mesh) == subcell_mesh,
            "Neighbor subcell mesh computed from the neighbor DG mesh ("
-               << evolution::dg::subcell::fd::mesh(neighbor_mesh)
-               << ") and my mesh (" << subcell_mesh << ") must be the same.");
+               << fd::mesh(neighbor_mesh) << ") and my mesh (" << subcell_mesh
+               << ") must be the same.");
     const Direction<Dim>& direction = directional_element_id.direction();
     const size_t total_number_of_ghost_zones =
         number_of_ghost_zones *
@@ -110,116 +249,69 @@ void insert_or_update_neighbor_volume_data(
     } else {
       // If our neighbor is in our block we can do simple dim-by-dim
       // interpolation.
-      const auto project_to_ghost_data =
-          [&direction, &computed_ghost_data, &number_of_ghost_zones,
-           &subcell_mesh](const Mesh<Dim>& neighbor_mesh_for_projection,
-                          const DataVector& neighbor_data_for_projection) {
-            // Project to ghosts
-            Matrix empty{};
-            auto ghost_projection_mat = make_array<Dim>(std::cref(empty));
-            for (size_t i = 0; i < Dim; ++i) {
-              if (i == direction.dimension()) {
-                gsl::at(ghost_projection_mat, i) =
-                    std::cref(evolution::dg::subcell::fd::projection_matrix(
-                        neighbor_mesh_for_projection.slice_through(i),
-                        subcell_mesh.extents(i), number_of_ghost_zones,
-                        direction.opposite().side()));
-              } else {
-                gsl::at(ghost_projection_mat, i) =
-                    std::cref(evolution::dg::subcell::fd::projection_matrix(
-                        neighbor_mesh_for_projection.slice_through(i),
-                        subcell_mesh.extents(i),
-                        Spectral::Quadrature::CellCentered));
-              }
-            }
-            apply_matrices(make_not_null(&computed_ghost_data),
-                           ghost_projection_mat, neighbor_data_for_projection,
-                           neighbor_mesh_for_projection.extents());
-          };
       const DataVector neighbor_data_without_rdmp_vars{
           // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
           const_cast<double*>(neighbor_subcell_data.data()),
           end_of_volume_data};
-      project_to_ghost_data(neighbor_mesh, neighbor_data_without_rdmp_vars);
+
+      if constexpr (Dim == 3) {
+        if (neighbor_mesh.basis(0) == Spectral::Basis::ZernikeB1 and
+            direction.dimension() != 0) {
+          // ZernikeB1 is in dimension 0 and is not the ghost direction, so
+          // we need to project even- and odd-parity components separately.
+          project_zernike_b1_ghost_data(
+              make_not_null(&computed_ghost_data),
+              neighbor_data_without_rdmp_vars, number_of_vars, neighbor_mesh,
+              subcell_mesh, number_of_ghost_zones, direction, parity_list,
+              num_even, num_odd);
+          ghost_data = std::move(computed_ghost_data);
+          return;
+        }
+      }
+
+      const Matrix empty{};
+      auto ghost_projection_mat = make_array<Dim>(std::cref(empty));
+      for (size_t i = 0; i < Dim; ++i) {
+        if (i == direction.dimension()) {
+          gsl::at(ghost_projection_mat, i) = std::cref(fd::projection_matrix(
+              neighbor_mesh.slice_through(i), subcell_mesh.extents(i),
+              number_of_ghost_zones, direction.opposite().side()));
+        } else {
+          gsl::at(ghost_projection_mat, i) = std::cref(fd::projection_matrix(
+              neighbor_mesh.slice_through(i), subcell_mesh.extents(i),
+              Spectral::Quadrature::CellCentered,
+              Spectral::Parity::Uninitialized));
+        }
+      }
+      apply_matrices(make_not_null(&computed_ghost_data), ghost_projection_mat,
+                     neighbor_data_without_rdmp_vars, neighbor_mesh.extents());
     }
   }
 
   ghost_data = std::move(computed_ghost_data);
 }
 
-template <size_t Dim>
-void insert_neighbor_rdmp_and_volume_data(
-    const gsl::not_null<RdmpTciData*> rdmp_tci_data_ptr,
-    const gsl::not_null<DirectionalIdMap<Dim, GhostData>*> ghost_data_ptr,
-    const DataVector& received_neighbor_subcell_data,
-    const size_t number_of_rdmp_vars,
-    const DirectionalId<Dim>& directional_element_id,
-    const Mesh<Dim>& neighbor_mesh, const Element<Dim>& element,
-    const Mesh<Dim>& subcell_mesh, const size_t number_of_ghost_zones,
-    const DirectionalIdMap<Dim, std::optional<intrp::Irregular<Dim>>>&
-        neighbor_dg_to_fd_interpolants) {
-  ASSERT(received_neighbor_subcell_data.size() != 0,
-         "received_neighbor_subcell_data must be non-empty");
-  // Note: since we determine the starting point of the RDMP vars
-  // from how many RDMP vars there are, we don't need to account for
-  // the mesh the neighbor sent (DG or FD)
-  const size_t max_offset =
-      received_neighbor_subcell_data.size() - 2 * number_of_rdmp_vars;
-  const size_t min_offset =
-      received_neighbor_subcell_data.size() - number_of_rdmp_vars;
-  for (size_t var_index = 0; var_index < number_of_rdmp_vars; ++var_index) {
-    rdmp_tci_data_ptr->max_variables_values[var_index] =
-        std::max(rdmp_tci_data_ptr->max_variables_values[var_index],
-                 received_neighbor_subcell_data[max_offset + var_index]);
-    rdmp_tci_data_ptr->min_variables_values[var_index] =
-        std::min(rdmp_tci_data_ptr->min_variables_values[var_index],
-                 received_neighbor_subcell_data[min_offset + var_index]);
-  }
-  // Note: it would be good to assert that the neighbor is at the same
-  // refinement level as us, but such a function does not yet exist.
-
-  insert_or_update_neighbor_volume_data<true>(
-      ghost_data_ptr, received_neighbor_subcell_data, number_of_rdmp_vars,
-      directional_element_id, neighbor_mesh, element, subcell_mesh,
-      number_of_ghost_zones, neighbor_dg_to_fd_interpolants);
-}
-
 #define GET_DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
-
-#define INSTANTIATION(r, data)                                               \
-  template void insert_neighbor_rdmp_and_volume_data(                        \
-      gsl::not_null<RdmpTciData*> rdmp_tci_data_ptr,                         \
-      gsl::not_null<DirectionalIdMap<GET_DIM(data), GhostData>*>             \
-          ghost_data_ptr,                                                    \
-      const DataVector& neighbor_subcell_data, size_t number_of_rdmp_vars,   \
-      const DirectionalId<GET_DIM(data)>& directional_element_id,            \
-      const Mesh<GET_DIM(data)>& neighbor_mesh,                              \
-      const Element<GET_DIM(data)>& element,                                 \
-      const Mesh<GET_DIM(data)>& subcell_mesh, size_t number_of_ghost_zones, \
-      const DirectionalIdMap<                                                \
-          GET_DIM(data), std::optional<intrp::Irregular<GET_DIM(data)>>>&);
-
-GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
-
-#undef INSTANTIATION
-
 #define GET_INSERT(data) BOOST_PP_TUPLE_ELEM(1, data)
 
-#define INSTANTIATION(r, data)                                               \
-  template void insert_or_update_neighbor_volume_data<GET_INSERT(data)>(     \
-      gsl::not_null<DirectionalIdMap<GET_DIM(data), GhostData>*>             \
-          ghost_data_ptr,                                                    \
-      const DataVector& received_neighbor_subcell_data,                      \
-      size_t number_of_rdmp_vars_in_buffer,                                  \
-      const DirectionalId<GET_DIM(data)>& directional_element_id,            \
-      const Mesh<GET_DIM(data)>& neighbor_mesh,                              \
-      const Element<GET_DIM(data)>& element,                                 \
-      const Mesh<GET_DIM(data)>& subcell_mesh, size_t number_of_ghost_zones, \
-      const DirectionalIdMap<                                                \
-          GET_DIM(data), std::optional<intrp::Irregular<GET_DIM(data)>>>&);
+#define INSTANTIATION(r, data)                                                \
+  template void insert_or_update_neighbor_volume_data_impl<GET_INSERT(data)>( \
+      gsl::not_null<DirectionalIdMap<GET_DIM(data), GhostData>*>              \
+          ghost_data_ptr,                                                     \
+      const DataVector& neighbor_subcell_data,                                \
+      size_t number_of_rdmp_vars_in_buffer,                                   \
+      const DirectionalId<GET_DIM(data)>& directional_element_id,             \
+      const Mesh<GET_DIM(data)>& neighbor_mesh,                               \
+      const Element<GET_DIM(data)>& element,                                  \
+      const Mesh<GET_DIM(data)>& subcell_mesh, size_t number_of_ghost_zones,  \
+      const DirectionalIdMap<GET_DIM(data),                                   \
+                             std::optional<intrp::Irregular<GET_DIM(data)>>>& \
+          neighbor_dg_to_fd_interpolants,                                     \
+      gsl::span<const size_t> parity_list, size_t num_even, size_t num_odd);
 
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3), (true, false))
 
 #undef INSTANTIATION
+#undef GET_INSERT
 #undef GET_DIM
-}  // namespace evolution::dg::subcell
+}  // namespace evolution::dg::subcell::detail

--- a/src/Evolution/DgSubcell/NeighborRdmpAndVolumeData.hpp
+++ b/src/Evolution/DgSubcell/NeighborRdmpAndVolumeData.hpp
@@ -3,18 +3,20 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cstddef>
-#include <utility>
+#include <optional>
 
 #include "DataStructures/DataVector.hpp"
-#include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/DirectionalId.hpp"
 #include "Domain/Structure/DirectionalIdMap.hpp"
 #include "Domain/Structure/ElementId.hpp"
 #include "Evolution/DgSubcell/GhostData.hpp"
 #include "Evolution/DgSubcell/RdmpTciData.hpp"
 #include "NumericalAlgorithms/Interpolation/IrregularInterpolant.hpp"
+#include "NumericalAlgorithms/Spectral/ParityFromSymmetry.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
 
 /// \cond
 template <size_t Dim>
@@ -22,6 +24,31 @@ class Element;
 template <size_t Dim>
 class Mesh;
 /// \endcond
+
+namespace evolution::dg::subcell::detail {
+/*!
+ * \brief Implementation of insert_or_update_neighbor_volume_data, accepting
+ * parity information as runtime arguments so the caller can be a thin
+ * template wrapper without needing VolumeFields in the function body.
+ *
+ * The impl-unique parameters are specifically for a ZernikeB1 basis:
+ * - **`parity_list`** Run-length encoded even/odd parity of each component
+ * (ignored when Dim != 3 or when the mesh is not ZernikeB1).
+ * - **`num_even`** Number of even-parity components (0 when unused).
+ * - **`num_odd`** Number of odd-parity components (0 when unused).
+ */
+template <bool InsertIntoMap, size_t Dim>
+void insert_or_update_neighbor_volume_data_impl(
+    gsl::not_null<DirectionalIdMap<Dim, GhostData>*> ghost_data_ptr,
+    const DataVector& neighbor_subcell_data,
+    size_t number_of_rdmp_vars_in_buffer,
+    const DirectionalId<Dim>& directional_element_id,
+    const Mesh<Dim>& neighbor_mesh, const Element<Dim>& element,
+    const Mesh<Dim>& subcell_mesh, size_t number_of_ghost_zones,
+    const DirectionalIdMap<Dim, std::optional<intrp::Irregular<Dim>>>&
+        neighbor_dg_to_fd_interpolants,
+    gsl::span<const size_t> parity_list, size_t num_even, size_t num_odd);
+}  // namespace evolution::dg::subcell::detail
 
 namespace evolution::dg::subcell {
 /*!
@@ -31,33 +58,84 @@ namespace evolution::dg::subcell {
  *
  * This is intended to be used during a rollback from DG to make sure neighbor
  * data is projected to the FD grid.
+ *
+ * The `VolumeFields` meta parameter is the tag list (a `tmpl::list`) of the
+ * packed ghost DataVector so that per-component parity information can be
+ * deduced for ZernikeB1 meshes.
  */
-template <bool InsertIntoMap, size_t Dim>
+template <bool InsertIntoMap, size_t Dim, typename VolumeFields>
 void insert_or_update_neighbor_volume_data(
-    gsl::not_null<DirectionalIdMap<Dim, GhostData>*> ghost_data_ptr,
+    const gsl::not_null<DirectionalIdMap<Dim, GhostData>*> ghost_data_ptr,
     const DataVector& neighbor_subcell_data,
     const size_t number_of_rdmp_vars_in_buffer,
     const DirectionalId<Dim>& directional_element_id,
     const Mesh<Dim>& neighbor_mesh, const Element<Dim>& element,
-    const Mesh<Dim>& subcell_mesh, size_t number_of_ghost_zones,
+    const Mesh<Dim>& subcell_mesh, const size_t number_of_ghost_zones,
     const DirectionalIdMap<Dim, std::optional<intrp::Irregular<Dim>>>&
-        Neighbor_dg_to_fd_interpolants);
+        neighbor_dg_to_fd_interpolants,
+    VolumeFields /*meta*/) {
+  if constexpr (Dim == 3) {
+    const auto parity_info = Spectral::compute_parity_list<VolumeFields>();
+    const auto& parity_list = std::get<0>(parity_info);
+    detail::insert_or_update_neighbor_volume_data_impl<InsertIntoMap, Dim>(
+        ghost_data_ptr, neighbor_subcell_data, number_of_rdmp_vars_in_buffer,
+        directional_element_id, neighbor_mesh, element, subcell_mesh,
+        number_of_ghost_zones, neighbor_dg_to_fd_interpolants,
+        gsl::span<const size_t>{parity_list.data(), parity_list.size()},
+        std::get<1>(parity_info), std::get<2>(parity_info));
+  } else {
+    detail::insert_or_update_neighbor_volume_data_impl<InsertIntoMap, Dim>(
+        ghost_data_ptr, neighbor_subcell_data, number_of_rdmp_vars_in_buffer,
+        directional_element_id, neighbor_mesh, element, subcell_mesh,
+        number_of_ghost_zones, neighbor_dg_to_fd_interpolants, {}, 0, 0);
+  }
+}
 
 /*!
  * \brief Check whether the neighbor sent is DG volume or FD ghost data, and
  * orient project DG volume data if necessary.
  *
  * This is intended to be used by the `ReceiveDataForReconstruction` action.
+ *
+ * The `VolumeFields` parameter is the tag list (a `tmpl::list`) of the
+ * packed ghost DataVector so that per-component parity information can be
+ * deduced for ZernikeB1 meshes.
  */
-template <size_t Dim>
+template <size_t Dim, typename VolumeFields>
 void insert_neighbor_rdmp_and_volume_data(
-    gsl::not_null<RdmpTciData*> rdmp_tci_data_ptr,
-    gsl::not_null<DirectionalIdMap<Dim, GhostData>*> ghost_data_ptr,
+    const gsl::not_null<RdmpTciData*> rdmp_tci_data_ptr,
+    const gsl::not_null<DirectionalIdMap<Dim, GhostData>*> ghost_data_ptr,
     const DataVector& received_neighbor_subcell_data,
-    size_t number_of_rdmp_vars,
+    const size_t number_of_rdmp_vars,
     const DirectionalId<Dim>& directional_element_id,
     const Mesh<Dim>& neighbor_mesh, const Element<Dim>& element,
-    const Mesh<Dim>& subcell_mesh, size_t number_of_ghost_zones,
+    const Mesh<Dim>& subcell_mesh, const size_t number_of_ghost_zones,
     const DirectionalIdMap<Dim, std::optional<intrp::Irregular<Dim>>>&
-        neighbor_dg_to_fd_interpolants);
+        neighbor_dg_to_fd_interpolants,
+    VolumeFields volume_fields) {
+  ASSERT(received_neighbor_subcell_data.size() != 0,
+         "received_neighbor_subcell_data must be non-empty");
+  // Note: since we determine the starting point of the RDMP vars
+  // from how many RDMP vars there are, we don't need to account for
+  // the mesh the neighbor sent (DG or FD)
+  const size_t max_offset =
+      received_neighbor_subcell_data.size() - 2 * number_of_rdmp_vars;
+  const size_t min_offset =
+      received_neighbor_subcell_data.size() - number_of_rdmp_vars;
+  for (size_t var_index = 0; var_index < number_of_rdmp_vars; ++var_index) {
+    rdmp_tci_data_ptr->max_variables_values[var_index] =
+        std::max(rdmp_tci_data_ptr->max_variables_values[var_index],
+                 received_neighbor_subcell_data[max_offset + var_index]);
+    rdmp_tci_data_ptr->min_variables_values[var_index] =
+        std::min(rdmp_tci_data_ptr->min_variables_values[var_index],
+                 received_neighbor_subcell_data[min_offset + var_index]);
+  }
+  // Note: it would be good to assert that the neighbor is at the same
+  // refinement level as us, but such a function does not yet exist.
+
+  insert_or_update_neighbor_volume_data<true>(
+      ghost_data_ptr, received_neighbor_subcell_data, number_of_rdmp_vars,
+      directional_element_id, neighbor_mesh, element, subcell_mesh,
+      number_of_ghost_zones, neighbor_dg_to_fd_interpolants, volume_fields);
+}
 }  // namespace evolution::dg::subcell

--- a/src/Evolution/DgSubcell/PrepareNeighborData.hpp
+++ b/src/Evolution/DgSubcell/PrepareNeighborData.hpp
@@ -142,7 +142,9 @@ void prepare_neighbor_data(
     make_const_view(make_not_null(&data_to_project), ghost_variables, 0,
                     ghost_variables.size() - rdmp_size);
     const DataVector projected_data = evolution::dg::subcell::fd::project(
-        data_to_project, dg_mesh, subcell_mesh.extents());
+        data_to_project, dg_mesh, subcell_mesh.extents(),
+        typename Metavariables::SubcellOptions::GhostVariables::
+            ghost_variables_tag_list{});
     typename evolution::dg::subcell::Tags::InterpolatorsFromFdToNeighborFd<
         Dim>::type directions_not_to_slice{};
     for (const auto& [directional_element_id, _] :

--- a/src/Evolution/DgSubcell/Projection.cpp
+++ b/src/Evolution/DgSubcell/Projection.cpp
@@ -9,7 +9,9 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Matrix.hpp"
 #include "Evolution/DgSubcell/Matrices.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Parity.hpp"
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
 #include "Utilities/Blas.hpp"
 #include "Utilities/ContainerHelpers.hpp"
@@ -22,13 +24,14 @@ namespace detail {
 template <size_t Dim>
 void project_impl(gsl::span<double> subcell_u,
                   const gsl::span<const double> dg_u, const Mesh<Dim>& dg_mesh,
-                  const Index<Dim>& subcell_extents) {
+                  const Index<Dim>& subcell_extents,
+                  const Spectral::Parity parity) {
   const Matrix empty{};
   auto projection_mat = make_array<Dim>(std::cref(empty));
   for (size_t d = 0; d < Dim; d++) {
     gsl::at(projection_mat, d) = std::cref(
         projection_matrix(dg_mesh.slice_through(d), subcell_extents[d],
-                          Spectral::Quadrature::CellCentered));
+                          Spectral::Quadrature::CellCentered, parity));
   }
   DataVector result{subcell_u.data(), subcell_u.size()};
   // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
@@ -44,18 +47,26 @@ void project_to_faces_impl(gsl::span<double> subcell_u,
                            const gsl::span<const double> dg_u,
                            const Mesh<Dim>& dg_mesh,
                            const Index<Dim>& subcell_extents,
-                           const size_t& face_direction) {
+                           const size_t& face_direction,
+                           const Spectral::Parity parity) {
+  if constexpr (Dim == 3) {
+    if (dg_mesh.basis(0) == Spectral::Basis::ZernikeB1) {
+      ASSERT(dg_mesh.basis(2) == Spectral::Basis::Cartoon,
+             "ZernikeB1 basis should only be used with Cartoon bases, got "
+                 << dg_mesh.basis());
+    }
+  }
   const Matrix empty{};
   auto projection_mat = make_array<Dim>(std::cref(empty));
   for (size_t d = 0; d < Dim; d++) {
     if (d == face_direction) {
       gsl::at(projection_mat, d) = std::cref(
           projection_matrix(dg_mesh.slice_through(d), subcell_extents[d],
-                            Spectral::Quadrature::FaceCentered));
+                            Spectral::Quadrature::FaceCentered, parity));
     } else {
       gsl::at(projection_mat, d) = std::cref(
           projection_matrix(dg_mesh.slice_through(d), subcell_extents[d],
-                            Spectral::Quadrature::CellCentered));
+                            Spectral::Quadrature::CellCentered, parity));
     }
   }
   DataVector result{subcell_u.data(), subcell_u.size()};
@@ -67,27 +78,34 @@ void project_to_faces_impl(gsl::span<double> subcell_u,
 
 template <size_t Dim>
 void project(const gsl::not_null<DataVector*> subcell_u, const DataVector& dg_u,
-             const Mesh<Dim>& dg_mesh, const Index<Dim>& subcell_extents) {
+             const Mesh<Dim>& dg_mesh, const Index<Dim>& subcell_extents,
+             const Spectral::Parity parity) {
   ASSERT(dg_u.size() % dg_mesh.number_of_grid_points() == 0,
          "The vector dg_u must have size that is a multiple of the number of "
          "grid points "
              << dg_mesh.number_of_grid_points() << " but got " << dg_u.size());
+  ASSERT(
+      parity == Spectral::Parity::Uninitialized or
+          dg_u.size() == dg_mesh.number_of_grid_points(),
+      "Trying to use the DataVector version of project() but passing more than "
+      "one component of a tensor. Must pass the types as a template");
   subcell_u->destructive_resize(subcell_extents.product() * dg_u.size() /
                                 dg_mesh.number_of_grid_points());
   detail::project_impl(gsl::span<double>{subcell_u->data(), subcell_u->size()},
                        gsl::span<const double>{dg_u.data(), dg_u.size()},
-                       dg_mesh, subcell_extents);
+                       dg_mesh, subcell_extents, parity);
 }
 
 template <size_t Dim>
 DataVector project(const DataVector& dg_u, const Mesh<Dim>& dg_mesh,
-                   const Index<Dim>& subcell_extents) {
+                   const Index<Dim>& subcell_extents,
+                   const Spectral::Parity parity) {
   ASSERT(dg_u.size() % dg_mesh.number_of_grid_points() == 0,
          "The vector dg_u must have size that is a multiple of the number of "
          "grid points "
              << dg_mesh.number_of_grid_points() << " but got " << dg_u.size());
   DataVector subcell_u{};
-  project(&subcell_u, dg_u, dg_mesh, subcell_extents);
+  project(&subcell_u, dg_u, dg_mesh, subcell_extents, parity);
   return subcell_u;
 }
 
@@ -95,7 +113,8 @@ template <size_t Dim>
 void project_to_faces(const gsl::not_null<DataVector*> subcell_u,
                       const DataVector& dg_u, const Mesh<Dim>& dg_mesh,
                       const Index<Dim>& subcell_extents,
-                      const size_t& face_direction) {
+                      const size_t& face_direction,
+                      const Spectral::Parity parity) {
   ASSERT(dg_u.size() % dg_mesh.number_of_grid_points() == 0,
          "The vector dg_u must have size that is a multiple of the number of "
          "grid points "
@@ -105,19 +124,21 @@ void project_to_faces(const gsl::not_null<DataVector*> subcell_u,
   detail::project_to_faces_impl(
       gsl::span<double>{subcell_u->data(), subcell_u->size()},
       gsl::span<const double>{dg_u.data(), dg_u.size()}, dg_mesh,
-      subcell_extents, face_direction);
+      subcell_extents, face_direction, parity);
 }
 
 template <size_t Dim>
 DataVector project_to_faces(const DataVector& dg_u, const Mesh<Dim>& dg_mesh,
                             const Index<Dim>& subcell_extents,
-                            const size_t& face_direction) {
+                            const size_t& face_direction,
+                            const Spectral::Parity parity) {
   ASSERT(dg_u.size() % dg_mesh.number_of_grid_points() == 0,
          "The vector dg_u must have size that is a multiple of the number of "
          "grid points "
              << dg_mesh.number_of_grid_points() << " but got " << dg_u.size());
   DataVector subcell_u{};
-  project_to_faces(&subcell_u, dg_u, dg_mesh, subcell_extents, face_direction);
+  project_to_faces(&subcell_u, dg_u, dg_mesh, subcell_extents, face_direction,
+                   parity);
   return subcell_u;
 }
 
@@ -125,23 +146,25 @@ DataVector project_to_faces(const DataVector& dg_u, const Mesh<Dim>& dg_mesh,
 
 #define INSTANTIATION(r, data)                                                 \
   template DataVector project(const DataVector&, const Mesh<DIM(data)>&,       \
-                              const Index<DIM(data)>&);                        \
+                              const Index<DIM(data)>&,                         \
+                              const Spectral::Parity parity);                  \
   template void project(gsl::not_null<DataVector*>, const DataVector&,         \
-                        const Mesh<DIM(data)>&, const Index<DIM(data)>&);      \
-  template void detail::project_impl(gsl::span<double> subcell_u,              \
-                                     const gsl::span<const double> dg_u,       \
-                                     const Mesh<DIM(data)>& dg_mesh,           \
-                                     const Index<DIM(data)>& subcell_extents); \
+                        const Mesh<DIM(data)>&, const Index<DIM(data)>&,       \
+                        const Spectral::Parity parity);                        \
+  template void detail::project_impl(                                          \
+      gsl::span<double> subcell_u, const gsl::span<const double> dg_u,         \
+      const Mesh<DIM(data)>& dg_mesh, const Index<DIM(data)>& subcell_extents, \
+      const Spectral::Parity parity);                                          \
   template DataVector project_to_faces(                                        \
       const DataVector&, const Mesh<DIM(data)>&, const Index<DIM(data)>&,      \
-      const size_t&);                                                          \
-  template void project_to_faces(gsl::not_null<DataVector*>,                   \
-                                 const DataVector&, const Mesh<DIM(data)>&,    \
-                                 const Index<DIM(data)>&, const size_t&);      \
+      const size_t&, const Spectral::Parity parity);                           \
+  template void project_to_faces(                                              \
+      gsl::not_null<DataVector*>, const DataVector&, const Mesh<DIM(data)>&,   \
+      const Index<DIM(data)>&, const size_t&, const Spectral::Parity parity);  \
   template void detail::project_to_faces_impl(                                 \
       gsl::span<double> subcell_u, const gsl::span<const double> dg_u,         \
       const Mesh<DIM(data)>& dg_mesh, const Index<DIM(data)>& subcell_extents, \
-      const size_t& face_direction);
+      const size_t& face_direction, const Spectral::Parity parity);
 
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 

--- a/src/Evolution/DgSubcell/Projection.hpp
+++ b/src/Evolution/DgSubcell/Projection.hpp
@@ -3,16 +3,21 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cstddef>
 
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
+#include "DataStructures/DataVector.hpp"
 #include "DataStructures/Variables.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/Parity.hpp"
+#include "NumericalAlgorithms/Spectral/ParityFromSymmetry.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/MemoryHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
-class DataVector;
 template <size_t>
 class Index;
 template <size_t>
@@ -23,13 +28,124 @@ namespace evolution::dg::subcell::fd {
 namespace detail {
 template <size_t Dim>
 void project_impl(gsl::span<double> subcell_u, gsl::span<const double> dg_u,
-                  const Mesh<Dim>& dg_mesh, const Index<Dim>& subcell_extents);
+                  const Mesh<Dim>& dg_mesh, const Index<Dim>& subcell_extents,
+                  Spectral::Parity parity);
 template <size_t Dim>
 void project_to_faces_impl(gsl::span<double> subcell_u,
                            gsl::span<const double> dg_u,
                            const Mesh<Dim>& dg_mesh,
                            const Index<Dim>& subcell_extents,
-                           const size_t& face_direction);
+                           const size_t& face_direction,
+                           Spectral::Parity parity);
+
+/*!
+ * \brief Project `dg_u` onto the subcell grid, sorting even- and odd-parity
+ * components into separate batches when a ZernikeB1 basis is present.
+ *
+ * For non-ZernikeB1 meshes this falls through to the default implementation.
+ * The `TagList` must be the full Variables tag list.
+ */
+template <typename TagList, size_t Dim>
+void project_impl_with_tag_list(gsl::span<double> subcell_u,
+                                gsl::span<const double> dg_u,
+                                const Mesh<Dim>& dg_mesh,
+                                const Index<Dim>& subcell_extents) {
+  if (dg_mesh.basis(0) == Spectral::Basis::ZernikeB1) {
+    ASSERT(Variables<TagList>::number_of_independent_components *
+                   dg_mesh.number_of_grid_points() ==
+               dg_u.size(),
+           "Passed TagList does not have the same components, "
+               << Variables<TagList>::number_of_independent_components
+               << ", as dg_u holds, "
+               << dg_u.size() / dg_mesh.number_of_grid_points());
+    constexpr auto parity_info = Spectral::compute_parity_list<TagList>();
+    constexpr auto parity_list = std::get<0>(parity_info);
+    constexpr size_t num_even = std::get<1>(parity_info);
+    constexpr size_t num_odd = std::get<2>(parity_info);
+
+    const size_t num_dg_pts = dg_mesh.number_of_grid_points();
+    const size_t num_subcell_pts = subcell_extents.product();
+
+    // NOLINTNEXTLINE(modernize-avoid-c-arrays)
+    auto buffer = cpp20::make_unique_for_overwrite<double[]>(
+        (num_even + num_odd) * (num_dg_pts + num_subcell_pts));
+    DataVector even_input{&buffer[0], num_even * num_dg_pts};
+    DataVector odd_input(&buffer[num_even * num_dg_pts], num_odd * num_dg_pts);
+    DataVector even_output(&buffer[(num_even + num_odd) * num_dg_pts],
+                           num_even * num_subcell_pts);
+    DataVector odd_output(
+        &buffer[(num_even + num_odd) * num_dg_pts + num_even * num_subcell_pts],
+        num_odd * num_subcell_pts);
+
+    // Sort input components into even/odd parity buffers
+    const double* p_in = dg_u.data();
+    double* p_even_in = even_input.data();
+    double* p_odd_in = odd_input.data();
+    bool is_even = true;
+    for (const size_t seg_size : parity_list) {
+      if (seg_size == 0) {
+        if (is_even) {
+          is_even = false;
+          continue;
+        } else {
+          break;
+        }
+      }
+      if (is_even) {
+        std::copy(p_in, p_in + seg_size * num_dg_pts, p_even_in);  // NOLINT
+        p_even_in += seg_size * num_dg_pts;                        // NOLINT
+      } else {
+        std::copy(p_in, p_in + seg_size * num_dg_pts, p_odd_in);  // NOLINT
+        p_odd_in += seg_size * num_dg_pts;                        // NOLINT
+      }
+      p_in += seg_size * num_dg_pts;  // NOLINT
+      is_even = not is_even;
+    }
+
+    // Project each parity batch with the appropriate projection matrix
+    if constexpr (num_even > 0) {
+      project_impl(
+          gsl::span<double>{even_output.data(), even_output.size()},
+          gsl::span<const double>{even_input.data(), even_input.size()},
+          dg_mesh, subcell_extents, Spectral::Parity::Even);
+    }
+    if constexpr (num_odd > 0) {
+      project_impl(gsl::span<double>{odd_output.data(), odd_output.size()},
+                   gsl::span<const double>{odd_input.data(), odd_input.size()},
+                   dg_mesh, subcell_extents, Spectral::Parity::Odd);
+    }
+
+    // Reassemble output in original component order
+    double* p_out = subcell_u.data();
+    const double* p_even_out = even_output.data();
+    const double* p_odd_out = odd_output.data();
+    is_even = true;
+    for (const size_t seg_size : parity_list) {
+      if (seg_size == 0) {
+        if (is_even) {
+          is_even = false;
+          continue;
+        } else {
+          break;
+        }
+      }
+      if (is_even) {
+        // NOLINTNEXTLINE
+        std::copy(p_even_out, p_even_out + seg_size * num_subcell_pts, p_out);
+        p_even_out += seg_size * num_subcell_pts;  // NOLINT
+      } else {
+        // NOLINTNEXTLINE
+        std::copy(p_odd_out, p_odd_out + seg_size * num_subcell_pts, p_out);
+        p_odd_out += seg_size * num_subcell_pts;  // NOLINT
+      }
+      p_out += seg_size * num_subcell_pts;  // NOLINT
+      is_even = not is_even;
+    }
+    return;
+  }
+  project_impl(subcell_u, dg_u, dg_mesh, subcell_extents,
+               Spectral::Parity::Uninitialized);
+}
 }  // namespace detail
 
 /// @{
@@ -38,17 +154,55 @@ void project_to_faces_impl(gsl::span<double> subcell_u,
  * \brief Project the variable `dg_u` onto the subcell grid with extents
  * `subcell_extents`.
  *
+ * When the DG mesh uses a ZernikeB1 basis the Variables overloads deduce
+ * per-component parity from the tag list automatically.  The raw `DataVector`
+ * overloads accepting a `Spectral::Parity` are for single-component data
+ * where the caller already knows the parity; the overloads accepting a
+ * `tmpl::list<TagList>` meta-parameter project a multi-component DataVector
+ * whose tensor-parity structure is encoded in `TagList`.
+ *
  * \note In the return-by-`gsl::not_null` with `Variables` interface, the
- * `SubcellTagList` and the `DgtagList` must be the same when all tag prefixes
+ * `SubcellTagList` and the `DgTagList` must be the same when all tag prefixes
  * are removed.
  */
 template <size_t Dim>
 DataVector project(const DataVector& dg_u, const Mesh<Dim>& dg_mesh,
-                   const Index<Dim>& subcell_extents);
+                   const Index<Dim>& subcell_extents,
+                   Spectral::Parity parity = Spectral::Parity::Uninitialized);
 
 template <size_t Dim>
 void project(gsl::not_null<DataVector*> subcell_u, const DataVector& dg_u,
-             const Mesh<Dim>& dg_mesh, const Index<Dim>& subcell_extents);
+             const Mesh<Dim>& dg_mesh, const Index<Dim>& subcell_extents,
+             Spectral::Parity parity = Spectral::Parity::Uninitialized);
+
+template <typename TagList, size_t Dim>
+void project(const gsl::not_null<DataVector*> subcell_u, const DataVector& dg_u,
+             const Mesh<Dim>& dg_mesh, const Index<Dim>& subcell_extents,
+             TagList /*meta*/) {
+  ASSERT(dg_u.size() % dg_mesh.number_of_grid_points() == 0,
+         "The vector dg_u must have size that is a multiple of the number of "
+         "grid points "
+             << dg_mesh.number_of_grid_points() << " but got " << dg_u.size());
+  subcell_u->destructive_resize(subcell_extents.product() * dg_u.size() /
+                                dg_mesh.number_of_grid_points());
+  detail::project_impl_with_tag_list<TagList>(
+      gsl::span<double>{subcell_u->data(), subcell_u->size()},
+      gsl::span<const double>{dg_u.data(), dg_u.size()}, dg_mesh,
+      subcell_extents);
+}
+
+template <typename TagList, size_t Dim>
+DataVector project(const DataVector& dg_u, const Mesh<Dim>& dg_mesh,
+                   const Index<Dim>& subcell_extents, TagList /*meta*/) {
+  ASSERT(dg_u.size() % dg_mesh.number_of_grid_points() == 0,
+         "The vector dg_u must have size that is a multiple of the number of "
+         "grid points "
+             << dg_mesh.number_of_grid_points() << " but got " << dg_u.size());
+  DataVector subcell_u(subcell_extents.product() * dg_u.size() /
+                       dg_mesh.number_of_grid_points());
+  project(make_not_null(&subcell_u), dg_u, dg_mesh, subcell_extents, TagList{});
+  return subcell_u;
+}
 
 template <typename SubcellTagList, typename DgTagList, size_t Dim>
 void project(const gsl::not_null<Variables<SubcellTagList>*> subcell_u,
@@ -70,9 +224,10 @@ void project(const gsl::not_null<Variables<SubcellTagList>*> subcell_u,
                subcell_extents.product())) {
     subcell_u->initialize(subcell_extents.product());
   }
-  detail::project_impl(gsl::span<double>{subcell_u->data(), subcell_u->size()},
-                       gsl::span<const double>{dg_u.data(), dg_u.size()},
-                       dg_mesh, subcell_extents);
+  detail::project_impl_with_tag_list<DgTagList>(
+      gsl::span<double>{subcell_u->data(), subcell_u->size()},
+      gsl::span<const double>{dg_u.data(), dg_u.size()}, dg_mesh,
+      subcell_extents);
 }
 
 template <typename TagList, size_t Dim>
@@ -87,20 +242,21 @@ Variables<TagList> project(const Variables<TagList>& dg_u,
 template <size_t Dim>
 DataVector project_to_faces(const DataVector& dg_u, const Mesh<Dim>& dg_mesh,
                             const Index<Dim>& subcell_extents,
-                            const size_t& face_direction);
+                            const size_t& face_direction,
+                            Spectral::Parity parity);
 
 template <size_t Dim>
 void project_to_faces(gsl::not_null<DataVector*> subcell_u,
                       const DataVector& dg_u, const Mesh<Dim>& dg_mesh,
                       const Index<Dim>& subcell_extents,
-                      const size_t& face_direction);
+                      const size_t& face_direction, Spectral::Parity parity);
 
 template <typename SubcellTagList, typename DgTagList, size_t Dim>
 void project_to_faces(const gsl::not_null<Variables<SubcellTagList>*> subcell_u,
                       const Variables<DgTagList>& dg_u,
                       const Mesh<Dim>& dg_mesh,
                       const Index<Dim>& subcell_extents,
-                      const size_t& face_direction) {
+                      const size_t& face_direction, Spectral::Parity parity) {
   static_assert(
       std::is_same_v<
           tmpl::transform<SubcellTagList,
@@ -120,17 +276,18 @@ void project_to_faces(const gsl::not_null<Variables<SubcellTagList>*> subcell_u,
   detail::project_to_faces_impl(
       gsl::span<double>{subcell_u->data(), subcell_u->size()},
       gsl::span<const double>{dg_u.data(), dg_u.size()}, dg_mesh,
-      subcell_extents, face_direction);
+      subcell_extents, face_direction, parity);
 }
 
 template <typename TagList, size_t Dim>
 Variables<TagList> project_to_faces(const Variables<TagList>& dg_u,
                                     const Mesh<Dim>& dg_mesh,
                                     const Index<Dim>& subcell_extents,
-                                    const size_t& face_direction) {
+                                    const size_t& face_direction,
+                                    Spectral::Parity parity) {
   Variables<TagList> subcell_u(subcell_extents.product());
   project_to_faces(make_not_null(&subcell_u), dg_u, dg_mesh, subcell_extents,
-                   face_direction);
+                   face_direction, parity);
   return subcell_u;
 }
 /// @}

--- a/src/Evolution/DgSubcell/Python/Bindings.cpp
+++ b/src/Evolution/DgSubcell/Python/Bindings.cpp
@@ -12,6 +12,7 @@
 #include "Evolution/DgSubcell/Reconstruction.hpp"
 #include "Evolution/DgSubcell/ReconstructionMethod.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Parity.hpp"
 #include "Utilities/ErrorHandling/SegfaultHandler.hpp"
 
 namespace py = pybind11;
@@ -25,10 +26,11 @@ void impl(py::module& m) {  // NOLINT
   m.def(
       "project",
       +[](const DataVector& dg_u, const Mesh<Dim>& dg_mesh,
-          const Index<Dim>& subcell_extents) {
-        return fd::project(dg_u, dg_mesh, subcell_extents);
+          const Index<Dim>& subcell_extents, const Spectral::Parity parity) {
+        return fd::project(dg_u, dg_mesh, subcell_extents, parity);
       },
-      py::arg("dg_u"), py::arg("dg_mesh"), py::arg("subcell_extents"));
+      py::arg("dg_u"), py::arg("dg_mesh"), py::arg("subcell_extents"),
+      py::arg("parity"));
   m.def(
       "reconstruct",
       +[](const DataVector& subcell_u_times_projected_det_jac,

--- a/src/Evolution/DgSubcell/Tags/ObserverMeshVelocity.cpp
+++ b/src/Evolution/DgSubcell/Tags/ObserverMeshVelocity.cpp
@@ -5,6 +5,7 @@
 
 #include "Evolution/DgSubcell/Projection.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Parity.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 
@@ -23,8 +24,9 @@ void ObserverMeshVelocityCompute<Dim>::function(
     *active_mesh_velocity = tnsr::I<DataVector, Dim, Frame::Inertial>{};
     for (size_t i = 0; i < Dim; ++i) {
       active_mesh_velocity->value().get(i) =
-          evolution::dg::subcell::fd::project(dg_mesh_velocity.value().get(i),
-                                              dg_mesh, subcell_mesh.extents());
+          evolution::dg::subcell::fd::project(
+              dg_mesh_velocity.value().get(i), dg_mesh, subcell_mesh.extents(),
+              i == 0 ? Spectral::Parity::Odd : Spectral::Parity::Even);
     }
   } else {
     *active_mesh_velocity = std::nullopt;

--- a/src/Evolution/Systems/Burgers/Subcell/GhostData.hpp
+++ b/src/Evolution/Systems/Burgers/Subcell/GhostData.hpp
@@ -26,6 +26,7 @@ namespace Burgers::subcell {
  */
 class GhostVariables {
  public:
+  using ghost_variables_tag_list = tmpl::list<Burgers::Tags::U>;
   using return_tags = tmpl::list<>;
   using argument_tags =
       tmpl::list<::Tags::Variables<tmpl::list<Burgers::Tags::U>>>;

--- a/src/Evolution/Systems/Ccz4/FiniteDifference/GhostData.hpp
+++ b/src/Evolution/Systems/Ccz4/FiniteDifference/GhostData.hpp
@@ -22,6 +22,7 @@ namespace Ccz4::fd {
  */
 class GhostVariables {
  public:
+  using ghost_variables_tag_list = Ccz4::fd::System::variables_tag_list;
   using return_tags = tmpl::list<>;
   using argument_tags =
       tmpl::list<::Tags::Variables<Ccz4::fd::System::variables_tag_list>>;

--- a/src/Evolution/Systems/ForceFree/Subcell/GhostData.hpp
+++ b/src/Evolution/Systems/ForceFree/Subcell/GhostData.hpp
@@ -35,6 +35,9 @@ class GhostVariables {
                  ForceFree::Tags::TildeQ>;
 
  public:
+  // TildeJ is prepended to evolved_vars in the packed DataVector (see .cpp)
+  using ghost_variables_tag_list =
+      tmpl::push_front<evolved_vars, ForceFree::Tags::TildeJ>;
   using return_tags = tmpl::list<>;
   using argument_tags =
       tmpl::list<::Tags::Variables<evolved_vars>, ForceFree::Tags::TildeJ>;

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/NeighborPackagedData.cpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/NeighborPackagedData.cpp
@@ -195,7 +195,8 @@ DirectionalIdMap<3, DataVector> NeighborPackagedData<System>::apply(
               evolution::dg::subcell::fd::project(
                   make_not_null(&mesh_velocity_on_subcell_face.value().get(i)),
                   mesh_velocity_on_dg_face.get(i), dg_face_mesh,
-                  subcell_face_extents);
+                  subcell_face_extents,
+                  i == 0 ? Spectral::Parity::Odd : Spectral::Parity::Even);
             }
           }
 
@@ -242,7 +243,8 @@ DirectionalIdMap<3, DataVector> NeighborPackagedData<System>::apply(
             evolution::dg::subcell::fd::project(
                 make_not_null(
                     &get(get<gh::Tags::ConstraintGamma1>(vars_on_face))),
-                get(gamma_on_dg_face), dg_face_mesh, subcell_face_extents);
+                get(gamma_on_dg_face), dg_face_mesh, subcell_face_extents,
+                Spectral::Parity::Even);
             data_on_slice(make_not_null(&gamma_on_dg_face),
                           get<gh::Tags::ConstraintGamma2>(box),
                           dg_mesh.extents(), direction.dimension(),
@@ -252,7 +254,8 @@ DirectionalIdMap<3, DataVector> NeighborPackagedData<System>::apply(
             evolution::dg::subcell::fd::project(
                 make_not_null(
                     &get(get<gh::Tags::ConstraintGamma2>(vars_on_face))),
-                get(gamma_on_dg_face), dg_face_mesh, subcell_face_extents);
+                get(gamma_on_dg_face), dg_face_mesh, subcell_face_extents,
+                Spectral::Parity::Even);
           }
 
           // Compute the neighbor's normal covector and normalize it.
@@ -271,7 +274,8 @@ DirectionalIdMap<3, DataVector> NeighborPackagedData<System>::apply(
                 normal_covector.get(i),
                 dg_mesh.slice_away(mortar_id.direction().dimension()),
                 subcell_mesh.extents().slice_away(
-                    mortar_id.direction().dimension()));
+                    mortar_id.direction().dimension()),
+                i == 0 ? Spectral::Parity::Odd : Spectral::Parity::Even);
           }
           // Need to renormalize the normal vector with the neighbor's
           // inverse spatial metric.

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/PrimitiveGhostData.cpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/PrimitiveGhostData.cpp
@@ -19,9 +19,10 @@ DataVector PrimitiveGhostVariables::apply(
     const size_t rdmp_size) {
   DataVector buffer{
       prims.number_of_grid_points() *
-          Variables<tags_for_reconstruction>::number_of_independent_components +
+          Variables<
+              ghost_variables_tag_list>::number_of_independent_components +
       rdmp_size};
-  Variables<tags_for_reconstruction> vars_to_reconstruct(
+  Variables<ghost_variables_tag_list> vars_to_reconstruct(
       buffer.data(), buffer.size() - rdmp_size);
   get<hydro::Tags::RestMassDensity<DataVector>>(vars_to_reconstruct) =
       get<hydro::Tags::RestMassDensity<DataVector>>(prims);

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/PrimitiveGhostData.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/PrimitiveGhostData.hpp
@@ -35,11 +35,9 @@ namespace grmhd::GhValenciaDivClean::subcell {
  * \note Only called on elements using FD.
  */
 class PrimitiveGhostVariables {
- private:
-  using tags_for_reconstruction = GhValenciaDivClean::Tags::
-      primitive_grmhd_and_spacetime_reconstruction_tags;
-
  public:
+  using ghost_variables_tag_list = GhValenciaDivClean::Tags::
+      primitive_grmhd_and_spacetime_reconstruction_tags;
   using return_tags = tmpl::list<>;
   using argument_tags =
       tmpl::list<::Tags::Variables<hydro::grmhd_tags<DataVector>>,

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/PrimsAfterRollback.cpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/PrimsAfterRollback.cpp
@@ -49,7 +49,8 @@ void PrimsAfterRollback<OrderedListOfRecoverySchemes>::apply(
     prim_vars->initialize(num_grid_points);
     evolution::dg::subcell::fd::project(
         make_not_null(&get(get<hydro::Tags::Pressure<DataVector>>(*prim_vars))),
-        get(dg_pressure), dg_mesh, subcell_mesh.extents());
+        get(dg_pressure), dg_mesh, subcell_mesh.extents(),
+        Spectral::Parity::Even);
 
     // Compute the spatial metric, inverse spatial metric, and sqrt{det{spatial
     // metric}} on the subcells since we need these for the prim recovery.

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/TimeDerivative.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/TimeDerivative.hpp
@@ -52,6 +52,7 @@
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/TimeDerivativeTerms.hpp"
 #include "NumericalAlgorithms/FiniteDifference/PartialDerivatives.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Parity.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/DerivSpatialMetric.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/ExtrinsicCurvature.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpatialDerivOfLapse.hpp"
@@ -171,9 +172,10 @@ struct ComputeTimeDerivImpl<
           subcell_mesh.number_of_grid_points()};
       for (size_t i = 0; i < 3; i++) {
         mesh_velocity_subcell.value().get(i) =
-            evolution::dg::subcell::fd::project(mesh_velocity_dg.value().get(i),
-                                                dg_mesh,
-                                                subcell_mesh.extents());
+            evolution::dg::subcell::fd::project(
+                mesh_velocity_dg.value().get(i), dg_mesh,
+                subcell_mesh.extents(),
+                i == 0 ? Spectral::Parity::Odd : Spectral::Parity::Even);
       }
     }
 
@@ -312,7 +314,7 @@ struct ComputeTimeDerivImpl<
       const DataVector div_mesh_velocity_subcell =
           evolution::dg::subcell::fd::project(
               div_mesh_velocity_dg.value().get(), dg_mesh,
-              subcell_mesh.extents());
+              subcell_mesh.extents(), Spectral::Parity::Even);
       tmpl::for_each<tmpl::list<GrmhdDtTags...>>(
           [&dt_vars_ptr, &div_mesh_velocity_subcell,
            &evolved_vars](auto evolved_var_tag_v) {
@@ -673,7 +675,9 @@ struct TimeDerivative {
                 mesh_velocity_on_face.value().get(j) =
                     evolution::dg::subcell::fd::project_to_faces(
                         mesh_velocity_dg.value().get(j), dg_mesh,
-                        face_mesh_extents, i);
+                        face_mesh_extents, i,
+                        j == 0 ? Spectral::Parity::Odd
+                               : Spectral::Parity::Even);
               }
 
               tmpl::for_each<grmhd_evolved_vars_tags>(
@@ -725,11 +729,14 @@ struct TimeDerivative {
             for (size_t j = 0; j < 3; j++) {
               lower_outward_conormal.get(j) =
                   evolution::dg::subcell::fd::project_to_faces(
-                      inv_jacobian_dg.get(i, j), dg_mesh, face_mesh_extents, i);
+                      inv_jacobian_dg.get(i, j), dg_mesh, face_mesh_extents, i,
+                      (i == 0) != (j == 0) ? Spectral::Parity::Odd
+                                           : Spectral::Parity::Even);
             }
             const auto det_inv_jacobian_face =
                 evolution::dg::subcell::fd::project_to_faces(
-                    get(det_inv_jacobian_dg), dg_mesh, face_mesh_extents, i);
+                    get(det_inv_jacobian_dg), dg_mesh, face_mesh_extents, i,
+                    Spectral::Parity::Even);
 
             const Scalar<DataVector> normalization{sqrt(get(
                 dot_product(lower_outward_conormal, lower_outward_conormal,

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/NeighborPackagedData.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/NeighborPackagedData.cpp
@@ -42,6 +42,7 @@
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/ComputeFluxes.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Parity.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/EquationOfState.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"
@@ -180,7 +181,8 @@ DirectionalIdMap<3, DataVector> NeighborPackagedData::apply(
             evolution::dg::subcell::fd::project(
                 make_not_null(&mesh_velocity_on_subcell_face.value().get(i)),
                 mesh_velocity_on_dg_face.get(i), dg_face_mesh,
-                subcell_face_extents);
+                subcell_face_extents,
+                i == 0 ? Spectral::Parity::Odd : Spectral::Parity::Even);
           }
         }
 
@@ -232,7 +234,8 @@ DirectionalIdMap<3, DataVector> NeighborPackagedData::apply(
               dg_normal_covector.get(i),
               dg_mesh.slice_away(mortar_id.direction().dimension()),
               subcell_mesh.extents().slice_away(
-                  mortar_id.direction().dimension()));
+                  mortar_id.direction().dimension()),
+              i == 0 ? Spectral::Parity::Odd : Spectral::Parity::Even);
         }
 
         // Compute the packaged data

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/PrimitiveGhostData.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/PrimitiveGhostData.hpp
@@ -38,6 +38,7 @@ class PrimitiveGhostVariables {
                  hydro::Tags::DivergenceCleaningField<DataVector>>;
 
  public:
+  using ghost_variables_tag_list = prims_to_reconstruct_tags;
   using return_tags = tmpl::list<>;
   using argument_tags =
       tmpl::list<::Tags::Variables<hydro::grmhd_tags<DataVector>>>;

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/PrimsAfterRollback.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/PrimsAfterRollback.cpp
@@ -47,7 +47,8 @@ void PrimsAfterRollback<OrderedListOfRecoverySchemes>::apply(
     prim_vars->initialize(num_grid_points);
     evolution::dg::subcell::fd::project(
         make_not_null(&get(get<hydro::Tags::Pressure<DataVector>>(*prim_vars))),
-        get(dg_pressure), dg_mesh, subcell_mesh.extents());
+        get(dg_pressure), dg_mesh, subcell_mesh.extents(),
+        Spectral::Parity::Even);
 
     grmhd::ValenciaDivClean::
         PrimitiveFromConservative<OrderedListOfRecoverySchemes, true>::apply(

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/SetInitialRdmpData.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/SetInitialRdmpData.cpp
@@ -35,13 +35,15 @@ void SetInitialRdmpData::apply(
   } else {
     const Scalar<DataVector> tilde_b_magnitude = magnitude(tilde_b);
     const auto subcell_tilde_b_mag = evolution::dg::subcell::fd::project(
-        get(tilde_b_magnitude), dg_mesh, subcell_mesh.extents());
+        get(tilde_b_magnitude), dg_mesh, subcell_mesh.extents(),
+        Spectral::Parity::Even);
     const auto subcell_tilde_d = evolution::dg::subcell::fd::project(
-        get(tilde_d), dg_mesh, subcell_mesh.extents());
+        get(tilde_d), dg_mesh, subcell_mesh.extents(), Spectral::Parity::Even);
     const auto subcell_tilde_ye = evolution::dg::subcell::fd::project(
-        get(tilde_ye), dg_mesh, subcell_mesh.extents());
+        get(tilde_ye), dg_mesh, subcell_mesh.extents(), Spectral::Parity::Even);
     const auto subcell_tilde_tau = evolution::dg::subcell::fd::project(
-        get(tilde_tau), dg_mesh, subcell_mesh.extents());
+        get(tilde_tau), dg_mesh, subcell_mesh.extents(),
+        Spectral::Parity::Even);
 
     using std::max;
     using std::min;

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnDgGrid.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnDgGrid.cpp
@@ -68,30 +68,30 @@ TciOnDgGrid<RecoveryScheme>::apply(
       };
   Scalar<DataVector> subcell_tilde_d{};
   assign_data(make_not_null(&subcell_tilde_d), num_subcell_pts);
-  evolution::dg::subcell::fd::project(make_not_null(&get(subcell_tilde_d)),
-                                      get(tilde_d), dg_mesh,
-                                      subcell_mesh.extents());
+  evolution::dg::subcell::fd::project(
+      make_not_null(&get(subcell_tilde_d)), get(tilde_d), dg_mesh,
+      subcell_mesh.extents(), Spectral::Parity::Even);
 
   Scalar<DataVector> subcell_tilde_ye{};
   assign_data(make_not_null(&subcell_tilde_ye), num_subcell_pts);
-  evolution::dg::subcell::fd::project(make_not_null(&get(subcell_tilde_ye)),
-                                      get(tilde_ye), dg_mesh,
-                                      subcell_mesh.extents());
+  evolution::dg::subcell::fd::project(
+      make_not_null(&get(subcell_tilde_ye)), get(tilde_ye), dg_mesh,
+      subcell_mesh.extents(), Spectral::Parity::Even);
 
   Scalar<DataVector> subcell_tilde_tau{};
   assign_data(make_not_null(&subcell_tilde_tau), num_subcell_pts);
-  evolution::dg::subcell::fd::project(make_not_null(&get(subcell_tilde_tau)),
-                                      get(tilde_tau), dg_mesh,
-                                      subcell_mesh.extents());
+  evolution::dg::subcell::fd::project(
+      make_not_null(&get(subcell_tilde_tau)), get(tilde_tau), dg_mesh,
+      subcell_mesh.extents(), Spectral::Parity::Even);
 
   Scalar<DataVector> mag_tilde_b{};
   assign_data(make_not_null(&mag_tilde_b), num_dg_pts);
   magnitude(make_not_null(&mag_tilde_b), tilde_b);
   Scalar<DataVector> subcell_mag_tilde_b{};
   assign_data(make_not_null(&subcell_mag_tilde_b), num_subcell_pts);
-  evolution::dg::subcell::fd::project(make_not_null(&get(subcell_mag_tilde_b)),
-                                      get(mag_tilde_b), dg_mesh,
-                                      subcell_mesh.extents());
+  evolution::dg::subcell::fd::project(
+      make_not_null(&get(subcell_mag_tilde_b)), get(mag_tilde_b), dg_mesh,
+      subcell_mesh.extents(), Spectral::Parity::Even);
   const double max_mag_tilde_b = max(get(mag_tilde_b));
 
   rdmp_tci_data.max_variables_values =

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TimeDerivative.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TimeDerivative.hpp
@@ -50,6 +50,7 @@
 #include "NumericalAlgorithms/FiniteDifference/DerivativeOrder.hpp"
 #include "NumericalAlgorithms/FiniteDifference/HighOrderFluxCorrection.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Parity.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"
 #include "Utilities/CallWithDynamicType.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
@@ -278,7 +279,9 @@ struct TimeDerivative {
                 mesh_velocity_on_face.value().get(j) =
                     evolution::dg::subcell::fd::project_to_faces(
                         mesh_velocity_dg.value().get(j), dg_mesh,
-                        face_mesh_extents, i);
+                        face_mesh_extents, i,
+                        j == 0 ? Spectral::Parity::Odd
+                               : Spectral::Parity::Even);
               }
               tmpl::for_each<evolved_vars_tags>([&vars_upper_face,
                                                  &vars_lower_face,
@@ -328,11 +331,14 @@ struct TimeDerivative {
             for (size_t j = 0; j < 3; j++) {
               lower_outward_conormal.get(j) =
                   evolution::dg::subcell::fd::project_to_faces(
-                      inv_jacobian_dg.get(i, j), dg_mesh, face_mesh_extents, i);
+                      inv_jacobian_dg.get(i, j), dg_mesh, face_mesh_extents, i,
+                      (i == 0) != (j == 0) ? Spectral::Parity::Odd
+                                           : Spectral::Parity::Even);
             }
             const auto det_inv_jacobian_face =
                 evolution::dg::subcell::fd::project_to_faces(
-                    get(det_inv_jacobian_dg), dg_mesh, face_mesh_extents, i);
+                    get(det_inv_jacobian_dg), dg_mesh, face_mesh_extents, i,
+                    Spectral::Parity::Even);
 
             const Scalar<DataVector> normalization{sqrt(get(
                 dot_product(lower_outward_conormal, lower_outward_conormal,
@@ -431,7 +437,8 @@ struct TimeDerivative {
     if (div_mesh_velocity.has_value()) {
       const DataVector div_mesh_velocity_subcell =
           evolution::dg::subcell::fd::project(div_mesh_velocity.value().get(),
-                                              dg_mesh, subcell_mesh.extents());
+                                              dg_mesh, subcell_mesh.extents(),
+                                              Spectral::Parity::Even);
       const auto& evolved_vars = db::get<evolved_vars_tag>(*box);
 
       tmpl::for_each<typename variables_tag::tags_list>(

--- a/src/Evolution/Systems/NewtonianEuler/Subcell/PrimitiveGhostData.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Subcell/PrimitiveGhostData.hpp
@@ -41,6 +41,7 @@ class PrimitiveGhostVariables {
   using prims_to_reconstruct_tags = tmpl::list<MassDensity, Velocity, Pressure>;
 
  public:
+  using ghost_variables_tag_list = prims_to_reconstruct_tags;
   using return_tags = tmpl::list<>;
   using argument_tags = tmpl::list<::Tags::Variables<prim_tags>>;
 

--- a/src/Evolution/Systems/ScalarAdvection/Subcell/GhostData.hpp
+++ b/src/Evolution/Systems/ScalarAdvection/Subcell/GhostData.hpp
@@ -26,6 +26,7 @@ namespace ScalarAdvection::subcell {
  */
 class GhostVariables {
  public:
+  using ghost_variables_tag_list = tmpl::list<ScalarAdvection::Tags::U>;
   using return_tags = tmpl::list<>;
   using argument_tags =
       tmpl::list<::Tags::Variables<tmpl::list<ScalarAdvection::Tags::U>>>;

--- a/tests/Unit/Evolution/DgSubcell/Actions/Test_ReconstructionCommunication.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Actions/Test_ReconstructionCommunication.cpp
@@ -175,6 +175,10 @@ struct Metavariables {
         const db::DataBox<DbTagsList>& box) {
       return db::get<Tags::Reconstructor>(box).ghost_zone_size();
     }
+
+    struct GhostVariables {
+      using ghost_variables_tag_list = tmpl::list<Var1>;
+    };
   };
 
   struct GhostDataMutator {

--- a/tests/Unit/Evolution/DgSubcell/Actions/Test_TciAndRollback.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Actions/Test_TciAndRollback.cpp
@@ -157,6 +157,10 @@ struct Metavariables {
         const db::DataBox<DbTagsList>& box) {
       return db::get<Tags::Reconstructor>(box).ghost_zone_size();
     }
+
+    struct GhostVariables {
+      using ghost_variables_tag_list = tmpl::list<Var1>;
+    };
   };
 
   struct TciOnDgGrid {
@@ -527,7 +531,9 @@ void test_impl(const bool rdmp_fails, const bool tci_fails,
           expected_ghost_data.at(directional_element_id)
               .neighbor_ghost_data_for_reconstruction(),
           0, directional_element_id, neighbor_mesh, element, subcell_mesh, 2,
-          Interps{});
+          Interps{},
+          typename metavars::SubcellOptions::GhostVariables::
+              ghost_variables_tag_list{});
     }
     const auto& ghost_data_for_reconstruction = ActionTesting::get_databox_tag<
         comp, evolution::dg::subcell::Tags::GhostDataForReconstruction<Dim>>(

--- a/tests/Unit/Evolution/DgSubcell/Test_Matrices.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_Matrices.cpp
@@ -16,9 +16,11 @@
 #include "Evolution/DgSubcell/Matrices.hpp"
 #include "Helpers/Evolution/DgSubcell/ProjectionTestHelpers.hpp"
 #include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/BasisFunctionValue.hpp"
 #include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/MinimumNumberOfPoints.hpp"
+#include "NumericalAlgorithms/Spectral/Parity.hpp"
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
 #include "Utilities/Blas.hpp"
 #include "Utilities/Gsl.hpp"
@@ -54,9 +56,9 @@ void test_projection_matrix() {
     Matrix empty{};
     auto projection_mat = make_array<Dim>(std::cref(empty));
     for (size_t d = 0; d < Dim; ++d) {
-      gsl::at(projection_mat, d) = std::cref(
-          projection_matrix(dg_mesh.slice_through(d), subcell_mesh.extents()[d],
-                            Spectral::Quadrature::CellCentered));
+      gsl::at(projection_mat, d) = std::cref(projection_matrix(
+          dg_mesh.slice_through(d), subcell_mesh.extents()[d],
+          Spectral::Quadrature::CellCentered, Spectral::Parity::Uninitialized));
     }
     DataVector cell_centered_values(num_subcells, 0.0);
     apply_matrices(make_not_null(&cell_centered_values), projection_mat,
@@ -165,11 +167,13 @@ void test_projection_matrix_to_face() {
       if (d == Face_Dim) {
         gsl::at(projection_mat, d) = std::cref(projection_matrix(
             dg_mesh.slice_through(d), subcell_mesh.extents()[d],
-            Spectral::Quadrature::FaceCentered));
+            Spectral::Quadrature::FaceCentered,
+            Spectral::Parity::Uninitialized));
       } else {
         gsl::at(projection_mat, d) = std::cref(projection_matrix(
             dg_mesh.slice_through(d), subcell_mesh.extents()[d],
-            Spectral::Quadrature::CellCentered));
+            Spectral::Quadrature::CellCentered,
+            Spectral::Parity::Uninitialized));
       }
     }
     DataVector subcell_values(num_subcells, 0.0);
@@ -235,7 +239,8 @@ void test_cartoon_matrices() {
     // projection_matrix for a Cartoon dimension returns a 1x1 identity matrix.
     const Mesh<1> cartoon_mesh{1, Spectral::Basis::Cartoon, quad};
     const Matrix& proj_mat =
-        projection_matrix(cartoon_mesh, /*subcell_extents=*/1, quad);
+        projection_matrix(cartoon_mesh, /*subcell_extents=*/1, quad,
+                          Spectral::Parity::Uninitialized);
     REQUIRE(proj_mat.rows() == 1);
     REQUIRE(proj_mat.columns() == 1);
     CHECK(proj_mat(0, 0) == approx(1.0));
@@ -253,16 +258,27 @@ void test_cartoon_matrices() {
   CHECK_THROWS_WITH(
       projection_matrix(Mesh<1>{3, Spectral::Basis::Legendre,
                                 Spectral::Quadrature::GaussLobatto},
-                        5, Spectral::Quadrature::GaussLobatto),
+                        5, Spectral::Quadrature::GaussLobatto,
+                        Spectral::Parity::Uninitialized),
       Catch::Matchers::ContainsSubstring(
           "subcell_quadrature option in projection_matrix should be"));
-  // projection_matrix: unsupported basis (not Legendre or Cartoon).
+  // projection_matrix: unsupported basis (not Legendre, Cartoon, or ZernikeB1).
   CHECK_THROWS_WITH(
       projection_matrix(Mesh<1>{3, Spectral::Basis::Chebyshev,
                                 Spectral::Quadrature::GaussLobatto},
-                        5, Spectral::Quadrature::CellCentered),
+                        5, Spectral::Quadrature::CellCentered,
+                        Spectral::Parity::Uninitialized),
       Catch::Matchers::ContainsSubstring(
-          "FD Subcell projection only supports Legendre or Cartoon bases"));
+          "FD Subcell projection only supports Legendre, Cartoon, or "
+          "ZernikeB1"));
+  // projection_matrix: ZernikeB1 requires non-Uninitialized parity.
+  CHECK_THROWS_WITH(
+      projection_matrix(Mesh<1>{3, Spectral::Basis::ZernikeB1,
+                                Spectral::Quadrature::GaussRadauUpper},
+                        5, Spectral::Quadrature::CellCentered,
+                        Spectral::Parity::Uninitialized),
+      Catch::Matchers::ContainsSubstring(
+          "Parity must be set when using ZernikeB1"));
   // reconstruction_matrix: unsupported basis at dim 0.
   CHECK_THROWS_WITH(
       subcell::fd::reconstruction_matrix(
@@ -342,8 +358,9 @@ void test_cartoon_mixed_matrices() {
         const auto subcell_quad = gsl::at(bases, d) == Spectral::Basis::Cartoon
                                       ? gsl::at(quadratures, d)
                                       : Spectral::Quadrature::CellCentered;
-        gsl::at(projection_mat, d) = std::cref(projection_matrix(
-            dg_mesh.slice_through(d), subcell_extents[d], subcell_quad));
+        gsl::at(projection_mat, d) = std::cref(
+            projection_matrix(dg_mesh.slice_through(d), subcell_extents[d],
+                              subcell_quad, Spectral::Parity::Uninitialized));
       }
 
       // Project DG -> subcell.
@@ -418,6 +435,62 @@ void test_cartoon_mixed_matrices() {
 #endif
 }
 
+// Tests projection from a ZernikeB1/GaussRadauUpper DG mesh to a FD subcell
+// mesh for both Even (m=0) and Odd (m=1) parities.
+void test_zernike_b1_projection_matrix() {
+  constexpr Spectral::Basis basis = Spectral::Basis::ZernikeB1;
+  constexpr Spectral::Quadrature quadrature =
+      Spectral::Quadrature::GaussRadauUpper;
+  const Approx custom_approx = Approx::custom().epsilon(1.0e-11).scale(1.);
+
+  for (size_t num_pts_1d =
+           Spectral::minimum_number_of_points<basis, quadrature>;
+       num_pts_1d <= 6; ++num_pts_1d) {
+    CAPTURE(num_pts_1d);
+    const Mesh<1> dg_mesh{num_pts_1d, basis, quadrature};
+    const auto xi_dg = get<0>(logical_coordinates(dg_mesh));
+    const size_t num_subcells_1d = 2 * num_pts_1d - 1;
+    const Mesh<1> subcell_mesh{num_subcells_1d,
+                               Spectral::Basis::FiniteDifference,
+                               Spectral::Quadrature::CellCentered};
+    const auto xi_fd = get<0>(logical_coordinates(subcell_mesh));
+
+    const Matrix empty{};
+    auto even_projection_mat = make_array<1>(std::cref(empty));
+    even_projection_mat[0] = std::cref(projection_matrix(
+        dg_mesh, subcell_mesh.extents()[0], Spectral::Quadrature::CellCentered,
+        Spectral::Parity::Even));
+    auto odd_projection_mat = make_array<1>(std::cref(empty));
+    odd_projection_mat[0] = std::cref(projection_matrix(
+        dg_mesh, subcell_mesh.extents()[0], Spectral::Quadrature::CellCentered,
+        Spectral::Parity::Odd));
+
+    for (size_t k = 0; k < num_pts_1d; ++k) {
+      CAPTURE(k);
+      // Even parity (m=0): basis functions Q^0_{2k}
+      const DataVector f_even_dg =
+          Spectral::compute_basis_function_value<basis>(2 * k, 0_st, xi_dg);
+      const DataVector f_even_fd_expected =
+          Spectral::compute_basis_function_value<basis>(2 * k, 0_st, xi_fd);
+      DataVector f_even_fd(num_subcells_1d, 0.0);
+      apply_matrices(make_not_null(&f_even_fd), even_projection_mat, f_even_dg,
+                     dg_mesh.extents());
+      CHECK_ITERABLE_CUSTOM_APPROX(f_even_fd, f_even_fd_expected,
+                                   custom_approx);
+
+      // Odd parity (m=1): basis functions Q^1_{2k+1}
+      const DataVector f_odd_dg =
+          Spectral::compute_basis_function_value<basis>(2 * k + 1, 1_st, xi_dg);
+      const DataVector f_odd_fd_expected =
+          Spectral::compute_basis_function_value<basis>(2 * k + 1, 1_st, xi_fd);
+      DataVector f_odd_fd(num_subcells_1d, 0.0);
+      apply_matrices(make_not_null(&f_odd_fd), odd_projection_mat, f_odd_dg,
+                     dg_mesh.extents());
+      CHECK_ITERABLE_CUSTOM_APPROX(f_odd_fd, f_odd_fd_expected, custom_approx);
+    }
+  }
+}
+
 SPECTRE_TEST_CASE("Unit.Evolution.Subcell.Fd.ProjectionMatrix",
                   "[Evolution][Unit]") {
   test_projection_matrix<10, 1, Spectral::Basis::Legendre,
@@ -453,6 +526,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Subcell.Fd.ProjectionMatrix",
   test_cartoon_matrices();
   test_cartoon_mixed_matrices<10, Spectral::Quadrature::GaussLobatto>();
   test_cartoon_mixed_matrices<10, Spectral::Quadrature::Gauss>();
+  test_zernike_b1_projection_matrix();
 }
 
 // [[TimeOut, 10]]

--- a/tests/Unit/Evolution/DgSubcell/Test_Mesh.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_Mesh.cpp
@@ -193,7 +193,7 @@ void test_cartoon_mesh() {
                    Spectral::Quadrature::SphericalSymmetry}}),
       Catch::Matchers::ContainsSubstring(
           "The DG mesh that is being converted to subcell can only mix "
-          "Legendre or Chebyshev with Cartoon"));
+          "Legendre, Chebyshev, or ZernikeB1 with Cartoon"));
   CHECK_THROWS_WITH(
       evolution::dg::subcell::fd::mesh(
           Mesh<3>{{{3, 3, 1}},
@@ -203,7 +203,7 @@ void test_cartoon_mesh() {
                    Spectral::Quadrature::AxialSymmetry}}),
       Catch::Matchers::ContainsSubstring(
           "The DG mesh that is being converted to subcell can only mix "
-          "Legendre or Chebyshev with Cartoon"));
+          "Legendre, Chebyshev, or ZernikeB1 with Cartoon"));
 
   // dg_mesh() assert: non-FiniteDifference dimension mixed with Cartoon
   CHECK_THROWS_WITH(
@@ -230,6 +230,26 @@ void test_cartoon_mesh() {
           "FiniteDifference with Cartoon"));
 #endif  // SPECTRE_DEBUG
 }
+void test_zernike_b1_cartoon_mesh() {
+  for (size_t i = 2; i < 5; ++i) {
+    // Spherically symmetric: ZernikeB1 in dim 0, Cartoon in dims 1 and 2.
+    const Mesh<3> dg_spherical{
+        {{i, 1, 1}},
+        {Spectral::Basis::ZernikeB1, Spectral::Basis::Cartoon,
+         Spectral::Basis::Cartoon},
+        {Spectral::Quadrature::GaussRadauUpper,
+         Spectral::Quadrature::SphericalSymmetry,
+         Spectral::Quadrature::SphericalSymmetry}};
+    const Mesh<3> subcell_spherical{
+        {{2 * i - 1, 1, 1}},
+        {Spectral::Basis::FiniteDifference, Spectral::Basis::Cartoon,
+         Spectral::Basis::Cartoon},
+        {Spectral::Quadrature::CellCentered,
+         Spectral::Quadrature::SphericalSymmetry,
+         Spectral::Quadrature::SphericalSymmetry}};
+    CHECK(evolution::dg::subcell::fd::mesh(dg_spherical) == subcell_spherical);
+  }
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Evolution.Subcell.FD.Mesh", "[Evolution][Unit]") {
@@ -243,5 +263,6 @@ SPECTRE_TEST_CASE("Unit.Evolution.Subcell.FD.Mesh", "[Evolution][Unit]") {
   test_cartoon_mesh<Spectral::Basis::Chebyshev,
                     Spectral::Quadrature::GaussLobatto>();
   test_cartoon_mesh<Spectral::Basis::Chebyshev, Spectral::Quadrature::Gauss>();
+  test_zernike_b1_cartoon_mesh();
   print_comparison_point_computation();
 }

--- a/tests/Unit/Evolution/DgSubcell/Test_NeighborRdmpAndVolumeData.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_NeighborRdmpAndVolumeData.cpp
@@ -28,10 +28,17 @@
 #include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Parity.hpp"
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
 
 namespace {
+// Tag list used as meta parameter for insert_*_volume_data; the ZernikeB1
+// parity-based code path is not exercised by these tests (Legendre meshes),
+// so an empty list suffices.
+using TestTagList = tmpl::list<>;
+
 template <size_t Dim>
 void test() {
   CAPTURE(Dim);
@@ -162,7 +169,8 @@ void test() {
     auto projection_matrices =
         make_array<Dim>(std::cref(evolution::dg::subcell::fd::projection_matrix(
             dg_mesh.slice_through(0), subcell_mesh.extents(0),
-            Spectral::Quadrature::CellCentered)));
+            Spectral::Quadrature::CellCentered,
+            Spectral::Parity::Uninitialized)));
     projection_matrices[0] =
         std::cref(evolution::dg::subcell::fd::projection_matrix(
             dg_mesh.slice_through(0), subcell_mesh.extents(0),
@@ -188,7 +196,7 @@ void test() {
       subcell_mesh,  // neighbor mesh is the same as my mesh since both are
                      // doing subcell
       element, subcell_mesh, number_of_ghost_zones,
-      neighbor_dg_to_fd_interpolants);
+      neighbor_dg_to_fd_interpolants, TestTagList{});
 
   const auto get_neighbor_data =
       [&neighbor_data](const auto mortar_id) -> const DataVector& {
@@ -215,7 +223,8 @@ void test() {
   evolution::dg::subcell::insert_neighbor_rdmp_and_volume_data(
       make_not_null(&rdmp_tci_data), make_not_null(&neighbor_data),
       received_dg_data, number_of_rdmp_vars, lower_xi_id, dg_mesh, element,
-      subcell_mesh, number_of_ghost_zones, neighbor_dg_to_fd_interpolants);
+      subcell_mesh, number_of_ghost_zones, neighbor_dg_to_fd_interpolants,
+      TestTagList{});
 
   {
     DataVector expected_max_rdmp_tci_data{number_of_rdmp_vars};
@@ -249,7 +258,7 @@ void test() {
     evolution::dg::subcell::insert_neighbor_rdmp_and_volume_data(
         make_not_null(&rdmp_tci_data), make_not_null(&neighbor_data),
         aligned_received_dg_data, number_of_rdmp_vars, upper_eta_id, dg_mesh,
-        element, subcell_mesh, number_of_ghost_zones, {});
+        element, subcell_mesh, number_of_ghost_zones, {}, TestTagList{});
 
     DataVector expected_max_rdmp_tci_data{number_of_rdmp_vars};
     DataVector expected_min_rdmp_tci_data{number_of_rdmp_vars};
@@ -274,7 +283,8 @@ void test() {
     auto projection_matrices =
         make_array<Dim>(std::cref(evolution::dg::subcell::fd::projection_matrix(
             dg_mesh.slice_through(0), subcell_mesh.extents(0),
-            Spectral::Quadrature::CellCentered)));
+            Spectral::Quadrature::CellCentered,
+            Spectral::Parity::Uninitialized)));
     projection_matrices[1] =
         std::cref(evolution::dg::subcell::fd::projection_matrix(
             dg_mesh.slice_through(0), subcell_mesh.extents(0),
@@ -296,7 +306,7 @@ void test() {
     evolution::dg::subcell::insert_or_update_neighbor_volume_data<false>(
         make_not_null(&neighbor_data), get_neighbor_data(lower_xi_id),
         number_of_rdmp_vars, lower_xi_id, subcell_mesh, element, subcell_mesh,
-        number_of_ghost_zones, neighbor_dg_to_fd_interpolants);
+        number_of_ghost_zones, neighbor_dg_to_fd_interpolants, TestTagList{});
     CHECK(get_neighbor_data(lower_xi_id).data() == expected_pointer);
   }
 
@@ -316,12 +326,13 @@ void test() {
     evolution::dg::subcell::insert_or_update_neighbor_volume_data<false>(
         make_not_null(&neighbor_data), get_neighbor_data(upper_zeta_id), 0,
         upper_zeta_id, dg_mesh, element, subcell_mesh, number_of_ghost_zones,
-        neighbor_dg_to_fd_interpolants);
+        neighbor_dg_to_fd_interpolants, TestTagList{});
 
     auto projection_matrices =
         make_array<Dim>(std::cref(evolution::dg::subcell::fd::projection_matrix(
             dg_mesh.slice_through(0), subcell_mesh.extents(0),
-            Spectral::Quadrature::CellCentered)));
+            Spectral::Quadrature::CellCentered,
+            Spectral::Parity::Uninitialized)));
     projection_matrices[2] =
         std::cref(evolution::dg::subcell::fd::projection_matrix(
             dg_mesh.slice_through(0), subcell_mesh.extents(0),
@@ -346,7 +357,7 @@ void test() {
     evolution::dg::subcell::insert_or_update_neighbor_volume_data<false>(
         make_not_null(&neighbor_data), get_neighbor_data(lower_zeta_id), 0,
         lower_zeta_id, dg_mesh, element, subcell_mesh, number_of_ghost_zones,
-        neighbor_dg_to_fd_interpolants);
+        neighbor_dg_to_fd_interpolants, TestTagList{});
 
     projection_matrices[2] =
         std::cref(evolution::dg::subcell::fd::projection_matrix(
@@ -372,7 +383,7 @@ void test() {
           DataVector{}, number_of_rdmp_vars,
           DirectionalId<Dim>{Direction<Dim>::upper_xi(), ElementId<Dim>{1}},
           subcell_mesh, element, subcell_mesh, number_of_ghost_zones,
-          neighbor_dg_to_fd_interpolants),
+          neighbor_dg_to_fd_interpolants, TestTagList{}),
       Catch::Matchers::ContainsSubstring(
           "received_neighbor_subcell_data must be non-empty"));
 
@@ -381,7 +392,7 @@ void test() {
           make_not_null(&neighbor_data), DataVector{}, number_of_rdmp_vars,
           DirectionalId<Dim>{Direction<Dim>::upper_xi(), ElementId<Dim>{1}},
           subcell_mesh, element, subcell_mesh, number_of_ghost_zones,
-          neighbor_dg_to_fd_interpolants),
+          neighbor_dg_to_fd_interpolants, TestTagList{}),
       Catch::Matchers::ContainsSubstring(
           "neighbor_subcell_data must be non-empty"));
   CHECK_THROWS_WITH(
@@ -389,7 +400,7 @@ void test() {
           make_not_null(&neighbor_data), DataVector{}, number_of_rdmp_vars,
           DirectionalId<Dim>{Direction<Dim>::upper_xi(), ElementId<Dim>{1}},
           subcell_mesh, element, subcell_mesh, number_of_ghost_zones,
-          neighbor_dg_to_fd_interpolants),
+          neighbor_dg_to_fd_interpolants, TestTagList{}),
       Catch::Matchers::ContainsSubstring(
           "neighbor_subcell_data must be non-empty"));
 
@@ -400,7 +411,7 @@ void test() {
           Mesh<Dim>{5, Spectral::Basis::FiniteDifference,
                     Spectral::Quadrature::CellCentered},
           element, subcell_mesh, number_of_ghost_zones,
-          neighbor_dg_to_fd_interpolants),
+          neighbor_dg_to_fd_interpolants, TestTagList{}),
       Catch::Matchers::ContainsSubstring(
           "must be the same if we are both doing subcell."));
   CHECK_THROWS_WITH(
@@ -410,7 +421,7 @@ void test() {
           Mesh<Dim>{5, Spectral::Basis::FiniteDifference,
                     Spectral::Quadrature::CellCentered},
           element, subcell_mesh, number_of_ghost_zones,
-          neighbor_dg_to_fd_interpolants),
+          neighbor_dg_to_fd_interpolants, TestTagList{}),
       Catch::Matchers::ContainsSubstring(
           "must be the same if we are both doing subcell."));
 
@@ -420,7 +431,7 @@ void test() {
           lower_xi_id, dg_mesh, element,
           Mesh<Dim>{4, Spectral::Basis::Legendre,
                     Spectral::Quadrature::GaussLobatto},
-          number_of_ghost_zones, neighbor_dg_to_fd_interpolants),
+          number_of_ghost_zones, neighbor_dg_to_fd_interpolants, TestTagList{}),
       Catch::Matchers::ContainsSubstring(
           "Neighbor subcell mesh computed from the neighbor DG mesh "));
   CHECK_THROWS_WITH(
@@ -429,7 +440,7 @@ void test() {
           lower_xi_id, dg_mesh, element,
           Mesh<Dim>{4, Spectral::Basis::Legendre,
                     Spectral::Quadrature::GaussLobatto},
-          number_of_ghost_zones, neighbor_dg_to_fd_interpolants),
+          number_of_ghost_zones, neighbor_dg_to_fd_interpolants, TestTagList{}),
       Catch::Matchers::ContainsSubstring(
           "Neighbor subcell mesh computed from the neighbor DG mesh "));
 
@@ -438,7 +449,7 @@ void test() {
           make_not_null(&neighbor_data),
           DataVector{2 * number_of_rdmp_vars + 1, 0.0}, number_of_rdmp_vars,
           lower_xi_id, dg_mesh, element, subcell_mesh, number_of_ghost_zones,
-          {}),
+          {}, TestTagList{}),
       Catch::Matchers::ContainsSubstring(
           "The number of DG volume grid points times the number of variables"));
   CHECK_THROWS_WITH(
@@ -446,7 +457,7 @@ void test() {
           make_not_null(&neighbor_data),
           DataVector{2 * number_of_rdmp_vars + 1, 0.0}, number_of_rdmp_vars,
           lower_xi_id, dg_mesh, element, subcell_mesh, number_of_ghost_zones,
-          {}),
+          {}, TestTagList{}),
       Catch::Matchers::ContainsSubstring(
           "The number of DG volume grid points times the number of variables"));
 
@@ -467,7 +478,7 @@ void test() {
             number_of_rdmp_vars,
             DirectionalId<Dim>{Direction<Dim>::upper_xi(), ElementId<Dim>{1}},
             non_uniform_mesh, element, subcell_mesh, number_of_ghost_zones,
-            neighbor_dg_to_fd_interpolants),
+            neighbor_dg_to_fd_interpolants, TestTagList{}),
         Catch::Matchers::ContainsSubstring(
             "The neighbor subcell mesh must have isotropic basis"));
     CHECK_THROWS_WITH(
@@ -476,7 +487,7 @@ void test() {
             number_of_rdmp_vars,
             DirectionalId<Dim>{Direction<Dim>::upper_xi(), ElementId<Dim>{1}},
             non_uniform_mesh, element, subcell_mesh, number_of_ghost_zones,
-            neighbor_dg_to_fd_interpolants),
+            neighbor_dg_to_fd_interpolants, TestTagList{}),
         Catch::Matchers::ContainsSubstring(
             "The neighbor subcell mesh must have isotropic basis"));
     if constexpr (Dim == 3) {
@@ -493,7 +504,8 @@ void test() {
               number_of_rdmp_vars,
               DirectionalId<Dim>{Direction<Dim>::upper_xi(), ElementId<Dim>{1}},
               non_uniform_cartoon_mesh, element, subcell_mesh,
-              number_of_ghost_zones, neighbor_dg_to_fd_interpolants),
+              number_of_ghost_zones, neighbor_dg_to_fd_interpolants,
+              TestTagList{}),
           Catch::Matchers::ContainsSubstring(
               "The non-cartoon neighbor subcell sub-mesh must have isotropic"));
     }

--- a/tests/Unit/Evolution/DgSubcell/Test_PrepareNeighborData.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_PrepareNeighborData.cpp
@@ -79,6 +79,7 @@ struct Metavariables {
     }
 
     struct GhostVariables {
+      using ghost_variables_tag_list = tmpl::list<Var1>;
       using return_tags = tmpl::list<>;
       using argument_tags = tmpl::list<typename system::variables_tag>;
       template <typename T>

--- a/tests/Unit/Evolution/DgSubcell/Test_Projection.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_Projection.cpp
@@ -14,9 +14,11 @@
 #include "Evolution/DgSubcell/Projection.hpp"
 #include "Helpers/Evolution/DgSubcell/ProjectionTestHelpers.hpp"
 #include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/BasisFunctionValue.hpp"
 #include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/MinimumNumberOfPoints.hpp"
+#include "NumericalAlgorithms/Spectral/Parity.hpp"
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
 #include "Utilities/MakeArray.hpp"
 #include "Utilities/TMPL.hpp"
@@ -120,6 +122,21 @@ void test_project_fd() {
                                         prefixed_vars, dg_mesh,
                                         subcell_mesh.extents());
     check_each_field_in_vars(prefixed_subcell_vars);
+
+    // Verify the DataVector + tmpl::list overload gives the same result as the
+    // Variables overload for non-ZernikeB1 (Legendre) meshes, exercising the
+    // non-ZernikeB1 fallback path in project_impl_with_tag_list.
+    {
+      using VarsTagList = tmpl::list<Tags::Scalar, Tags::Vector<Dim>>;
+      DataVector packed_dg(vars.size());
+      std::copy(vars.data(), vars.data() + vars.size(), packed_dg.data());
+      const DataVector subcell_dv_taglist = evolution::dg::subcell::fd::project(
+          packed_dg, dg_mesh, subcell_mesh.extents(), VarsTagList{});
+      DataVector packed_subcell(subcell_vars.size());
+      std::copy(subcell_vars.data(), subcell_vars.data() + subcell_vars.size(),
+                packed_subcell.data());
+      CHECK_ITERABLE_APPROX(subcell_dv_taglist, packed_subcell);
+    }
   }
 }
 
@@ -167,10 +184,203 @@ void test_project_on_face_fd() {
     // Test projection of a DataVector
     const DataVector subcell_values =
         evolution::dg::subcell::fd::project_to_faces(
-            nodal_coeffs, dg_mesh, subcell_mesh.extents(), Face_Dim);
+            nodal_coeffs, dg_mesh, subcell_mesh.extents(), Face_Dim,
+            Spectral::Parity::Uninitialized);
     CHECK_ITERABLE_APPROX(subcell_values, expected_subcell_values);
   }
 }
+
+void test_project_zernike_b1() {
+  constexpr Spectral::Basis zb1 = Spectral::Basis::ZernikeB1;
+  constexpr Spectral::Quadrature zb1_quad =
+      Spectral::Quadrature::GaussRadauUpper;
+  const Approx custom_approx = Approx::custom().epsilon(1.0e-11).scale(1.);
+
+  for (size_t n_r = Spectral::minimum_number_of_points<zb1, zb1_quad>; n_r <= 5;
+       ++n_r) {
+    CAPTURE(n_r);
+    const size_t n_fd = 2 * n_r - 1;
+    {
+      INFO("Spherical");
+      const Mesh<3> dg_mesh{
+          {{n_r, 1, 1}},
+          {zb1, Spectral::Basis::Cartoon, Spectral::Basis::Cartoon},
+          {zb1_quad, Spectral::Quadrature::SphericalSymmetry,
+           Spectral::Quadrature::SphericalSymmetry}};
+      const Index<3> subcell_extents{{n_fd, 1, 1}};
+      const auto xi_dg_r = get<0>(logical_coordinates(dg_mesh));
+      const Mesh<1> fd_1d{n_fd, Spectral::Basis::FiniteDifference,
+                          Spectral::Quadrature::CellCentered};
+      const auto xi_fd_r = get<0>(logical_coordinates(fd_1d));
+
+      for (const Spectral::Parity parity :
+           {Spectral::Parity::Even, Spectral::Parity::Odd}) {
+        CAPTURE(parity);
+        for (size_t k = 0; k < n_r; ++k) {
+          CAPTURE(k);
+          const size_t n = parity == Spectral::Parity::Even ? 2 * k : 2 * k + 1;
+          const size_t m =
+              parity == Spectral::Parity::Even ? size_t{0} : size_t{1};
+          const DataVector dg_u =
+              Spectral::compute_basis_function_value<zb1>(n, m, xi_dg_r);
+          const DataVector expected =
+              Spectral::compute_basis_function_value<zb1>(n, m, xi_fd_r);
+          const DataVector result = evolution::dg::subcell::fd::project(
+              dg_u, dg_mesh, subcell_extents, parity);
+          CHECK_ITERABLE_CUSTOM_APPROX(result, expected, custom_approx);
+        }
+      }
+    }
+    {
+      INFO("Axial");
+      for (size_t n_phi = 2; n_phi <= 4; ++n_phi) {
+        CAPTURE(n_phi);
+        const size_t n_fd_phi = 2 * n_phi - 1;
+        const Mesh<3> dg_mesh{
+            {{n_r, n_phi, 1}},
+            {zb1, Spectral::Basis::Legendre, Spectral::Basis::Cartoon},
+            {zb1_quad, Spectral::Quadrature::GaussLobatto,
+             Spectral::Quadrature::AxialSymmetry}};
+        const Index<3> subcell_extents{{n_fd, n_fd_phi, 1}};
+
+        const auto xi_dg = logical_coordinates(dg_mesh);
+        const auto& xi_dg_r = get<0>(xi_dg);
+        const auto& xi_dg_phi = get<1>(xi_dg);
+
+        const Mesh<3> subcell_mesh{
+            {{n_fd, n_fd_phi, 1}},
+            {Spectral::Basis::FiniteDifference,
+             Spectral::Basis::FiniteDifference, Spectral::Basis::Cartoon},
+            {Spectral::Quadrature::CellCentered,
+             Spectral::Quadrature::CellCentered,
+             Spectral::Quadrature::AxialSymmetry}};
+        const auto xi_fd = logical_coordinates(subcell_mesh);
+        const auto& xi_fd_r = get<0>(xi_fd);
+        const auto& xi_fd_phi = get<1>(xi_fd);
+
+        for (const Spectral::Parity parity :
+             {Spectral::Parity::Even, Spectral::Parity::Odd}) {
+          CAPTURE(parity);
+          // Use the lowest-degree basis function of the given parity times
+          // the phi coordinate (degree-1 Legendre, exact for n_phi >= 2).
+          const size_t n =
+              parity == Spectral::Parity::Even ? size_t{0} : size_t{1};
+          const size_t m =
+              parity == Spectral::Parity::Even ? size_t{0} : size_t{1};
+          const DataVector dg_u =
+              Spectral::compute_basis_function_value<zb1>(n, m, xi_dg_r) *
+              xi_dg_phi;
+          const DataVector expected =
+              Spectral::compute_basis_function_value<zb1>(n, m, xi_fd_r) *
+              xi_fd_phi;
+          const DataVector result = evolution::dg::subcell::fd::project(
+              dg_u, dg_mesh, subcell_extents, parity);
+          CHECK_ITERABLE_CUSTOM_APPROX(result, expected, custom_approx);
+        }
+      }
+    }
+  }
+}
+
+// Tests the Variables overload and the DataVector + tmpl::list overload on
+// ZernikeB1 DG meshes
+void test_project_zernike_b1_variables_and_datavector_taglist() {
+  constexpr Spectral::Basis zb1 = Spectral::Basis::ZernikeB1;
+  constexpr Spectral::Quadrature zb1_quad =
+      Spectral::Quadrature::GaussRadauUpper;
+  const Approx custom_approx = Approx::custom().epsilon(1.0e-11).scale(1.);
+
+  for (size_t n_r = Spectral::minimum_number_of_points<zb1, zb1_quad>; n_r <= 5;
+       ++n_r) {
+    CAPTURE(n_r);
+    const size_t n_fd = 2 * n_r - 1;
+
+    const Mesh<3> dg_mesh{
+        {{n_r, 1, 1}},
+        {zb1, Spectral::Basis::Cartoon, Spectral::Basis::Cartoon},
+        {zb1_quad, Spectral::Quadrature::SphericalSymmetry,
+         Spectral::Quadrature::SphericalSymmetry}};
+    const Index<3> subcell_extents{{n_fd, 1, 1}};
+    const auto xi_dg_r = get<0>(logical_coordinates(dg_mesh));
+    const Mesh<1> fd_1d{n_fd, Spectral::Basis::FiniteDifference,
+                        Spectral::Quadrature::CellCentered};
+    const auto xi_fd_r = get<0>(logical_coordinates(fd_1d));
+
+    using VarsTagList = tmpl::list<Tags::Scalar, Tags::Vector<3>>;
+
+    // Lowest-degree ZernikeB1 basis functions of each parity.
+    const DataVector even_dg =
+        Spectral::compute_basis_function_value<zb1>(0, 0, xi_dg_r);
+    const DataVector odd_dg =
+        Spectral::compute_basis_function_value<zb1>(1, 1, xi_dg_r);
+    const DataVector even_fd =
+        Spectral::compute_basis_function_value<zb1>(0, 0, xi_fd_r);
+    const DataVector odd_fd =
+        Spectral::compute_basis_function_value<zb1>(1, 1, xi_fd_r);
+
+    Variables<VarsTagList> dg_vars(dg_mesh.number_of_grid_points());
+    get(get<Tags::Scalar>(dg_vars)) = even_dg;
+    get<Tags::Vector<3>>(dg_vars).get(0) = 2.0 * odd_dg;
+    get<Tags::Vector<3>>(dg_vars).get(1) = 3.0 * even_dg;
+    get<Tags::Vector<3>>(dg_vars).get(2) = 4.0 * even_dg;
+
+    const Variables<VarsTagList> subcell_vars =
+        evolution::dg::subcell::fd::project(dg_vars, dg_mesh, subcell_extents);
+    CHECK_ITERABLE_CUSTOM_APPROX(get(get<Tags::Scalar>(subcell_vars)), even_fd,
+                                 custom_approx);
+    CHECK_ITERABLE_CUSTOM_APPROX(get<Tags::Vector<3>>(subcell_vars).get(0),
+                                 2.0 * odd_fd, custom_approx);
+    CHECK_ITERABLE_CUSTOM_APPROX(get<Tags::Vector<3>>(subcell_vars).get(1),
+                                 3.0 * even_fd, custom_approx);
+    CHECK_ITERABLE_CUSTOM_APPROX(get<Tags::Vector<3>>(subcell_vars).get(2),
+                                 4.0 * even_fd, custom_approx);
+
+    DataVector packed_dg(dg_vars.size());
+    std::copy(dg_vars.data(), dg_vars.data() + dg_vars.size(),
+              packed_dg.data());
+    const DataVector subcell_dv = evolution::dg::subcell::fd::project(
+        packed_dg, dg_mesh, subcell_extents, VarsTagList{});
+    DataVector expected_packed_subcell(subcell_vars.size());
+    std::copy(subcell_vars.data(), subcell_vars.data() + subcell_vars.size(),
+              expected_packed_subcell.data());
+    CHECK_ITERABLE_CUSTOM_APPROX(subcell_dv, expected_packed_subcell,
+                                 custom_approx);
+  }
+}
+
+#ifdef SPECTRE_DEBUG
+void test_projection_asserts() {
+  // ZernikeB1 mesh with Parity::Uninitialized
+  {
+    const Mesh<3> dg_mesh{{{4, 1, 1}},
+                          {Spectral::Basis::ZernikeB1, Spectral::Basis::Cartoon,
+                           Spectral::Basis::Cartoon},
+                          {Spectral::Quadrature::GaussRadauUpper,
+                           Spectral::Quadrature::SphericalSymmetry,
+                           Spectral::Quadrature::SphericalSymmetry}};
+    const Index<3> subcell_extents{{7, 1, 1}};
+    const DataVector dg_u(4, 1.0);
+    CHECK_THROWS_WITH(
+        evolution::dg::subcell::fd::project(dg_u, dg_mesh, subcell_extents,
+                                            Spectral::Parity::Uninitialized),
+        Catch::Matchers::ContainsSubstring(
+            "Parity must be set when using ZernikeB1"));
+  }
+  // Passing a multi-component DataVector (size > num_dg_pts) with a
+  // non-Uninitialized parity
+  {
+    const Mesh<3> dg_mesh{4, Spectral::Basis::Legendre,
+                          Spectral::Quadrature::GaussLobatto};
+    const Index<3> subcell_extents{7};
+    const DataVector dg_u(2 * dg_mesh.number_of_grid_points(), 1.0);
+    CHECK_THROWS_WITH(
+        evolution::dg::subcell::fd::project(dg_u, dg_mesh, subcell_extents,
+                                            Spectral::Parity::Even),
+        Catch::Matchers::ContainsSubstring(
+            "Must pass the types as a template"));
+  }
+}
+#endif
 
 SPECTRE_TEST_CASE("Unit.Evolution.Subcell.Fd.Projection", "[Evolution][Unit]") {
   test_project_fd<10, 1, Spectral::Basis::Legendre,
@@ -203,5 +413,10 @@ SPECTRE_TEST_CASE("Unit.Evolution.Subcell.Fd.Projection", "[Evolution][Unit]") {
                           Spectral::Quadrature::GaussLobatto>();
   test_project_on_face_fd<4, 3, 2, Spectral::Basis::Legendre,
                           Spectral::Quadrature::Gauss>();
+  test_project_zernike_b1();
+  test_project_zernike_b1_variables_and_datavector_taglist();
+#ifdef SPECTRE_DEBUG
+  test_projection_asserts();
+#endif
 }
 }  // namespace

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_PrimsAfterRollback.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_PrimsAfterRollback.cpp
@@ -171,7 +171,7 @@ void test(const gsl::not_null<std::mt19937*> gen,
     get(get<hydro::Tags::Pressure<DataVector>>(expected_subcell_prims)) =
         evolution::dg::subcell::fd::project(
             get(get<hydro::Tags::Pressure<DataVector>>(dg_prims)), dg_mesh,
-            subcell_mesh.extents());
+            subcell_mesh.extents(), Spectral::Parity::Even);
     PrimitiveFromConservative<recovery_schemes>::apply(
         make_not_null(&get<hydro::Tags::RestMassDensity<DataVector>>(
             expected_subcell_prims)),
@@ -206,6 +206,150 @@ void test(const gsl::not_null<std::mt19937*> gen,
   }
 }
 
+// Constant parity-respecting data avoids the need for parity-aware
+// reconstruction from subcell to DG
+void test_zernike_b1() {
+  const Mesh<3> dg_mesh{{4, 1, 1},
+                        {Spectral::Basis::ZernikeB1, Spectral::Basis::Cartoon,
+                         Spectral::Basis::Cartoon},
+                        {Spectral::Quadrature::GaussRadauUpper,
+                         Spectral::Quadrature::SphericalSymmetry,
+                         Spectral::Quadrature::SphericalSymmetry}};
+  const Mesh<3> subcell_mesh = evolution::dg::subcell::fd::mesh(dg_mesh);
+
+  using cons_tag = typename grmhd::ValenciaDivClean::System::variables_tag;
+  using prim_tag =
+      typename grmhd::ValenciaDivClean::System::primitive_variables_tag;
+  using ConsVars = typename cons_tag::type;
+  using PrimVars = typename prim_tag::type;
+
+  const size_t subcell_num_pts = subcell_mesh.number_of_grid_points();
+  const size_t dg_num_pts = dg_mesh.number_of_grid_points();
+
+  tnsr::aa<DataVector, 3, Frame::Inertial> spacetime_metric{subcell_num_pts,
+                                                            0.0};
+  get<0, 0>(spacetime_metric) = -1.0;
+  for (size_t i = 1; i < 4; ++i) {
+    spacetime_metric.get(i, i) = 1.0;
+  }
+  tnsr::ii<DataVector, 3, Frame::Inertial> spatial_metric{subcell_num_pts, 0.0};
+  tnsr::II<DataVector, 3, Frame::Inertial> inv_spatial_metric{subcell_num_pts,
+                                                              0.0};
+  for (size_t i = 0; i < 3; ++i) {
+    spatial_metric.get(i, i) = 1.0;
+    inv_spatial_metric.get(i, i) = 1.0;
+  }
+  const Scalar<DataVector> sqrt_det_spatial_metric{
+      DataVector{subcell_num_pts, 1.0}};
+
+  std::unique_ptr<EquationsOfState::EquationOfState<true, 1>> eos =
+      std::make_unique<EquationsOfState::PolytropicFluid<true>>(1.4, 5.0 / 3.0);
+
+  // Constant parity-respecting subcell prims: scalars (even) are positive
+  // constants, radial vector components (odd) are zero.
+  PrimVars subcell_prims{subcell_num_pts, 0.0};
+  get(get<hydro::Tags::RestMassDensity<DataVector>>(subcell_prims)) = 0.5;
+  get<hydro::Tags::Pressure<DataVector>>(subcell_prims) =
+      eos->pressure_from_density(
+          get<hydro::Tags::RestMassDensity<DataVector>>(subcell_prims));
+  get<hydro::Tags::SpecificInternalEnergy<DataVector>>(subcell_prims) =
+      eos->specific_internal_energy_from_density(
+          get<hydro::Tags::RestMassDensity<DataVector>>(subcell_prims));
+  get(get<hydro::Tags::LorentzFactor<DataVector>>(subcell_prims)) = 1.0;
+  get<hydro::Tags::MagneticField<DataVector, 3>>(subcell_prims).get(1) = 0.1;
+  get<hydro::Tags::MagneticField<DataVector, 3>>(subcell_prims).get(2) = 0.1;
+
+  ConsVars subcell_cons{subcell_num_pts};
+  ConservativeFromPrimitive::apply(
+      make_not_null(&get<Tags::TildeD>(subcell_cons)),
+      make_not_null(&get<Tags::TildeYe>(subcell_cons)),
+      make_not_null(&get<Tags::TildeTau>(subcell_cons)),
+      make_not_null(&get<Tags::TildeS<Frame::Inertial>>(subcell_cons)),
+      make_not_null(&get<Tags::TildeB<Frame::Inertial>>(subcell_cons)),
+      make_not_null(&get<Tags::TildePhi>(subcell_cons)),
+      get<hydro::Tags::RestMassDensity<DataVector>>(subcell_prims),
+      get<hydro::Tags::ElectronFraction<DataVector>>(subcell_prims),
+      get<hydro::Tags::SpecificInternalEnergy<DataVector>>(subcell_prims),
+      get<hydro::Tags::Pressure<DataVector>>(subcell_prims),
+      get<hydro::Tags::SpatialVelocity<DataVector, 3>>(subcell_prims),
+      get<hydro::Tags::LorentzFactor<DataVector>>(subcell_prims),
+      get<hydro::Tags::MagneticField<DataVector, 3>>(subcell_prims),
+      sqrt_det_spatial_metric, spatial_metric,
+      get<hydro::Tags::DivergenceCleaningField<DataVector>>(subcell_prims));
+
+  const double pressure_val =
+      get(get<hydro::Tags::Pressure<DataVector>>(subcell_prims))[0];
+  const double sie_val = get(
+      get<hydro::Tags::SpecificInternalEnergy<DataVector>>(subcell_prims))[0];
+  PrimVars dg_prims{dg_num_pts, 0.0};
+  get(get<hydro::Tags::RestMassDensity<DataVector>>(dg_prims)) = 0.5;
+  get(get<hydro::Tags::Pressure<DataVector>>(dg_prims)) = pressure_val;
+  get(get<hydro::Tags::SpecificInternalEnergy<DataVector>>(dg_prims)) = sie_val;
+  get(get<hydro::Tags::LorentzFactor<DataVector>>(dg_prims)) = 1.0;
+  get<hydro::Tags::MagneticField<DataVector, 3>>(dg_prims).get(1) = 0.1;
+  get<hydro::Tags::MagneticField<DataVector, 3>>(dg_prims).get(2) = 0.1;
+
+  const double cutoff_d_for_inversion = 0.0;
+  const double density_when_skipping_inversion = 0.0;
+  const double kastaun_max_lorentz = 1.0e4;
+  const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions
+      primitive_from_conservative_options(cutoff_d_for_inversion,
+                                          density_when_skipping_inversion,
+                                          kastaun_max_lorentz);
+
+  auto box = db::create<db::AddSimpleTags<
+      evolution::dg::subcell::Tags::DidRollback, cons_tag, prim_tag,
+      gr::Tags::SpacetimeMetric<DataVector, 3>, ::domain::Tags::Mesh<3>,
+      evolution::dg::subcell::Tags::Mesh<3>, hydro::Tags::GrmhdEquationOfState,
+      grmhd::ValenciaDivClean::Tags::PrimitiveFromConservativeOptions>>(
+      true, subcell_cons, dg_prims, spacetime_metric, dg_mesh, subcell_mesh,
+      eos->promote_to_3d_eos(), primitive_from_conservative_options);
+
+  using recovery_schemes = tmpl::list<
+      grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::KastaunEtAl,
+      grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::NewmanHamlin,
+      grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::PalenzuelaEtAl>;
+  db::mutate_apply<
+      GhValenciaDivClean::subcell::PrimsAfterRollback<recovery_schemes>>(
+      make_not_null(&box));
+
+  REQUIRE(db::get<prim_tag>(box).number_of_grid_points() == subcell_num_pts);
+  PrimVars expected_subcell_prims = subcell_prims;
+  get(get<hydro::Tags::Pressure<DataVector>>(expected_subcell_prims)) =
+      evolution::dg::subcell::fd::project(
+          get(get<hydro::Tags::Pressure<DataVector>>(dg_prims)), dg_mesh,
+          subcell_mesh.extents(), Spectral::Parity::Even);
+  PrimitiveFromConservative<recovery_schemes>::apply(
+      make_not_null(&get<hydro::Tags::RestMassDensity<DataVector>>(
+          expected_subcell_prims)),
+      make_not_null(&get<hydro::Tags::ElectronFraction<DataVector>>(
+          expected_subcell_prims)),
+      make_not_null(&get<hydro::Tags::SpecificInternalEnergy<DataVector>>(
+          expected_subcell_prims)),
+      make_not_null(&get<hydro::Tags::SpatialVelocity<DataVector, 3>>(
+          expected_subcell_prims)),
+      make_not_null(&get<hydro::Tags::MagneticField<DataVector, 3>>(
+          expected_subcell_prims)),
+      make_not_null(&get<hydro::Tags::DivergenceCleaningField<DataVector>>(
+          expected_subcell_prims)),
+      make_not_null(
+          &get<hydro::Tags::LorentzFactor<DataVector>>(expected_subcell_prims)),
+      make_not_null(
+          &get<hydro::Tags::Pressure<DataVector>>(expected_subcell_prims)),
+      make_not_null(
+          &get<hydro::Tags::Temperature<DataVector>>(expected_subcell_prims)),
+      get<grmhd::ValenciaDivClean::Tags::TildeD>(box),
+      get<grmhd::ValenciaDivClean::Tags::TildeYe>(box),
+      get<grmhd::ValenciaDivClean::Tags::TildeTau>(box),
+      get<grmhd::ValenciaDivClean::Tags::TildeS<Frame::Inertial>>(box),
+      get<grmhd::ValenciaDivClean::Tags::TildeB<Frame::Inertial>>(box),
+      get<grmhd::ValenciaDivClean::Tags::TildePhi>(box), spatial_metric,
+      inv_spatial_metric, sqrt_det_spatial_metric,
+      db::get<hydro::Tags::GrmhdEquationOfState>(box),
+      primitive_from_conservative_options);
+  CHECK_VARIABLES_APPROX(db::get<prim_tag>(box), expected_subcell_prims);
+}
+
 SPECTRE_TEST_CASE(
     "Unit.Evolution.Systems.GhValenciaDivClean.Subcell.PrimsAfterRollback",
     "[Unit][Evolution]") {
@@ -223,6 +367,7 @@ SPECTRE_TEST_CASE(
     test(make_not_null(&gen), make_not_null(&dist), did_rollback,
          wrapped_3d_polytropic_eos);
   }
+  test_zernike_b1();
 }
 }  // namespace
 }  // namespace grmhd::ValenciaDivClean

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_PrimsAfterRollback.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_PrimsAfterRollback.cpp
@@ -148,7 +148,7 @@ void test(const gsl::not_null<std::mt19937*> gen,
     get(get<hydro::Tags::Pressure<DataVector>>(expected_subcell_prims)) =
         evolution::dg::subcell::fd::project(
             get(get<hydro::Tags::Pressure<DataVector>>(dg_prims)), dg_mesh,
-            subcell_mesh.extents());
+            subcell_mesh.extents(), Spectral::Parity::Even);
     PrimitiveFromConservative<recovery_schemes>::apply(
         make_not_null(&get<hydro::Tags::RestMassDensity<DataVector>>(
             expected_subcell_prims)),
@@ -183,6 +183,147 @@ void test(const gsl::not_null<std::mt19937*> gen,
   }
 }
 
+void test_zernike_b1() {
+  const Mesh<3> dg_mesh{{4, 1, 1},
+                        {Spectral::Basis::ZernikeB1, Spectral::Basis::Cartoon,
+                         Spectral::Basis::Cartoon},
+                        {Spectral::Quadrature::GaussRadauUpper,
+                         Spectral::Quadrature::SphericalSymmetry,
+                         Spectral::Quadrature::SphericalSymmetry}};
+  const Mesh<3> subcell_mesh = evolution::dg::subcell::fd::mesh(dg_mesh);
+
+  using cons_tag = typename grmhd::ValenciaDivClean::System::variables_tag;
+  using prim_tag =
+      typename grmhd::ValenciaDivClean::System::primitive_variables_tag;
+  using ConsVars = typename cons_tag::type;
+  using PrimVars = typename prim_tag::type;
+
+  const size_t subcell_num_pts = subcell_mesh.number_of_grid_points();
+  const size_t dg_num_pts = dg_mesh.number_of_grid_points();
+
+  tnsr::ii<DataVector, 3, Frame::Inertial> spatial_metric{subcell_num_pts, 0.0};
+  for (size_t i = 0; i < 3; ++i) {
+    spatial_metric.get(i, i) = 1.0;
+  }
+  tnsr::II<DataVector, 3, Frame::Inertial> inv_spatial_metric{subcell_num_pts,
+                                                              0.0};
+  for (size_t i = 0; i < 3; ++i) {
+    inv_spatial_metric.get(i, i) = 1.0;
+  }
+  const Scalar<DataVector> sqrt_det_spatial_metric{
+      DataVector{subcell_num_pts, 1.0}};
+
+  std::unique_ptr<EquationsOfState::EquationOfState<true, 1>> eos =
+      std::make_unique<EquationsOfState::PolytropicFluid<true>>(1.4, 5.0 / 3.0);
+
+  // Build subcell prims with parity-respecting constant values.
+  PrimVars subcell_prims{subcell_num_pts, 0.0};
+  get(get<hydro::Tags::RestMassDensity<DataVector>>(subcell_prims)) = 0.5;
+  get<hydro::Tags::Pressure<DataVector>>(subcell_prims) =
+      eos->pressure_from_density(
+          get<hydro::Tags::RestMassDensity<DataVector>>(subcell_prims));
+  get<hydro::Tags::SpecificInternalEnergy<DataVector>>(subcell_prims) =
+      eos->specific_internal_energy_from_density(
+          get<hydro::Tags::RestMassDensity<DataVector>>(subcell_prims));
+  get(get<hydro::Tags::LorentzFactor<DataVector>>(subcell_prims)) = 1.0;
+  get<hydro::Tags::MagneticField<DataVector, 3>>(subcell_prims).get(1) = 0.1;
+  get<hydro::Tags::MagneticField<DataVector, 3>>(subcell_prims).get(2) = 0.1;
+
+  ConsVars subcell_cons{subcell_num_pts};
+  ConservativeFromPrimitive::apply(
+      make_not_null(&get<Tags::TildeD>(subcell_cons)),
+      make_not_null(&get<Tags::TildeYe>(subcell_cons)),
+      make_not_null(&get<Tags::TildeTau>(subcell_cons)),
+      make_not_null(&get<Tags::TildeS<Frame::Inertial>>(subcell_cons)),
+      make_not_null(&get<Tags::TildeB<Frame::Inertial>>(subcell_cons)),
+      make_not_null(&get<Tags::TildePhi>(subcell_cons)),
+      get<hydro::Tags::RestMassDensity<DataVector>>(subcell_prims),
+      get<hydro::Tags::ElectronFraction<DataVector>>(subcell_prims),
+      get<hydro::Tags::SpecificInternalEnergy<DataVector>>(subcell_prims),
+      get<hydro::Tags::Pressure<DataVector>>(subcell_prims),
+      get<hydro::Tags::SpatialVelocity<DataVector, 3>>(subcell_prims),
+      get<hydro::Tags::LorentzFactor<DataVector>>(subcell_prims),
+      get<hydro::Tags::MagneticField<DataVector, 3>>(subcell_prims),
+      sqrt_det_spatial_metric, spatial_metric,
+      get<hydro::Tags::DivergenceCleaningField<DataVector>>(subcell_prims));
+
+  // For constant data the DG representation has the same constant values,
+  // so we set dg_prims directly rather than using fd::reconstruct.
+  const double pressure_val =
+      get(get<hydro::Tags::Pressure<DataVector>>(subcell_prims))[0];
+  const double sie_val = get(
+      get<hydro::Tags::SpecificInternalEnergy<DataVector>>(subcell_prims))[0];
+  PrimVars dg_prims{dg_num_pts, 0.0};
+  get(get<hydro::Tags::RestMassDensity<DataVector>>(dg_prims)) = 0.5;
+  get(get<hydro::Tags::Pressure<DataVector>>(dg_prims)) = pressure_val;
+  get(get<hydro::Tags::SpecificInternalEnergy<DataVector>>(dg_prims)) = sie_val;
+  get(get<hydro::Tags::LorentzFactor<DataVector>>(dg_prims)) = 1.0;
+  get<hydro::Tags::MagneticField<DataVector, 3>>(dg_prims).get(1) = 0.1;
+  get<hydro::Tags::MagneticField<DataVector, 3>>(dg_prims).get(2) = 0.1;
+
+  const double cutoff_d_for_inversion = 0.0;
+  const double density_when_skipping_inversion = 0.0;
+  const double kastaun_max_lorentz = 1.0e4;
+  const grmhd::ValenciaDivClean::PrimitiveFromConservativeOptions
+      primitive_from_conservative_options(cutoff_d_for_inversion,
+                                          density_when_skipping_inversion,
+                                          kastaun_max_lorentz);
+
+  auto box = db::create<db::AddSimpleTags<
+      evolution::dg::subcell::Tags::DidRollback, cons_tag, prim_tag,
+      gr::Tags::SpatialMetric<DataVector, 3>,
+      gr::Tags::InverseSpatialMetric<DataVector, 3>,
+      gr::Tags::SqrtDetSpatialMetric<DataVector>, ::domain::Tags::Mesh<3>,
+      evolution::dg::subcell::Tags::Mesh<3>, hydro::Tags::GrmhdEquationOfState,
+      grmhd::ValenciaDivClean::Tags::PrimitiveFromConservativeOptions>>(
+      true, subcell_cons, dg_prims, spatial_metric, inv_spatial_metric,
+      sqrt_det_spatial_metric, dg_mesh, subcell_mesh, eos->promote_to_3d_eos(),
+      primitive_from_conservative_options);
+
+  using recovery_schemes = tmpl::list<
+      grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::KastaunEtAl,
+      grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::NewmanHamlin,
+      grmhd::ValenciaDivClean::PrimitiveRecoverySchemes::PalenzuelaEtAl>;
+  db::mutate_apply<subcell::PrimsAfterRollback<recovery_schemes>>(
+      make_not_null(&box));
+
+  REQUIRE(db::get<prim_tag>(box).number_of_grid_points() == subcell_num_pts);
+  PrimVars expected_subcell_prims = subcell_prims;
+  get(get<hydro::Tags::Pressure<DataVector>>(expected_subcell_prims)) =
+      evolution::dg::subcell::fd::project(
+          get(get<hydro::Tags::Pressure<DataVector>>(dg_prims)), dg_mesh,
+          subcell_mesh.extents(), Spectral::Parity::Even);
+  PrimitiveFromConservative<recovery_schemes>::apply(
+      make_not_null(&get<hydro::Tags::RestMassDensity<DataVector>>(
+          expected_subcell_prims)),
+      make_not_null(&get<hydro::Tags::ElectronFraction<DataVector>>(
+          expected_subcell_prims)),
+      make_not_null(&get<hydro::Tags::SpecificInternalEnergy<DataVector>>(
+          expected_subcell_prims)),
+      make_not_null(&get<hydro::Tags::SpatialVelocity<DataVector, 3>>(
+          expected_subcell_prims)),
+      make_not_null(&get<hydro::Tags::MagneticField<DataVector, 3>>(
+          expected_subcell_prims)),
+      make_not_null(&get<hydro::Tags::DivergenceCleaningField<DataVector>>(
+          expected_subcell_prims)),
+      make_not_null(
+          &get<hydro::Tags::LorentzFactor<DataVector>>(expected_subcell_prims)),
+      make_not_null(
+          &get<hydro::Tags::Pressure<DataVector>>(expected_subcell_prims)),
+      make_not_null(
+          &get<hydro::Tags::Temperature<DataVector>>(expected_subcell_prims)),
+      get<grmhd::ValenciaDivClean::Tags::TildeD>(box),
+      get<grmhd::ValenciaDivClean::Tags::TildeYe>(box),
+      get<grmhd::ValenciaDivClean::Tags::TildeTau>(box),
+      get<grmhd::ValenciaDivClean::Tags::TildeS<Frame::Inertial>>(box),
+      get<grmhd::ValenciaDivClean::Tags::TildeB<Frame::Inertial>>(box),
+      get<grmhd::ValenciaDivClean::Tags::TildePhi>(box), spatial_metric,
+      inv_spatial_metric, sqrt_det_spatial_metric,
+      db::get<hydro::Tags::GrmhdEquationOfState>(box),
+      primitive_from_conservative_options);
+  CHECK_VARIABLES_APPROX(db::get<prim_tag>(box), expected_subcell_prims);
+}
+
 SPECTRE_TEST_CASE(
     "Unit.Evolution.Systems.ValenciaDivClean.Subcell.PrimsAfterRollback",
     "[Unit][Evolution]") {
@@ -194,6 +335,7 @@ SPECTRE_TEST_CASE(
   for (const bool did_rollback : {true, false}) {
     test(make_not_null(&gen), make_not_null(&dist), did_rollback);
   }
+  test_zernike_b1();
 }
 }  // namespace
 }  // namespace grmhd::ValenciaDivClean

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_SetInitialRdmpData.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_SetInitialRdmpData.cpp
@@ -1,7 +1,6 @@
 // Distributed under the MIT License.
 // See LICENSE.txt for details.
 
-#include "Evolution/DgSubcell/Reconstruction.hpp"
 #include "Framework/TestingFramework.hpp"
 
 #include <cstddef>
@@ -18,8 +17,80 @@
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/SetInitialRdmpData.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp"
 #include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+
+namespace {
+void test_zernike_b1() {
+  const Mesh<3> dg_mesh{{4, 1, 1},
+                        {Spectral::Basis::ZernikeB1, Spectral::Basis::Cartoon,
+                         Spectral::Basis::Cartoon},
+                        {Spectral::Quadrature::GaussRadauUpper,
+                         Spectral::Quadrature::SphericalSymmetry,
+                         Spectral::Quadrature::SphericalSymmetry}};
+  const DataVector dg_logical_coordinates =
+      0.25 * (get<0>(logical_coordinates(dg_mesh)) + 1.0);
+  const Mesh<3> subcell_mesh = evolution::dg::subcell::fd::mesh(dg_mesh);
+  const size_t num_dg_pts = dg_mesh.number_of_grid_points();
+
+  using ConsVars =
+      typename grmhd::ValenciaDivClean::System::variables_tag::type;
+  ConsVars dg_vars{num_dg_pts, 0.0};
+
+  get(get<grmhd::ValenciaDivClean::Tags::TildeD>(dg_vars)) =
+      1.0 + dg_logical_coordinates;
+  get(get<grmhd::ValenciaDivClean::Tags::TildeYe>(dg_vars)) = 0.1;
+  get(get<grmhd::ValenciaDivClean::Tags::TildeTau>(dg_vars)) = 2.0;
+  get<grmhd::ValenciaDivClean::Tags::TildeB<>>(dg_vars).get(1) = 0.3;
+  get<grmhd::ValenciaDivClean::Tags::TildeB<>>(dg_vars).get(2) = 0.4;
+
+  const auto subcell_vars = evolution::dg::subcell::fd::project(
+      dg_vars, dg_mesh, subcell_mesh.extents());
+
+  evolution::dg::subcell::RdmpTciData rdmp_data{};
+  grmhd::ValenciaDivClean::subcell::SetInitialRdmpData::apply(
+      make_not_null(&rdmp_data),
+      get<grmhd::ValenciaDivClean::Tags::TildeD>(dg_vars),
+      get<grmhd::ValenciaDivClean::Tags::TildeYe>(dg_vars),
+      get<grmhd::ValenciaDivClean::Tags::TildeTau>(dg_vars),
+      get<grmhd::ValenciaDivClean::Tags::TildeB<>>(dg_vars),
+      evolution::dg::subcell::ActiveGrid::Dg, dg_mesh, subcell_mesh);
+
+  const auto& dg_tilde_d = get<grmhd::ValenciaDivClean::Tags::TildeD>(dg_vars);
+  const auto& dg_tilde_ye =
+      get<grmhd::ValenciaDivClean::Tags::TildeYe>(dg_vars);
+  const auto& dg_tilde_tau =
+      get<grmhd::ValenciaDivClean::Tags::TildeTau>(dg_vars);
+  const auto dg_tilde_b_magnitude =
+      magnitude(get<grmhd::ValenciaDivClean::Tags::TildeB<>>(dg_vars));
+  const auto& subcell_tilde_d =
+      get<grmhd::ValenciaDivClean::Tags::TildeD>(subcell_vars);
+  const auto& subcell_tilde_ye =
+      get<grmhd::ValenciaDivClean::Tags::TildeYe>(subcell_vars);
+  const auto& subcell_tilde_tau =
+      get<grmhd::ValenciaDivClean::Tags::TildeTau>(subcell_vars);
+  const auto projected_subcell_tilde_b_magnitude =
+      Scalar<DataVector>(evolution::dg::subcell::fd::project(
+          get(dg_tilde_b_magnitude), dg_mesh, subcell_mesh.extents(),
+          Spectral::Parity::Even));
+
+  using std::max;
+  using std::min;
+  const evolution::dg::subcell::RdmpTciData expected_rdmp_data{
+      {max(max(get(dg_tilde_d)), max(get(subcell_tilde_d))),
+       max(max(get(dg_tilde_ye)), max(get(subcell_tilde_ye))),
+       max(max(get(dg_tilde_tau)), max(get(subcell_tilde_tau))),
+       max(max(get(dg_tilde_b_magnitude)),
+           max(get(projected_subcell_tilde_b_magnitude)))},
+      {min(min(get(dg_tilde_d)), min(get(subcell_tilde_d))),
+       min(min(get(dg_tilde_ye)), min(get(subcell_tilde_ye))),
+       min(min(get(dg_tilde_tau)), min(get(subcell_tilde_tau))),
+       min(min(get(dg_tilde_b_magnitude)),
+           min(get(projected_subcell_tilde_b_magnitude)))}};
+  CHECK(rdmp_data == expected_rdmp_data);
+}
+}  // namespace
 
 SPECTRE_TEST_CASE(
     "Unit.Evolution.Systems.ValenciaDivClean.Subcell.SetInitialRdmpData",
@@ -59,7 +130,8 @@ SPECTRE_TEST_CASE(
       get<grmhd::ValenciaDivClean::Tags::TildeTau>(subcell_vars);
   const auto projected_subcell_tilde_b_magnitude =
       Scalar<DataVector>(evolution::dg::subcell::fd::project(
-          get(dg_tilde_b_magnitude), dg_mesh, subcell_mesh.extents()));
+          get(dg_tilde_b_magnitude), dg_mesh, subcell_mesh.extents(),
+          Spectral::Parity::Even));
 
   evolution::dg::subcell::RdmpTciData expected_dg_rdmp_data{};
   using std::max;
@@ -96,4 +168,6 @@ SPECTRE_TEST_CASE(
       min(get(subcell_tilde_d)), min(get(subcell_tilde_ye)),
       min(get(subcell_tilde_tau)), min(get(subcell_tilde_b_magnitude))};
   CHECK(rdmp_data == expected_subcell_rdmp_data);
+
+  test_zernike_b1();
 }

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TciOnDgGrid.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TciOnDgGrid.cpp
@@ -267,34 +267,36 @@ void test(const TestThis test_this, const int expected_tci_status,
       max(max(get(db::get<grmhd::ValenciaDivClean::Tags::TildeD>(box))),
           max(evolution::dg::subcell::fd::project(
               get(db::get<grmhd::ValenciaDivClean::Tags::TildeD>(box)), mesh,
-              subcell_mesh.extents()))),
+              subcell_mesh.extents(), Spectral::Parity::Even))),
       max(max(get(db::get<grmhd::ValenciaDivClean::Tags::TildeYe>(box))),
           max(evolution::dg::subcell::fd::project(
               get(db::get<grmhd::ValenciaDivClean::Tags::TildeYe>(box)), mesh,
-              subcell_mesh.extents()))),
+              subcell_mesh.extents(), Spectral::Parity::Even))),
       max(max(get(db::get<grmhd::ValenciaDivClean::Tags::TildeTau>(box))),
           max(evolution::dg::subcell::fd::project(
               get(db::get<grmhd::ValenciaDivClean::Tags::TildeTau>(box)), mesh,
-              subcell_mesh.extents()))),
+              subcell_mesh.extents(), Spectral::Parity::Even))),
       max(max(get(magnitude_tilde_b)),
           max(evolution::dg::subcell::fd::project(get(magnitude_tilde_b), mesh,
-                                                  subcell_mesh.extents())))};
+                                                  subcell_mesh.extents(),
+                                                  Spectral::Parity::Even)))};
   past_rdmp_tci_data.min_variables_values = DataVector{
       min(min(get(db::get<grmhd::ValenciaDivClean::Tags::TildeD>(box))),
           min(evolution::dg::subcell::fd::project(
               get(db::get<grmhd::ValenciaDivClean::Tags::TildeD>(box)), mesh,
-              subcell_mesh.extents()))),
+              subcell_mesh.extents(), Spectral::Parity::Even))),
       min(min(get(db::get<grmhd::ValenciaDivClean::Tags::TildeYe>(box))),
           min(evolution::dg::subcell::fd::project(
               get(db::get<grmhd::ValenciaDivClean::Tags::TildeYe>(box)), mesh,
-              subcell_mesh.extents()))),
+              subcell_mesh.extents(), Spectral::Parity::Even))),
       min(min(get(db::get<grmhd::ValenciaDivClean::Tags::TildeTau>(box))),
           min(evolution::dg::subcell::fd::project(
               get(db::get<grmhd::ValenciaDivClean::Tags::TildeTau>(box)), mesh,
-              subcell_mesh.extents()))),
+              subcell_mesh.extents(), Spectral::Parity::Even))),
       min(min(get(magnitude_tilde_b)),
           min(evolution::dg::subcell::fd::project(get(magnitude_tilde_b), mesh,
-                                                  subcell_mesh.extents())))};
+                                                  subcell_mesh.extents(),
+                                                  Spectral::Parity::Even)))};
 
   const evolution::dg::subcell::RdmpTciData expected_rdmp_tci_data =
       past_rdmp_tci_data;


### PR DESCRIPTION
## Proposed changes

We need ZernikeB1 projection for cartoon subcell. We need to know the parity for each projection, which can either be passed or inferred by the type (so now the type needs to be passed).

This is achieved by either passing the parity as an argument for DataVectors, or for when the passed DataVector is multiple components (i.e. GhostData) the underlying types must be passed.

Depends on:
- [x] #7179 
- [x] #7232 

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
