### PR TITLE
Add --removing-overlapping-segments flag to CombineH5Dat.py 

### DIFF
--- a/src/IO/H5/Python/CombineH5Dat.py
+++ b/src/IO/H5/Python/CombineH5Dat.py
@@ -7,24 +7,31 @@ import shutil
 
 import click
 import h5py
+import numpy as np
 
 from spectre.IO.H5 import available_subfiles
 
 
-def combine_h5_dat(h5files, output, force):
+def combine_h5_dat(h5files, output, force, remove_overlapping_segments):
     """Combines multiple HDF5 dat files
 
     This executable is used for combining a series of HDF5 files, each
     containing one or more dat files, into a single HDF5 file. A typical
     use case is to join dat-containing HDF5 files from different segments
     of a simulation, with each segment containing values of the dat files
-    during different time intervals.
+    during different time intervals. The executable is sensitive to order, so
+    if you aim to combine h5 files from different segments of a simulation,
+    verify that the order you combine is chronological to preserve relative time
+    continuity.
 
     \f
     Arguments:
       h5files: List of H5 dat files to join
       output: Output filename. An extension '.h5' will be added if not present.
-      force: If specified, overwrite output file if it already exists
+      force: If specified, overwrite output file if it already exists.
+      remove_overlapping_segments: If specified, remove data with overlapping
+        times, preserving later times from h5 files. Verify h5 files are ordered
+        correctly, otherwise the option will remove more data than desired.
     """
     # Copy first input file to output file
     if not output.endswith(".h5"):
@@ -38,24 +45,58 @@ def combine_h5_dat(h5files, output, force):
     with h5py.File(output, "r+") as out:
         # Get a list of all dat file keys (keys ending in ".dat")
         dat_file_keys = available_subfiles(out, extension=".dat")
-
+        # Sort first h5 file with monotonically increasing times before
+        # appending other files to it
+        if remove_overlapping_segments:
+            for dat_file_key in dat_file_keys:
+                data_to_sort = np.asarray(out[dat_file_key])
+                # Assuming time is the first column in all dat files
+                time_order = np.argsort(data_to_sort[:, 0])
+                monotonic_data = data_to_sort[time_order]
+                out[dat_file_key][:] = monotonic_data
         # Loop over remaining input files, appending each dat file
         for input_file in h5files[1:]:
             with h5py.File(input_file, "r") as input:
                 for dat_file_key in dat_file_keys:
                     if dat_file_key in input.keys():
-                        data_to_append = input[dat_file_key]
+                        # Sort dat files by time to guarantee each segment is
+                        # monotonically increasing since spectre does not do
+                        # this during simulations.
+                        if remove_overlapping_segments:
+                            data_to_sort = np.asarray(input[dat_file_key])
+                            # Assuming time is the first column in all dat files
+                            time_order = np.argsort(data_to_sort[:, 0])
+                            data_to_append = data_to_sort[time_order]
+                        else:
+                            data_to_append = input[dat_file_key]
                         start_size = out[dat_file_key].shape[0]
-                        append_size = input[dat_file_key].shape[0]
+                        append_size = data_to_append.shape[0]
                         out[dat_file_key].resize(
                             start_size + append_size, axis=0
                         )
-                        out[dat_file_key][start_size:] = input[dat_file_key]
+                        out[dat_file_key][start_size:] = data_to_append
                     else:
                         logging.warning(
                             f"CombineH5Dat: Dat file '{dat_file_key}'"
                             f" not found in input file '{input_file}'"
                         )
