### PR TITLE
Move restarting phase logic to Main

### DIFF
--- a/docs/Tutorials/CheckpointRestart.md
+++ b/docs/Tutorials/CheckpointRestart.md
@@ -78,9 +78,8 @@ For example: activation thresholds on various algorithms, or frequency of data
 observation, are safe parameters to modify.
 
 The executable will update the global cache with new input file values during
-the phase `UpdateOptionsAtRestartFromCheckpoint`. The
-`CheckpointAndExitAfterWallclock` phase control automatically directs code flow
-to this phase after a restart.
+the phase `UpdateOptionsAtRestartFromCheckpoint`. The restart logic
+automatically directs code flow to this phase after a restart.
 
 In this option-updating phase, the code tries to read an "overlay" input file
 whose name is computed from the original input file and the number of the
@@ -89,3 +88,10 @@ and the code is restarted using a checkpoint
 `+restart Checkpoints/Checkpoint_0123`, then the overlay input file to read
 has name `path/to/Input.overlay_0123.yaml`. If this file does not exist, the
 executable continues with previous parameter values.
+
+After the `UpdateOptionsAtRestartFromCheckpoint` phase runs, the code will
+automatically transition to the `Restart` phase.  This phase is usually used to
+redo various registration actions that may have been invalidated by the restart
+or option-overlaying.  Control is then returned to the normal phase-arbitration
+code, which will usually return to the phase that was active before the
+checkpoint.

--- a/src/Parallel/Main.hpp
+++ b/src/Parallel/Main.hpp
@@ -51,6 +51,7 @@
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TypeTraits/CreateGetTypeAliasOrDefault.hpp"
 #include "Utilities/TypeTraits/CreateIsCallable.hpp"
+#include "Utilities/UtcTime.hpp"
 
 #include "Parallel/Main.decl.h"
 
@@ -767,9 +768,20 @@ void Main<Metavariables>::execute_next_phase() {
       sys::abort("");
     }
 
