### PR TITLE
Add filled sphere capability to SphericalShells domain creator

### DIFF
--- a/src/Domain/Creators/SphericalShells.cpp
+++ b/src/Domain/Creators/SphericalShells.cpp
@@ -44,7 +44,8 @@ SphericalShells::SphericalShells(
     std::vector<double> radial_partitioning,
     const typename RadialDistribution::type& radial_distribution,
     std::optional<TimeDepOptionType> time_dependent_options,
-    std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+    std::optional<
+        std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>
         inner_boundary_condition,
     std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
         outer_boundary_condition,
@@ -57,7 +58,8 @@ SphericalShells::SphericalShells(
       initial_spherical_harmonic_l_(initial_spherical_harmonic_l),
       radial_partitioning_(std::move(radial_partitioning)),
       time_dependent_options_(std::move(time_dependent_options)),
-      inner_boundary_condition_(std::move(inner_boundary_condition)),
+      inner_boundary_condition_(
+          std::move(inner_boundary_condition).value_or(nullptr)),
       outer_boundary_condition_(std::move(outer_boundary_condition)),
       grid_anchors_{{{"Center", tnsr::I<double, 3, Frame::Grid>{
                                     std::array{0.0, 0.0, 0.0}}}}} {
@@ -72,7 +74,13 @@ SphericalShells::SphericalShells(
       make_not_null(&num_blocks_), make_not_null(&radial_distribution_),
       radial_partitioning_, radial_distribution, inner_radius_, outer_radius_,
       "inner", "outer", context);
-  for (size_t shell = 0; shell < num_blocks_; ++shell) {
+  excise_center_ = inner_radius_ != 0.0;
+  if (not excise_center_) {
+    block_names_.emplace_back("FilledSphere");
+    block_groups_["FilledSphere"].insert("FilledSphere");
+  }
+  const size_t num_shells = excise_center_ ? num_blocks_ : num_blocks_ - 1;
+  for (size_t shell = 0; shell < num_shells; ++shell) {
     const std::string shell_name = "Shell" + std::to_string(shell);
     block_names_.emplace_back(shell_name);
     // This makes consistent block groups with those created by Sphere
@@ -81,12 +89,23 @@ SphericalShells::SphericalShells(
 
   // Validate boundary conditions
   using domain::BoundaryConditions::is_none;
-  if (is_none(inner_boundary_condition_) or
-      is_none(outer_boundary_condition_)) {
-    PARSE_ERROR(
-        context,
-        "None boundary condition is not supported. If you would like an "
-        "outflow-type boundary condition, you must use that.");
+  if (excise_center_ and is_none(inner_boundary_condition_)) {
+    PARSE_ERROR(context,
+                "None boundary condition for the inner boundary is not "
+                "supported when the center is excised. If you would like an "
+                "outflow-type boundary condition, you must use that.");
+  }
+  if (not excise_center_ and not(is_none(inner_boundary_condition_) or
+                                 inner_boundary_condition_ == nullptr)) {
+    PARSE_ERROR(context,
+                "Cannot set a boundary condition for the inner boundary when "
+                "the center is not excised.");
+  }
+  if (is_none(outer_boundary_condition_)) {
+    PARSE_ERROR(context,
+                "None boundary condition is not supported for the outer "
+                "boundary. If you would like an outflow-type boundary "
+                "condition, you must use that.");
   }
   using domain::BoundaryConditions::is_periodic;
   if (is_periodic(inner_boundary_condition_) or
@@ -96,8 +115,8 @@ SphericalShells::SphericalShells(
         "Cannot have periodic boundary conditions with SphericalShells");
   }
   // Validate consistency of inner and outer boundary condition
-  if ((inner_boundary_condition_ == nullptr) !=
-      (outer_boundary_condition_ == nullptr)) {
+  if (excise_center_ and (inner_boundary_condition_ == nullptr) !=
+                             (outer_boundary_condition_ == nullptr)) {
     PARSE_ERROR(context,
                 "Must specify either both inner and outer boundary conditions "
                 "or neither.");
@@ -142,16 +161,20 @@ Domain<3> SphericalShells::create_domain() const {
       neighbors.emplace(std::pair{Direction<3>::upper_xi(),
                                   BlockNeighbors<3>{i + 1, aligned}});
     }
-    blocks.emplace_back(std::move(stationary_map), i, std::move(neighbors),
-                        block_names_.at(i),
-                        domain::topologies::spherical_shell);
+    blocks.emplace_back(
+        std::move(stationary_map), i, std::move(neighbors), block_names_.at(i),
+        (not excise_center_ and i == 0) ? domain::topologies::full_sphere
+                                        : domain::topologies::spherical_shell);
   }
 
   std::unordered_map<std::string, ExcisionSphere<3>> excision_spheres{};
-  excision_spheres.emplace(
-      "ExcisionSphere", ExcisionSphere<3>{inner_radius_,
-                                          tnsr::I<double, 3, Frame::Grid>{0.0},
-                                          {{0, Direction<3>::lower_xi()}}});
+  if (excise_center_) {
+    excision_spheres.emplace(
+        "ExcisionSphere",
+        ExcisionSphere<3>{inner_radius_,
+                          tnsr::I<double, 3, Frame::Grid>{0.0},
+                          {{0, Direction<3>::lower_xi()}}});
+  }
 
   Domain<3> domain(std::move(blocks), std::move(excision_spheres),
                    block_groups_);
@@ -224,18 +247,26 @@ SphericalShells::external_boundary_conditions() const {
   std::vector<DirectionMap<
       3, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
       boundary_conditions{num_blocks_};
-  boundary_conditions[0][Direction<3>::lower_xi()] =
-      inner_boundary_condition_->get_clone();
+  if (excise_center_) {
+    boundary_conditions[0][Direction<3>::lower_xi()] =
+        inner_boundary_condition_->get_clone();
+  }
   boundary_conditions[num_blocks_ - 1][Direction<3>::upper_xi()] =
       outer_boundary_condition_->get_clone();
   return boundary_conditions;
 }
 
 std::vector<std::array<size_t, 3>> SphericalShells::initial_extents() const {
-  return std::vector{num_blocks_,
-                     std::array{initial_number_of_radial_grid_points_,
-                                initial_spherical_harmonic_l_ + 1,
-                                2 * initial_spherical_harmonic_l_ + 1}};
+  std::vector<std::array<size_t, 3>> extents{
+      num_blocks_, std::array{initial_number_of_radial_grid_points_,
+                              initial_spherical_harmonic_l_ + 1,
+                              2 * initial_spherical_harmonic_l_ + 1}};
+  if (not excise_center_) {
+    // setting B3's number of r points based on minimizing the spectral space
+    // restriction inequality: l_max < 2 * n_r - 1
+    extents[0][0] = (initial_spherical_harmonic_l_ + 3) / 2;
+  }
+  return extents;
 }
 
 std::vector<std::array<size_t, 3>> SphericalShells::initial_refinement_levels()

--- a/src/Domain/Creators/SphericalShells.hpp
+++ b/src/Domain/Creators/SphericalShells.hpp
@@ -51,6 +51,9 @@ namespace domain::creators {
 ///
 /// \see Sphere for a spherical domain compatible with subcell
 ///
+/// Setting the inner radius to $0$ will set the inner-most element to be a
+/// filled sphere.
+///
 /// This domain creator offers one grid anchor "Center" at the origin.
 ///
 /// #### Time dependent maps
@@ -95,7 +98,9 @@ class SphericalShells : public DomainCreator<3> {
   struct InnerRadius {
     using type = double;
     static constexpr Options::String help = {
-        "Inner radius of the spherical shells."};
+        "Inner radius of the spherical shells. If set to 0, the innermost "
+        "element with be a B3 in which case the inner boundary condition is "
+        "not used"};
   };
 
   /*!
@@ -186,7 +191,8 @@ class SphericalShells : public DomainCreator<3> {
   struct InnerBoundaryCondition {
     static constexpr Options::String help =
         "Options for the boundary conditions at the inner radius.";
-    using type = std::unique_ptr<BoundaryConditionsBase>;
+    using type = Options::Auto<std::unique_ptr<BoundaryConditionsBase>,
+                               Options::AutoLabel::None>;
   };
 
   /*!
@@ -219,7 +225,8 @@ class SphericalShells : public DomainCreator<3> {
       basic_options>;
 
   static constexpr Options::String help{
-      "A set of concentric spherical shells centered at the origin."};
+      "An optional B3 surrounded by a set of concentric spherical shells "
+      "centered at the origin."};
 
   SphericalShells(
       double inner_radius, double outer_radius,
@@ -230,8 +237,9 @@ class SphericalShells : public DomainCreator<3> {
       const typename RadialDistribution::type& radial_distribution =
           domain::CoordinateMaps::Distribution::Linear,
       std::optional<TimeDepOptionType> time_dependent_options = std::nullopt,
-      std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
-          inner_boundary_condition = nullptr,
+      std::optional<
+          std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>
+          inner_boundary_condition = std::nullopt,
       std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
           outer_boundary_condition = nullptr,
       const Options::Context& context = {});
@@ -277,6 +285,7 @@ class SphericalShells : public DomainCreator<3> {
   double outer_radius_{};
   size_t initial_radial_refinement_{};
   size_t initial_number_of_radial_grid_points_{};
+  bool excise_center_{};
   size_t initial_spherical_harmonic_l_{};
   std::vector<double> radial_partitioning_{};
   std::vector<domain::CoordinateMaps::Distribution> radial_distribution_{};

--- a/src/Domain/Creators/SphericalShells.hpp
+++ b/src/Domain/Creators/SphericalShells.hpp
@@ -89,30 +89,45 @@ class SphericalShells : public DomainCreator<3> {
                        domain::CoordinateMaps::SphericalToCartesianPfaffian>>,
                    typename sphere::TimeDependentMapOptions::maps_list>;
 
+  /*!
+   * \brief Radius of innermost spherical shell
+   */
   struct InnerRadius {
     using type = double;
     static constexpr Options::String help = {
         "Inner radius of the spherical shells."};
   };
 
+  /*!
+   * \brief Radius of outer boundary
+   */
   struct OuterRadius {
     using type = double;
     static constexpr Options::String help = {
         "Outer radius of the spherical shells."};
   };
 
+  /*!
+   * \brief Initial refinement in radial direction
+   */
   struct InitialRadialRefinement {
     using type = size_t;
     static constexpr Options::String help = {
         "Initial radial refinement level."};
   };
 
+  /*!
+   * \brief Initial number of radial grid points
+   */
   struct InitialNumberOfRadialGridPoints {
     using type = size_t;
     static constexpr Options::String help = {
         "Initial number of radial grid points."};
   };
 
+  /*!
+   * \brief Initial spherical harmonic resolution
+   */
   struct InitialSphericalHarmonicL {
     using type = size_t;
     static size_t lower_bound() { return 6; }
@@ -121,6 +136,9 @@ class SphericalShells : public DomainCreator<3> {
         "spherical harmonic represented on the grid.  Minimum value is 6."};
   };
 
+  /*!
+   * \brief Radial coordinates of the boundaries splitting elements
+   */
   struct RadialPartitioning {
     using type = std::vector<double>;
     static constexpr Options::String help = {
@@ -131,6 +149,9 @@ class SphericalShells : public DomainCreator<3> {
         "are important, use InitialRefinement instead."};
   };
 
+  /*!
+   * \brief Distributions to apply to the radial coordinates
+   */
   struct RadialDistribution {
     using type =
         std::variant<domain::CoordinateMaps::Distribution,
@@ -147,6 +168,9 @@ class SphericalShells : public DomainCreator<3> {
       sphere::TimeDependentMapOptions,
       std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>>;
 
+  /*!
+   * \brief Time dependence of the domain
+   */
   struct TimeDependentMaps {
     using type = Options::Auto<TimeDepOptionType, Options::AutoLabel::None>;
     static constexpr Options::String help = {
@@ -155,6 +179,9 @@ class SphericalShells : public DomainCreator<3> {
         "for no time dependent maps."};
   };
 
+  /*!
+   * \brief Boundary condition to apply to inner boundary when not filled
+   */
   template <typename BoundaryConditionsBase>
   struct InnerBoundaryCondition {
     static constexpr Options::String help =
@@ -162,6 +189,9 @@ class SphericalShells : public DomainCreator<3> {
     using type = std::unique_ptr<BoundaryConditionsBase>;
   };
 
+  /*!
+   * \brief Boundary condition to apply to outer boundary
+   */
   template <typename BoundaryConditionsBase>
   struct OuterBoundaryCondition {
     static constexpr Options::String help =

--- a/tests/Unit/Domain/Creators/Test_SphericalShells.cpp
+++ b/tests/Unit/Domain/Creators/Test_SphericalShells.cpp
@@ -26,6 +26,7 @@
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/ElementId.hpp"
 #include "Domain/Structure/ObjectLabel.hpp"
+#include "Domain/Structure/Topology.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/Domain/BoundaryConditions/BoundaryCondition.hpp"
 #include "Helpers/Domain/Creators/TestHelpers.hpp"
@@ -63,7 +64,7 @@ std::string option_string(
     const std::vector<domain::CoordinateMaps::Distribution>&
         radial_distribution,
     const bool time_dependent, const bool hard_coded_time_dependent_maps,
-    const bool with_boundary_conditions) {
+    const bool with_boundary_conditions, const bool inner_bc_is_none = false) {
   const std::string time_dependent_option =
       time_dependent ? (hard_coded_time_dependent_maps
                             ? "  TimeDependentMaps:\n"
@@ -84,12 +85,14 @@ std::string option_string(
                               "      InitialTime: 1.0\n"
                               "      Velocity: [2.3, -0.3, 0.5]\n")
                      : "  TimeDependentMaps: None\n";
-  const std::string inner_bc_option = with_boundary_conditions
-                                          ? "  InnerBoundaryCondition:\n"
-                                            "    TestBoundaryCondition:\n"
-                                            "      Direction: lower-xi\n"
-                                            "      BlockId: 50\n"
-                                          : "";
+  const std::string inner_bc_option =
+      with_boundary_conditions
+          ? (inner_bc_is_none ? "  InnerBoundaryCondition: None\n"
+                              : "  InnerBoundaryCondition:\n"
+                                "    TestBoundaryCondition:\n"
+                                "      Direction: lower-xi\n"
+                                "      BlockId: 50\n")
+          : "";
   const std::string outer_bc_option = with_boundary_conditions
                                           ? "  OuterBoundaryCondition:\n"
                                             "    TestBoundaryCondition:\n"
@@ -218,8 +221,9 @@ void test_parse_errors() {
                                TestNoneBoundaryCondition<3>>(),
           Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
-          "None boundary condition is not supported. If you would like "
-          "an outflow-type boundary condition, you must use that."));
+          "None boundary condition is not supported for the outer "
+          "boundary. If you would like an outflow-type boundary "
+          "condition, you must use that."));
   CHECK_THROWS_WITH(
       domain::creators::SphericalShells(
           inner_radius, outer_radius, radial_refinement, radial_extents, l,
@@ -228,8 +232,26 @@ void test_parse_errors() {
                                TestNoneBoundaryCondition<3>>(),
           create_boundary_condition(true), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
-          "None boundary condition is not supported. If you would like "
-          "an outflow-type boundary condition, you must use that."));
+          "None boundary condition for the inner boundary is not "
+          "supported when the center is excised. If you would like an "
+          "outflow-type boundary condition, you must use that."));
+  CHECK_THROWS_WITH(
+      domain::creators::SphericalShells(
+          0.0, outer_radius, radial_refinement, radial_extents, l,
+          radial_partitioning, radial_distribution, std::nullopt,
+          std::make_unique<TestHelpers::domain::BoundaryConditions::
+                               TestBoundaryCondition<3>>(),
+          create_boundary_condition(true), Options::Context{false, {}, 1, 1}),
+      Catch::Matchers::ContainsSubstring(
+          "Cannot set a boundary condition for the inner boundary when "
+          "the center is not excised."));
+  // None BC is allowed when inner_radius = 0.0 (no inner BC is applied)
+  CHECK_NOTHROW(domain::creators::SphericalShells(
+      0.0, outer_radius, radial_refinement, radial_extents, l,
+      radial_partitioning, radial_distribution, std::nullopt,
+      std::make_unique<TestHelpers::domain::BoundaryConditions::
+                           TestNoneBoundaryCondition<3>>(),
+      create_boundary_condition(true), Options::Context{false, {}, 1, 1}));
 }
 
 template <typename Generator>
@@ -250,6 +272,14 @@ void test_spherical_shells_construction(
   CHECK(grid_anchors.at("Center") ==
         tnsr::I<double, 3, Frame::Grid>{std::array{0.0, 0.0, 0.0}});
 
+  // Check excision spheres
+  if (inner_radius == 0.0) {
+    CHECK(domain.excision_spheres().empty());
+  } else {
+    CHECK(domain.excision_spheres().size() == 1);
+    CHECK(domain.excision_spheres().count("ExcisionSphere") == 1);
+  }
+
   const auto& blocks = domain.blocks();
   const auto block_names = spherical_shells.block_names();
   const size_t num_blocks = blocks.size();
@@ -265,7 +295,11 @@ void test_spherical_shells_construction(
       alg::accumulate(blocks, 0_st, [](const size_t count, const auto& block) {
         return count + block.external_boundaries().size();
       });
-  CHECK(num_external_boundaries == 2);
+  // inner_radius == 0 means the innermost block is a filled ball (B3 topology):
+  // its lower-xi face is the degenerate center point, not a real boundary,
+  // so there is only one external boundary (the outer sphere).
+  const size_t expected_num_external_boundaries = (inner_radius == 0.0) ? 1 : 2;
+  CHECK(num_external_boundaries == expected_num_external_boundaries);
 
   std::vector<double> expected_radii = radial_partitioning;
   expected_radii.insert(expected_radii.begin(), inner_radius);
@@ -326,18 +360,46 @@ void test_spherical_shells_construction(
     {
       INFO("External boundaries");
       const auto& external_boundaries = block.external_boundaries();
-      if (num_blocks == 1) {
-        CHECK(external_boundaries.size() == 2);
-        CHECK(alg::found(external_boundaries, Direction<3>::lower_xi()));
-        CHECK(alg::found(external_boundaries, Direction<3>::upper_xi()));
-      } else if (block_id == 0) {
-        CHECK(external_boundaries.size() == 1);
-        CHECK(alg::found(external_boundaries, Direction<3>::lower_xi()));
-      } else if (block_id == num_blocks - 1) {
-        CHECK(external_boundaries.size() == 1);
-        CHECK(alg::found(external_boundaries, Direction<3>::upper_xi()));
+      if (inner_radius == 0.0) {
+        // B3Radial topology: lower-xi (center) is not a real boundary.
+        if (block_id == num_blocks - 1) {
+          CHECK(external_boundaries.size() == 1);
+          CHECK(alg::found(external_boundaries, Direction<3>::upper_xi()));
+        } else {
+          CHECK(external_boundaries.empty());
+        }
       } else {
-        CHECK(external_boundaries.empty());
+        if (num_blocks == 1) {
+          CHECK(external_boundaries.size() == 2);
+          CHECK(alg::found(external_boundaries, Direction<3>::lower_xi()));
+          CHECK(alg::found(external_boundaries, Direction<3>::upper_xi()));
+        } else if (block_id == 0) {
+          CHECK(external_boundaries.size() == 1);
+          CHECK(alg::found(external_boundaries, Direction<3>::lower_xi()));
+        } else if (block_id == num_blocks - 1) {
+          CHECK(external_boundaries.size() == 1);
+          CHECK(alg::found(external_boundaries, Direction<3>::upper_xi()));
+        } else {
+          CHECK(external_boundaries.empty());
+        }
+      }
+    }
+    {
+      INFO("Block topology");
+      if (inner_radius == 0.0 and block_id == 0) {
+        CHECK(block.topologies() == domain::topologies::full_sphere);
+      } else {
+        CHECK(block.topologies() == domain::topologies::spherical_shell);
+      }
+    }
+    {
+      INFO("Block name");
+      if (inner_radius == 0.0 and block_id == 0) {
+        CHECK(block_names[block_id] == "FilledSphere");
+      } else {
+        const size_t shell_index =
+            (inner_radius == 0.0) ? block_id - 1 : block_id;
+        CHECK(block_names[block_id] == "Shell" + std::to_string(shell_index));
       }
     }
     if (expect_boundary_conditions) {
@@ -586,6 +648,76 @@ void test_shape_distortion() {
     }
   }
 }
+
+template <typename Generator>
+void test_filled_sphere(const gsl::not_null<Generator*> gen) {
+  const double inner_radius = 0.0;
+  const double outer_radius = 2.0;
+  const size_t radial_refinement = 2;
+  const size_t radial_extents = 5;
+  const size_t l = 6;
+  const std::vector<domain::CoordinateMaps::Distribution> radial_distribution{
+      domain::CoordinateMaps::Distribution::Linear};
+
+  {
+    INFO("Single filled ball, no boundary conditions");
+    const domain::creators::SphericalShells spherical_shells{
+        inner_radius, outer_radius, radial_refinement, radial_extents, l};
+    test_spherical_shells_construction(gen, spherical_shells, inner_radius,
+                                       outer_radius, {}, false);
+    TestHelpers::domain::creators::test_creation(
+        option_string(inner_radius, outer_radius, radial_refinement,
+                      radial_extents, l, {}, radial_distribution, false, false,
+                      false),
+        spherical_shells, false);
+  }
+  {
+    INFO("Single filled ball, with boundary conditions");
+    const domain::creators::SphericalShells spherical_shells{
+        inner_radius,
+        outer_radius,
+        radial_refinement,
+        radial_extents,
+        l,
+        {},
+        domain::CoordinateMaps::Distribution::Linear,
+        std::nullopt,
+        std::make_unique<TestHelpers::domain::BoundaryConditions::
+                             TestNoneBoundaryCondition<3>>(),
+        create_boundary_condition(true)};
+    test_spherical_shells_construction(gen, spherical_shells, inner_radius,
+                                       outer_radius, {}, true);
+    TestHelpers::domain::creators::test_creation(
+        option_string(inner_radius, outer_radius, radial_refinement,
+                      radial_extents, l, {}, radial_distribution, false, false,
+                      true, true),
+        spherical_shells, true);
+  }
+  {
+    INFO("Filled ball with one radial partition, no boundary conditions");
+    const std::vector<double> radial_partitioning{1.0};
+    const std::vector<domain::CoordinateMaps::Distribution>
+        radial_distribution_2{
+            domain::CoordinateMaps::Distribution::Linear,
+            domain::CoordinateMaps::Distribution::Logarithmic};
+    const domain::creators::SphericalShells spherical_shells{
+        inner_radius,
+        outer_radius,
+        radial_refinement,
+        radial_extents,
+        l,
+        radial_partitioning,
+        radial_distribution_2};
+    test_spherical_shells_construction(gen, spherical_shells, inner_radius,
+                                       outer_radius, radial_partitioning,
+                                       false);
+    TestHelpers::domain::creators::test_creation(
+        option_string(inner_radius, outer_radius, radial_refinement,
+                      radial_extents, l, radial_partitioning,
+                      radial_distribution_2, false, false, false),
+        spherical_shells, false);
+  }
+}
 }  // namespace
 
 // [[TimeOut, 15]]
@@ -594,5 +726,6 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.SphericalShells", "[Domain][Unit]") {
   domain::creators::time_dependence::register_derived_with_charm();
   test_parse_errors();
   test_sphere(make_not_null(&gen));
+  test_filled_sphere(make_not_null(&gen));
   test_shape_distortion();
 }


### PR DESCRIPTION
## Proposed changes

When `inner_radius == 0`, set topology to `full_sphere`.

The code already supports radial refinement (so when we use `full_sphere` topology, the innermost block can be radially refined and will correctly set non-inner elements to spherical shells).

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
