### PR TITLE
Create Cartoon-type BC

### DIFF
--- a/src/Domain/BoundaryConditions/CMakeLists.txt
+++ b/src/Domain/BoundaryConditions/CMakeLists.txt
@@ -8,6 +8,7 @@ add_spectre_library(${LIBRARY})
 spectre_target_sources(
   ${LIBRARY}
   PRIVATE
+  Cartoon.cpp
   None.cpp
   Periodic.cpp
   )
@@ -17,6 +18,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   BoundaryCondition.hpp
+  Cartoon.hpp
   GetBoundaryConditionsBase.hpp
   None.hpp
   Periodic.hpp
@@ -27,6 +29,7 @@ target_link_libraries(
   PUBLIC
   Options
   Serialization
+  Spectral
   Utilities
   INTERFACE
   ErrorHandling

--- a/src/Domain/BoundaryConditions/Cartoon.cpp
+++ b/src/Domain/BoundaryConditions/Cartoon.cpp
@@ -1,0 +1,35 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/BoundaryConditions/Cartoon.hpp"
+
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+
+namespace domain::BoundaryConditions {
+MarkAsCartoon::~MarkAsCartoon() = default;
+
+bool is_cartoon(const std::unique_ptr<BoundaryCondition>& boundary_condition) {
+  return dynamic_cast<const MarkAsCartoon* const>(boundary_condition.get()) !=
+         nullptr;
+}
+
+template <size_t Dim>
+bool dg_mesh_is_cartoon_compatible(const Mesh<Dim>& dg_mesh) {
+  if constexpr (Dim == 3) {
+    return (dg_mesh.basis(0) == Spectral::Basis::Legendre or
+            dg_mesh.basis(0) == Spectral::Basis::Chebyshev or
+            dg_mesh.basis(0) == Spectral::Basis::ZernikeB1) and
+           (dg_mesh.basis(1) == Spectral::Basis::Legendre or
+            dg_mesh.basis(1) == Spectral::Basis::Chebyshev or
+            dg_mesh.basis(1) == Spectral::Basis::Cartoon) and
+           dg_mesh.basis(2) == Spectral::Basis::Cartoon;
+  } else {
+    return false;
+  }
+}
+
+template bool dg_mesh_is_cartoon_compatible(const Mesh<1>& dg_mesh);
+template bool dg_mesh_is_cartoon_compatible(const Mesh<2>& dg_mesh);
+template bool dg_mesh_is_cartoon_compatible(const Mesh<3>& dg_mesh);
+}  // namespace domain::BoundaryConditions

--- a/src/Domain/BoundaryConditions/Cartoon.hpp
+++ b/src/Domain/BoundaryConditions/Cartoon.hpp
@@ -1,0 +1,186 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <memory>
+#include <pup.h>
+
+#include "Domain/BoundaryConditions/BoundaryCondition.hpp"
+#include "Options/String.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+template <size_t Dim>
+class Mesh;
+/// \endcond
+
+namespace domain::BoundaryConditions {
+/// Mark a boundary condition as being used as an internal Cartoon boundary.
+///
+/// The cartoon method requires a ZernikeB1 basis to be stable at small
+/// \f$x\f$, which should not have a boundary condition applied. However, FD
+/// does require ghost zones to be filled on this boundary, so `is_cartoon()`
+/// can be used to determine whether to treat this boundary condition as
+/// something to implement or skip.
+class MarkAsCartoon {
+ public:
+  MarkAsCartoon() = default;
+  MarkAsCartoon(MarkAsCartoon&&) = default;
+  MarkAsCartoon& operator=(MarkAsCartoon&&) = default;
+  MarkAsCartoon(const MarkAsCartoon&) = default;
+  MarkAsCartoon& operator=(const MarkAsCartoon&) = default;
+  virtual ~MarkAsCartoon() = 0;
+};
+
+/*!
+ * \brief Cartoon boundary conditions, to be used as the default placeholder in
+ * systems without Subcell.
+ *
+ * To use with a specific system, add:
+ *
+ * \code
+ *  domain::BoundaryConditions::Cartoon<your::system::BoundaryConditionBase>
+ * \endcode
+ *
+ * to the list of creatable classes.
+ *
+ * Note: Cartoon boundary conditions should only be specified with systems
+ * set-up to use the cartoon method. It should not be used as an external
+ * boundary.
+ */
+template <typename SystemBoundaryConditionBaseClass>
+struct Cartoon final : public SystemBoundaryConditionBaseClass,
+                       public MarkAsCartoon {
+ public:
+  using options = tmpl::list<>;
+  static constexpr Options::String help{
+      "Cartoon boundary condition, to be used in systems that do not implement "
+      "Subcell.\n\nNote: This should never be used as an external boundary, it "
+      "is only used on specific cartoon-system boundaries that are "
+      "automatically handled in the domain creators."};
+  static std::string name() { return "Cartoon"; }
+
+  Cartoon() = default;
+  Cartoon(Cartoon&&) = default;
+  Cartoon& operator=(Cartoon&&) = default;
+  Cartoon(const Cartoon&) = default;
+  Cartoon& operator=(const Cartoon&) = default;
+  ~Cartoon() override = default;
+
+  explicit Cartoon(CkMigrateMessage* msg);
+
+  WRAPPED_PUPable_decl_base_template(
+      domain::BoundaryConditions::BoundaryCondition, Cartoon);
+
+  auto get_clone() const -> std::unique_ptr<
+      domain::BoundaryConditions::BoundaryCondition> override;
+
+  void pup(PUP::er& p) override;
+};
+
+template <typename SystemBoundaryConditionBaseClass>
+Cartoon<SystemBoundaryConditionBaseClass>::Cartoon(CkMigrateMessage* const msg)
+    : SystemBoundaryConditionBaseClass(msg) {}
+
+template <typename SystemBoundaryConditionBaseClass>
+std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+Cartoon<SystemBoundaryConditionBaseClass>::get_clone() const {
+  return std::make_unique<Cartoon>(*this);
+}
+
+template <typename SystemBoundaryConditionBaseClass>
+void Cartoon<SystemBoundaryConditionBaseClass>::pup(PUP::er& p) {
+  BoundaryCondition::pup(p);
+}
+
+/// \cond
+template <typename SystemBoundaryConditionBaseClass>
+// NOLINTNEXTLINE
+PUP::able::PUP_ID Cartoon<SystemBoundaryConditionBaseClass>::my_PUP_ID = 0;
+/// \endcond
+
+/// Check if a boundary condition inherits from `MarkAsCartoon`, which
+/// constitutes as it being marked as an internal Cartoon boundary condition.
+bool is_cartoon(const std::unique_ptr<BoundaryCondition>& boundary_condition);
+
+/// Check if a mesh is compatible with a Cartoon boundary condition, i.e. it is
+/// using cartoon bases in a proper way.
+template <size_t Dim>
+bool dg_mesh_is_cartoon_compatible(const Mesh<Dim>& dg_mesh);
+
+namespace detail {
+template <typename T>
+struct inherits_from_mark_as_cartoon : std::is_base_of<MarkAsCartoon, T> {};
+
+template <typename List>
+struct find_cartoon_bc_impl {
+  using filtered_list =
+      tmpl::filter<List, inherits_from_mark_as_cartoon<tmpl::_1>>;
+
+  // Ensure there's exactly one cartoon BC, not zero or multiple
+  static_assert(tmpl::size<filtered_list>::value <= 1,
+                "Multiple cartoon boundary conditions found in factory list. "
+                "Only one cartoon boundary condition is allowed per system.");
+
+  // Need lazy evaluation in case list is empty
+  template <typename L>
+  using get_maybe_first = tmpl::apply<tmpl::apply<
+      tmpl::if_<std::bool_constant<(tmpl::size<L>::value != 0)>,
+                tmpl::defer<tmpl::bind<tmpl::front, tmpl::pin<L>>>, void>>>;
+
+  using type = get_maybe_first<filtered_list>;
+};
+
+/// Find the unique type in a tmpl::list that inherits from MarkAsCartoon
+template <typename List>
+using find_cartoon_bc = typename find_cartoon_bc_impl<List>::type;
+
+/// Check if a tmpl::list contains any types that inherit from MarkAsCartoon
+template <typename List>
+constexpr bool has_cartoon_bc_v = not std::is_void_v<find_cartoon_bc<List>>;
+
+/// Filter out cartoon boundary conditions from a list, leaving only external
+/// BCs
+template <typename List>
+using filter_out_cartoon_bcs =
+    tmpl::remove_if<List, inherits_from_mark_as_cartoon<tmpl::_1>>;
+}  // namespace detail
+
+/// Extract the cartoon boundary condition type from a system's boundary
+/// condition list. Returns void if no cartoon boundary condition is found.
+template <typename Metavariables>
+using get_cartoon_boundary_condition_from_system = detail::find_cartoon_bc<
+    tmpl::at<typename Metavariables::factory_creation::factory_classes,
+             typename Metavariables::system::boundary_conditions_base>>;
+
+/// Extract only the external (non-cartoon) boundary conditions from a system's
+/// boundary condition list. This should be used for user-selectable boundary
+/// condition options to prevent cartoon BCs from being specified as external
+/// BCs.
+template <typename Metavariables>
+using get_external_boundary_conditions_from_system =
+    detail::filter_out_cartoon_bcs<
+        tmpl::at<typename Metavariables::factory_creation::factory_classes,
+                 typename Metavariables::system::boundary_conditions_base>>;
+
+/// Check if a system has a cartoon boundary condition available
+template <typename Metavariables>
+constexpr bool system_has_cartoon_bc_v = not std::is_void_v<
+    get_cartoon_boundary_condition_from_system<Metavariables>>;
+
+/// Create a cartoon boundary condition for systems that support it.
+/// Returns nullptr if the system doesn't have a cartoon boundary condition.
+template <typename Metavariables>
+std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+make_cartoon_boundary_condition() {
+  if constexpr (system_has_cartoon_bc_v<Metavariables>) {
+    using cartoon_bc_type =
+        get_cartoon_boundary_condition_from_system<Metavariables>;
+    return std::make_unique<cartoon_bc_type>();
+  } else {
+    return nullptr;
+  }
+}
+}  // namespace domain::BoundaryConditions

--- a/src/Evolution/DiscontinuousGalerkin/Actions/BoundaryConditionsImpl.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/BoundaryConditionsImpl.hpp
@@ -20,6 +20,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Domain/Block.hpp"
+#include "Domain/BoundaryConditions/Cartoon.hpp"
 #include "Domain/BoundaryConditions/None.hpp"
 #include "Domain/BoundaryConditions/Periodic.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
@@ -696,11 +697,30 @@ void apply_boundary_conditions_on_all_external_faces(
   using factory_classes =
       typename std::decay_t<decltype(db::get<Parallel::Tags::Metavariables>(
           *box))>::factory_creation::factory_classes;
+
+  // If cartoon BC is available, verify mesh is compatible before removing BC
+  // (cartoon BCs are coupled with ZernikeB1 basis which does not need a BC, but
+  // subcell version of mesh does)
+  if constexpr (domain::BoundaryConditions::detail::has_cartoon_bc_v<
+                    tmpl::at<factory_classes,
+                             typename System::boundary_conditions_base>>) {
+    const auto& mesh = db::get<::domain::Tags::Mesh<Dim>>(*box);
+    if (not domain::BoundaryConditions::dg_mesh_is_cartoon_compatible(mesh)) {
+      ERROR(
+          "You might have used a Cartoon boundary condition on an external "
+          "boundary condition. Alternatively and less likely, there is a bug. "
+          "The mesh is: "
+          << mesh);
+    }
+  }
+
   using derived_boundary_conditions = tmpl::remove_if<
       tmpl::at<factory_classes, typename System::boundary_conditions_base>,
       tmpl::or_<
-          std::is_base_of<domain::BoundaryConditions::MarkAsPeriodic, tmpl::_1>,
-          std::is_base_of<domain::BoundaryConditions::MarkAsNone, tmpl::_1>>>;
+          std::is_base_of<domain::BoundaryConditions::MarkAsCartoon, tmpl::_1>,
+          std::is_base_of<domain::BoundaryConditions::MarkAsNone, tmpl::_1>,
+          std::is_base_of<domain::BoundaryConditions::MarkAsPeriodic,
+                          tmpl::_1>>>;
 
   using variables_tag = typename System::variables_tag;
   using flux_variables = typename System::flux_variables;

--- a/tests/Unit/Domain/BoundaryConditions/CMakeLists.txt
+++ b/tests/Unit/Domain/BoundaryConditions/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_DomainBoundaryConditions")
 
 set(LIBRARY_SOURCES
   Test_BoundaryCondition.cpp
+  Test_Cartoon.cpp
   Test_GenericBcs.cpp
   Test_GetBoundaryConditionsBase.cpp
   )

--- a/tests/Unit/Domain/BoundaryConditions/Test_Cartoon.cpp
+++ b/tests/Unit/Domain/BoundaryConditions/Test_Cartoon.cpp
@@ -1,0 +1,196 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <type_traits>
+
+#include "Domain/BoundaryConditions/Cartoon.hpp"
+#include "Helpers/Domain/BoundaryConditions/BoundaryCondition.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+namespace helpers = TestHelpers::domain::BoundaryConditions;
+
+using MockCartoonBC = helpers::TestCartoonBoundaryCondition<3>;
+using MockRegularBC = helpers::TestBoundaryCondition<3>;
+using MockSystemBCBase = helpers::BoundaryConditionBase<3>;
+
+// Mock metavariables for testing
+template <typename BCList>
+struct MockMetavariables {
+  using system = helpers::SystemWithBoundaryConditions<3>;
+
+  struct factory_creation {
+    using factory_classes = tmpl::map<tmpl::pair<MockSystemBCBase, BCList>>;
+  };
+};
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.Domain.BoundaryConditions.Cartoon.TemplateMetafunctions",
+    "[Unit][Domain]") {
+  {
+    INFO("Testing basic metafunctions");
+    // Test inherits_from_mark_as_cartoon trait
+    static_assert(
+        domain::BoundaryConditions::detail::inherits_from_mark_as_cartoon<
+            MockCartoonBC>::value);
+    static_assert(
+        not domain::BoundaryConditions::detail::inherits_from_mark_as_cartoon<
+            MockRegularBC>::value);
+
+    // Test find_cartoon_bc with list containing cartoon BC
+    using list_with_cartoon = tmpl::list<MockRegularBC, MockCartoonBC>;
+    using found_cartoon =
+        domain::BoundaryConditions::detail::find_cartoon_bc<list_with_cartoon>;
+    static_assert(std::is_same_v<found_cartoon, MockCartoonBC>);
+
+    // Test find_cartoon_bc with list containing no cartoon BC
+    using list_without_cartoon = tmpl::list<MockRegularBC>;
+    using found_none = domain::BoundaryConditions::detail::find_cartoon_bc<
+        list_without_cartoon>;
+    static_assert(std::is_same_v<found_none, void>);
+
+    // Test find_cartoon_bc with empty list
+    using empty_list = tmpl::list<>;
+    using found_empty =
+        domain::BoundaryConditions::detail::find_cartoon_bc<empty_list>;
+    static_assert(std::is_same_v<found_empty, void>);
+
+    // Test has_cartoon_bc_v
+    static_assert(domain::BoundaryConditions::detail::has_cartoon_bc_v<
+                  list_with_cartoon>);
+    static_assert(not domain::BoundaryConditions::detail::has_cartoon_bc_v<
+                  list_without_cartoon>);
+    static_assert(
+        not domain::BoundaryConditions::detail::has_cartoon_bc_v<empty_list>);
+
+    // Test filter_out_cartoon_bcs
+    using filtered_list =
+        domain::BoundaryConditions::detail::filter_out_cartoon_bcs<
+            list_with_cartoon>;
+    using expected_filtered = tmpl::list<MockRegularBC>;
+    static_assert(std::is_same_v<filtered_list, expected_filtered>);
+
+    // Test filter_out_cartoon_bcs with list that has no cartoon BCs
+    using filtered_no_cartoon =
+        domain::BoundaryConditions::detail::filter_out_cartoon_bcs<
+            list_without_cartoon>;
+    static_assert(std::is_same_v<filtered_no_cartoon, list_without_cartoon>);
+
+    // Test get_cartoon_boundary_condition_from_system
+    using metavars_with_cartoon = MockMetavariables<list_with_cartoon>;
+    using system_cartoon_bc =
+        domain::BoundaryConditions::get_cartoon_boundary_condition_from_system<
+            metavars_with_cartoon>;
+    static_assert(std::is_same_v<system_cartoon_bc, MockCartoonBC>);
+
+    using metavars_without_cartoon = MockMetavariables<list_without_cartoon>;
+    using system_no_cartoon_bc =
+        domain::BoundaryConditions::get_cartoon_boundary_condition_from_system<
+            metavars_without_cartoon>;
+    static_assert(std::is_same_v<system_no_cartoon_bc, void>);
+
+    // Test get_external_boundary_conditions_from_system
+    using external_bcs = domain::BoundaryConditions::
+        get_external_boundary_conditions_from_system<metavars_with_cartoon>;
+    static_assert(std::is_same_v<external_bcs, expected_filtered>);
+
+    using external_bcs_no_cartoon = domain::BoundaryConditions::
+        get_external_boundary_conditions_from_system<metavars_without_cartoon>;
+    static_assert(
+        std::is_same_v<external_bcs_no_cartoon, list_without_cartoon>);
+
+    // Test system_has_cartoon_bc_v
+    static_assert(domain::BoundaryConditions::system_has_cartoon_bc_v<
+                  metavars_with_cartoon>);
+    static_assert(not domain::BoundaryConditions::system_has_cartoon_bc_v<
+                  metavars_without_cartoon>);
+  }
+  {
+    INFO("Testing multiple cartoon BC");
+    // Test that having multiple cartoon BCs triggers static_assert
+    // We can't test the static_assert directly, but we can test that
+    // find_cartoon_bc_impl would catch it at the right place
+
+    // Create a second mock cartoon BC using the existing test helper pattern
+    using AnotherMockCartoonBC =
+        domain::BoundaryConditions::Cartoon<MockSystemBCBase>;
+
+    // Test that the filter correctly identifies both as cartoon BCs
+    using list_with_two_cartoons =
+        tmpl::list<MockCartoonBC, AnotherMockCartoonBC, MockRegularBC>;
+    using filtered_two_cartoons =
+        domain::BoundaryConditions::detail::filter_out_cartoon_bcs<
+            list_with_two_cartoons>;
+    using expected_filtered_two = tmpl::list<MockRegularBC>;
+    static_assert(std::is_same_v<filtered_two_cartoons, expected_filtered_two>);
+
+    // Note: The static_assert in find_cartoon_bc_impl will prevent compilation
+    // if someone tries to use get_cartoon_boundary_condition_from_system with
+    // a list containing multiple cartoon BCs
+  }
+  {
+    INFO("Testing make cartoon BC");
+    // Test make_cartoon_boundary_condition function
+    using metavars_with_cartoon =
+        MockMetavariables<tmpl::list<MockCartoonBC, MockRegularBC>>;
+    using metavars_without_cartoon =
+        MockMetavariables<tmpl::list<MockRegularBC>>;
+
+    // Test with system that has cartoon BC
+    auto cartoon_bc =
+        domain::BoundaryConditions::make_cartoon_boundary_condition<
+            metavars_with_cartoon>();
+    CHECK(cartoon_bc != nullptr);
+    CHECK(domain::BoundaryConditions::is_cartoon(cartoon_bc));
+
+    // Test with system that doesn't have cartoon BC
+    auto no_cartoon_bc =
+        domain::BoundaryConditions::make_cartoon_boundary_condition<
+            metavars_without_cartoon>();
+    CHECK(no_cartoon_bc == nullptr);
+  }
+  {
+    INFO("Testing compatibility check");
+    CHECK(domain::BoundaryConditions::dg_mesh_is_cartoon_compatible(
+        Mesh<3>{{3, 1, 1},
+                {Spectral::Basis::ZernikeB1, Spectral::Basis::Cartoon,
+                 Spectral::Basis::Cartoon},
+                {Spectral::Quadrature::GaussRadauUpper,
+                 Spectral::Quadrature::AxialSymmetry,
+                 Spectral::Quadrature::AxialSymmetry}}));
+    CHECK(domain::BoundaryConditions::dg_mesh_is_cartoon_compatible(Mesh<3>{
+        {3, 4, 1},
+        {Spectral::Basis::ZernikeB1, Spectral::Basis::Legendre,
+         Spectral::Basis::Cartoon},
+        {Spectral::Quadrature::GaussRadauUpper, Spectral::Quadrature::Gauss,
+         Spectral::Quadrature::SphericalSymmetry}}));
+    CHECK(domain::BoundaryConditions::dg_mesh_is_cartoon_compatible(Mesh<3>{
+        {5, 4, 1},
+        {Spectral::Basis::Legendre, Spectral::Basis::Chebyshev,
+         Spectral::Basis::Cartoon},
+        {Spectral::Quadrature::GaussLobatto, Spectral::Quadrature::Gauss,
+         Spectral::Quadrature::SphericalSymmetry}}));
+    CHECK_FALSE(
+        domain::BoundaryConditions::dg_mesh_is_cartoon_compatible(Mesh<3>{
+            3, Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto}));
+    CHECK_FALSE(
+        domain::BoundaryConditions::dg_mesh_is_cartoon_compatible(Mesh<2>{
+            3, Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto}));
+    CHECK_FALSE(
+        domain::BoundaryConditions::dg_mesh_is_cartoon_compatible(Mesh<1>{
+            3, Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto}));
+    CHECK_FALSE(domain::BoundaryConditions::dg_mesh_is_cartoon_compatible(
+        Mesh<3>{{3, 4, 1},
+                {Spectral::Basis::Legendre, Spectral::Basis::Cartoon,
+                 Spectral::Basis::Chebyshev},
+                {Spectral::Quadrature::GaussLobatto,
+                 Spectral::Quadrature::AxialSymmetry,
+                 Spectral::Quadrature::GaussLobatto}}));
+  }
+}

--- a/tests/Unit/Domain/BoundaryConditions/Test_GenericBcs.cpp
+++ b/tests/Unit/Domain/BoundaryConditions/Test_GenericBcs.cpp
@@ -8,6 +8,7 @@
 #include <string>
 
 #include "Domain/BoundaryConditions/BoundaryCondition.hpp"
+#include "Domain/BoundaryConditions/Cartoon.hpp"
 #include "Domain/BoundaryConditions/None.hpp"
 #include "Domain/BoundaryConditions/Periodic.hpp"
 #include "Framework/TestHelpers.hpp"
@@ -22,25 +23,49 @@ SPECTRE_TEST_CASE("Unit.Domain.BoundaryConditions.GenericBcs",
                   "[Unit][Domain]") {
   helpers::register_derived_with_charm();
 
-  std::unique_ptr<domain::BoundaryConditions::BoundaryCondition> periodic =
-      std::make_unique<helpers::TestPeriodicBoundaryCondition<1>>();
+  const std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+      periodic = std::make_unique<helpers::TestPeriodicBoundaryCondition<1>>();
   CHECK(is_periodic(periodic));
   CHECK(is_periodic(serialize_and_deserialize(periodic)));
   CHECK_FALSE(is_none(periodic));
   CHECK_FALSE(is_none(serialize_and_deserialize(periodic)));
+  CHECK_FALSE(is_cartoon(periodic));
+  CHECK_FALSE(is_cartoon(serialize_and_deserialize(periodic)));
 
-  std::unique_ptr<domain::BoundaryConditions::BoundaryCondition> not_periodic =
-      std::make_unique<helpers::TestBoundaryCondition<1>>();
+  const std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+      not_periodic = std::make_unique<helpers::TestBoundaryCondition<1>>();
   CHECK_FALSE(is_periodic(not_periodic));
   CHECK_FALSE(is_periodic(serialize_and_deserialize(not_periodic)));
   CHECK_FALSE(is_none(not_periodic));
   CHECK_FALSE(is_none(serialize_and_deserialize(not_periodic)));
+  CHECK_FALSE(is_cartoon(not_periodic));
+  CHECK_FALSE(is_cartoon(serialize_and_deserialize(not_periodic)));
 
-  std::unique_ptr<domain::BoundaryConditions::BoundaryCondition> none =
+  const std::unique_ptr<domain::BoundaryConditions::BoundaryCondition> cartoon =
+      std::make_unique<helpers::TestCartoonBoundaryCondition<3>>();
+  CHECK(is_cartoon(cartoon));
+  CHECK(is_cartoon(serialize_and_deserialize(cartoon)));
+  CHECK_FALSE(is_none(cartoon));
+  CHECK_FALSE(is_none(serialize_and_deserialize(cartoon)));
+  CHECK_FALSE(is_periodic(cartoon));
+  CHECK_FALSE(is_periodic(serialize_and_deserialize(cartoon)));
+
+  const std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+      not_cartoon = std::make_unique<helpers::TestBoundaryCondition<1>>();
+  CHECK_FALSE(is_cartoon(not_cartoon));
+  CHECK_FALSE(is_cartoon(serialize_and_deserialize(not_cartoon)));
+  CHECK_FALSE(is_none(not_cartoon));
+  CHECK_FALSE(is_none(serialize_and_deserialize(not_cartoon)));
+  CHECK_FALSE(is_periodic(not_cartoon));
+  CHECK_FALSE(is_periodic(serialize_and_deserialize(not_cartoon)));
+
+  const std::unique_ptr<domain::BoundaryConditions::BoundaryCondition> none =
       std::make_unique<helpers::TestNoneBoundaryCondition<1>>();
   CHECK(is_none(none));
   CHECK(is_none(serialize_and_deserialize(none)));
   CHECK_FALSE(is_periodic(none));
   CHECK_FALSE(is_periodic(serialize_and_deserialize(none)));
+  CHECK_FALSE(is_cartoon(none));
+  CHECK_FALSE(is_cartoon(serialize_and_deserialize(none)));
 }
 }  // namespace

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_BoundaryConditions.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_BoundaryConditions.cpp
@@ -25,6 +25,7 @@
 #include "DataStructures/VariablesTag.hpp"
 #include "Domain/Block.hpp"
 #include "Domain/BoundaryConditions/BoundaryCondition.hpp"