-    const auto next_phase = PhaseControl::arbitrate_phase_change(
-        make_not_null(&phase_change_decision_data_), current_phase_,
-        *Parallel::local_branch(global_cache_proxy_));
+    std::optional<Parallel::Phase> next_phase{};
+    if (just_restored_from_checkpoint_) {
+      just_restored_from_checkpoint_ = false;
+      Parallel::printf("Restarting from checkpoint. Date and time: %s\n",
+                       utc_time());
+      next_phase.emplace(Parallel::Phase::UpdateOptionsAtRestartFromCheckpoint);
+    } else if (current_phase_ ==
+               Parallel::Phase::UpdateOptionsAtRestartFromCheckpoint) {
+      next_phase.emplace(Parallel::Phase::Restart);
+    } else {
+      next_phase = PhaseControl::arbitrate_phase_change(
+          make_not_null(&phase_change_decision_data_), current_phase_,
+          *Parallel::local_branch(global_cache_proxy_));
+    }
     if (next_phase.has_value()) {
       // Only print info if there was an actual phase change.
       if (current_phase_ != next_phase.value()) {
@@ -844,15 +856,9 @@ void Main<Metavariables>::execute_next_phase() {
 
   // We skip the reparsing and overlaying if there are no eligible tags
   if constexpr (tmpl::size<overlayable_option_list>::value > 0) {
-    // Make sure we only update the options the first time we run the phase
-    // UpdateOptionsAtRestartFromCheckpoint after restoring from checkpoint.
-    // Else, the code might try to update options each time the phase was
-    // encountered, even if there was no checkpoint/restart...
-    if (just_restored_from_checkpoint_ and
-        current_phase_ ==
-            Parallel::Phase::UpdateOptionsAtRestartFromCheckpoint) {
+    if (current_phase_ ==
+        Parallel::Phase::UpdateOptionsAtRestartFromCheckpoint) {
       update_const_global_cache_from_input_file();
-      just_restored_from_checkpoint_ = false;
     }
   }
 

--- a/src/Parallel/PhaseControl/CheckpointAndExitAfterWallclock.hpp
+++ b/src/Parallel/PhaseControl/CheckpointAndExitAfterWallclock.hpp
@@ -24,7 +24,6 @@
 #include "Utilities/Serialization/CharmPupable.hpp"
 #include "Utilities/System/ParallelInfo.hpp"
 #include "Utilities/TMPL.hpp"
-#include "Utilities/UtcTime.hpp"
 
 namespace PhaseControl {
 
@@ -71,10 +70,6 @@ struct CheckpointAndExitRequested {
  * Writing a single checkpoint at the end of the job's allocated time allows
  * the computation to be continued, while minimizing the disc space taken up by
  * checkpoint files.
- *
- * When restarting from the checkpoint, this phase control sends the control
- * flow to a UpdateOptionsAtRestartFromCheckpoint phase, allowing the user to
- * update (some) simulation parameters for the continuation of the run.
  *
  * Note that this phase control is not a trigger on wallclock time. Rather,
  * it checks the elapsed wallclock time when called, likely from a global sync
@@ -215,18 +210,6 @@ CheckpointAndExitAfterWallclock::arbitrate_phase_change_impl(
       return std::make_pair(Parallel::Phase::Exit,
                             ArbitrationStrategy::RunPhaseImmediately);
     } else {
-      // if current_phase is WriteCheckpoint, we follow with updating options
-      if (current_phase == Parallel::Phase::WriteCheckpoint) {
-        Parallel::printf("Restarting from checkpoint. Date and time: %s\n",
-                         utc_time());
-        return std::make_pair(
-            Parallel::Phase::UpdateOptionsAtRestartFromCheckpoint,
-            ArbitrationStrategy::PermitAdditionalJumps);
-      } else if (current_phase ==
-                 Parallel::Phase::UpdateOptionsAtRestartFromCheckpoint) {
-        return std::make_pair(Parallel::Phase::Restart,
-                              ArbitrationStrategy::PermitAdditionalJumps);
-      }
       // Reset restart_phase until it is needed for the next checkpoint
       const auto result = restart_phase;
       restart_phase.reset();

--- a/tests/Unit/Parallel/PhaseControl/Test_CheckpointAndExitAfterWallclock.cpp
+++ b/tests/Unit/Parallel/PhaseControl/Test_CheckpointAndExitAfterWallclock.cpp
@@ -106,31 +106,10 @@ SPECTRE_TEST_CASE("Unit.Parallel.PhaseControl.CheckpointAndExitAfterWallclock",
         serialize_and_deserialize(phase_change0);
     PhaseChangeDecisionData phase_change_decision_data{
         Parallel::Phase::Execute, false, true, Parallel::ExitCode::Complete};
+
+    // Main will normally run some phases on its own at this point,
+    // but will return control to us after the Restart phase.
     auto decision_result = phase_change_restart.arbitrate_phase_change(
-        make_not_null(&phase_change_decision_data),
-        Parallel::Phase::WriteCheckpoint, cache);
-    CHECK(decision_result ==
-          std::make_pair(
-              Parallel::Phase::UpdateOptionsAtRestartFromCheckpoint,
-              PhaseControl::ArbitrationStrategy::PermitAdditionalJumps));
-    CHECK(phase_change_decision_data ==
-          PhaseChangeDecisionData{Parallel::Phase::Execute, false, true,
-                                  Parallel::ExitCode::Complete});
-
-    // Next, from update phase, go to Restart
-    decision_result = phase_change_restart.arbitrate_phase_change(
-        make_not_null(&phase_change_decision_data),
-        Parallel::Phase::UpdateOptionsAtRestartFromCheckpoint, cache);
-    CHECK(decision_result ==
-          std::make_pair(
-              Parallel::Phase::Restart,
-              PhaseControl::ArbitrationStrategy::PermitAdditionalJumps));
-    CHECK(phase_change_decision_data ==
-          PhaseChangeDecisionData{Parallel::Phase::Execute, false, true,
-                                  Parallel::ExitCode::Complete});
-
-    // Finally, go back to Execute
-    decision_result = phase_change_restart.arbitrate_phase_change(
         make_not_null(&phase_change_decision_data), Parallel::Phase::Restart,
         cache);
     CHECK(decision_result ==

--- a/tests/Unit/Parallel/Test_CheckpointRestart.cpp
+++ b/tests/Unit/Parallel/Test_CheckpointRestart.cpp
@@ -283,10 +283,15 @@ struct TestMetavariables {
 
   static constexpr Options::String help = "";
 
-  static constexpr std::array<Parallel::Phase, 5> default_phase_order{
-      {Parallel::Phase::Initialization, Parallel::Phase::Execute,
-       Parallel::Phase::WriteCheckpoint, Parallel::Phase::Testing,
-       Parallel::Phase::Exit}};
+  static constexpr std::array default_phase_order{
+      Parallel::Phase::Initialization, Parallel::Phase::Execute,
+      Parallel::Phase::WriteCheckpoint,
+      // Test doesn't do anything in Restart phase, but Main puts us
+      // there after a restart.  Normally phase arbitration would
+      // restore the correct phase from there, but this test doesn't
+      // use that.
+      Parallel::Phase::Restart, Parallel::Phase::Testing,
+      Parallel::Phase::Exit};
 
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& /*p*/) {}


### PR DESCRIPTION
We need to go through the restarting phases for any checkpoint, not just one written from CheckpointAndExitAfterWallclock.

Submitting initially as a draft because I haven't yet removed the code in CheckpointAndExitAfterWallclock.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
