### PR TITLE
Fix check for observation value in GenerateTetrahedralConnectivity

### DIFF
--- a/src/Visualization/Python/GenerateTetrahedralConnectivity.py
+++ b/src/Visualization/Python/GenerateTetrahedralConnectivity.py
@@ -113,6 +113,7 @@ def generate_tetrahedral_connectivity(
         [
             (key, vol_subfile[key].attrs["observation_value"])
             for key in vol_subfile.keys()
+            if key.startswith("ObservationId")
         ],
         key=lambda key_and_time: key_and_time[1],
     )


### PR DESCRIPTION
## Proposed changes

One-line fix to `GenerateTetrahedralConnectivity`. There seems to had been a change to the format of the output volume files which required this line (present in `GenerateXdmf`), but it was missed here.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