+#include "Domain/BoundaryConditions/Cartoon.hpp"
 #include "Domain/BoundaryConditions/None.hpp"
 #include "Domain/BoundaryConditions/Periodic.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
@@ -2101,12 +2102,30 @@ using standard_boundary_conditions =
                domain::BoundaryConditions::None<BoundaryCondition<System>>>;
 
 template <typename System>
+using boundary_conditions_with_cartoon =
+    tmpl::list<DemandOutgoingCharSpeeds<System>, Ghost<System>,
+               TimeDerivative<System>, GhostAndTimeDerivative<System>,
+               domain::BoundaryConditions::Periodic<BoundaryCondition<System>>,
+               domain::BoundaryConditions::None<BoundaryCondition<System>>,
+               domain::BoundaryConditions::Cartoon<BoundaryCondition<System>>>;
+
+template <typename System>
 struct Metavariables {
   struct factory_creation
       : tt::ConformsTo<Options::protocols::FactoryCreation> {
     using factory_classes =
         tmpl::map<tmpl::pair<BoundaryCondition<System>,
                              standard_boundary_conditions<System>>>;
+  };
+};
+
+template <typename System>
+struct MetavariablesWithCartoon {
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes =
+        tmpl::map<tmpl::pair<BoundaryCondition<System>,
+                             boundary_conditions_with_cartoon<System>>>;
   };
 };
 
