### PR TITLE
Skip adding ID attributes with tetrahedral connectivity

### DIFF
--- a/src/Visualization/Python/GenerateXdmf.py
+++ b/src/Visualization/Python/GenerateXdmf.py
@@ -368,7 +368,7 @@ def _xmf_grid(
 
     # For new-format volume data, add cell-centered element_id and block_id
     # attributes (not for the pole-filling grid, which uses pole_connectivity).
-    if is_new_format and not filling_poles:
+    if is_new_format and not filling_poles and not use_tetrahedral_connectivity:
         number_of_cells = _count_cells_in_mixed_connectivity(
             observation["connectivity"][:]
         )


### PR DESCRIPTION
## Proposed changes

One-line fix to stop segfaults when rendering data that used tetrahedral connectivity. A block of code in `GenerateXdmf` added `ElementID` and `BlockID` attributes, but this section does not work well with the case of tetrahedral connectivity.
- The _count_cells_in_mixed_connectivity expects information about connectivity in a different format than is provided in the tetrahedral case. This causes the segfault.
- The value for these attributes is ambiguous at element/block boundaries, making a solution that would include this data even in the tetrahedral case is not trivial.
For now the best solution seems to be to just skip this step in the tetrahedral case.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