+        # With sorted h5 files now combined, parse through the times of each dat
+        # file in reverse order and remove data if time not increasing.
+        if remove_overlapping_segments:
+            for dat_file_key in dat_file_keys:
+                data = out[dat_file_key][:]
+                if len(data) == 0:
+                    raise ValueError(f"Dat file '{dat_file_key}' is empty")
+                times = data[:, 0]
+                rev_cummin = np.minimum.accumulate(times[::-1])[::-1]
+                mask = np.empty(len(times), dtype=bool)
+                mask[-1] = True
+                mask[:-1] = times[:-1] < rev_cummin[1:]
+                filtered = data[mask]
+                out[dat_file_key].resize(filtered.shape)
+                # Overwriting with data from monotonically increasing times
+                # to preserve metadata
+                out[dat_file_key][:] = filtered
 
 
 @click.command(name="combine-h5-dat", help=combine_h5_dat.__doc__)
@@ -84,13 +125,23 @@ def combine_h5_dat(h5files, output, force):
     help="Combined output filename.",
 )
 @click.option(
+    "--remove-overlapping-segments",
+    is_flag=True,
+    help="Sort h5 files by time and remove overlapping times before combining.",
+)
+@click.option(
     "--force",
     "-f",
     is_flag=True,
     help="If the output file already exists, overwrite it.",
 )
 def combine_h5_dat_command(**kwargs):
-    combine_h5_dat(kwargs["h5files"], kwargs["output"], kwargs["force"])
+    combine_h5_dat(
+        kwargs["h5files"],
+        kwargs["output"],
+        kwargs["force"],
+        kwargs["remove_overlapping_segments"],
+    )
 
 
 if __name__ == "__main__":

--- a/tests/Unit/IO/H5/Python/Test_CombineH5Dat.py
+++ b/tests/Unit/IO/H5/Python/Test_CombineH5Dat.py
@@ -35,7 +35,7 @@ class TestCombineH5Dat(unittest.TestCase):
 
         self.input_file_paths = [
             os.path.join(self.input_dir, "TestDatSeg" + str(i) + ".h5")
-            for i in range(1, 4, 1)
+            for i in range(1, 6, 1)
         ]
         self.output_file_path = os.path.join(
             self.output_dir, "TestDatSegJoined.h5"
@@ -46,19 +46,37 @@ class TestCombineH5Dat(unittest.TestCase):
         self.expected_file_path = os.path.join(
             self.output_dir, "TestDatSegExpected.h5"
         )
+        self.output_file_path_overlap = os.path.join(
+            self.output_dir, "TestDatSegJoinedOverlap.h5"
+        )
+        self.expected_file_path_overlap = os.path.join(
+            self.output_dir, "TestDatSegExpectedOverlap.h5"
+        )
 
         # Generate sample dat data for H5 files to be joined
         self.wave_1 = np.array(
             [[t, np.sin(t), np.cos(t)] for t in np.arange(0, 10.0, 0.1)]
         )
+        # Reverse order to test time sorting for the first h5 file
+        self.reverse_wave_1 = self.wave_1[np.argsort(-self.wave_1[:, 0])]
         self.wave_2 = np.array(
             [[t, np.sin(t), np.cos(t)] for t in np.arange(10.0, 20.0, 0.1)]
         )
         self.wave_3 = np.array(
             [[t, np.sin(t), np.cos(t)] for t in np.arange(20.0, 30.0, 0.1)]
         )
+        # Overlapping segment data to test remove_overlapping_segments option
+        self.wave_4 = np.array(
+            [[t, np.sin(t), np.cos(t)] for t in np.arange(29.0, 40.0, 0.1)]
+        )
+        # Reverse order to test time sorting within each segment/H5 file
+        self.reverse_wave_4 = self.wave_4[np.argsort(-self.wave_4[:, 0])]
         self.wave_joined = np.concatenate(
             (self.wave_1, self.wave_2, self.wave_3), axis=0
+        )
+        # Joined data that preserves later times/data
+        self.wave_joined_overlap = np.concatenate(
+            (self.wave_1, self.wave_2, self.wave_3[:-10], self.wave_4), axis=0
         )
         self.pow_1 = np.array(
             [[t, t**2, t**3, t**4] for t in np.arange(0, 10.0, 0.1)]
@@ -69,18 +87,24 @@ class TestCombineH5Dat(unittest.TestCase):
         self.pow_3 = np.array(
             [[t, t**2, t**3, t**4] for t in np.arange(20.0, 30.0, 0.1)]
         )
+        self.pow_4 = np.array(
+            [[t, t**2, t**3, t**4] for t in np.arange(29.0, 40.0, 0.1)]
+        )
         self.pow_joined = np.concatenate(
             (self.pow_1, self.pow_2, self.pow_3), axis=0
         )
+        self.pow_joined_overlap = np.concatenate(
+            (self.pow_1, self.pow_2, self.pow_3[:-10], self.pow_4), axis=0
+        )
 
-        # Generate 3 H5 files with two dat files inside each
+        # Generate 4 H5 files with two dat files inside each
         with spectre_h5.H5File(
             file_name=self.input_file_paths[0], mode="r+"
         ) as h5file:
             wave_datfile = h5file.insert_dat(
                 path="/Waves", legend=["Time", "Sin(t)", "Cos(t)"], version=0
             )
-            wave_datfile.append(self.wave_1)
+            wave_datfile.append(self.reverse_wave_1)
         with spectre_h5.H5File(
             file_name=self.input_file_paths[0], mode="r+"
         ) as h5file:
@@ -96,7 +120,7 @@ class TestCombineH5Dat(unittest.TestCase):
             wave_datfile = h5file.insert_dat(
                 path="/Waves", legend=["Time", "Sin(t)", "Cos(t)"], version=0
             )
-            wave_datfile.append(self.wave_2)
+            wave_datfile.append(self.wave_1)
         with spectre_h5.H5File(
             file_name=self.input_file_paths[1], mode="r+"
         ) as h5file:
@@ -105,14 +129,14 @@ class TestCombineH5Dat(unittest.TestCase):
                 legend=["Time", "t*t", "t*t*t", "t*t*t*t"],
                 version=0,
             )
-            pow_datfile.append(self.pow_2)
+            pow_datfile.append(self.pow_1)
         with spectre_h5.H5File(
             file_name=self.input_file_paths[2], mode="r+"
         ) as h5file:
             wave_datfile = h5file.insert_dat(
                 path="/Waves", legend=["Time", "Sin(t)", "Cos(t)"], version=0
             )
-            wave_datfile.append(self.wave_3)
+            wave_datfile.append(self.wave_2)
         with spectre_h5.H5File(
             file_name=self.input_file_paths[2], mode="r+"
         ) as h5file:
@@ -121,7 +145,39 @@ class TestCombineH5Dat(unittest.TestCase):
                 legend=["Time", "t*t", "t*t*t", "t*t*t*t"],
                 version=0,
             )