@@ -2593,6 +2612,96 @@ void test_1d(const bool moving_mesh, const dg::Formulation formulation,
   check_ghost_and_dt_combined_bc(Direction<Dim>::lower_xi());
 }
 
+void test_cartoon_mesh_compatibility() {
+  INFO("Test that non-cartoon mesh throws with cartoon boundary conditions");
+
+  // Create a 1D system with cartoon boundary conditions
+  using TestSystem = System<1, SystemType::Conservative, false, false>;
+
+  // Create a non-cartoon compatible mesh (regular Legendre basis)
+  const Mesh<1> non_cartoon_mesh{3, Spectral::Basis::Legendre,
+                                 Spectral::Quadrature::GaussLobatto};
+
+  const ElementId<1> element_id{0};
+  const Element<1> element{element_id, {}};
+  const double boundary_condition_volume_tag_number{2.5};
+  const double boundary_correction_volume_tag_number{3.5};
+
+  // Set up boundary conditions with cartoon BC on one boundary
+  std::vector<DirectionMap<
+      1, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
+      external_boundary_conditions{1};
+  external_boundary_conditions[0][Direction<1>::lower_xi()] = std::make_unique<
+      domain::BoundaryConditions::Cartoon<BoundaryCondition<TestSystem>>>();
+
+  auto boundary_correction =
+      BoundaryTerms<1, false, SystemType::Conservative, false>{false, 1.0};
+
+  using dt_variables_tag =
+      db::add_tag_prefix<::Tags::dt, typename TestSystem::variables_tag>;
+  using simple_tags = tmpl::list<
+      Parallel::Tags::MetavariablesImpl<MetavariablesWithCartoon<TestSystem>>,
+      domain::Tags::ExternalBoundaryConditions<1>, domain::Tags::Mesh<1>,
+      domain::Tags::Element<1>, domain::Tags::ElementMap<1, Frame::Grid>,
+      domain::CoordinateMaps::Tags::CoordinateMap<1, Frame::Grid,
+                                                  Frame::Inertial>,
+      ::Tags::Time, domain::Tags::FunctionsOfTime,
+      domain::Tags::MeshVelocity<1>,
+      domain::Tags::InverseJacobian<1, Frame::ElementLogical, Frame::Inertial>,
+      domain::Tags::DetInvJacobian<Frame::ElementLogical, Frame::Inertial>,
+      evolution::dg::Tags::NormalCovectorAndMagnitude<1>,
+      typename TestSystem::variables_tag, dt_variables_tag,
+      Tags::BoundaryConditionVolumeTag, Tags::BoundaryCorrectionVolumeTag,
+      ::dg::Tags::Formulation>;
+  using compute_tags = tmpl::list<>;
+
+  Variables<typename TestSystem::variables_tag::tags_list> evolved_vars{3, 1.0};
+  Variables<db::wrap_tags_in<::Tags::dt,
+                             typename TestSystem::variables_tag::tags_list>>
+      dt_evolved_vars{3, 0.0};
+
+  auto box = db::create<simple_tags, compute_tags>(
+      MetavariablesWithCartoon<TestSystem>{},
+      std::move(external_boundary_conditions), non_cartoon_mesh, element,
+      ElementMap<1, Frame::Grid>{
+          element_id,
+          domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Grid>(
+              domain::CoordinateMaps::Identity<1>{})},
+      domain::make_coordinate_map_base<Frame::Grid, Frame::Inertial>(
+          domain::CoordinateMaps::Identity<1>{}),
+      0.0,
+      std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{},
+      std::optional<tnsr::I<DataVector, 1>>{},
+      InverseJacobian<DataVector, 1, Frame::ElementLogical, Frame::Inertial>{
+          3_st, 1.0},
+      Scalar<DataVector>{3_st, 1.0},
+      evolution::dg::Tags::NormalCovectorAndMagnitude<1>::type{}, evolved_vars,
+      dt_evolved_vars, boundary_condition_volume_tag_number,
+      boundary_correction_volume_tag_number, dg::Formulation::StrongInertial);
+
+  // Create minimal temporaries, fluxes, and partial derivatives
+  const Variables<tmpl::list<Tags::Var3Squared>> temporaries{3, 1.0};
+  const Variables<
+      db::wrap_tags_in<::Tags::Flux, tmpl::list<Tags::Var1, Tags::Var2<1>>,
+                       tmpl::size_t<1>, Frame::Inertial>>
+      volume_fluxes{3, 1.0};
+  const Variables<db::wrap_tags_in<::Tags::deriv, tmpl::list<>, tmpl::size_t<1>,
+                                   Frame::Inertial>>
+      partial_derivs{};
+
+  // This should throw because we have cartoon BC but non-cartoon mesh
+  CHECK_THROWS_WITH(
+      (evolution::dg::Actions::detail::
+           apply_boundary_conditions_on_all_external_faces<TestSystem, 1>(
+               make_not_null(&box), boundary_correction, temporaries,
+               volume_fluxes, partial_derivs, nullptr)),
+      Catch::Matchers::ContainsSubstring(
+          "You might have used a Cartoon boundary condition on an external "
+          "boundary condition"));
+}
+
 SPECTRE_TEST_CASE("Unit.Evolution.DG.ComputeTimeDerivative.BoundaryConditions",
                   "[Unit][Evolution][Actions]") {
   // The test proceeds as follows:
@@ -2650,5 +2759,6 @@ SPECTRE_TEST_CASE("Unit.Evolution.DG.ComputeTimeDerivative.BoundaryConditions",
       }
     }
   }
