### PR TITLE
Have exp filter weight Fourier m modes equally

### DIFF
--- a/src/NumericalAlgorithms/Spectral/Filtering.cpp
+++ b/src/NumericalAlgorithms/Spectral/Filtering.cpp
@@ -50,9 +50,29 @@ Matrix exponential_filter(const Mesh<1>& mesh, const double alpha,
   const Matrix& modal_to_nodal = Spectral::modal_to_nodal_matrix(mesh);
   Matrix filter_matrix(mesh.number_of_grid_points(),
                        mesh.number_of_grid_points(), 0.0);
-  const double order = mesh.number_of_grid_points() - 1.0;
-  for (size_t i = 0; i < mesh.number_of_grid_points(); ++i) {
-    filter_matrix(i, i) = exp(-alpha * pow(i / order, 2 * half_power));
+  if (mesh.basis(0) == Spectral::Basis::Fourier) {
+    ASSERT(mesh.number_of_grid_points() % 2 == 1,
+           "The Fourier basis is required to have an odd number of grid points "
+           "for stability, got "
+               << mesh.number_of_grid_points());
+    filter_matrix(0, 0) = 1.0;
+    // Maximum mode
+    const size_t M = mesh.number_of_grid_points() / 2;
+    const auto order = static_cast<double>(M);
+    for (size_t i = 1; i < mesh.number_of_grid_points(); i += 2) {
+      const size_t m = (i + 1) / 2;
+      const double weight =
+          exp(-alpha * pow(static_cast<double>(m) / order, 2 * half_power));
+      filter_matrix(i, i) = weight;
+      filter_matrix(i + 1, i + 1) = weight;
+    }
+  } else {
+    const double order =
+        static_cast<double>(mesh.number_of_grid_points()) - 1.0;
+    for (size_t i = 0; i < mesh.number_of_grid_points(); ++i) {
+      filter_matrix(i, i) =
+          exp(-alpha * pow(static_cast<double>(i) / order, 2 * half_power));
+    }
   }
   return modal_to_nodal * filter_matrix * nodal_to_modal;
 }

--- a/src/NumericalAlgorithms/Spectral/Filtering.hpp
+++ b/src/NumericalAlgorithms/Spectral/Filtering.hpp
@@ -36,6 +36,9 @@ namespace filtering {
  * more coefficients). Setting \f$\alpha=36\f$ results in setting the highest
  * coefficient to machine precision, effectively zeroing it out.
  *
+ * For filtering the Fourier basis, both \f$\cos\f$ and \f$\sin\f$
+ * contributions to a given \f$m\f$-mode are equally weighted.
+ *
  * The Parity argument is only used for ZernikeB1 bases, where the modal space
  * is parity dependent.
  *

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Filters/Test_Hypercube.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Filters/Test_Hypercube.cpp
@@ -320,6 +320,11 @@ void test_apply_in_volume() {
   for (size_t num_pts =
            Spectral::minimum_number_of_points<BasisType, QuadratureType>;
        num_pts < max_pts; ++num_pts) {
+    if constexpr (BasisType == Spectral::Basis::Fourier) {
+      if (num_pts % 2 == 0) {
+        continue;
+      }
+    }
     CAPTURE(num_pts);
     const Mesh<Dim> mesh(num_pts, BasisType, QuadratureType);
     const auto initial_vars = deterministic_vars<Dim>(mesh);
@@ -361,6 +366,11 @@ void test_apply_on_boundary() {
   for (size_t num_pts =
            Spectral::minimum_number_of_points<BasisType, QuadratureType>;
        num_pts < max_pts; ++num_pts) {
+    if constexpr (BasisType == Spectral::Basis::Fourier) {
+      if (num_pts % 2 == 0) {
+        continue;
+      }
+    }
     CAPTURE(num_pts);
     const Mesh<Dim> volume_mesh(num_pts, BasisType, QuadratureType);
     const Mesh<Dim - 1> face_mesh = volume_mesh.slice_away(0);

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Filtering.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Filtering.cpp
@@ -194,6 +194,11 @@ void test_exponential_filter_action(const double alpha,
            Spectral::minimum_number_of_points<BasisType, QuadratureType>;
        num_pts < max_pts; ++num_pts) {
     CAPTURE(num_pts);
+    if constexpr (BasisType == Spectral::Basis::Fourier) {
+      if (num_pts % 2 == 0) {
+        continue;
+      }
+    }
     const Mesh<Dim> mesh(num_pts, BasisType, QuadratureType);
 
     Variables<tmpl::list<Tags::ScalarVar, Tags::VectorVar<Dim>>> initial_vars(

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_Filtering.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_Filtering.cpp
@@ -65,6 +65,63 @@ void test_exponential_filter(const double alpha, const unsigned half_power,
   }
 }
 
+void test_fourier_exponential_filter() {
+  const Approx local_approx = Approx::custom().epsilon(1.0e-11).scale(1.0);
+
+  const std::vector<size_t> num_pts_list{1, 3, 5, 15};
+  const std::vector<double> alphas{10.0, 20.0, 36.0};
+  const std::vector<unsigned> half_powers{2, 4, 8};
+
+  for (const size_t num_pts : num_pts_list) {
+    CAPTURE(num_pts);
+    const Mesh<1> mesh{num_pts, Spectral::Basis::Fourier,
+                       Spectral::Quadrature::Equiangular};
+    const DataVector& x = Spectral::collocation_points<
+        Spectral::Basis::Fourier, Spectral::Quadrature::Equiangular>(num_pts);
+    const size_t M = (num_pts - 1) / 2;
+
+    for (const double alpha : alphas) {
+      CAPTURE(alpha);
+      for (const unsigned half_power : half_powers) {
+        CAPTURE(half_power);
+        const Matrix filter =
+            Spectral::filtering::exponential_filter(mesh, alpha, half_power);
+
+        for (size_t m = 1; m <= M; ++m) {
+          CAPTURE(m);
+          const double expected_weight =
+              exp(-alpha * pow(static_cast<double>(m) / static_cast<double>(M),
+                               2 * half_power));
+
+          DataVector cos_vals = cos(static_cast<double>(m) * x);
+          DataVector sin_vals = sin(static_cast<double>(m) * x);
+
+          DataVector filtered_cos(num_pts, 0.0);
+          DataVector filtered_sin(num_pts, 0.0);
+          dgemv_('N', num_pts, num_pts, 1., filter.data(), filter.spacing(),
+                 cos_vals.data(), 1, 0.0, filtered_cos.data(), 1);
+          dgemv_('N', num_pts, num_pts, 1., filter.data(), filter.spacing(),
+                 sin_vals.data(), 1, 0.0, filtered_sin.data(), 1);
+
+          CHECK_ITERABLE_CUSTOM_APPROX(filtered_cos, expected_weight * cos_vals,
+                                       local_approx);
+          CHECK_ITERABLE_CUSTOM_APPROX(filtered_sin, expected_weight * sin_vals,
+                                       local_approx);
+        }
+      }
+    }
+  }
+#ifdef SPECTRE_DEBUG
+  CHECK_THROWS_WITH(
+      Spectral::filtering::exponential_filter(
+          Mesh<1>{4, Spectral::Basis::Fourier,
+                  Spectral::Quadrature::Equiangular},
+          2.0, 1),
+      Catch::Matchers::ContainsSubstring("The Fourier basis is required to "
+                                         "have an odd number of grid points"));
+#endif  // SPECTRE_DEBUG
+}
+
 SPECTRE_TEST_CASE("Unit.Numerical.Spectral.ExponentialFilter",
                   "[NumericalAlgorithms][Spectral][Unit]") {
   const std::vector<double> alphas{10.0, 20.0, 30.0, 40.0};
@@ -85,6 +142,7 @@ SPECTRE_TEST_CASE("Unit.Numerical.Spectral.ExponentialFilter",
                                                            1.0e-10);
     }
   }
+  test_fourier_exponential_filter();
 }
 
 template <Spectral::Basis BasisType, Spectral::Quadrature QuadratureType>


### PR DESCRIPTION
## Proposed changes

Spectral space structure requires modified weighting.

Noticed in #7238

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