+            pow_datfile.append(self.pow_2)
+        with spectre_h5.H5File(
+            file_name=self.input_file_paths[3], mode="r+"
+        ) as h5file:
+            wave_datfile = h5file.insert_dat(
+                path="/Waves", legend=["Time", "Sin(t)", "Cos(t)"], version=0
+            )
+            wave_datfile.append(self.wave_3)
+        with spectre_h5.H5File(
+            file_name=self.input_file_paths[3], mode="r+"
+        ) as h5file:
+            pow_datfile = h5file.insert_dat(
+                path="/Powers/Pow",
+                legend=["Time", "t*t", "t*t*t", "t*t*t*t"],
+                version=0,
+            )
             pow_datfile.append(self.pow_3)
+        with spectre_h5.H5File(
+            file_name=self.input_file_paths[4], mode="r+"
+        ) as h5file:
+            wave_datfile = h5file.insert_dat(
+                path="/Waves", legend=["Time", "Sin(t)", "Cos(t)"], version=0
+            )
+            wave_datfile.append(self.reverse_wave_4)
+        with spectre_h5.H5File(
+            file_name=self.input_file_paths[4], mode="r+"
+        ) as h5file:
+            pow_datfile = h5file.insert_dat(
+                path="/Powers/Pow",
+                legend=["Time", "t*t", "t*t*t", "t*t*t*t"],
+                version=0,
+            )
+            pow_datfile.append(self.pow_4)
 
         self.test_yaml = """
         # Distributed under the MIT License.
@@ -137,6 +193,10 @@ class TestCombineH5Dat(unittest.TestCase):
             h5file.attrs.modify("InputSource.yaml", self.test_yaml)
         with h5py.File(self.input_file_paths[2], "r+") as h5file:
             h5file.attrs.modify("InputSource.yaml", self.test_yaml)
+        with h5py.File(self.input_file_paths[3], "r+") as h5file:
+            h5file.attrs.modify("InputSource.yaml", self.test_yaml)
+        with h5py.File(self.input_file_paths[4], "r+") as h5file:
+            h5file.attrs.modify("InputSource.yaml", self.test_yaml)
 
     def tearDown(self):
         if os.path.exists(self.input_dir):
@@ -147,7 +207,14 @@ class TestCombineH5Dat(unittest.TestCase):
     def test_combine_h5_dat(self):
         combine_h5_dat(
             output=self.output_file_path,
+            h5files=self.input_file_paths[1:4],
+            remove_overlapping_segments=False,
+            force=None,
+        )
+        combine_h5_dat(
+            output=self.output_file_path_overlap,
             h5files=self.input_file_paths,
+            remove_overlapping_segments=True,
             force=None,
         )
 
@@ -155,12 +222,18 @@ class TestCombineH5Dat(unittest.TestCase):
             npt.assert_allclose(h5file["Waves.dat"], self.wave_joined)
             npt.assert_allclose(h5file["Powers/Pow.dat"], self.pow_joined)
             self.assertEqual(h5file.attrs["InputSource.yaml"], self.test_yaml)
+        with h5py.File(self.output_file_path_overlap) as h5file:
+            npt.assert_allclose(h5file["Waves.dat"], self.wave_joined_overlap)
+            npt.assert_allclose(
+                h5file["Powers/Pow.dat"], self.pow_joined_overlap
+            )
+            self.assertEqual(h5file.attrs["InputSource.yaml"], self.test_yaml)
 
     def test_cli(self):
         runner = CliRunner()
         result = runner.invoke(
             combine_h5_dat_command,
-            ["-o", self.output_file_path_cli, *self.input_file_paths],
+            ["-o", self.output_file_path_cli, *self.input_file_paths[:3]],
             catch_exceptions=False,
         )
         with self.assertRaisesRegex(
@@ -168,7 +241,7 @@ class TestCombineH5Dat(unittest.TestCase):
         ):
             runner.invoke(
                 combine_h5_dat_command,
-                ["-o", self.output_file_path_cli, *self.input_file_paths],
+                ["-o", self.output_file_path_cli, *self.input_file_paths[:3]],
                 catch_exceptions=False,
             )
         result_force = runner.invoke(
@@ -177,11 +250,29 @@ class TestCombineH5Dat(unittest.TestCase):
                 "-o",
                 self.output_file_path_cli,
                 "--force",
+                *self.input_file_paths[1:4],
+            ],
+            catch_exceptions=False,
+        )
+        result_overlap = runner.invoke(
+            combine_h5_dat_command,
+            [
+                "-o",
+                self.output_file_path_cli,
+                "--force",
+                "--remove-overlapping-segments",
                 *self.input_file_paths,
             ],
             catch_exceptions=False,
         )
+        with h5py.File(self.output_file_path_cli) as h5file:
+            npt.assert_allclose(h5file["Waves.dat"], self.wave_joined_overlap)
+            npt.assert_allclose(
+                h5file["Powers/Pow.dat"], self.pow_joined_overlap
+            )
         self.assertEqual(result.exit_code, 0)
+        self.assertEqual(result_force.exit_code, 0)
+        self.assertEqual(result_overlap.exit_code, 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

## Proposed changes

Add an option to remove non-monotonic time points when combining H5 files, preserving later time points/data. 

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [X] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [X] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