+  test_cartoon_mesh_compatibility();
 }
 }  // namespace

--- a/tests/Unit/Helpers/Domain/BoundaryConditions/BoundaryCondition.hpp
+++ b/tests/Unit/Helpers/Domain/BoundaryConditions/BoundaryCondition.hpp
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "Domain/BoundaryConditions/BoundaryCondition.hpp"
+#include "Domain/BoundaryConditions/Cartoon.hpp"
 #include "Domain/BoundaryConditions/None.hpp"
 #include "Domain/BoundaryConditions/Periodic.hpp"
 #include "Domain/Creators/DomainCreator.hpp"
@@ -39,7 +40,8 @@ class BoundaryConditionBase
   using creatable_classes = tmpl::list<
       TestBoundaryCondition<Dim>,
       ::domain::BoundaryConditions::None<BoundaryConditionBase<Dim>>,
-      ::domain::BoundaryConditions::Periodic<BoundaryConditionBase<Dim>>>;
+      ::domain::BoundaryConditions::Periodic<BoundaryConditionBase<Dim>>,
+      ::domain::BoundaryConditions::Cartoon<BoundaryConditionBase<Dim>>>;
 
   BoundaryConditionBase() = default;
   BoundaryConditionBase(BoundaryConditionBase&&) = default;
