### PR TITLE
Add function to return array of parity (for cartoon evolution)

### DIFF
--- a/src/NumericalAlgorithms/Spectral/ParityFromSymmetry.hpp
+++ b/src/NumericalAlgorithms/Spectral/ParityFromSymmetry.hpp
@@ -14,6 +14,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "DataStructures/Variables.hpp"
+#include "NumericalAlgorithms/Spectral/Parity.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Requires.hpp"
 #include "Utilities/TMPL.hpp"
@@ -129,5 +130,42 @@ compute_parity_list() {
                              typename TensorType::index_list>;
   using vars_list = ::Tags::convert_to_temp_tensors<tmpl::list<tensor_type>, 0>;
   return compute_parity_list<vars_list>();
+}
+/*!
+ * \brief Returns a compile-time array mapping each component index of
+ * `TensorType` to its `Parity` (Even or Odd) based on the number of
+ * \f$x\f$-coordinate indices, for use in an axisymmetric spacetime with the
+ * Cartoon method.
+ *
+ * A component is `Parity::Even` if it has an even number of
+ * \f$x\f$-coordinate indices, or `Parity::Odd` otherwise.
+ *
+ * \see `compute_parity_list`
+ */
+template <typename TensorType>
+  requires(tt::is_a_v<Tensor, TensorType>)
+constexpr std::array<Parity, TensorType::size()> make_component_parity_array() {
+  constexpr auto parity_info = compute_parity_list<TensorType>();
+  constexpr auto parity_list = std::get<0>(parity_info);
+  constexpr size_t N = TensorType::size();
+  std::array<Parity, N> result{};
+  size_t component = 0;
+  bool is_even = true;
+  for (size_t i = 0; component < N; ++i) {
+    const size_t seg_size = parity_list[i];
+    if (seg_size == 0) {
+      if (is_even) {
+        is_even = false;
+        continue;
+      } else {
+        break;
+      }
+    }
+    for (size_t k = 0; k < seg_size; ++k, ++component) {
+      result[component] = is_even ? Parity::Even : Parity::Odd;
+    }
+    is_even = not is_even;
+  }
+  return result;
 }
 }  // namespace Spectral

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_ParityFromSymmetry.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_ParityFromSymmetry.cpp
@@ -9,6 +9,7 @@
 #include "DataStructures/Tags/TempTensor.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/System.hpp"
+#include "NumericalAlgorithms/Spectral/Parity.hpp"
 #include "NumericalAlgorithms/Spectral/ParityFromSymmetry.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -122,6 +123,59 @@ void test_constexpr() {
   check_scalar_constexpr(scalar);
 }
 
+void test_make_component_parity_array() {
+  {
+    constexpr auto result = make_component_parity_array<Scalar<DataVector>>();
+    static_assert(result.size() == 1);
+    static_assert(result[0] == Parity::Even);
+  }
+  {
+    constexpr auto result =
+        make_component_parity_array<tnsr::i<DataVector, 3>>();
+    static_assert(result.size() == 3);
+    static_assert(result[0] == Parity::Odd);
+    static_assert(result[1] == Parity::Even);
+    static_assert(result[2] == Parity::Even);
+  }
+  {
+    constexpr auto result =
+        make_component_parity_array<tnsr::ii<DataVector, 3>>();
+    static_assert(result.size() == 6);
+    static_assert(result[0] == Parity::Even);
+    static_assert(result[1] == Parity::Odd);
+    static_assert(result[2] == Parity::Odd);
+    static_assert(result[3] == Parity::Even);
+    static_assert(result[4] == Parity::Even);
+    static_assert(result[5] == Parity::Even);
+  }
+  {
+    constexpr auto result =
+        make_component_parity_array<tnsr::I<DataVector, 3>>();
+    static_assert(result.size() == 3);
+    static_assert(result[0] == Parity::Odd);
+    static_assert(result[1] == Parity::Even);
+    static_assert(result[2] == Parity::Even);
+  }
+  {
+    // Consistency: sum of each parity matches compute_parity_list counts
+    constexpr auto result =
+        make_component_parity_array<tnsr::iaB<DataVector, 3>>();
+    const auto [plist, n_even, n_odd] =
+        compute_parity_list<tnsr::iaB<DataVector, 3>>();
+    size_t even_count = 0;
+    size_t odd_count = 0;
+    for (const auto& p : result) {
+      if (p == Parity::Even) {
+        ++even_count;
+      } else {
+        ++odd_count;
+      }
+    }
+    CHECK(even_count == n_even);
+    CHECK(odd_count == n_odd);
+  }
+}
+
 void test_gh_system() {
   using gh_tags = gh::System<3>::gradients_tags;
   const auto [gh_list, gh_even, gh_odd] = compute_parity_list<gh_tags>();
@@ -145,5 +199,6 @@ SPECTRE_TEST_CASE("Unit.Numerical.Spectral.ParityFromSymmetry",
   test_expected_properties();
   test_constexpr();
   test_gh_system();
+  test_make_component_parity_array();
 }
 }  // namespace Spectral


### PR DESCRIPTION
## Proposed changes

Having the parity array is needed for filtering with ZernikeB1

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
