### PR TITLE
Update CartoonSphere1D creator to use ZernikeB1 and internal BCs

### DIFF
--- a/src/Domain/Creators/CartoonSphere1D.cpp
+++ b/src/Domain/Creators/CartoonSphere1D.cpp
@@ -13,6 +13,7 @@
 #include "Domain/BoundaryConditions/Periodic.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/Distribution.hpp"
 #include "Domain/CoordinateMaps/Identity.hpp"
 #include "Domain/CoordinateMaps/Interval.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
@@ -29,6 +30,7 @@
 #include "Domain/Structure/Topology.hpp"
 #include "Options/Context.hpp"
 #include "Options/ParseError.hpp"
+#include "Utilities/Gsl.hpp"
 
 namespace Frame {
 struct BlockLogical;
@@ -36,6 +38,30 @@ struct Inertial;
 }  // namespace Frame
 
 namespace domain::creators {
+
+detail::CartoonSphere1DOptionsHelper::CartoonSphere1DOptionsHelper(
+    double inner_bound, double outer_bound,
+    typename InitialRadialRefinement::type&& initial_refinement_levels,
+    typename InitialNumberOfRadialGridPoints::type&& initial_num_points,
+    std::vector<double> radial_partitioning,
+    typename RadialDistributions::type&& radial_distributions,
+    std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>
+        time_dependence,
+    std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+        inner_boundary_condition,
+    std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+        outer_boundary_condition,
+    Options::Context&& context)
+    : inner_bound_(inner_bound),
+      outer_bound_(outer_bound),
+      initial_refinement_levels_(std::move(initial_refinement_levels)),
+      initial_num_points_(std::move(initial_num_points)),
+      radial_partitioning_(std::move(radial_partitioning)),
+      radial_distributions_(std::move(radial_distributions)),
+      time_dependence_(std::move(time_dependence)),
+      inner_boundary_condition_(std::move(inner_boundary_condition)),
+      outer_boundary_condition_(std::move(outer_boundary_condition)),
+      context_(std::move(context)) {}
 
 CartoonSphere1D::CartoonSphere1D(
     double inner_bound, double outer_bound,
@@ -49,12 +75,15 @@ CartoonSphere1D::CartoonSphere1D(
         inner_boundary_condition,
     std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
         outer_boundary_condition,
+    std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+        cartoon_boundary_condition,
     const Options::Context& context)
     : inner_bound_(inner_bound),
       outer_bound_(outer_bound),
       radial_partitioning_(std::move(radial_partitioning)),
       inner_boundary_condition_(std::move(inner_boundary_condition)),
       outer_boundary_condition_(std::move(outer_boundary_condition)),
+      cartoon_boundary_condition_(std::move(cartoon_boundary_condition)),
       time_dependence_(std::move(time_dependence)) {
   if (time_dependence_ == nullptr) {
     time_dependence_ =
@@ -95,6 +124,31 @@ CartoonSphere1D::CartoonSphere1D(
       std::move(initial_refinement_levels), "InitialRadialRefinement");
   initial_num_points_ = check_possible_list_instantiation(
       std::move(initial_num_points), "InitialNumberOfRadialGridPoints");
+  use_zernike_ = inner_bound_ == 0.0;
+
+  // Check if cartoon boundary condition is not provided
+  if (cartoon_boundary_condition_ == nullptr) {
+    PARSE_ERROR(
+        context,
+        "CartoonSphere1D should only be used with systems that have a "
+        "cartoon-style boundary condition, but none was provided. This "
+        "means the system is not set up to use cartoon methods. Make sure your "
+        "system has a boundary condition that inherits from MarkAsCartoon in "
+        "its standard_boundary_conditions list.");
+  }
+
+  // Check if user specified a cartoon BC as an external boundary
+  if ((inner_boundary_condition_ != nullptr and
+       domain::BoundaryConditions::is_cartoon(inner_boundary_condition_)) or
+      (outer_boundary_condition_ != nullptr and
+       domain::BoundaryConditions::is_cartoon(outer_boundary_condition_))) {
+    PARSE_ERROR(
+        context,
+        "Cartoon boundary conditions should not be specified as external "
+        "boundary conditions. They are automatically applied to internal "
+        "cartoon boundaries. Please choose a different boundary condition "
+        "for the inner and outer boundaries.");
+  }
 
   if ((inner_boundary_condition_ == nullptr) !=
       (outer_boundary_condition_ == nullptr)) {
@@ -120,7 +174,7 @@ CartoonSphere1D::CartoonSphere1D(
   for (size_t block = 0; block < num_blocks_; ++block) {
     const std::string block_name = "Block" + std::to_string(block);
     block_names_.emplace_back(block_name);
-    block_groups_[block_name].insert(block_name);
+    block_groups_["PositiveBlocks"].insert(block_name);
   }
 }
 
@@ -130,10 +184,11 @@ Domain<3> CartoonSphere1D::create_domain() const {
   using cartoon_sphere_map =
       CoordinateMaps::ProductOf3Maps<Interval, Identity1D, Identity1D>;
   const Identity1D identity_map;
+  const auto aligned = OrientationMap<3>::create_aligned();
 
   std::vector<Block<3>> blocks;
   blocks.reserve(num_blocks_);
-  const auto aligned = OrientationMap<3>::create_aligned();
+
   for (size_t i = 0; i < num_blocks_; ++i) {
     auto block_map = cartoon_sphere_map{
         {-1.0, 1.0, i == 0 ? inner_bound_ : radial_partitioning_[i - 1],
@@ -153,8 +208,15 @@ Domain<3> CartoonSphere1D::create_domain() const {
       neighbors.emplace(std::pair{Direction<3>::upper_xi(),
                                   BlockNeighbors<3>{i + 1, aligned}});
     }
-    blocks.emplace_back(std::move(stationary_map), i, std::move(neighbors),
-                        block_names_.at(i), domain::topologies::cartoon_sphere);
+    if (use_zernike_ and i == 0) {
+      blocks.emplace_back(std::move(stationary_map), i, std::move(neighbors),
+                          gsl::at(block_names_, i),
+                          domain::topologies::cartoon_sphere_inner);
+    } else {
+      blocks.emplace_back(std::move(stationary_map), i, std::move(neighbors),
+                          gsl::at(block_names_, i),
+                          domain::topologies::cartoon_sphere);
+    }
   }
 
   Domain<3> domain(std::move(blocks), {}, block_groups_);
@@ -191,8 +253,13 @@ CartoonSphere1D::external_boundary_conditions() const {
   std::vector<DirectionMap<
       3, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
       boundary_conditions{num_blocks_};
-  boundary_conditions[0][Direction<3>::lower_xi()] =
-      inner_boundary_condition_->get_clone();
+  if (use_zernike_) {
+    boundary_conditions[0][Direction<3>::lower_xi()] =
+        cartoon_boundary_condition_->get_clone();
+  } else {
+    boundary_conditions[0][Direction<3>::lower_xi()] =
+        inner_boundary_condition_->get_clone();
+  }
   boundary_conditions[num_blocks_ - 1][Direction<3>::upper_xi()] =
       outer_boundary_condition_->get_clone();
   return boundary_conditions;
@@ -200,7 +267,7 @@ CartoonSphere1D::external_boundary_conditions() const {
 
 std::vector<std::array<size_t, 3>> CartoonSphere1D::initial_extents() const {
   std::vector<std::array<size_t, 3>> output;
-  output.reserve(initial_num_points_.size());
+  output.reserve(num_blocks_);
   for (const auto& val : initial_num_points_) {
     // cartoon bases always have extents set to 1
     output.push_back({val, 1_st, 1_st});
@@ -211,7 +278,7 @@ std::vector<std::array<size_t, 3>> CartoonSphere1D::initial_extents() const {
 std::vector<std::array<size_t, 3>> CartoonSphere1D::initial_refinement_levels()
     const {
   std::vector<std::array<size_t, 3>> output;
-  output.reserve(initial_refinement_levels_.size());
+  output.reserve(num_blocks_);
   for (const auto& val : initial_refinement_levels_) {
     // cartoon bases always have no refinement
     output.push_back({val, 0_st, 0_st});

--- a/src/Domain/Creators/CartoonSphere1D.hpp
+++ b/src/Domain/Creators/CartoonSphere1D.hpp
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "Domain/BoundaryConditions/BoundaryCondition.hpp"
+#include "Domain/BoundaryConditions/Cartoon.hpp"
 #include "Domain/BoundaryConditions/GetBoundaryConditionsBase.hpp"
 #include "Domain/CoordinateMaps/Distribution.hpp"
 #include "Domain/Creators/DomainCreator.hpp"
@@ -51,8 +52,9 @@ class CartoonSphere1D : public DomainCreator<3> {
   struct InnerRadius {
     using type = double;
     static constexpr Options::String help = {
-        "Inner radius of domain, which is a sphere if set to 0, otherwise a "
-        "spherical shell."};
+        "Inner radius of domain, greater than or equal to 0. If the origin is "
+        "included, the innermost element will use a 1D Zernike basis, "
+        "otherwise the domain will be a spherical shell."};
   };
 
   struct OuterRadius {
@@ -108,6 +110,15 @@ class CartoonSphere1D : public DomainCreator<3> {
     using type = std::unique_ptr<BoundaryConditionsBase>;
   };
 
+  template <typename BoundaryConditionsBase>
+  struct CartoonBoundaryCondition {
+    static constexpr Options::String help =
+        "Cartoon boundary condition will be automatically applied to "
+        "internal cartoon boundaries. No user options needed.";
+    using type = std::nullptr_t;
+    static std::string name() { return "CartoonBC"; }
+  };
+
   struct TimeDependence {
     using type =
         std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>;
@@ -139,7 +150,8 @@ class CartoonSphere1D : public DomainCreator<3> {
       "A sphere domain that requires/enforces spherical symmetry, resulting in "
       "a 1D computational domain (the radial axis). It uses Cartoon partial "
       "derivatives for the angular directions not in the computational "
-      "domain."};
+      "domain. If an element touches the x=0 axis, it uses ZernikeB1 bases and "
+      "automatically applies a system's Cartoon-type boundary condition."};
 
   CartoonSphere1D(
       double inner_bound, double outer_bound,
@@ -154,6 +166,8 @@ class CartoonSphere1D : public DomainCreator<3> {
           inner_boundary_condition = nullptr,
       std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
           outer_boundary_condition = nullptr,
+      std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+          cartoon_boundary_condition = nullptr,
       const Options::Context& context = {});
 
   CartoonSphere1D() = default;
@@ -177,8 +191,7 @@ class CartoonSphere1D : public DomainCreator<3> {
   // Block.
   std::vector<std::string> block_names() const override;
 
-  // The block groups are Block0, Block1, ..., starting with the innermost
-  // Block.
+  // The only block group is PositiveBlocks
   std::unordered_map<std::string, std::unordered_set<std::string>>
   block_groups() const override;
 
@@ -195,10 +208,13 @@ class CartoonSphere1D : public DomainCreator<3> {
   std::vector<size_t> initial_num_points_{};
   std::vector<double> radial_partitioning_{};
   std::vector<CoordinateMaps::Distribution> radial_distributions_{};
+  bool use_zernike_{};
   std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
       inner_boundary_condition_{};
   std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
       outer_boundary_condition_{};
+  std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+      cartoon_boundary_condition_{};
   std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>
       time_dependence_;
   size_t num_blocks_{};
@@ -208,3 +224,113 @@ class CartoonSphere1D : public DomainCreator<3> {
 };
 
 }  // namespace domain::creators
+
+namespace domain::creators::detail {
+/// \brief Helper struct for CartoonSphere1D options parsing so the internal
+/// cartoon boundary condition at $x = 0$ is not a required argument.
+///
+/// \details To get the cartoon-type boundary condition from a system we need
+/// access to the system's metavariables, which is only present when parsing
+/// options. The point of this design is so that the input file does not require
+/// a dummy value for an InnerBoundaryCondition that is always the same for a
+/// given system.
+///
+/// This helper's constructor does not take an InnerBoundaryCondition, which
+/// means if we parse a CartoonSphere1D as a CartonSphere1DOptionsHelper
+/// by having an options parsing specialization (so the input file values are
+/// the helper's construtor, not CartoonSphere1D's), we can detect the
+/// cartoon-type boundary condition for the given system and only then call the
+/// CartoonSphere1D constructor with the extra information.
+struct CartoonSphere1DOptionsHelper {
+  // Inherit the options template from CartoonSphere1D
+  template <typename Metavariables>
+  using options = typename domain::creators::CartoonSphere1D::template options<
+      Metavariables>;
+
+  using InitialRadialRefinement =
+      domain::creators::CartoonSphere1D::InitialRadialRefinement;
+  using InitialNumberOfRadialGridPoints =
+      domain::creators::CartoonSphere1D::InitialNumberOfRadialGridPoints;
+  using RadialDistributions =
+      domain::creators::CartoonSphere1D::RadialDistributions;
+
+  static constexpr Options::String help = {"CartoonSphere1DOptionsHelper"};
+
+  // Default constructor required by Options system
+  CartoonSphere1DOptionsHelper() = default;
+
+  // Does not take cartoon BC
+  CartoonSphere1DOptionsHelper(
+      double inner_bound, double outer_bound,
+      typename InitialRadialRefinement::type&& initial_refinement_levels,
+      typename InitialNumberOfRadialGridPoints::type&& initial_num_points,
+      std::vector<double> radial_partitioning = {},
+      typename RadialDistributions::type&& radial_distributions =
+          domain::CoordinateMaps::Distribution::Linear,
+      std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>
+          time_dependence = nullptr,
+      std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+          inner_boundary_condition = nullptr,
+      std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+          outer_boundary_condition = nullptr,
+      Options::Context&& context = {});
+
+  // Same members as in CartoonSphere1D; public, to be extracted
+  double inner_bound_{std::numeric_limits<double>::signaling_NaN()};
+  double outer_bound_{std::numeric_limits<double>::signaling_NaN()};
+  typename domain::creators::CartoonSphere1D::InitialRadialRefinement::type
+      initial_refinement_levels_{};
+  typename domain::creators::CartoonSphere1D::InitialNumberOfRadialGridPoints::
+      type initial_num_points_{};
+  std::vector<double> radial_partitioning_{};
+  domain::creators::CartoonSphere1D::RadialDistributions::type
+      radial_distributions_{domain::CoordinateMaps::Distribution::Linear};
+  std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>
+      time_dependence_{nullptr};
+  std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+      inner_boundary_condition_{nullptr};
+  std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+      outer_boundary_condition_{nullptr};
+  std::nullptr_t cartoon_boundary_condition_{
+      nullptr};  // For CartoonBoundaryCondition option
+  Options::Context context_{};
+};
+}  // namespace domain::creators::detail
+
+// Options parsing specialization to automate CartoonSphere1D's cartoon
+// boundary condition
+template <>
+struct Options::create_from_yaml<domain::creators::CartoonSphere1D> {
+  template <typename Metavariables>
+  static domain::creators::CartoonSphere1D create(
+      const Options::Option& options) {
+    auto helper =
+        options.parse_as<domain::creators::detail::CartoonSphere1DOptionsHelper,
+                         Metavariables>();
+
+    // Create cartoon BC if system supports it, if not will throw parse error in
+    // real constructor
+    std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+        cartoon_boundary_condition = nullptr;
+    if constexpr (domain::BoundaryConditions::has_boundary_conditions_base_v<
+                      typename Metavariables::system>) {
+      if constexpr (domain::BoundaryConditions::system_has_cartoon_bc_v<
+                        Metavariables>) {
+        cartoon_boundary_condition =
+            domain::BoundaryConditions::make_cartoon_boundary_condition<
+                Metavariables>();
+      }
+    }
+
+    // Construct CartoonSphere1D using the helper's parsed data + cartoon BC
+    return domain::creators::CartoonSphere1D(
+        helper.inner_bound_, helper.outer_bound_,
+        std::move(helper.initial_refinement_levels_),
+        std::move(helper.initial_num_points_),
+        std::move(helper.radial_partitioning_), helper.radial_distributions_,
+        std::move(helper.time_dependence_),
+        std::move(helper.inner_boundary_condition_),
+        std::move(helper.outer_boundary_condition_),
+        std::move(cartoon_boundary_condition), helper.context_);
+  }
+};

--- a/src/Domain/Creators/CartoonSphere2D.cpp
+++ b/src/Domain/Creators/CartoonSphere2D.cpp
@@ -43,13 +43,39 @@ struct BlockLogical;
 
 namespace domain::creators {
 
+detail::CartoonSphere2DOptionsHelper::CartoonSphere2DOptionsHelper(
+    double inner_radius, double outer_radius, size_t initial_angular_refinement,
+    typename InitialRadialRefinement::type&& initial_radial_refinement,
+    std::array<size_t, 2> initial_number_of_grid_points,
+    std::vector<double> radial_partitioning, bool use_equiangular_map,
+    std::variant<Excision, InnerSquare> interior,
+    typename domain::creators::CartoonSphere2D::RadialDistribution::type
+        radial_distribution,
+    std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>
+        time_dependence,
+    std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+        outer_boundary_condition,
+    Options::Context&& context)
+    : inner_radius_(inner_radius),
+      outer_radius_(outer_radius),
+      initial_angular_refinement_(initial_angular_refinement),
+      initial_radial_refinement_(std::move(initial_radial_refinement)),
+      initial_number_of_grid_points_(std::move(initial_number_of_grid_points)),
+      radial_partitioning_(std::move(radial_partitioning)),
+      use_equiangular_map_(use_equiangular_map),
+      interior_(std::move(interior)),
+      radial_distribution_(std::move(radial_distribution)),
+      time_dependence_(std::move(time_dependence)),
+      outer_boundary_condition_(std::move(outer_boundary_condition)),
+      context_(std::move(context)) {}
+
 CartoonSphere2D::CartoonSphere2D(
     double inner_radius, double outer_radius, size_t initial_angular_refinement,
     const typename InitialRadialRefinement::type& initial_radial_refinement,
     std::array<size_t, 2> initial_number_of_grid_points,
     std::vector<double> radial_partitioning, bool use_equiangular_map,
     std::variant<Excision, InnerSquare> interior,
-    CoordinateMaps::Distribution radial_distribution,
+    const typename RadialDistribution::type& radial_distribution,
     std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>
         time_dependence,
     std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
@@ -66,7 +92,6 @@ CartoonSphere2D::CartoonSphere2D(
       interior_(std::move(interior)),
       fill_interior_(std::holds_alternative<InnerSquare>(interior_)),
       time_dependence_(std::move(time_dependence)),
-      radial_distribution_(std::move(radial_distribution)),
       outer_boundary_condition_(std::move(outer_boundary_condition)),
       cartoon_boundary_condition_(std::move(cartoon_boundary_condition)) {
   if (time_dependence_ == nullptr) {
@@ -80,22 +105,20 @@ CartoonSphere2D::CartoonSphere2D(
                     std::to_string(inner_radius_) + " and outer radius is " +
                     std::to_string(outer_radius_) + ".");
   }
+  set_shell_distribution(
+      make_not_null(&num_shells_), make_not_null(&radial_distributions_),
+      radial_partitioning_, radial_distribution, inner_radius_, outer_radius_,
+      "inner", "outer", context);
+
+  // radial_distributions_[0] is the innermost shell
   if (fill_interior_ and std::get<InnerSquare>(interior_).sphericity != 1.0 and
-      radial_distribution_ != CoordinateMaps::Distribution::Linear) {
+      radial_distributions_[0] != CoordinateMaps::Distribution::Linear) {
     PARSE_ERROR(
         context,
-        "Cannot have a non-linear radial distribution when the sphericity of "
-        "wedges is not 1.0, got "
-            << radial_distribution << ". You need to excise the center.");
+        "Cannot have a non-linear radial distribution in the innermost shell "
+        "when the sphericity of wedges is not 1.0, got "
+            << radial_distributions_[0] << ". You need to excise the center.");
   }
-
-  std::vector<domain::CoordinateMaps::Distribution> dummy_vec;
-  const auto dummy_distribution = CoordinateMaps::Distribution::Linear;
-  // using this for checks of input values
-  set_shell_distribution(make_not_null(&num_shells_), make_not_null(&dummy_vec),
-                         radial_partitioning_, dummy_distribution,
-                         inner_radius_, outer_radius_, "inner", "outer",
-                         context);
   // num_shells_ is the number of wedge shells, always > 0
   num_blocks_ = 3 * num_shells_ + (fill_interior_ ? 1 : 0);
   if (std::holds_alternative<size_t>(initial_radial_refinement)) {
@@ -233,6 +256,8 @@ Domain<3> CartoonSphere2D::create_domain() const {
         i == 0 ? outer_radius_
                : radial_partitioning_[radial_partitioning_.size() - i];
     const double inner_sphericity = has_square ? inner_square_sphericity : 1.0;
+    // radial_distributions_[0] is innermost; loop goes outer->inner
+    const auto shell_distribution = radial_distributions_[num_shells_ - 1 - i];
     // this is a half-wedge, -y
     auto coord_maps = make_vector_coordinate_map_base<Frame::BlockLogical,
                                                       Frame::Inertial, 3>(
@@ -244,7 +269,7 @@ Domain<3> CartoonSphere2D::create_domain() const {
                     {Direction<2>::upper_eta(), Direction<2>::lower_xi()}}},
                 use_equiangular_map_,
                 domain::CoordinateMaps::Wedge<2>::WedgeHalves::UpperOnly,
-                radial_distribution_},
+                shell_distribution},
             Identity1D{}});
     // this is a full wedge, +x
     coord_maps.emplace_back(
@@ -257,7 +282,7 @@ Domain<3> CartoonSphere2D::create_domain() const {
                         {Direction<2>::upper_xi(), Direction<2>::upper_eta()}}},
                     use_equiangular_map_,
                     domain::CoordinateMaps::Wedge<2>::WedgeHalves::Both,
-                    radial_distribution_},
+                    shell_distribution},
                 Identity1D{}}));
     // this is a half-wedge, +y
     coord_maps.emplace_back(
@@ -270,7 +295,7 @@ Domain<3> CartoonSphere2D::create_domain() const {
                         {Direction<2>::lower_eta(), Direction<2>::upper_xi()}}},
                     use_equiangular_map_,
                     domain::CoordinateMaps::Wedge<2>::WedgeHalves::LowerOnly,
-                    radial_distribution_},
+                    shell_distribution},
                 Identity1D{}}));
     if (has_square) {
       if (use_equiangular_map_) {

--- a/src/Domain/Creators/CartoonSphere2D.hpp
+++ b/src/Domain/Creators/CartoonSphere2D.hpp
@@ -9,6 +9,7 @@
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
+#include <variant>
 #include <vector>
 
 #include "Domain/BoundaryConditions/BoundaryCondition.hpp"
@@ -170,11 +171,14 @@ class CartoonSphere2D : public DomainCreator<3> {
   };
 
   struct RadialDistribution {
-    using type = CoordinateMaps::Distribution;
+    using type = std::variant<CoordinateMaps::Distribution,
+                              std::vector<CoordinateMaps::Distribution>>;
     static constexpr Options::String help = {
         "Distribution of grid points for the radial direction of the wedges. "
-        "For anything but linear, the center must be excised with sphericity = "
-        "1.0"};
+        "A single value will be applied to all shells, or every shell can be "
+        "specified individually, in which case for N partitions there must be "
+        "N+1 distributions. For anything but linear in the innermost shell, "
+        "the center must be excised."};
   };
 
   struct TimeDependence {
@@ -224,7 +228,7 @@ class CartoonSphere2D : public DomainCreator<3> {
       std::array<size_t, 2> initial_number_of_grid_points,
       std::vector<double> radial_partitioning, bool use_equiangular_map,
       std::variant<Excision, InnerSquare> interior,
-      CoordinateMaps::Distribution radial_distribution,
+      const typename RadialDistribution::type& radial_distribution,
       std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>
           time_dependence,
       std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
@@ -250,8 +254,15 @@ class CartoonSphere2D : public DomainCreator<3> {
 
   std::vector<std::array<size_t, 3>> initial_refinement_levels() const override;
 
+  /// The block names are Shell0_LowerY, Shell0_UpperX, Shell0_UpperY,
+  /// Shell1_LowerY, and so on. The naming and numbering goes from outer-most
+  /// shell, starting from bottom and going counterclockwise, going to inside
+  /// neighboring shell. If the center is included, the "center" half-circle
+  /// follows same numbering with the _HalfSquare being the last block.
   std::vector<std::string> block_names() const override { return block_names_; }
 
+  /// The block groups are Shell0, Shell1, ... starting from the outermost
+  /// partition and working in.
   std::unordered_map<std::string, std::unordered_set<std::string>>
   block_groups() const override {
     return block_groups_;
@@ -275,8 +286,7 @@ class CartoonSphere2D : public DomainCreator<3> {
   bool fill_interior_{false};
   std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>
       time_dependence_ = nullptr;
-  CoordinateMaps::Distribution radial_distribution_ =
-      CoordinateMaps::Distribution::Linear;
+  std::vector<CoordinateMaps::Distribution> radial_distributions_{};
   std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
       outer_boundary_condition_ = nullptr;
   std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
@@ -293,7 +303,7 @@ namespace domain::creators::detail {
 /// \brief Helper struct for CartoonSphere2D options parsing so the internal
 /// cartoon boundary condition at $x = 0$ is not a required argument.
 ///
-/// \detail To get the cartoon-type boundary condition from a system we need
+/// \details To get the cartoon-type boundary condition from a system we need
 /// access to the system's metavariables, which is only present when parsing
 /// options. The point of this design is so that the input file does not require
 /// a dummy value for an InnerBoundaryCondition that is always the same for a
@@ -333,26 +343,13 @@ struct CartoonSphere2DOptionsHelper {
       std::array<size_t, 2> initial_number_of_grid_points,
       std::vector<double> radial_partitioning, bool use_equiangular_map,
       std::variant<Excision, InnerSquare> interior,
-      CoordinateMaps::Distribution radial_distribution =
-          CoordinateMaps::Distribution::Linear,
+      typename domain::creators::CartoonSphere2D::RadialDistribution::type
+          radial_distribution = CoordinateMaps::Distribution::Linear,
       std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>
           time_dependence = nullptr,
       std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
           outer_boundary_condition = nullptr,
-      Options::Context&& context = {})
-      : inner_radius_(inner_radius),
-        outer_radius_(outer_radius),
-        initial_angular_refinement_(initial_angular_refinement),
-        initial_radial_refinement_(std::move(initial_radial_refinement)),
-        initial_number_of_grid_points_(
-            std::move(initial_number_of_grid_points)),
-        radial_partitioning_(std::move(radial_partitioning)),
-        use_equiangular_map_(use_equiangular_map),
-        interior_(std::move(interior)),
-        radial_distribution_(radial_distribution),
-        time_dependence_(std::move(time_dependence)),
-        outer_boundary_condition_(std::move(outer_boundary_condition)),
-        context_(std::move(context)) {}
+      Options::Context&& context = {});
 
   // Same members as in CartoonSphere2D; public, to be extracted
   double inner_radius_{std::numeric_limits<double>::signaling_NaN()};
@@ -363,8 +360,8 @@ struct CartoonSphere2DOptionsHelper {
   std::vector<double> radial_partitioning_{};
   bool use_equiangular_map_{false};
   typename Interior::type interior_{};
-  CoordinateMaps::Distribution radial_distribution_{
-      CoordinateMaps::Distribution::Linear};
+  typename domain::creators::CartoonSphere2D::RadialDistribution::type
+      radial_distribution_{CoordinateMaps::Distribution::Linear};
   std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>
       time_dependence_{nullptr};
   std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Factory.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Factory.hpp
@@ -5,6 +5,7 @@
 
 #include <cstddef>
 
+#include "Domain/BoundaryConditions/Cartoon.hpp"
 #include "Domain/BoundaryConditions/Periodic.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Bjorhus.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/BoundaryCondition.hpp"
@@ -17,7 +18,8 @@ namespace gh::BoundaryConditions {
 /// Typelist of standard BoundaryConditions
 template <size_t Dim>
 using standard_boundary_conditions =
-    tmpl::list<ConstraintPreservingBjorhus<Dim>, DemandOutgoingCharSpeeds<Dim>,
+    tmpl::list<domain::BoundaryConditions::Cartoon<BoundaryCondition<Dim>>,
+               ConstraintPreservingBjorhus<Dim>, DemandOutgoingCharSpeeds<Dim>,
                DirichletAnalytic<Dim>, DirichletMinkowski<Dim>,
                domain::BoundaryConditions::Periodic<BoundaryCondition<Dim>>>;
 }  // namespace gh::BoundaryConditions

--- a/tests/Unit/Domain/Creators/Test_CartoonSphere1D.cpp
+++ b/tests/Unit/Domain/Creators/Test_CartoonSphere1D.cpp
@@ -14,6 +14,7 @@
 #include "Domain/BoundaryConditions/BoundaryCondition.hpp"
 #include "Domain/CoordinateMaps/Distribution.hpp"
 #include "Domain/Creators/CartoonSphere1D.hpp"
+#include "Domain/Creators/OptionTags.hpp"
 #include "Domain/Creators/TimeDependence/RegisterDerivedWithCharm.hpp"
 #include "Domain/Creators/TimeDependence/UniformTranslation.hpp"
 #include "Domain/Creators/TimeDependentOptions/Sphere.hpp"
@@ -21,6 +22,7 @@
 #include "Domain/ElementMap.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/Topology.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/Domain/BoundaryConditions/BoundaryCondition.hpp"
 #include "Helpers/Domain/Creators/TestHelpers.hpp"
@@ -35,6 +37,12 @@ create_boundary_condition(const bool outer) {
   return std::make_unique<
       TestHelpers::domain::BoundaryConditions::TestBoundaryCondition<3>>(
       outer ? Direction<3>::upper_xi() : Direction<3>::lower_xi(), 50);
+}
+
+std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+create_cartoon_boundary_condition() {
+  return std::make_unique<TestHelpers::domain::BoundaryConditions::
+                              TestCartoonBoundaryCondition<3>>();
 }
 
 template <typename T>
@@ -114,6 +122,7 @@ void test_parse_errors() {
       domain::creators::CartoonSphere1D(
           lower_bound, 0.5 * lower_bound, radial_refinement, radial_extents,
           radial_partitioning, radial_distribution, nullptr, nullptr, nullptr,
+          create_cartoon_boundary_condition(),
           Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "Inner radius must be smaller than outer radius"));
@@ -122,7 +131,8 @@ void test_parse_errors() {
       domain::creators::CartoonSphere1D(
           lower_bound, upper_bound, radial_refinement, radial_extents,
           radial_partitioning_unordered, radial_distribution, nullptr, nullptr,
-          nullptr, Options::Context{false, {}, 1, 1}),
+          nullptr, create_cartoon_boundary_condition(),
+          Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "Specify radial partitioning in ascending order."));
 
@@ -130,27 +140,31 @@ void test_parse_errors() {
       domain::creators::CartoonSphere1D(
           lower_bound, upper_bound, radial_refinement, radial_extents,
           radial_partitioning_low, radial_distribution, nullptr, nullptr,
-          nullptr, Options::Context{false, {}, 1, 1}),
+          nullptr, create_cartoon_boundary_condition(),
+          Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "First radial partition must be larger than the inner"));
   CHECK_THROWS_WITH(
       domain::creators::CartoonSphere1D(
           lower_bound, upper_bound, radial_refinement, radial_extents,
           radial_partitioning_high, radial_distribution, nullptr, nullptr,
-          nullptr, Options::Context{false, {}, 1, 1}),
+          nullptr, create_cartoon_boundary_condition(),
+          Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "Last radial partition must be smaller than the outer"));
   CHECK_THROWS_WITH(
       domain::creators::CartoonSphere1D(
           lower_bound, upper_bound, radial_refinement, radial_extents,
           radial_partitioning, radial_distribution_too_many, nullptr, nullptr,
-          nullptr, Options::Context{false, {}, 1, 1}),
+          nullptr, create_cartoon_boundary_condition(),
+          Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "Specify a 'RadialDistribution' for every spherical shell. You"));
   CHECK_THROWS_WITH(
       domain::creators::CartoonSphere1D(
           lower_bound, upper_bound, radial_refinement_high, radial_extents,
           radial_partitioning, radial_distribution, nullptr, nullptr, nullptr,
+          create_cartoon_boundary_condition(),
           Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "must be the same size as RadialDistributions "));
@@ -158,6 +172,7 @@ void test_parse_errors() {
       domain::creators::CartoonSphere1D(
           lower_bound, upper_bound, radial_refinement, radial_extents_high,
           radial_partitioning, radial_distribution, nullptr, nullptr, nullptr,
+          create_cartoon_boundary_condition(),
           Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "must be the same size as RadialDistributions "));
@@ -166,6 +181,7 @@ void test_parse_errors() {
           lower_bound, upper_bound, radial_refinement, radial_extents,
           radial_partitioning, radial_distribution, nullptr,
           create_boundary_condition(false), nullptr,
+          create_cartoon_boundary_condition(),
           Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "Must specify either both inner and outer boundary conditions "
@@ -177,6 +193,7 @@ void test_parse_errors() {
           create_boundary_condition(false),
           std::make_unique<TestHelpers::domain::BoundaryConditions::
                                TestPeriodicBoundaryCondition<3>>(),
+          create_cartoon_boundary_condition(),
           Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "Cannot have periodic boundary conditions with CartoonSphere1D"));
@@ -186,7 +203,8 @@ void test_parse_errors() {
           radial_partitioning, radial_distribution, nullptr,
           std::make_unique<TestHelpers::domain::BoundaryConditions::
                                TestPeriodicBoundaryCondition<3>>(),
-          create_boundary_condition(true), Options::Context{false, {}, 1, 1}),
+          create_boundary_condition(true), create_cartoon_boundary_condition(),
+          Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "Cannot have periodic boundary conditions with CartoonSphere1D"));
   CHECK_THROWS_WITH(
@@ -196,6 +214,7 @@ void test_parse_errors() {
           create_boundary_condition(false),
           std::make_unique<TestHelpers::domain::BoundaryConditions::
                                TestNoneBoundaryCondition<3>>(),
+          create_cartoon_boundary_condition(),
           Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "None boundary condition is not supported. If you would like "
@@ -206,10 +225,47 @@ void test_parse_errors() {
           radial_partitioning, radial_distribution, nullptr,
           std::make_unique<TestHelpers::domain::BoundaryConditions::
                                TestNoneBoundaryCondition<3>>(),
-          create_boundary_condition(true), Options::Context{false, {}, 1, 1}),
+          create_boundary_condition(true), create_cartoon_boundary_condition(),
+          Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "None boundary condition is not supported. If you would like "
           "an outflow-type boundary condition, you must use that."));
+  CHECK_THROWS_WITH(
+      domain::creators::CartoonSphere1D(
+          lower_bound, upper_bound, radial_refinement, radial_extents,
+          radial_partitioning, radial_distribution, nullptr,
+          create_boundary_condition(true), create_cartoon_boundary_condition(),
+          create_cartoon_boundary_condition(),
+          Options::Context{false, {}, 1, 1}),
+      Catch::Matchers::ContainsSubstring(
+          "Cartoon boundary conditions should not be specified as external "));
+  // Test that using a system without a cartoon BC triggers a parse error via
+  // the create_from_yaml path.
+  CHECK_THROWS_WITH(
+      (TestHelpers::test_option_tag<
+          domain::OptionTags::DomainCreator<3>,
+          TestHelpers::domain::BoundaryConditions::
+              MetavariablesWithBoundaryConditions<
+                  3, domain::creators::CartoonSphere1D>>(
+          "CartoonSphere1D:\n"
+          "  InnerRadius: 1.0\n"
+          "  OuterRadius: 2.0\n"
+          "  InitialRadialRefinement: 3\n"
+          "  InitialNumberOfRadialGridPoints: 5\n"
+          "  RadialPartitioning: [1.5]\n"
+          "  TimeDependence: None\n"
+          "  RadialDistributions: Linear\n"
+          "  InnerBoundaryCondition:\n"
+          "    TestBoundaryCondition:\n"
+          "      Direction: lower-xi\n"
+          "      BlockId: 0\n"
+          "  OuterBoundaryCondition: \n"
+          "    TestBoundaryCondition:\n"
+          "      Direction: upper-xi\n"
+          "      BlockId: 1\n")),
+      Catch::Matchers::ContainsSubstring(
+          "CartoonSphere1D should only be used with systems that have a "
+          "cartoon-style boundary condition"));
 }
 
 void test_cartoon_sphere_construction(
@@ -295,16 +351,30 @@ void test_cartoon_sphere_construction(
         CHECK(external_boundaries.empty());
       }
     }
+    const bool using_zernike =
+        lower_bound == 0.0 and (block_id % 3 == 0 or block_id % 3 == 2);
+    {
+      INFO("Block topology");
+      if (using_zernike) {
+        CHECK(block.topologies() == domain::topologies::cartoon_sphere_inner);
+      } else {
+        CHECK(block.topologies() == domain::topologies::cartoon_sphere);
+      }
+    }
     if (expect_boundary_conditions) {
       INFO("Boundary conditions");
       const auto& boundary_conditions = all_boundary_conditions[block_id];
       for (const auto& direction : block.external_boundaries()) {
         CAPTURE(direction);
-        const auto& boundary_condition =
-            dynamic_cast<const TestHelpers::domain::BoundaryConditions::
-                             TestBoundaryCondition<3>&>(
-                *boundary_conditions.at(direction));
-        CHECK(boundary_condition.direction() == direction);
+        if (using_zernike) {
+          CHECK(is_cartoon(boundary_conditions.at(direction)));
+        } else {
+          const auto& boundary_condition =
+              dynamic_cast<const TestHelpers::domain::BoundaryConditions::
+                               TestBoundaryCondition<3>&>(
+                  *boundary_conditions.at(direction));
+          CHECK(boundary_condition.direction() == direction);
+        }
       }
     }
   }
@@ -330,13 +400,11 @@ void test_sphere(const gsl::not_null<Generator*> gen) {
 
   const std::array<double, 3> velocity{{2.3, -0.3, 0.5}};
   const std::vector<double> times{1., 10.};
-  for (auto [index, time_dependent, with_boundary_conditions] :
-       random_sample<5>(
-           cartesian_product(make_array(0_st, 1_st, 2_st),
-                             make_array(true, false), make_array(true, false)),
-           gen)) {
+  for (auto [index, time_dependent] :
+       random_sample<5>(cartesian_product(make_array(0_st, 1_st, 2_st),
+                                          make_array(true, false)),
+                        gen)) {
     CAPTURE(time_dependent);
-    CAPTURE(with_boundary_conditions);
     CAPTURE(gsl::at(radial_partitioning, index));
     CAPTURE(gsl::at(radial_distributions, index));
     domain::creators::CartoonSphere1D::RadialDistributions::type
@@ -357,7 +425,8 @@ void test_sphere(const gsl::not_null<Generator*> gen) {
           1.0, velocity);
       translation_velocity = velocity;
     }
-
+    // Must hardcode having boundary conditions for test_creation() to
+    // properly parse and give the domain a cartoon-type boundary condition
     const domain::creators::CartoonSphere1D cartoon_sphere{
         lower_bound,
         upper_bound,
@@ -366,19 +435,45 @@ void test_sphere(const gsl::not_null<Generator*> gen) {
         gsl::at(radial_partitioning, index),
         radial_distributions_variant,
         std::move(time_dependency),
-        with_boundary_conditions ? create_boundary_condition(false) : nullptr,
-        with_boundary_conditions ? create_boundary_condition(true) : nullptr};
+        create_boundary_condition(false),
+        create_boundary_condition(true),
+        create_cartoon_boundary_condition()};
     test_cartoon_sphere_construction(
         cartoon_sphere, lower_bound, upper_bound,
-        gsl::at(radial_partitioning, index), with_boundary_conditions,
+        gsl::at(radial_partitioning, index), true,
         time_dependent ? times : std::vector<double>{1.}, translation_velocity);
     TestHelpers::domain::creators::test_creation(
         option_string(lower_bound, upper_bound, radial_refinement,
                       radial_extents, gsl::at(radial_partitioning, index),
                       gsl::at(radial_distributions, index), time_dependent,
-                      with_boundary_conditions),
-        cartoon_sphere, with_boundary_conditions);
+                      true),
+        cartoon_sphere, true);
   }
+  const auto cartoon_sphere = TestHelpers::test_option_tag<
+      domain::OptionTags::DomainCreator<3>,
+      TestHelpers::domain::BoundaryConditions::
+          MetavariablesWithBoundaryConditionsCartoon<
+              3, domain::creators::CartoonSphere1D>>(
+      "CartoonSphere1D:\n"
+      "  InnerRadius: 0.0\n"
+      "  OuterRadius: 2.0\n"
+      "  InitialRadialRefinement: 3\n"
+      "  InitialNumberOfRadialGridPoints: 5\n"
+      "  RadialPartitioning: [1.5]\n"
+      "  TimeDependence: None\n"
+      "  RadialDistributions: Linear\n"
+      "  InnerBoundaryCondition:\n"
+      "    TestBoundaryCondition:\n"
+      "      Direction: lower-xi\n"
+      "      BlockId: 0\n"
+      "  OuterBoundaryCondition: \n"
+      "    TestBoundaryCondition:\n"
+      "      Direction: upper-xi\n"
+      "      BlockId: 1\n");
+  const std::vector<double> radial_partitioning_val(1, 1.5);
+  test_cartoon_sphere_construction(
+      dynamic_cast<const domain::creators::CartoonSphere1D&>(*cartoon_sphere),
+      0.0, upper_bound, radial_partitioning_val, true);
 }
 }  // namespace
 

--- a/tests/Unit/Domain/Creators/Test_CartoonSphere2D.cpp
+++ b/tests/Unit/Domain/Creators/Test_CartoonSphere2D.cpp
@@ -533,6 +533,43 @@ void test_sphere_factory() {
                            radial_refinement, grid_points, radial_partition,
                            false, std::move(excise1), true);
 
+  {
+    INFO("Multiple distributions via list parsing");
+    const auto sphere_multi_dist = TestHelpers::test_option_tag<
+        domain::OptionTags::DomainCreator<3>,
+        TestHelpers::domain::BoundaryConditions::
+            MetavariablesWithBoundaryConditionsCartoon<
+                3, domain::creators::CartoonSphere2D>>(
+        "CartoonSphere2D:\n"
+        "  InnerRadius: 1.0\n"
+        "  OuterRadius: 5.0\n"
+        "  InitialAngularRefinement: 3\n"
+        "  InitialRadialRefinement:\n"
+        "    - 3\n"
+        "    - 3\n"
+        "    - 2\n"
+        "  InitialGridPoints: [2,3]\n"
+        "  RadialPartitioning: [3.5, 4.5]\n"
+        "  UseEquiangularMap: false\n"
+        "  RadialDistribution: [Linear, Linear, Linear]\n"
+        "  TimeDependence: None\n"
+        "  Interior:\n"
+        "    ExciseWithBoundaryCondition:\n"
+        "      TestBoundaryCondition:\n"
+        "        Direction: lower-eta\n"
+        "        BlockId: 3\n"
+        "  OuterBoundaryCondition:\n"
+        "    TestBoundaryCondition:\n"
+        "      Direction: lower-xi\n"
+        "      BlockId: 2\n");
+    domain::creators::detail::Excision excise_multi{
+        create_boundary_condition_inner()};
+    test_sphere_construction(
+        dynamic_cast<const creators::CartoonSphere2D&>(*sphere_multi_dist),
+        inner_radius, outer_radius, angular_refinement, radial_refinement,
+        grid_points, radial_partition, false, std::move(excise_multi), true);
+  }
+
   INFO("With TimeDependent Map");
   const auto sphere_time_dependent = TestHelpers::test_option_tag<
       domain::OptionTags::DomainCreator<3>,
@@ -697,6 +734,19 @@ void test_sphere_errors() {
           Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "Cartoon boundary conditions should not be specified as external "));
+  CHECK_THROWS_WITH(
+      creators::CartoonSphere2D(
+          inner_radius, outer_radius, angular_refinement, radial_refinement_vec,
+          grid_points, radial_partitioning, false, fill_center,
+          std::vector<CoordinateMaps::Distribution>{
+              CoordinateMaps::Distribution::Logarithmic,
+              CoordinateMaps::Distribution::Linear,
+              CoordinateMaps::Distribution::Linear},
+          nullptr, nullptr, create_cartoon_boundary_condition(),
+          Options::Context{false, {}, 1, 1}),
+      Catch::Matchers::ContainsSubstring(
+          "Cannot have a non-linear radial distribution in the innermost "
+          "shell"));
   // Test that using a system without a cartoon BC triggers a parse error via
   // the create_from_yaml path. MetavariablesWithBoundaryConditions has a system
   // with boundary conditions but no Cartoon BC in its factory list, so

--- a/tests/Unit/Helpers/Domain/Creators/TestHelpers.hpp
+++ b/tests/Unit/Helpers/Domain/Creators/TestHelpers.hpp
@@ -158,7 +158,7 @@ void test_creation(const std::string& option_string, const Creator& rhs,
   auto created = [&option_string, &with_boundary_conditions]() {
     if (with_boundary_conditions) {
       using metavars = TestHelpers::domain::BoundaryConditions::
-          MetavariablesWithBoundaryConditions<Dim, Creator>;
+          MetavariablesWithBoundaryConditionsCartoon<Dim, Creator>;
       return TestHelpers::test_option_tag<
           ::domain::OptionTags::DomainCreator<Dim>, metavars>(option_string);
     } else {


### PR DESCRIPTION
## Proposed changes

Identical cartoon-type boundary condition handling as in #7260

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