@@ -116,6 +118,10 @@ using TestPeriodicBoundaryCondition =
     ::domain::BoundaryConditions::Periodic<BoundaryConditionBase<Dim>>;
 
 template <size_t Dim>
+using TestCartoonBoundaryCondition =
+    ::domain::BoundaryConditions::Cartoon<BoundaryConditionBase<Dim>>;
+
+template <size_t Dim>
 using TestNoneBoundaryCondition =
     ::domain::BoundaryConditions::None<BoundaryConditionBase<Dim>>;
 
@@ -136,7 +142,27 @@ struct MetavariablesWithBoundaryConditions {
   struct factory_creation
       : tt::ConformsTo<Options::protocols::FactoryCreation> {
     using factory_classes =
-        tmpl::map<tmpl::pair<DomainCreator<Dim>, tmpl::list<Creator>>>;
+        tmpl::map<tmpl::pair<DomainCreator<Dim>, tmpl::list<Creator>>,
+                  tmpl::pair<BoundaryConditionBase<Dim>,
+                             tmpl::list<TestBoundaryCondition<Dim>,
+                                        TestPeriodicBoundaryCondition<Dim>,
+                                        TestNoneBoundaryCondition<Dim>>>>;
+  };
+};
+
+/// Metavariables with a system that has boundary conditions including cartoon
+template <size_t Dim, typename Creator>
+struct MetavariablesWithBoundaryConditionsCartoon {
+  using system = SystemWithBoundaryConditions<Dim>;
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes =
+        tmpl::map<tmpl::pair<DomainCreator<Dim>, tmpl::list<Creator>>,
+                  tmpl::pair<BoundaryConditionBase<Dim>,
+                             tmpl::list<TestBoundaryCondition<Dim>,
+                                        TestPeriodicBoundaryCondition<Dim>,
+                                        TestNoneBoundaryCondition<Dim>,
+                                        TestCartoonBoundaryCondition<Dim>>>>;
   };
 };
 


### PR DESCRIPTION
## Proposed changes

Elements neighboring the $y$-axis use ZernikeB1 basis when doing cartoon, which does not need a boundary condition. However, when using subcell we do need to give ghost data. This PR makes a BC type that will be skipped for the DG time derivatives but properly plugs in FG ghost data. 

Systems without subcell can put the default `Cartoon` BC in their factory list and be fine (currently just ScalarWave) while systems using subcell will have to create a system-specific BC (currently just Valencia and GhValencia)

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
