### PR TITLE
Update CartoonSphere2D creator to use ZernikeB1 and internal BCs

### DIFF
--- a/src/Domain/Creators/CartoonSphere2D.cpp
+++ b/src/Domain/Creators/CartoonSphere2D.cpp
@@ -31,7 +31,9 @@
 #include "Domain/DomainHelpers.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/DirectionMap.hpp"
+#include "Domain/Structure/HasBoundary.hpp"
 #include "Domain/Structure/OrientationMap.hpp"
+#include "Domain/Structure/Topology.hpp"
 #include "Options/ParseError.hpp"
 
 namespace Frame {
@@ -40,28 +42,33 @@ struct BlockLogical;
 }  // namespace Frame
 
 namespace domain::creators {
+
 CartoonSphere2D::CartoonSphere2D(
-    double inner_radius, double outer_radius,
-    typename InitialRefinement::type&& initial_refinement,
-    typename InitialGridPoints::type&& initial_number_of_grid_points,
+    double inner_radius, double outer_radius, size_t initial_angular_refinement,
+    const typename InitialRadialRefinement::type& initial_radial_refinement,
+    std::array<size_t, 2> initial_number_of_grid_points,
     std::vector<double> radial_partitioning, bool use_equiangular_map,
     std::variant<Excision, InnerSquare> interior,
+    CoordinateMaps::Distribution radial_distribution,
     std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>
         time_dependence,
     std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
-        y_axis_boundary_condition,
-    std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
         outer_boundary_condition,
+    std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+        cartoon_boundary_condition,
     const Options::Context& context)
     : inner_radius_(inner_radius),
       outer_radius_(outer_radius),
+      initial_angular_refinement_(std::move(initial_angular_refinement)),
+      initial_number_of_grid_points_(std::move(initial_number_of_grid_points)),
       radial_partitioning_(std::move(radial_partitioning)),
       use_equiangular_map_(use_equiangular_map),
       interior_(std::move(interior)),
       fill_interior_(std::holds_alternative<InnerSquare>(interior_)),
       time_dependence_(std::move(time_dependence)),
-      y_axis_boundary_condition_(std::move(y_axis_boundary_condition)),
-      outer_boundary_condition_(std::move(outer_boundary_condition)) {
+      radial_distribution_(std::move(radial_distribution)),
+      outer_boundary_condition_(std::move(outer_boundary_condition)),
+      cartoon_boundary_condition_(std::move(cartoon_boundary_condition)) {
   if (time_dependence_ == nullptr) {
     time_dependence_ =
         std::make_unique<domain::creators::time_dependence::None<3>>();
@@ -73,6 +80,14 @@ CartoonSphere2D::CartoonSphere2D(
                     std::to_string(inner_radius_) + " and outer radius is " +
                     std::to_string(outer_radius_) + ".");
   }
+  if (fill_interior_ and std::get<InnerSquare>(interior_).sphericity != 1.0 and
+      radial_distribution_ != CoordinateMaps::Distribution::Linear) {
+    PARSE_ERROR(
+        context,
+        "Cannot have a non-linear radial distribution when the sphericity of "
+        "wedges is not 1.0, got "
+            << radial_distribution << ". You need to excise the center.");
+  }
 
   std::vector<domain::CoordinateMaps::Distribution> dummy_vec;
   const auto dummy_distribution = CoordinateMaps::Distribution::Linear;
@@ -83,54 +98,35 @@ CartoonSphere2D::CartoonSphere2D(
                          context);
   // num_shells_ is the number of wedge shells, always > 0
   num_blocks_ = 3 * num_shells_ + (fill_interior_ ? 1 : 0);
-
-  const auto check_possible_list_instantiation =
-      [this, &context](std::variant<std::array<size_t, 2>,
-                                    std::vector<std::array<size_t, 2>>>
-                           input_param,
-                       const std::string& name) {
-        if (std::holds_alternative<std::array<size_t, 2>>(input_param)) {
-          const auto input_value = std::get<std::array<size_t, 2>>(input_param);
-          return std::vector<std::array<size_t, 2>>(num_blocks_, input_value);
-        } else {
-          const auto& input_vec =
-              std::get<std::vector<std::array<size_t, 2>>>(input_param);
-          if (input_vec.size() != num_shells_) {
-            PARSE_ERROR(
-                context,
-                name << " must be one larger than RadialPartitioning (size="
-                     << radial_partitioning_.size() << "), but has size "
-                     << input_vec.size() << ".");
-          }
-          std::vector<std::array<size_t, 2>> extended;
-          extended.reserve(num_blocks_);
-          if (fill_interior_) {
-            extended.push_back(input_vec[0]);
-          }
-          for (size_t i = 0; i < num_shells_; ++i) {
-            for (size_t j = 0; j < 3; ++j) {
-              extended.push_back(input_vec[i]);
-            }
-          }
-          // reversing due to block_id scheme going from outer to inner layers
-          std::reverse(extended.begin(), extended.end());
-          return extended;
-        }
-      };
-  initial_refinement_ = check_possible_list_instantiation(
-      std::move(initial_refinement), "InitialRefinement");
-  initial_number_of_grid_points_ = check_possible_list_instantiation(
-      std::move(initial_number_of_grid_points), "InitialGridPoints");
-
-  if ((y_axis_boundary_condition_ == nullptr) !=
-      (outer_boundary_condition_ == nullptr)) {
-    PARSE_ERROR(context,
-                "Must specify either both inner and outer boundary conditions "
-                "or neither.");
+  if (std::holds_alternative<size_t>(initial_radial_refinement)) {
+    const auto input_value = std::get<size_t>(initial_radial_refinement);
+    initial_radial_refinement_ = std::vector<size_t>(num_blocks_, input_value);
+  } else {
+    const auto& input_vec =
+        std::get<std::vector<size_t>>(initial_radial_refinement);
+    if (input_vec.size() != num_shells_) {
+      PARSE_ERROR(context,
+                  "InitialRadialRefinement must be one larger than "
+                  "RadialPartitioning (size="
+                      << radial_partitioning_.size() << "), but has size "
+                      << input_vec.size() << ".");
+    }
+    initial_radial_refinement_.reserve(num_blocks_);
+    if (fill_interior_) {
+      initial_radial_refinement_.push_back(input_vec[0]);
+    }
+    for (size_t i = 0; i < num_shells_; ++i) {
+      for (size_t j = 0; j < 3; ++j) {
+        initial_radial_refinement_.push_back(input_vec[i]);
+      }
+    }
+    // reversing due to block_id scheme going from outer to inner layers
+    std::reverse(initial_radial_refinement_.begin(),
+                 initial_radial_refinement_.end());
   }
+
   using domain::BoundaryConditions::is_none;
-  if (is_none(y_axis_boundary_condition_) or
-      is_none(outer_boundary_condition_) or
+  if (is_none(outer_boundary_condition_) or
       (not fill_interior_ and
        is_none(std::get<Excision>(interior_).boundary_condition))) {
     PARSE_ERROR(
@@ -139,12 +135,32 @@ CartoonSphere2D::CartoonSphere2D(
         "outflow-type boundary condition, you must use that.");
   }
   using domain::BoundaryConditions::is_periodic;
-  if (is_periodic(y_axis_boundary_condition_) or
-      is_periodic(outer_boundary_condition_) or
+  if (is_periodic(outer_boundary_condition_) or
       (not fill_interior_ and
        is_periodic(std::get<Excision>(interior_).boundary_condition))) {
     PARSE_ERROR(context,
                 "Cannot have periodic boundary conditions on a 2D sphere.");
+  }
+
+  if (cartoon_boundary_condition_ == nullptr) {
+    PARSE_ERROR(
+        context,
+        "CartoonSphere2D should only be used with systems that have a "
+        "cartoon-style boundary condition, but none was provided. This "
+        "means the system is not set up to use cartoon methods. Make sure your "
+        "system has a boundary condition that inherits from MarkAsCartoon in "
+        "its standard_boundary_conditions list.");
+  }
+
+  // Check if user mistakenly specified a cartoon BC as an external boundary
+  if (outer_boundary_condition_ != nullptr and
+      domain::BoundaryConditions::is_cartoon(outer_boundary_condition_)) {
+    PARSE_ERROR(
+        context,
+        "Cartoon boundary conditions should not be specified as external "
+        "boundary conditions. They are automatically applied to internal "
+        "cartoon boundaries. Please choose a different boundary condition "
+        "for the outer boundary.");
   }
 
   block_names_.reserve(num_blocks_);
@@ -154,6 +170,7 @@ CartoonSphere2D::CartoonSphere2D(
   // block
   const std::array<std::string, 3> wedge_directions{"_LowerY", "_UpperX",
                                                     "_UpperY"};
+
   for (size_t i = 0; i < num_shells_; ++i) {
     const std::string shell = "Shell" + std::to_string(i);
     block_groups_[shell];
@@ -226,7 +243,8 @@ Domain<3> CartoonSphere2D::create_domain() const {
                 OrientationMap<2>{std::array<Direction<2>, 2>{
                     {Direction<2>::upper_eta(), Direction<2>::lower_xi()}}},
                 use_equiangular_map_,
-                domain::CoordinateMaps::Wedge<2>::WedgeHalves::UpperOnly},
+                domain::CoordinateMaps::Wedge<2>::WedgeHalves::UpperOnly,
+                radial_distribution_},
             Identity1D{}});
     // this is a full wedge, +x
     coord_maps.emplace_back(
@@ -237,7 +255,9 @@ Domain<3> CartoonSphere2D::create_domain() const {
                     inner_radius, outer_radius, inner_sphericity, 1.0,
                     OrientationMap<2>{std::array<Direction<2>, 2>{
                         {Direction<2>::upper_xi(), Direction<2>::upper_eta()}}},
-                    use_equiangular_map_},
+                    use_equiangular_map_,
+                    domain::CoordinateMaps::Wedge<2>::WedgeHalves::Both,
+                    radial_distribution_},
                 Identity1D{}}));
     // this is a half-wedge, +y
     coord_maps.emplace_back(
@@ -249,7 +269,8 @@ Domain<3> CartoonSphere2D::create_domain() const {
                     OrientationMap<2>{std::array<Direction<2>, 2>{
                         {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}},
                     use_equiangular_map_,
-                    domain::CoordinateMaps::Wedge<2>::WedgeHalves::LowerOnly},
+                    domain::CoordinateMaps::Wedge<2>::WedgeHalves::LowerOnly,
+                    radial_distribution_},
                 Identity1D{}}));
     if (has_square) {
       if (use_equiangular_map_) {
@@ -335,9 +356,12 @@ Domain<3> CartoonSphere2D::create_domain() const {
     }
 
     for (size_t j = 0; j < neighbors.size(); ++j) {
-      blocks.emplace_back(
-          std::move(coord_maps.at(j)), 3 * i + j, std::move(neighbors.at(j)),
-          block_names_.at(3 * i + j), domain::topologies::cartoon_cylinder);
+      const auto topology = j % 3 == 1
+                                ? domain::topologies::cartoon_cylinder
+                                : domain::topologies::cartoon_cylinder_inner;
+      blocks.emplace_back(std::move(coord_maps.at(j)), 3 * i + j,
+                          std::move(neighbors.at(j)),
+                          block_names_.at(3 * i + j), topology);
     }
   }
 
@@ -387,13 +411,13 @@ CartoonSphere2D::external_boundary_conditions() const {
   // x=0 axis
   for (size_t i = 0; i < num_shells_; ++i) {
     boundary_conditions[3 * i + 0][Direction<3>::lower_xi()] =
-        y_axis_boundary_condition_->get_clone();
+        cartoon_boundary_condition_->get_clone();
     boundary_conditions[3 * i + 2][Direction<3>::lower_xi()] =
-        y_axis_boundary_condition_->get_clone();
+        cartoon_boundary_condition_->get_clone();
   }
   if (fill_interior_) {
     boundary_conditions[num_blocks_ - 1][Direction<3>::lower_xi()] =
-        y_axis_boundary_condition_->get_clone();
+        cartoon_boundary_condition_->get_clone();
   } else {
     const auto& excision_boundary_condition =
         std::get<Excision>(interior_).boundary_condition;
@@ -411,13 +435,12 @@ std::vector<std::array<size_t, 3>> CartoonSphere2D::initial_extents() const {
   std::vector<std::array<size_t, 3>> extended;
   extended.reserve(num_blocks_);
 
-  std::transform(initial_number_of_grid_points_.begin(),
-                 initial_number_of_grid_points_.end(),
-                 std::back_inserter(extended),
-                 [](const std::array<size_t, 2>& arr) -> std::array<size_t, 3> {
-                   // data is read as [r, theta] but coordinates are [theta, r]
-                   return {arr[1], arr[0], 1};
-                 });
+  for (size_t i = 0; i < num_blocks_; ++i) {
+    // data is read as [r, theta] but coordinates are [theta, r]
+    extended.emplace_back(
+        std::array<size_t, 3>{initial_number_of_grid_points_[1],
+                              initial_number_of_grid_points_[0], 1});
+  }
   if (fill_interior_) {
     // dealing with half-square, want identical extents, matching to wedge theta
     extended.back()[1] = extended.back()[0];
@@ -429,21 +452,20 @@ std::vector<std::array<size_t, 3>> CartoonSphere2D::initial_refinement_levels()
     const {
   std::vector<std::array<size_t, 3>> extended;
   extended.reserve(num_blocks_);
-
-  size_t n = 0;
-  std::transform(
-      initial_refinement_.begin(), initial_refinement_.end(),
-      std::back_inserter(extended),
-      [&n](const std::array<size_t, 2>& arr) -> std::array<size_t, 3> {
-        const size_t shift = (n % 3 == 0 or n % 3 == 2) and arr[1] != 0 ? 1 : 0;
-        ++n;
-        // data is read as [r, theta] but coordinates are [theta, r]
-        return {arr[1] - shift, arr[0], 0};
-      });
+  for (size_t i = 0; i < num_blocks_; ++i) {
+    // the angular refinement is that of a full wedge; for the half-wedges at
+    // the top and bottom of the domain, we must decrease the refinement so
+    // that the "physical" refinement is uniform
+    const size_t shift =
+        (i % 3 == 0 or i % 3 == 2) and initial_angular_refinement_ != 0 ? 1 : 0;
+    // Coordinates are [theta, r]
+    extended.emplace_back(std::array<size_t, 3>{
+        initial_angular_refinement_ - shift, initial_radial_refinement_[i], 0});
+  }
   if (fill_interior_) {
     // dealing with half-square, want proportional refinement, matching to wedge
     // theta
-    extended.back()[1] = initial_refinement_.back()[1];
+    extended.back()[1] = initial_angular_refinement_;
     const size_t shift = extended.back()[1] != 0 ? 1 : 0;
     extended.back()[0] = extended.back()[1] - shift;
   }

--- a/src/Domain/Creators/CartoonSphere2D.hpp
+++ b/src/Domain/Creators/CartoonSphere2D.hpp
@@ -12,7 +12,9 @@
 #include <vector>
 
 #include "Domain/BoundaryConditions/BoundaryCondition.hpp"
+#include "Domain/BoundaryConditions/Cartoon.hpp"
 #include "Domain/BoundaryConditions/GetBoundaryConditionsBase.hpp"
+#include "Domain/CoordinateMaps/Distribution.hpp"
 #include "Domain/Creators/DomainCreator.hpp"
 #include "Domain/Creators/Sphere.hpp"
 #include "Domain/Creators/TimeDependence/TimeDependence.hpp"
@@ -44,9 +46,8 @@ class CoordinateMap;
 }  // namespace domain
 /// \endcond
 
-namespace domain::creators::detail{
-
-/// Options for filling the interior of the sphere with a cube
+namespace domain::creators::detail {
+/// Options for filling the interior of the disk with a square
 struct InnerSquare {
   static constexpr Options::String help = {
       "Fill the interior of the 2D sphere with a half-square."};
@@ -64,7 +65,7 @@ struct InnerSquare {
   explicit InnerSquare(double sphericity_in) : sphericity(sphericity_in) {}
   double sphericity = std::numeric_limits<double>::signaling_NaN();
 };
-} // namespace domain::creators::detail
+}  // namespace domain::creators::detail
 
 namespace domain::creators {
 /// Create a 3D Domain with a half-disk computational domain employing axial
@@ -103,12 +104,12 @@ class CartoonSphere2D : public DomainCreator<3> {
     static constexpr Options::String help = {"Outer radius of the half-disk."};
   };
 
-  struct InitialRefinement {
-    using type =
-        std::variant<std::array<size_t, 2>, std::vector<std::array<size_t, 2>>>;
+  struct InitialAngularRefinement {
+    using type = size_t;
     static constexpr Options::String help = {
-        "Initial refinement level in [r, theta]. If one pair is given, it will "
-        "be applied to all blocks, otherwise each shell can be specified.\n"
+        "Initial refinement level in theta. It will be applied to all "
+        "blocks because h-refinement is not supported for the ZernikeB1 "
+        "basis.\n"
         "Note: the half-wedges will have their theta values decremented by "
         "one.\n"
         "Note: the inner square, if included, will have refinement set to "
@@ -116,13 +117,20 @@ class CartoonSphere2D : public DomainCreator<3> {
         "(decremented by one in the halved dimension)."};
   };
 
-  struct InitialGridPoints {
-    using type =
-        std::variant<std::array<size_t, 2>, std::vector<std::array<size_t, 2>>>;
+  struct InitialRadialRefinement {
+    using type = std::variant<size_t, std::vector<size_t>>;
     static constexpr Options::String help = {
-        "Initial number of grid points in [r,theta]. If one pair is given, it "
-        "will be applied to all blocks, otherwise each shell can be "
-        "specified, from innermost to outermost.\n"
+        "Initial refinement level in r. If one value is given, it will be "
+        "applied to all blocks, otherwise each shell can be specificed, "
+        "from innermost to outermost.\n"};
+  };
+
+  struct InitialGridPoints {
+    using type = std::array<size_t, 2>;
+    static constexpr Options::String help = {
+        "Initial number of grid points in [r,theta]. It will be applied to all "
+        "blocks because p-refinement is not supported for the ZernikeB1 "
+        "basis.\n"
         "Note: if included, the inner square will have both dimensions'"
         "number of grid points set to the theta value of the surrounding "
         "wedges."};
@@ -132,7 +140,7 @@ class CartoonSphere2D : public DomainCreator<3> {
     using type = std::vector<double>;
     static constexpr Options::String help = {
         "Radial coordinates of the boundaries splitting the radial shells. "
-        "Leave emtpy for only one layer."};
+        "Leave empty for only one layer."};
   };
 
   struct UseEquiangularMap {
@@ -154,18 +162,19 @@ class CartoonSphere2D : public DomainCreator<3> {
   };
 
   template <typename BoundaryConditionsBase>
-  struct YAxisBoundaryCondition {
-    using type = std::unique_ptr<BoundaryConditionsBase>;
-    static constexpr Options::String help = {
-      "The boundary condition to impose at the x=z=0 boundary."};
-  };
-
-  template <typename BoundaryConditionsBase>
   struct OuterBoundaryCondition {
     using type = std::unique_ptr<BoundaryConditionsBase>;
     static constexpr Options::String help = {
         "The boundary condition to impose at the outer boundary of the "
         "domain."};
+  };
+
+  struct RadialDistribution {
+    using type = CoordinateMaps::Distribution;
+    static constexpr Options::String help = {
+        "Distribution of grid points for the radial direction of the wedges. "
+        "For anything but linear, the center must be excised with sphericity = "
+        "1.0"};
   };
 
   struct TimeDependence {
@@ -177,8 +186,9 @@ class CartoonSphere2D : public DomainCreator<3> {
   };
 
   using basic_options =
-      tmpl::list<InnerRadius, OuterRadius, InitialRefinement, InitialGridPoints,
-                 RadialPartitioning, UseEquiangularMap, Interior,
+      tmpl::list<InnerRadius, OuterRadius, InitialAngularRefinement,
+                 InitialRadialRefinement, InitialGridPoints, RadialPartitioning,
+                 UseEquiangularMap, Interior, RadialDistribution,
                  TimeDependence>;
 
   template <typename Metavariables>
@@ -187,9 +197,6 @@ class CartoonSphere2D : public DomainCreator<3> {
           typename Metavariables::system>,
       tmpl::push_back<
           basic_options,
-          YAxisBoundaryCondition<
-              domain::BoundaryConditions::get_boundary_conditions_base<
-                  typename Metavariables::system>>,
           OuterBoundaryCondition<
               domain::BoundaryConditions::get_boundary_conditions_base<
                   typename Metavariables::system>>>,
@@ -204,21 +211,27 @@ class CartoonSphere2D : public DomainCreator<3> {
       "in which case the inner sphericity is set to 1.\n"
       "Equiangular coordinates give better gridpoint spacings in the angular\n"
       "direction, while equidistant coordinates give better gridpoint\n"
-      "spacings in the center half-square."};
+      "spacings in the center half-square.\n"
+      "Elements touching the x=0 axis use ZernikeB1 bases in the x direction\n"
+      "and automatically apply a system's Cartoon-type boundary condition.\n"
+      "Angular refinement must be globally set as the required mortar\n"
+      "projection has not been implemented."};
 
   CartoonSphere2D(
       double inner_radius, double outer_radius,
-      typename InitialRefinement::type&& initial_refinement,
-      typename InitialGridPoints::type&& initial_number_of_grid_points,
+      size_t initial_angular_refinement,
+      const typename InitialRadialRefinement::type& initial_radial_refinement,
+      std::array<size_t, 2> initial_number_of_grid_points,
       std::vector<double> radial_partitioning, bool use_equiangular_map,
       std::variant<Excision, InnerSquare> interior,
+      CoordinateMaps::Distribution radial_distribution,
       std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>
-          time_dependence = nullptr,
+          time_dependence,
       std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
-          y_axis_boundary_condition = nullptr,
+          outer_boundary_condition,
       std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
-          outer_boundary_condition = nullptr,
-      const Options::Context& context = {});
+          cartoon_boundary_condition,
+      const Options::Context& context);
 
   CartoonSphere2D() = default;
   CartoonSphere2D(const CartoonSphere2D&) = delete;
@@ -253,18 +266,21 @@ class CartoonSphere2D : public DomainCreator<3> {
  private:
   double inner_radius_{};
   double outer_radius_{};
-  std::vector<std::array<size_t, 2>> initial_refinement_{};
-  std::vector<std::array<size_t, 2>> initial_number_of_grid_points_{};
+  size_t initial_angular_refinement_{};
+  std::vector<size_t> initial_radial_refinement_{};
+  std::array<size_t, 2> initial_number_of_grid_points_{};
   std::vector<double> radial_partitioning_{};
   bool use_equiangular_map_{false};
   std::variant<Excision, InnerSquare> interior_{};
   bool fill_interior_{false};
   std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>
       time_dependence_ = nullptr;
-  std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
-      y_axis_boundary_condition_ = nullptr;
+  CoordinateMaps::Distribution radial_distribution_ =
+      CoordinateMaps::Distribution::Linear;
   std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
       outer_boundary_condition_ = nullptr;
+  std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+      cartoon_boundary_condition_ = nullptr;
   std::vector<std::string> block_names_;
   std::unordered_map<std::string, std::unordered_set<std::string>>
       block_groups_;
@@ -272,3 +288,126 @@ class CartoonSphere2D : public DomainCreator<3> {
   size_t num_blocks_{};
 };
 }  // namespace domain::creators
+
+namespace domain::creators::detail {
+/// \brief Helper struct for CartoonSphere2D options parsing so the internal
+/// cartoon boundary condition at $x = 0$ is not a required argument.
+///
+/// \detail To get the cartoon-type boundary condition from a system we need
+/// access to the system's metavariables, which is only present when parsing
+/// options. The point of this design is so that the input file does not require
+/// a dummy value for an InnerBoundaryCondition that is always the same for a
+/// given system.
+///
+/// This helper's constructor does not take an InnerBoundaryCondition, which
+/// means if we parse a CartoonSphere2D as a CartonSphere2DOptionsHelper
+/// by having an options parsing specialization (so the input file values are
+/// the helper's construtor, not CartoonSphere2D's), we can detect the
+/// cartoon-type boundary condition for the given system and only then call the
+/// CartoonSphere2D constructor with the extra information.
+struct CartoonSphere2DOptionsHelper {
+  // Inherit the options template from CartoonSphere2D
+  template <typename Metavariables>
+  using options = typename domain::creators::CartoonSphere2D::template options<
+      Metavariables>;
+
+  using InitialRadialRefinement =
+      domain::creators::CartoonSphere2D::InitialRadialRefinement;
+  using Interior = domain::creators::CartoonSphere2D::Interior;
+
+  template <typename BoundaryConditionsBase>
+  using OuterBoundaryCondition =
+      domain::creators::CartoonSphere2D::OuterBoundaryCondition<
+          BoundaryConditionsBase>;
+
+  static constexpr Options::String help = {"CartoonSphere2DOptionsHelper."};
+
+  // Default constructor required by Options system
+  CartoonSphere2DOptionsHelper() = default;
+
+  // Does not take cartoon BC
+  CartoonSphere2DOptionsHelper(
+      double inner_radius, double outer_radius,
+      size_t initial_angular_refinement,
+      typename InitialRadialRefinement::type&& initial_radial_refinement,
+      std::array<size_t, 2> initial_number_of_grid_points,
+      std::vector<double> radial_partitioning, bool use_equiangular_map,
+      std::variant<Excision, InnerSquare> interior,
+      CoordinateMaps::Distribution radial_distribution =
+          CoordinateMaps::Distribution::Linear,
+      std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>
+          time_dependence = nullptr,
+      std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+          outer_boundary_condition = nullptr,
+      Options::Context&& context = {})
+      : inner_radius_(inner_radius),
+        outer_radius_(outer_radius),
+        initial_angular_refinement_(initial_angular_refinement),
+        initial_radial_refinement_(std::move(initial_radial_refinement)),
+        initial_number_of_grid_points_(
+            std::move(initial_number_of_grid_points)),
+        radial_partitioning_(std::move(radial_partitioning)),
+        use_equiangular_map_(use_equiangular_map),
+        interior_(std::move(interior)),
+        radial_distribution_(radial_distribution),
+        time_dependence_(std::move(time_dependence)),
+        outer_boundary_condition_(std::move(outer_boundary_condition)),
+        context_(std::move(context)) {}
+
+  // Same members as in CartoonSphere2D; public, to be extracted
+  double inner_radius_{std::numeric_limits<double>::signaling_NaN()};
+  double outer_radius_{std::numeric_limits<double>::signaling_NaN()};
+  size_t initial_angular_refinement_{0};
+  typename InitialRadialRefinement::type initial_radial_refinement_{};
+  std::array<size_t, 2> initial_number_of_grid_points_{};
+  std::vector<double> radial_partitioning_{};
+  bool use_equiangular_map_{false};
+  typename Interior::type interior_{};
+  CoordinateMaps::Distribution radial_distribution_{
+      CoordinateMaps::Distribution::Linear};
+  std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>
+      time_dependence_{nullptr};
+  std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+      outer_boundary_condition_{nullptr};
+  Options::Context context_{};
+};
+}  // namespace domain::creators::detail
+
+// Options parsing specialization to automate CartoonSphere2D's cartoon
+// boundary condition
+template <>
+struct Options::create_from_yaml<domain::creators::CartoonSphere2D> {
+  template <typename Metavariables>
+  static domain::creators::CartoonSphere2D create(
+      const Options::Option& options) {
+    auto helper =
+        options.parse_as<domain::creators::detail::CartoonSphere2DOptionsHelper,
+                         Metavariables>();
+
+    // Create cartoon BC if system supports it, if not will throw parse error in
+    // real constructor
+    std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+        cartoon_boundary_condition = nullptr;
+    if constexpr (domain::BoundaryConditions::has_boundary_conditions_base_v<
+                      typename Metavariables::system>) {
+      if constexpr (domain::BoundaryConditions::system_has_cartoon_bc_v<
+                        Metavariables>) {
+        cartoon_boundary_condition =
+            domain::BoundaryConditions::make_cartoon_boundary_condition<
+                Metavariables>();
+      }
+    }
+
+    // Construct CartoonSphere2D using the helper's parsed data + cartoon BC
+    return domain::creators::CartoonSphere2D(
+        helper.inner_radius_, helper.outer_radius_,
+        helper.initial_angular_refinement_,
+        std::move(helper.initial_radial_refinement_),
+        std::move(helper.initial_number_of_grid_points_),
+        std::move(helper.radial_partitioning_), helper.use_equiangular_map_,
+        std::move(helper.interior_), helper.radial_distribution_,
+        std::move(helper.time_dependence_),
+        std::move(helper.outer_boundary_condition_),
+        std::move(cartoon_boundary_condition), helper.context_);
+  }
+};

--- a/src/Evolution/DiscontinuousGalerkin/Actions/BoundaryConditionsImpl.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/BoundaryConditionsImpl.hpp
@@ -698,22 +698,6 @@ void apply_boundary_conditions_on_all_external_faces(
       typename std::decay_t<decltype(db::get<Parallel::Tags::Metavariables>(
           *box))>::factory_creation::factory_classes;
 
-  // If cartoon BC is available, verify mesh is compatible before removing BC
-  // (cartoon BCs are coupled with ZernikeB1 basis which does not need a BC, but
-  // subcell version of mesh does)
-  if constexpr (domain::BoundaryConditions::detail::has_cartoon_bc_v<
-                    tmpl::at<factory_classes,
-                             typename System::boundary_conditions_base>>) {
-    const auto& mesh = db::get<::domain::Tags::Mesh<Dim>>(*box);
-    if (not domain::BoundaryConditions::dg_mesh_is_cartoon_compatible(mesh)) {
-      ERROR(
-          "You might have used a Cartoon boundary condition on an external "
-          "boundary condition. Alternatively and less likely, there is a bug. "
-          "The mesh is: "
-          << mesh);
-    }
-  }
-
   using derived_boundary_conditions = tmpl::remove_if<
       tmpl::at<factory_classes, typename System::boundary_conditions_base>,
       tmpl::or_<
@@ -737,6 +721,28 @@ void apply_boundary_conditions_on_all_external_faces(
   const auto& external_boundary_conditions =
       db::get<domain::Tags::ExternalBoundaryConditions<Dim>>(*box).at(
           element.id().block_id());
+
+  // Error if any cartoon-type BC is used with an incompatible mesh.
+  // Cartoon BCs are coupled only to ZernikeB1 basis elements, which do not need
+  // a DG boundary condition but do require one with subcell
+  if constexpr (domain::BoundaryConditions::detail::has_cartoon_bc_v<
+                    tmpl::at<factory_classes,
+                             typename System::boundary_conditions_base>>) {
+    const auto& mesh = db::get<::domain::Tags::Mesh<Dim>>(*box);
+    if (not domain::BoundaryConditions::dg_mesh_is_cartoon_compatible(mesh)) {
+      for (const Direction<Dim>& direction : element.external_boundaries()) {
+        if (domain::BoundaryConditions::is_cartoon(
+                external_boundary_conditions.at(direction))) {
+          ERROR(
+              "You might have used a Cartoon boundary condition on an external "
+              "boundary condition. Alternatively and less likely, there is a "
+              "bug. The problematic BC is in direction "
+              << direction << ", the mesh is: " << mesh);
+        }
+      }
+    }
+  }
+
   tmpl::for_each<derived_boundary_conditions>(
       [&boundary_correction, &box, &element, &external_boundary_conditions,
        &number_of_boundaries_left, &partial_derivs, &primitive_vars,

--- a/src/Evolution/Systems/ScalarWave/BoundaryConditions/Factory.hpp
+++ b/src/Evolution/Systems/ScalarWave/BoundaryConditions/Factory.hpp
@@ -5,6 +5,7 @@
 
 #include <cstddef>
 
+#include "Domain/BoundaryConditions/Cartoon.hpp"
 #include "Domain/BoundaryConditions/Periodic.hpp"
 #include "Evolution/Systems/ScalarWave/BoundaryConditions/BoundaryCondition.hpp"
 #include "Evolution/Systems/ScalarWave/BoundaryConditions/ConstraintPreservingSphericalRadiation.hpp"
@@ -19,5 +20,6 @@ using standard_boundary_conditions =
     tmpl::list<ConstraintPreservingSphericalRadiation<Dim>,
                DirichletAnalytic<Dim>,
                domain::BoundaryConditions::Periodic<BoundaryCondition<Dim>>,
+               domain::BoundaryConditions::Cartoon<BoundaryCondition<Dim>>,
                SphericalRadiation<Dim>>;
 }  // namespace ScalarWave::BoundaryConditions

--- a/tests/InputFiles/ScalarWave/PlaneWave3DCartoonSphere2D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave3DCartoonSphere2D.yaml
@@ -46,17 +46,18 @@ Evolution:
       Order: 3
 
 DomainCreator:
-  CartoonSphere1D:
-    InnerRadius: 0.0
+  CartoonSphere2D:
+    InnerRadius: 5.0
     OuterRadius: 20.0
-    InitialRadialRefinement: [3, 2]
-    InitialNumberOfRadialGridPoints: 5
+    InitialAngularRefinement: 1
+    InitialRadialRefinement: 2
+    InitialGridPoints: [10, 11]
     RadialPartitioning: [10.0]
-    RadialDistributions: [Linear, Logarithmic]
+    UseEquiangularMap: true
+    RadialDistribution: Linear
     TimeDependence: None
-    InnerBoundaryCondition:
-      DirichletAnalytic:
-        AnalyticPrescription: *InitialData
+    Interior:
+      FillWithSphericity: 0.0
     OuterBoundaryCondition:
       DirichletAnalytic:
         AnalyticPrescription: *InitialData

--- a/tests/Unit/Domain/Creators/Test_CartoonSphere2D.cpp
+++ b/tests/Unit/Domain/Creators/Test_CartoonSphere2D.cpp
@@ -45,8 +45,8 @@ namespace {
 template <typename... FuncsOfTime>
 void test_sphere_construction(
     const creators::CartoonSphere2D& sphere, const double inner_radius,
-    const double outer_radius,
-    const std::vector<std::array<size_t, 2>>& expected_refinement_levels_param,
+    const double outer_radius, const size_t expected_angular_refinement,
+    const std::vector<size_t>& expected_radial_refinement,
     const std::vector<std::array<size_t, 2>>& expected_extents_param,
     const std::vector<double>& expected_radial_partitioning,
     const bool use_equiangular_map,
@@ -203,37 +203,22 @@ void test_sphere_construction(
   }
   CHECK(sphere.initial_extents() == expected_extents);
 
-  std::vector<std::array<size_t, 2>> expected_refinement_levels_temp{};
   std::vector<std::array<size_t, 3>> expected_refinement_levels{};
-  expected_refinement_levels_temp.reserve(num_blocks);
   expected_refinement_levels.reserve(num_blocks);
-  if (fill_interior) {
-    expected_refinement_levels_temp.push_back(
-        expected_refinement_levels_param[0]);
-  }
   for (size_t i = 0; i < num_shells; ++i) {
     for (size_t j = 0; j < 3; ++j) {
-      expected_refinement_levels_temp.push_back(
-          expected_refinement_levels_param[i]);
+      const size_t index = num_shells - i - 1;
+      const size_t shift =
+          (j == 0 or j == 2) and expected_angular_refinement != 0 ? 1 : 0;
+      expected_refinement_levels.push_back({expected_angular_refinement - shift,
+                                            expected_radial_refinement[index],
+                                            0});
     }
   }
-  std::reverse(expected_refinement_levels_temp.begin(),
-               expected_refinement_levels_temp.end());
-  size_t n = 0;
-  std::transform(
-      expected_refinement_levels_temp.begin(),
-      expected_refinement_levels_temp.end(),
-      std::back_inserter(expected_refinement_levels),
-      [&n](const std::array<size_t, 2>& arr) -> std::array<size_t, 3> {
-        const size_t shift = (n % 3 == 0 or n % 3 == 2) and arr[1] != 0 ? 1 : 0;
-        ++n;
-        return {arr[1] - shift, arr[0], 0};
-      });
   if (fill_interior) {
-    expected_refinement_levels.back()[1] =
-        expected_refinement_levels_temp.back()[1];
-    expected_refinement_levels.back()[0] =
-        expected_refinement_levels.back()[1] - 1;
+    const size_t shift = expected_angular_refinement != 0 ? 1 : 0;
+    expected_refinement_levels.push_back(
+        {expected_angular_refinement - shift, expected_angular_refinement, 0});
   }
   CHECK(sphere.initial_refinement_levels() == expected_refinement_levels);
 
@@ -336,237 +321,236 @@ void test_sphere_construction(
 }
 
 std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
-create_boundary_condition1() {
-  return std::make_unique<
-      TestHelpers::domain::BoundaryConditions::TestBoundaryCondition<3>>(
-      Direction<3>::upper_eta(), 1);
-}
-std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
-create_boundary_condition2() {
+create_boundary_condition_outer() {
   return std::make_unique<
       TestHelpers::domain::BoundaryConditions::TestBoundaryCondition<3>>(
       Direction<3>::lower_xi(), 2);
 }
 std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
-create_boundary_condition3() {
+create_boundary_condition_inner() {
   return std::make_unique<
       TestHelpers::domain::BoundaryConditions::TestBoundaryCondition<3>>(
       Direction<3>::lower_eta(), 3);
+}
+
+std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+create_cartoon_boundary_condition() {
+  return std::make_unique<TestHelpers::domain::BoundaryConditions::
+                              TestCartoonBoundaryCondition<3>>();
 }
 
 void test_sphere_boundaries() {
   INFO("CartoonSphere2D boundaries");
   const double inner_radius = 1.0;
   const double outer_radius = 2.0;
-  const std::array<size_t, 2> refinement_level_arr{{2, 3}};
-  const std::vector<std::array<size_t, 2>> refinement_level_vec{
-      {4, 4}, {3, 5}, {2, 6}};
+  const size_t angular_refinement = 2;
+  const size_t radial_refinement = 4;
+  const std::array<size_t, 2> grid_points_arr{{4, 4}};
+  const std::vector<size_t> radial_refinement_partitioned{4, 6, 5};
   const std::vector<double> radial_partitioning{{1.3, 1.8}};
   const std::vector<double> radial_partitioning_empty{};
-  const std::array<size_t, 2> grid_points_arr{{4, 4}};
-  const std::vector<std::array<size_t, 2>> grid_points_vec{
-      {4, 4}, {5, 3}, {6, 7}};
   const domain::creators::detail::InnerSquare fill_center{0.0};
+  const auto linear_map = CoordinateMaps::Distribution::Linear;
 
   {
-    INFO("No BC, no refinement, equiangular");
+    INFO("No partitioning, equiangular");
     const creators::CartoonSphere2D sphere{inner_radius,
                                            outer_radius,
-                                           refinement_level_arr,
+                                           angular_refinement,
+                                           radial_refinement,
                                            grid_points_arr,
                                            radial_partitioning_empty,
                                            true,
-                                           fill_center};
+                                           fill_center,
+                                           linear_map,
+                                           nullptr,
+                                           create_boundary_condition_outer(),
+                                           create_cartoon_boundary_condition(),
+                                           {}};
     test_sphere_construction(
-        sphere, inner_radius, outer_radius,
-        std::vector<std::array<size_t, 2>>{1, refinement_level_arr},
-        std::vector<std::array<size_t, 2>>{1, grid_points_arr},
-        radial_partitioning_empty, true, fill_center);
+        sphere, inner_radius, outer_radius, angular_refinement,
+        std::vector<size_t>(1, radial_refinement),
+        std::vector<std::array<size_t, 2>>(1, grid_points_arr),
+        radial_partitioning_empty, true, fill_center, true);
   }
   {
-    INFO("No BC, no refinement, affine");
+    INFO("No partitioning, affine");
     const creators::CartoonSphere2D sphere{inner_radius,
                                            outer_radius,
-                                           refinement_level_arr,
+                                           angular_refinement,
+                                           radial_refinement,
                                            grid_points_arr,
                                            radial_partitioning_empty,
                                            false,
-                                           fill_center};
+                                           fill_center,
+                                           linear_map,
+                                           nullptr,
+                                           create_boundary_condition_outer(),
+                                           create_cartoon_boundary_condition(),
+                                           {}};
     test_sphere_construction(
-        sphere, inner_radius, outer_radius,
-        std::vector<std::array<size_t, 2>>{1, refinement_level_arr},
-        std::vector<std::array<size_t, 2>>{1, grid_points_arr},
-        radial_partitioning_empty, false, fill_center);
+        sphere, inner_radius, outer_radius, angular_refinement,
+        std::vector<size_t>(1, radial_refinement),
+        std::vector<std::array<size_t, 2>>(1, grid_points_arr),
+        radial_partitioning_empty, false, fill_center, true);
   }
   {
-    INFO("No BC, with refinement and extents array");
+    INFO("Partitioning and refinement array");
     const creators::CartoonSphere2D sphere{inner_radius,
                                            outer_radius,
-                                           refinement_level_vec,
+                                           angular_refinement,
+                                           radial_refinement_partitioned,
                                            grid_points_arr,
-                                           radial_partitioning,
-                                           true,
-                                           fill_center};
-    test_sphere_construction(
-        sphere, inner_radius, outer_radius, refinement_level_vec,
-        std::vector<std::array<size_t, 2>>{3, grid_points_arr},
-        radial_partitioning, true, fill_center);
-  }
-  {
-    INFO("No BC, with refinement and refinement array");
-    const creators::CartoonSphere2D sphere{inner_radius,
-                                           outer_radius,
-                                           refinement_level_arr,
-                                           grid_points_vec,
-                                           radial_partitioning,
-                                           true,
-                                           fill_center};
-    test_sphere_construction(
-        sphere, inner_radius, outer_radius,
-        std::vector<std::array<size_t, 2>>{3, refinement_level_arr},
-        grid_points_vec, radial_partitioning, true, fill_center);
-  }
-  {
-    INFO("With BC, no excision");
-    const creators::CartoonSphere2D sphere{inner_radius,
-                                           outer_radius,
-                                           refinement_level_vec,
-                                           grid_points_vec,
                                            radial_partitioning,
                                            true,
                                            fill_center,
+                                           linear_map,
                                            nullptr,
-                                           create_boundary_condition1(),
-                                           create_boundary_condition2()};
-    test_sphere_construction(sphere, inner_radius, outer_radius,
-                             refinement_level_vec, grid_points_vec,
-                             radial_partitioning, true, fill_center, true);
+                                           create_boundary_condition_outer(),
+                                           create_cartoon_boundary_condition(),
+                                           {}};
+    test_sphere_construction(
+        sphere, inner_radius, outer_radius, angular_refinement,
+        radial_refinement_partitioned,
+        std::vector<std::array<size_t, 2>>(3, grid_points_arr),
+        radial_partitioning, true, fill_center, true);
   }
   {
-    INFO("With BC, with excision");
-    domain::creators::detail::Excision excise1{create_boundary_condition3()};
-    domain::creators::detail::Excision excise2{create_boundary_condition3()};
+    INFO("Partitioning and refinement vector");
     const creators::CartoonSphere2D sphere{inner_radius,
                                            outer_radius,
-                                           refinement_level_vec,
-                                           grid_points_vec,
+                                           angular_refinement,
+                                           radial_refinement,
+                                           grid_points_arr,
+                                           radial_partitioning,
+                                           true,
+                                           fill_center,
+                                           linear_map,
+                                           nullptr,
+                                           create_boundary_condition_outer(),
+                                           create_cartoon_boundary_condition(),
+                                           {}};
+    test_sphere_construction(
+        sphere, inner_radius, outer_radius, angular_refinement,
+        std::vector<size_t>(3, radial_refinement),
+        std::vector<std::array<size_t, 2>>(3, grid_points_arr),
+        radial_partitioning, true, fill_center, true);
+  }
+  {
+    INFO("With excision");
+    domain::creators::detail::Excision excise1{
+        create_boundary_condition_inner()};
+    domain::creators::detail::Excision excise2{
+        create_boundary_condition_inner()};
+    const creators::CartoonSphere2D sphere{inner_radius,
+                                           outer_radius,
+                                           angular_refinement,
+                                           radial_refinement_partitioned,
+                                           grid_points_arr,
                                            radial_partitioning,
                                            true,
                                            std::move(excise1),
+                                           linear_map,
                                            nullptr,
-                                           create_boundary_condition1(),
-                                           create_boundary_condition2()};
+                                           create_boundary_condition_outer(),
+                                           create_cartoon_boundary_condition(),
+                                           {}};
     test_sphere_construction(
-        sphere, inner_radius, outer_radius, refinement_level_vec,
-        grid_points_vec, radial_partitioning, true, std::move(excise2), true);
+        sphere, inner_radius, outer_radius, angular_refinement,
+        radial_refinement_partitioned,
+        std::vector<std::array<size_t, 2>>(3, grid_points_arr),
+        radial_partitioning, true, std::move(excise2), true);
   }
   {
-    INFO("With BC, with excision and no partitioning");
-    domain::creators::detail::Excision excise1{create_boundary_condition3()};
-    domain::creators::detail::Excision excise2{create_boundary_condition3()};
+    INFO("With excision and no partitioning");
+    domain::creators::detail::Excision excise1{
+        create_boundary_condition_inner()};
+    domain::creators::detail::Excision excise2{
+        create_boundary_condition_inner()};
     const creators::CartoonSphere2D sphere{inner_radius,
                                            outer_radius,
-                                           refinement_level_arr,
+                                           angular_refinement,
+                                           radial_refinement,
                                            grid_points_arr,
                                            radial_partitioning_empty,
-                                           true,
+                                           false,
                                            std::move(excise1),
+                                           linear_map,
                                            nullptr,
-                                           create_boundary_condition1(),
-                                           create_boundary_condition2()};
+                                           create_boundary_condition_outer(),
+                                           create_cartoon_boundary_condition(),
+                                           {}};
     test_sphere_construction(
-        sphere, inner_radius, outer_radius,
-        std::vector<std::array<size_t, 2>>{1, refinement_level_arr},
-        std::vector<std::array<size_t, 2>>{1, grid_points_arr},
-        radial_partitioning_empty, true, std::move(excise2), true);
+        sphere, inner_radius, outer_radius, angular_refinement,
+        std::vector<size_t>(1, radial_refinement),
+        std::vector<std::array<size_t, 2>>(1, grid_points_arr),
+        radial_partitioning_empty, false, std::move(excise2), true);
   }
 }
 
 void test_sphere_factory() {
   INFO("CartoonSphere2D factory");
   using Translation3D = CoordinateMaps::TimeDependent::Translation<3>;
-  const auto sphere = TestHelpers::test_option_tag<
-      domain::OptionTags::DomainCreator<3>,
-      TestHelpers::domain::BoundaryConditions::
-          MetavariablesWithoutBoundaryConditions<
-              3, domain::creators::CartoonSphere2D>>(
-      "CartoonSphere2D:\n"
-      "  InnerRadius: 1.0\n"
-      "  OuterRadius: 5.0\n"
-      "  InitialRefinement:\n"
-      "    - [3, 4]\n"
-      "    - [3, 3]\n"
-      "    - [2, 4]\n"
-      "  InitialGridPoints: [2,3]\n"
-      "  RadialPartitioning: [3.5, 4.5]\n"
-      "  UseEquiangularMap: true\n"
-      "  Interior:\n"
-      "    FillWithSphericity: 0.0\n"
-      "  TimeDependence: None\n");
   const double inner_radius = 1.0;
   const double outer_radius = 5.0;
-  const std::vector<std::array<size_t, 2>> refinement_levels{
-      {3, 4}, {3, 3}, {2, 4}};
+  const size_t angular_refinement = 3;
+  const std::vector<size_t> radial_refinement{3, 3, 2};
   const std::vector<std::array<size_t, 2>> grid_points{3, {2, 3}};
   const std::vector<double> radial_partition{{3.5, 4.5}};
   const domain::creators::detail::InnerSquare fill_center{0.0};
-  test_sphere_construction(
-      dynamic_cast<const creators::CartoonSphere2D&>(*sphere), inner_radius,
-      outer_radius, refinement_levels, grid_points, radial_partition, true,
-      fill_center);
 
   const auto sphere_boundary_conditions = TestHelpers::test_option_tag<
       domain::OptionTags::DomainCreator<3>,
       TestHelpers::domain::BoundaryConditions::
-          MetavariablesWithBoundaryConditions<
+          MetavariablesWithBoundaryConditionsCartoon<
               3, domain::creators::CartoonSphere2D>>(
       "CartoonSphere2D:\n"
       "  InnerRadius: 1.0\n"
       "  OuterRadius: 5.0\n"
-      "  InitialRefinement:\n"
-      "    - [3, 4]\n"
-      "    - [3, 3]\n"
-      "    - [2, 4]\n"
+      "  InitialAngularRefinement: 3\n"
+      "  InitialRadialRefinement:\n"
+      "    - 3\n"
+      "    - 3\n"
+      "    - 2\n"
       "  InitialGridPoints: [2,3]\n"
       "  RadialPartitioning: [3.5, 4.5]\n"
       "  UseEquiangularMap: false\n"
+      "  RadialDistribution: Linear\n"
       "  TimeDependence: None\n"
       "  Interior:\n"
       "    ExciseWithBoundaryCondition:\n"
       "      TestBoundaryCondition:\n"
       "        Direction: lower-eta\n"
       "        BlockId: 3\n"
-      "  YAxisBoundaryCondition:\n"
-      "    TestBoundaryCondition:\n"
-      "      Direction: upper-eta\n"
-      "      BlockId: 1\n"
       "  OuterBoundaryCondition:\n"
       "    TestBoundaryCondition:\n"
       "      Direction: lower-xi\n"
       "      BlockId: 2\n");
-  domain::creators::detail::Excision excise1{create_boundary_condition3()};
+  domain::creators::detail::Excision excise1{create_boundary_condition_inner()};
   test_sphere_construction(dynamic_cast<const creators::CartoonSphere2D&>(
                                *sphere_boundary_conditions),
-                           inner_radius, outer_radius, refinement_levels,
-                           grid_points, radial_partition, false,
-                           std::move(excise1), true);
+                           inner_radius, outer_radius, angular_refinement,
+                           radial_refinement, grid_points, radial_partition,
+                           false, std::move(excise1), true);
 
   INFO("With TimeDependent Map");
   const auto sphere_time_dependent = TestHelpers::test_option_tag<
       domain::OptionTags::DomainCreator<3>,
       TestHelpers::domain::BoundaryConditions::
-          MetavariablesWithBoundaryConditions<
+          MetavariablesWithBoundaryConditionsCartoon<
               3, domain::creators::CartoonSphere2D>>(
       "CartoonSphere2D:\n"
       "  InnerRadius: 1.0\n"
       "  OuterRadius: 5.0\n"
-      "  InitialRefinement:\n"
-      "    - [3, 4]\n"
-      "    - [3, 3]\n"
-      "    - [2, 4]\n"
+      "  InitialAngularRefinement: 3\n"
+      "  InitialRadialRefinement:\n"
+      "    - 3\n"
+      "    - 3\n"
+      "    - 2\n"
       "  InitialGridPoints: [2,3]\n"
       "  RadialPartitioning: [3.5, 4.5]\n"
       "  UseEquiangularMap: false\n"
+      "  RadialDistribution: Linear\n"
       "  TimeDependence:\n"
       "    UniformTranslation:\n"
       "      InitialTime: 2.3\n"
@@ -576,16 +560,12 @@ void test_sphere_factory() {
       "      TestBoundaryCondition:\n"
       "        Direction: lower-eta\n"
       "        BlockId: 3\n"
-      "  YAxisBoundaryCondition:\n"
-      "    TestBoundaryCondition:\n"
-      "      Direction: upper-eta\n"
-      "      BlockId: 1\n"
       "  OuterBoundaryCondition:\n"
       "    TestBoundaryCondition:\n"
       "      Direction: lower-xi\n"
       "      BlockId: 2\n");
-  domain::creators::detail::Excision excise2{create_boundary_condition3()};
-  domain::creators::detail::Excision excise3{create_boundary_condition3()};
+  domain::creators::detail::Excision excise2{create_boundary_condition_inner()};
+  domain::creators::detail::Excision excise3{create_boundary_condition_inner()};
   const double initial_time = 2.3;
   const DataVector velocity{{1.1, -0.1, 0.3}};
   const std::string f_of_t_name = "Translation";
@@ -603,8 +583,8 @@ void test_sphere_factory() {
   // without expiration times
   test_sphere_construction(
       dynamic_cast<const creators::CartoonSphere2D&>(*sphere_time_dependent),
-      inner_radius, outer_radius, refinement_levels, grid_points,
-      radial_partition, false, std::move(excise2), true,
+      inner_radius, outer_radius, angular_refinement, radial_refinement,
+      grid_points, radial_partition, false, std::move(excise2), true,
       std::make_tuple(
           std::pair<std::string,
                     domain::FunctionsOfTime::PiecewisePolynomial<2>>{
@@ -616,8 +596,8 @@ void test_sphere_factory() {
   // with expiration times
   test_sphere_construction(
       dynamic_cast<const creators::CartoonSphere2D&>(*sphere_time_dependent),
-      inner_radius, outer_radius, refinement_levels, grid_points,
-      radial_partition, false, std::move(excise3), true,
+      inner_radius, outer_radius, angular_refinement, radial_refinement,
+      grid_points, radial_partition, false, std::move(excise3), true,
       std::make_tuple(
           std::pair<std::string,
                     domain::FunctionsOfTime::PiecewisePolynomial<2>>{
@@ -633,84 +613,120 @@ void test_sphere_errors() {
   const double inner_radius = 1.0;
   const double high_inner_radius = 3.0;
   const double outer_radius = 2.0;
-  const std::vector<std::array<size_t, 2>> refinement_level_vec{
-      {3, 4}, {3, 5}, {4, 6}};
-  const std::vector<std::array<size_t, 2>> refinement_level_short{{3, 4},
-                                                                  {3, 2}};
-  const std::vector<std::array<size_t, 2>> grid_points_vec{
-      {4, 4}, {5, 3}, {6, 7}};
+  const size_t angular_refinement = 2;
+  const std::vector<size_t> radial_refinement_vec{3, 3, 4};
+  const std::vector<size_t> radial_refinement_short{3, 2};
+  const std::array<size_t, 2> grid_points{5, 3};
   const std::vector<double> radial_partitioning{{1.3, 1.8}};
   const std::vector<double> radial_partitioning_unordered{{1.6, 1.3}};
   const std::vector<double> radial_partitioning_low{{0.8, 1.3}};
   const std::vector<double> radial_partitioning_high{{1.6, 3.3}};
   const domain::creators::detail::InnerSquare fill_center{0.0};
+  const auto linear_map = CoordinateMaps::Distribution::Linear;
 
   CHECK_THROWS_WITH(
-      creators::CartoonSphere2D(
-          high_inner_radius, outer_radius, refinement_level_vec,
-          grid_points_vec, radial_partitioning, false, fill_center, nullptr,
-          nullptr, nullptr, Options::Context{false, {}, 1, 1}),
+      creators::CartoonSphere2D(high_inner_radius, outer_radius,
+                                angular_refinement, radial_refinement_vec,
+                                grid_points, radial_partitioning, false,
+                                fill_center, linear_map, nullptr, nullptr,
+                                create_cartoon_boundary_condition(),
+                                Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring("Inner radius must be smaller than "
                                          "outer radius, but inner radius is "));
   CHECK_THROWS_WITH(
       creators::CartoonSphere2D(
-          inner_radius, outer_radius, refinement_level_vec, grid_points_vec,
-          radial_partitioning_unordered, false, fill_center, nullptr, nullptr,
-          nullptr, Options::Context{false, {}, 1, 1}),
+          inner_radius, outer_radius, angular_refinement, radial_refinement_vec,
+          grid_points, radial_partitioning_unordered, false, fill_center,
+          linear_map, nullptr, nullptr, create_cartoon_boundary_condition(),
+          Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "Specify radial partitioning in ascending order."));
   CHECK_THROWS_WITH(
       creators::CartoonSphere2D(
-          inner_radius, outer_radius, refinement_level_vec, grid_points_vec,
-          radial_partitioning_low, false, fill_center, nullptr, nullptr,
-          nullptr, Options::Context{false, {}, 1, 1}),
+          inner_radius, outer_radius, angular_refinement, radial_refinement_vec,
+          grid_points, radial_partitioning_low, false, fill_center, linear_map,
+          nullptr, nullptr, create_cartoon_boundary_condition(),
+          Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "First radial partition must be larger than the inner"));
   CHECK_THROWS_WITH(
       creators::CartoonSphere2D(
-          inner_radius, outer_radius, refinement_level_vec, grid_points_vec,
-          radial_partitioning_high, false, fill_center, nullptr, nullptr,
-          nullptr, Options::Context{false, {}, 1, 1}),
+          inner_radius, outer_radius, angular_refinement, radial_refinement_vec,
+          grid_points, radial_partitioning_high, false, fill_center, linear_map,
+          nullptr, nullptr, create_cartoon_boundary_condition(),
+          Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "Last radial partition must be smaller than the outer"));
+  CHECK_THROWS_WITH(creators::CartoonSphere2D(
+                        inner_radius, outer_radius, angular_refinement,
+                        radial_refinement_short, grid_points,
+                        radial_partitioning, false, fill_center, linear_map,
+                        nullptr, nullptr, create_cartoon_boundary_condition(),
+                        Options::Context{false, {}, 1, 1}),
+                    Catch::Matchers::ContainsSubstring(
+                        "InitialRadialRefinement must be one larger "
+                        "than RadialPartitioning (size"));
   CHECK_THROWS_WITH(
       creators::CartoonSphere2D(
-          inner_radius, outer_radius, refinement_level_short, grid_points_vec,
-          radial_partitioning, false, fill_center, nullptr, nullptr, nullptr,
-          Options::Context{false, {}, 1, 1}),
-      Catch::Matchers::ContainsSubstring("InitialRefinement must be one larger "
-                                         "than RadialPartitioning (size"));
-  CHECK_THROWS_WITH(
-      creators::CartoonSphere2D(
-          inner_radius, outer_radius, refinement_level_vec, grid_points_vec,
-          radial_partitioning, false, fill_center, nullptr,
-          std::make_unique<TestHelpers::domain::BoundaryConditions::
-                               TestPeriodicBoundaryCondition<3>>(),
-          nullptr, Options::Context{false, {}, 1, 1}),
-      Catch::Matchers::ContainsSubstring(
-          "Must specify either both inner and outer boundary conditions "));
-  CHECK_THROWS_WITH(
-      creators::CartoonSphere2D(
-          inner_radius, outer_radius, refinement_level_vec, grid_points_vec,
-          radial_partitioning, false, fill_center, nullptr,
+          inner_radius, outer_radius, angular_refinement, radial_refinement_vec,
+          grid_points, radial_partitioning, false, fill_center, linear_map,
+          nullptr,
           std::make_unique<TestHelpers::domain::BoundaryConditions::
                                TestNoneBoundaryCondition<3>>(),
-          std::make_unique<TestHelpers::domain::BoundaryConditions::
-                               TestNoneBoundaryCondition<3>>(),
+          create_cartoon_boundary_condition(),
           Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "None boundary condition is not supported. If you would like an "));
   CHECK_THROWS_WITH(
       creators::CartoonSphere2D(
-          inner_radius, outer_radius, refinement_level_vec, grid_points_vec,
-          radial_partitioning, false, fill_center, nullptr,
+          inner_radius, outer_radius, angular_refinement, radial_refinement_vec,
+          grid_points, radial_partitioning, false, fill_center, linear_map,
+          nullptr,
           std::make_unique<TestHelpers::domain::BoundaryConditions::
                                TestPeriodicBoundaryCondition<3>>(),
-          std::make_unique<TestHelpers::domain::BoundaryConditions::
-                               TestPeriodicBoundaryCondition<3>>(),
+          create_cartoon_boundary_condition(),
           Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "Cannot have periodic boundary conditions on a 2D sphere."));
+  CHECK_THROWS_WITH(
+      creators::CartoonSphere2D(
+          inner_radius, outer_radius, angular_refinement, radial_refinement_vec,
+          grid_points, radial_partitioning, false, fill_center, linear_map,
+          nullptr, create_cartoon_boundary_condition(),
+          create_cartoon_boundary_condition(),
+          Options::Context{false, {}, 1, 1}),
+      Catch::Matchers::ContainsSubstring(
+          "Cartoon boundary conditions should not be specified as external "));
+  // Test that using a system without a cartoon BC triggers a parse error via
+  // the create_from_yaml path. MetavariablesWithBoundaryConditions has a system
+  // with boundary conditions but no Cartoon BC in its factory list, so
+  // cartoon_boundary_condition_ will be nullptr when CartoonSphere2D is
+  // constructed.
+  CHECK_THROWS_WITH(
+      (TestHelpers::test_option_tag<
+          domain::OptionTags::DomainCreator<3>,
+          TestHelpers::domain::BoundaryConditions::
+              MetavariablesWithBoundaryConditions<
+                  3, domain::creators::CartoonSphere2D>>(
+          "CartoonSphere2D:\n"
+          "  InnerRadius: 1.0\n"
+          "  OuterRadius: 2.0\n"
+          "  InitialAngularRefinement: 2\n"
+          "  InitialRadialRefinement: 4\n"
+          "  InitialGridPoints: [4, 4]\n"
+          "  RadialPartitioning: []\n"
+          "  UseEquiangularMap: false\n"
+          "  RadialDistribution: Linear\n"
+          "  TimeDependence: None\n"
+          "  Interior:\n"
+          "    FillWithSphericity: 0.0\n"
+          "  OuterBoundaryCondition:\n"
+          "    TestBoundaryCondition:\n"
+          "      Direction: lower-xi\n"
+          "      BlockId: 2\n")),
+      Catch::Matchers::ContainsSubstring(
+          "CartoonSphere2D should only be used with systems that have a "
+          "cartoon-style boundary condition"));
 }
 }  // namespace
 

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_BoundaryConditions.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_BoundaryConditions.cpp
@@ -2633,6 +2633,8 @@ void test_cartoon_mesh_compatibility() {
       external_boundary_conditions{1};
   external_boundary_conditions[0][Direction<1>::lower_xi()] = std::make_unique<
       domain::BoundaryConditions::Cartoon<BoundaryCondition<TestSystem>>>();
+  external_boundary_conditions[0][Direction<1>::upper_xi()] = std::make_unique<
+      domain::BoundaryConditions::None<BoundaryCondition<TestSystem>>>();
 
   auto boundary_correction =
       BoundaryTerms<1, false, SystemType::Conservative, false>{false, 1.0};
@@ -2691,7 +2693,8 @@ void test_cartoon_mesh_compatibility() {
                                    Frame::Inertial>>
       partial_derivs{};
 
-  // This should throw because we have cartoon BC but non-cartoon mesh
+  // This should throw because a cartoon BC is used on lower_xi with
+  // an incompatible mesh.
   CHECK_THROWS_WITH(
       (evolution::dg::Actions::detail::
            apply_boundary_conditions_on_all_external_faces<TestSystem, 1>(
@@ -2700,6 +2703,55 @@ void test_cartoon_mesh_compatibility() {
       Catch::Matchers::ContainsSubstring(
           "You might have used a Cartoon boundary condition on an external "
           "boundary condition"));
+
+  // Negative test: cartoon BCs are in the factory and the mesh is incompatible,
+  // but no cartoon BC is actually used on any external face. This must not
+  // error
+  {
+    INFO(
+        "Test that non-cartoon mesh does not throw when cartoon BC is not "
+        "used");
+    std::vector<DirectionMap<
+        1, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
+        no_cartoon_bcs{1};
+    no_cartoon_bcs[0][Direction<1>::lower_xi()] = std::make_unique<
+        domain::BoundaryConditions::None<BoundaryCondition<TestSystem>>>();
+    no_cartoon_bcs[0][Direction<1>::upper_xi()] = std::make_unique<
+        domain::BoundaryConditions::None<BoundaryCondition<TestSystem>>>();
+
+    Variables<typename TestSystem::variables_tag::tags_list> evolved_vars2{3,
+                                                                           1.0};
+    Variables<db::wrap_tags_in<::Tags::dt,
+                               typename TestSystem::variables_tag::tags_list>>
+        dt_evolved_vars2{3, 0.0};
+
+    auto box2 = db::create<simple_tags, compute_tags>(
+        MetavariablesWithCartoon<TestSystem>{}, std::move(no_cartoon_bcs),
+        non_cartoon_mesh, element,
+        ElementMap<1, Frame::Grid>{
+            element_id,
+            domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Grid>(
+                domain::CoordinateMaps::Identity<1>{})},
+        domain::make_coordinate_map_base<Frame::Grid, Frame::Inertial>(
+            domain::CoordinateMaps::Identity<1>{}),
+        0.0,
+        std::unordered_map<
+            std::string,
+            std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{},
+        std::optional<tnsr::I<DataVector, 1>>{},
+        InverseJacobian<DataVector, 1, Frame::ElementLogical, Frame::Inertial>{
+            3_st, 1.0},
+        Scalar<DataVector>{3_st, 1.0},
+        evolution::dg::Tags::NormalCovectorAndMagnitude<1>::type{},
+        evolved_vars2, dt_evolved_vars2, boundary_condition_volume_tag_number,
+        boundary_correction_volume_tag_number, dg::Formulation::StrongInertial);
+
+    CHECK_NOTHROW(
+        (evolution::dg::Actions::detail::
+             apply_boundary_conditions_on_all_external_faces<TestSystem, 1>(
+                 make_not_null(&box2), boundary_correction, temporaries,
+                 volume_fluxes, partial_derivs, nullptr)));
+  }
 }
 
 SPECTRE_TEST_CASE("Unit.Evolution.DG.ComputeTimeDerivative.BoundaryConditions",


### PR DESCRIPTION
## Proposed changes

Two main changes:
1.  Elements touching the y axis use ZernikeB1 in the x dimension
2. Have the cartoon-type BC of a system be automatically used at appropriate internal boundary

The logic at the bottom of the creator's hpp is identically updated for the other two cartoon creators (will make PRs after this one is merged)

This also updates the scalar wave system so you can see how this works

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
