### PR TITLE
Create cartoon-type BC for ValenciaDivClean

### DIFF
--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/CMakeLists.txt
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/CMakeLists.txt
@@ -5,6 +5,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   BoundaryCondition.cpp
+  CartoonGhost.cpp
   DemandOutgoingCharSpeeds.cpp
   DirichletAnalytic.cpp
   HydroFreeOutflow.cpp
@@ -16,6 +17,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   BoundaryCondition.hpp
+  CartoonGhost.hpp
   DemandOutgoingCharSpeeds.hpp
   DirichletAnalytic.hpp
   Factory.hpp

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/CartoonGhost.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/CartoonGhost.cpp
@@ -1,0 +1,333 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/CartoonGhost.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <pup.h>
+
+#include "DataStructures/DataBox/PrefixHelpers.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Index.hpp"
+#include "DataStructures/SliceVariables.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "DataStructures/Tensor/Expressions/Evaluate.hpp"
+#include "DataStructures/Tensor/Slice.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/ComputeFluxesFromPrimitives.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/ConservativeFromPrimitive.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Reconstructor.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Fluxes.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace grmhd::ValenciaDivClean::BoundaryConditions {
+CartoonGhost::CartoonGhost(CkMigrateMessage* const msg)
+    : BoundaryCondition(msg) {}
+
+std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+CartoonGhost::get_clone() const {
+  return std::make_unique<CartoonGhost>(*this);
+}
+
+void CartoonGhost::pup(PUP::er& p) { BoundaryCondition::pup(p); }
+// NOLINTNEXTLINE
+PUP::able::PUP_ID CartoonGhost::my_PUP_ID = 0;
+
+void CartoonGhost::fd_ghost(
+    const gsl::not_null<Scalar<DataVector>*> rest_mass_density,
+    const gsl::not_null<Scalar<DataVector>*> electron_fraction,
+    const gsl::not_null<Scalar<DataVector>*> temperature,
+    const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
+        lorentz_factor_times_spatial_velocity,
+    const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
+        magnetic_field,
+    const gsl::not_null<Scalar<DataVector>*> divergence_cleaning_field,
+
+    const gsl::not_null<std::optional<Variables<db::wrap_tags_in<
+        Flux, typename grmhd::ValenciaDivClean::System::flux_variables>>>*>
+        cell_centered_ghost_fluxes,
+
+    const Direction<3>& direction,
+
+    // fd_interior_temporary_tags
+    const Mesh<3>& subcell_mesh,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& interior_shift,
+    const Scalar<DataVector>& interior_lapse,
+    const tnsr::ii<DataVector, 3, Frame::Inertial>& interior_spatial_metric,
+
+    // fd_interior_primitive_variables_tags
+    const Scalar<DataVector>& interior_rest_mass_density,
+    const Scalar<DataVector>& interior_electron_fraction,
+    const Scalar<DataVector>& interior_temperature,
+    const Scalar<DataVector>& interior_pressure,
+    const Scalar<DataVector>& interior_specific_internal_energy,
+    const Scalar<DataVector>& interior_lorentz_factor,
+    const Scalar<DataVector>& interior_divergence_cleaning_field,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& interior_spatial_velocity,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& interior_magnetic_field,
+
+    // fd_gridless_tags
+    const fd::Reconstructor& reconstructor) {
+  Variables<tmpl::push_back<
+      tmpl::append<typename System::variables_tag::tags_list,
+                   typename System::primitive_variables_tag::tags_list>,
+      SqrtDetSpatialMetric, SpatialMetric, InvSpatialMetric, Lapse, Shift>>
+      temp_vars{get(*rest_mass_density).size()};
+
+  fd_ghost_impl(make_not_null(&get<RestMassDensity>(temp_vars)),
+                make_not_null(&get<ElectronFraction>(temp_vars)),
+                make_not_null(&get<Temperature>(temp_vars)),
+                make_not_null(&get<Pressure>(temp_vars)),
+                make_not_null(&get<SpecificInternalEnergy>(temp_vars)),
+                lorentz_factor_times_spatial_velocity,
+                make_not_null(&get<SpatialVelocity>(temp_vars)),
+                make_not_null(&get<LorentzFactor>(temp_vars)),
+                make_not_null(&get<MagneticField>(temp_vars)),
+                make_not_null(&get<DivergenceCleaningField>(temp_vars)),
+                make_not_null(&get<SpatialMetric>(temp_vars)),
+                make_not_null(&get<InvSpatialMetric>(temp_vars)),
+                make_not_null(&get<SqrtDetSpatialMetric>(temp_vars)),
+                make_not_null(&get<Lapse>(temp_vars)),
+                make_not_null(&get<Shift>(temp_vars)),
+
+                direction,
+
+                // fd_interior_temporary_tags
+                subcell_mesh,
+
+                // fd_interior_primitive_variables_tags
+                interior_rest_mass_density, interior_electron_fraction,
+                interior_temperature, interior_pressure,
+                interior_specific_internal_energy, interior_lorentz_factor,
+                interior_divergence_cleaning_field, interior_spatial_velocity,
+                interior_magnetic_field, interior_spatial_metric,
+                interior_lapse, interior_shift,
+
+                reconstructor.ghost_zone_size(),
+
+                cell_centered_ghost_fluxes->has_value());
+
+  if (cell_centered_ghost_fluxes->has_value()) {
+    compute_fluxes_from_primitives(
+        make_not_null(&cell_centered_ghost_fluxes->value()), temp_vars);
+  }
+
+  *rest_mass_density = get<hydro::Tags::RestMassDensity<DataVector>>(temp_vars);
+  *electron_fraction =
+      get<hydro::Tags::ElectronFraction<DataVector>>(temp_vars);
+  *temperature = get<hydro::Tags::Temperature<DataVector>>(temp_vars);
+  *magnetic_field = get<hydro::Tags::MagneticField<DataVector, 3>>(temp_vars);
+  *divergence_cleaning_field =
+      get<hydro::Tags::DivergenceCleaningField<DataVector>>(temp_vars);
+}
+
+void CartoonGhost::fd_ghost_impl(
+    const gsl::not_null<Scalar<DataVector>*> rest_mass_density,
+    const gsl::not_null<Scalar<DataVector>*> electron_fraction,
+    const gsl::not_null<Scalar<DataVector>*> temperature,
+    const gsl::not_null<Scalar<DataVector>*> pressure,
+    const gsl::not_null<Scalar<DataVector>*> specific_internal_energy,
+    const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
+        lorentz_factor_times_spatial_velocity,
+    const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
+        spatial_velocity,
+    const gsl::not_null<Scalar<DataVector>*> lorentz_factor,
+    const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
+        magnetic_field,
+    const gsl::not_null<Scalar<DataVector>*> divergence_cleaning_field,
+    const gsl::not_null<tnsr::ii<DataVector, 3, Frame::Inertial>*>
+        spatial_metric,
+    const gsl::not_null<tnsr::II<DataVector, 3, Frame::Inertial>*>
+        inv_spatial_metric,
+    const gsl::not_null<Scalar<DataVector>*> sqrt_det_spatial_metric,
+    const gsl::not_null<Scalar<DataVector>*> lapse,
+    const gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> shift,
+
+    const Direction<3>& direction,
+
+    // fd_interior_temporary_tags
+    const Mesh<3>& subcell_mesh,
+
+    // fd_interior_primitive_variables_tags
+    const Scalar<DataVector>& interior_rest_mass_density,
+    const Scalar<DataVector>& interior_electron_fraction,
+    const Scalar<DataVector>& interior_temperature,
+    const Scalar<DataVector>& interior_pressure,
+    const Scalar<DataVector>& interior_specific_internal_energy,
+    const Scalar<DataVector>& interior_lorentz_factor,
+    const Scalar<DataVector>& interior_divergence_cleaning_field,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& interior_spatial_velocity,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& interior_magnetic_field,
+    const tnsr::ii<DataVector, 3, Frame::Inertial>& interior_spatial_metric,
+    const Scalar<DataVector>& interior_lapse,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& interior_shift,
+
+    const size_t ghost_zone_size, const bool need_tags_for_fluxes) {
+  const size_t dim_direction{direction.dimension()};
+  ASSERT(dim_direction == 0,
+         "Cartoon BC can only be applied in the x-direction, got "
+             << dim_direction);
+
+  const auto subcell_extents{subcell_mesh.extents()};
+  const size_t num_face_pts{
+      subcell_extents.slice_away(dim_direction).product()};
+
+  using prim_tags = tmpl::list<RestMassDensity, ElectronFraction, Temperature,
+                               LorentzFactorTimesSpatialVelocity, MagneticField,
+                               DivergenceCleaningField>;
+
+  // Create a single large DV to reduce the number of Variables allocations
+  using fluxes_tags =
+      tmpl::list<Pressure, SpecificInternalEnergy, SpatialMetric, Lapse, Shift>;
+  const size_t buffer_size_for_fluxes =
+      need_tags_for_fluxes
+          ? Variables<fluxes_tags>::number_of_independent_components
+          : 0;
+  const size_t buffer_size_per_grid_pts =
+      Variables<prim_tags>::number_of_independent_components;
+  DataVector buffer_for_vars{
+      num_face_pts * ((1 + ghost_zone_size) *
+                      (buffer_size_per_grid_pts + buffer_size_for_fluxes)),
+      0.0};
+
+  // outermost_prim_vars is scratch space for one ghost layer at a time.
+  Variables<prim_tags> outermost_prim_vars{
+      buffer_for_vars.data(), num_face_pts * buffer_size_per_grid_pts};
+  Variables<prim_tags> ghost_prim_vars{
+      outermost_prim_vars.data() + outermost_prim_vars.size(),
+      num_face_pts * buffer_size_per_grid_pts * ghost_zone_size};
+
+  // The ghost data stencil is ordered deepest-first: ghost[j=0] is the cell
+  // furthest from the element at xi = -(ghost_zone_size-0.5)*dxi, and
+  // ghost[j=ghost_zone_size-1] is nearest at xi = -0.5*dxi. By parity,
+  // ghost[j=k] mirrors interior cell ix = ghost_zone_size-1-k.
+  Index<3> ghost_data_extents = subcell_extents;
+  ghost_data_extents[dim_direction] = ghost_zone_size;
+
+  for (size_t k = 0; k < ghost_zone_size; ++k) {
+    const size_t interior_ix = ghost_zone_size - 1 - k;
+
+    get<RestMassDensity>(outermost_prim_vars) =
+        data_on_slice(interior_rest_mass_density, subcell_extents,
+                      dim_direction, interior_ix);
+    get<ElectronFraction>(outermost_prim_vars) =
+        data_on_slice(interior_electron_fraction, subcell_extents,
+                      dim_direction, interior_ix);
+    get<Temperature>(outermost_prim_vars) = data_on_slice(
+        interior_temperature, subcell_extents, dim_direction, interior_ix);
+    get<DivergenceCleaningField>(outermost_prim_vars) =
+        data_on_slice(interior_divergence_cleaning_field, subcell_extents,
+                      dim_direction, interior_ix);
+
+    {
+      // reflect both the outgoing and ingoing normal components of
+      // spatial velocity and the magnetic field.
+      const auto sliced_lorentz_factor = data_on_slice(
+          interior_lorentz_factor, subcell_extents, dim_direction, interior_ix);
+      const auto sliced_spatial_velocity =
+          data_on_slice(interior_spatial_velocity, subcell_extents,
+                        dim_direction, interior_ix);
+      const auto sliced_magnetic_field = data_on_slice(
+          interior_magnetic_field, subcell_extents, dim_direction, interior_ix);
+      for (size_t i = 0; i < 3; ++i) {
+        if (i == dim_direction) {
+          get<LorentzFactorTimesSpatialVelocity>(outermost_prim_vars).get(i) =
+              -get(sliced_lorentz_factor) * sliced_spatial_velocity.get(i);
+          get<MagneticField>(outermost_prim_vars).get(i) =
+              -1.0 * sliced_magnetic_field.get(i);
+        } else {
+          get<LorentzFactorTimesSpatialVelocity>(outermost_prim_vars).get(i) =
+              get(sliced_lorentz_factor) * sliced_spatial_velocity.get(i);
+          get<MagneticField>(outermost_prim_vars).get(i) =
+              sliced_magnetic_field.get(i);
+        }
+      }
+    }
+
+    add_slice_to_data(make_not_null(&ghost_prim_vars), outermost_prim_vars,
+                      ghost_data_extents, dim_direction, k);
+  }
+
+  *rest_mass_density = get<RestMassDensity>(ghost_prim_vars);
+  *electron_fraction = get<ElectronFraction>(ghost_prim_vars);
+  *temperature = get<Temperature>(ghost_prim_vars);
+  *lorentz_factor_times_spatial_velocity =
+      get<LorentzFactorTimesSpatialVelocity>(ghost_prim_vars);
+  *magnetic_field = get<MagneticField>(ghost_prim_vars);
+  *divergence_cleaning_field = get<DivergenceCleaningField>(ghost_prim_vars);
+
+  if (need_tags_for_fluxes) {
+    Variables<fluxes_tags> outermost_fluxes_vars{
+        std::next(ghost_prim_vars.data(),
+                  static_cast<std::ptrdiff_t>(ghost_prim_vars.size())),
+        num_face_pts * buffer_size_for_fluxes};
+    Variables<fluxes_tags> ghost_fluxes_vars{
+        std::next(outermost_fluxes_vars.data(),
+                  static_cast<std::ptrdiff_t>(outermost_fluxes_vars.size())),
+        num_face_pts * buffer_size_for_fluxes * ghost_zone_size};
+
+    for (size_t k = 0; k < ghost_zone_size; ++k) {
+      const size_t interior_ix = ghost_zone_size - 1 - k;
+
+      get<Pressure>(outermost_fluxes_vars) = data_on_slice(
+          interior_pressure, subcell_extents, dim_direction, interior_ix);
+      get<SpecificInternalEnergy>(outermost_fluxes_vars) =
+          data_on_slice(interior_specific_internal_energy, subcell_extents,
+                        dim_direction, interior_ix);
+      get<SpatialMetric>(outermost_fluxes_vars) = data_on_slice(
+          interior_spatial_metric, subcell_extents, dim_direction, interior_ix);
+      // Components with exactly one index in dim_direction are odd under the
+      // cartoon reflection and must be negated.
+      for (size_t i = 0; i < 3; ++i) {
+        for (size_t j = 0; j <= i; ++j) {
+          if ((i == dim_direction) != (j == dim_direction)) {
+            get<SpatialMetric>(outermost_fluxes_vars).get(i, j) *= -1.0;
+          }
+        }
+      }
+      get<Lapse>(outermost_fluxes_vars) = data_on_slice(
+          interior_lapse, subcell_extents, dim_direction, interior_ix);
+      get<Shift>(outermost_fluxes_vars) = data_on_slice(
+          interior_shift, subcell_extents, dim_direction, interior_ix);
+      // The x component of the shift is odd under the cartoon reflection
+      get<0>(get<Shift>(outermost_fluxes_vars)) *= -1.0;
+
+      add_slice_to_data(make_not_null(&ghost_fluxes_vars),
+                        outermost_fluxes_vars, ghost_data_extents,
+                        dim_direction, k);
+    }
+
+    // Need pressure for high-order finite difference
+    *pressure = get<Pressure>(ghost_fluxes_vars);
+    *specific_internal_energy = get<SpecificInternalEnergy>(ghost_fluxes_vars);
+    *spatial_metric = get<SpatialMetric>(ghost_fluxes_vars);
+    *lapse = get<Lapse>(ghost_fluxes_vars);
+    *shift = get<Shift>(ghost_fluxes_vars);
+
+    determinant_and_inverse(sqrt_det_spatial_metric, inv_spatial_metric,
+                            *spatial_metric);
+    get(*sqrt_det_spatial_metric) = sqrt(get(*sqrt_det_spatial_metric));
+    tenex::evaluate(
+        lorentz_factor,
+        sqrt(1.0 + (*spatial_metric)(ti::i, ti::j) *
+                       (*lorentz_factor_times_spatial_velocity)(ti::I) *
+                       (*lorentz_factor_times_spatial_velocity)(ti::J)));
+    tenex::evaluate<ti::I>(
+        spatial_velocity,
+        (*lorentz_factor_times_spatial_velocity)(ti::I) / (*lorentz_factor)());
+  }
+}
+}  // namespace grmhd::ValenciaDivClean::BoundaryConditions

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/CartoonGhost.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/CartoonGhost.hpp
@@ -1,0 +1,239 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <pup.h>
+#include <string>
+
+#include "DataStructures/DataBox/PrefixHelpers.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/BoundaryConditions/BoundaryCondition.hpp"
+#include "Domain/BoundaryConditions/Cartoon.hpp"
+#include "Evolution/BoundaryConditions/Type.hpp"
+#include "Evolution/DgSubcell/Tags/Mesh.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Tag.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp"
+#include "Options/String.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+template <size_t VolumeDim>
+class Direction;
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+/// \endcond
+
+namespace grmhd::ValenciaDivClean::BoundaryConditions {
+/*!
+ * \brief Apply parity-respecting FD ghost values for internal boundaries in a
+ * Cartoon evolution.
+ *
+ * Domains using the cartoon method have boundaries at $x = 0$, which require
+ * ghost data for FD evolution. We fill this FD ghost data by reflecting the
+ * data appropriately: due to the symmetry of cartoon simulations, we can
+ * determine the parity of each component of an arbitrary tensor, allowing us
+ * to either reflect the data or reflect and negate the data.
+ *
+ * This only has `fd_ghost()` implemented because this boundary uses ZernikeB1
+ * bases in DG elements which do not require a boundary condition.
+ */
+class CartoonGhost final : public BoundaryCondition,
+                           public domain::BoundaryConditions::MarkAsCartoon {
+ private:
+  using RestMassDensity = hydro::Tags::RestMassDensity<DataVector>;
+  using ElectronFraction = hydro::Tags::ElectronFraction<DataVector>;
+  using Temperature = hydro::Tags::Temperature<DataVector>;
+  using Pressure = hydro::Tags::Pressure<DataVector>;
+  using LorentzFactorTimesSpatialVelocity =
+      hydro::Tags::LorentzFactorTimesSpatialVelocity<DataVector, 3>;
+  using MagneticField = hydro::Tags::MagneticField<DataVector, 3>;
+  using DivergenceCleaningField =
+      hydro::Tags::DivergenceCleaningField<DataVector>;
+  using SpecificInternalEnergy =
+      hydro::Tags::SpecificInternalEnergy<DataVector>;
+  using SpatialVelocity = hydro::Tags::SpatialVelocity<DataVector, 3>;
+  using LorentzFactor = hydro::Tags::LorentzFactor<DataVector>;
+  using SqrtDetSpatialMetric = gr::Tags::SqrtDetSpatialMetric<DataVector>;
+  using SpatialMetric = gr::Tags::SpatialMetric<DataVector, 3>;
+  using InvSpatialMetric = gr::Tags::InverseSpatialMetric<DataVector, 3>;
+  using Lapse = gr::Tags::Lapse<DataVector>;
+  using Shift = gr::Tags::Shift<DataVector, 3>;
+
+  template <typename T>
+  using Flux = ::Tags::Flux<T, tmpl::size_t<3>, Frame::Inertial>;
+
+ public:
+  using options = tmpl::list<>;
+  static constexpr Options::String help{
+      "Sets FD ghost data based off tensor-component parity. This should only "
+      "be used with cartoon evolution and is automatically handled by the "
+      "domain creators. This class should never be specified as a boundary "
+      "condition in an input file."};
+
+  CartoonGhost() = default;
+  CartoonGhost(CartoonGhost&&) = default;
+  CartoonGhost& operator=(CartoonGhost&&) = default;
+  CartoonGhost(const CartoonGhost&) = default;
+  CartoonGhost& operator=(const CartoonGhost&) = default;
+  ~CartoonGhost() override = default;
+
+  explicit CartoonGhost(CkMigrateMessage* msg);
+
+  WRAPPED_PUPable_decl_base_template(
+      domain::BoundaryConditions::BoundaryCondition, CartoonGhost);
+
+  auto get_clone() const -> std::unique_ptr<
+      domain::BoundaryConditions::BoundaryCondition> override;
+
+  static constexpr evolution::BoundaryConditions::Type bc_type =
+      evolution::BoundaryConditions::Type::Ghost;
+
+  void pup(PUP::er& p) override;
+
+  using dg_interior_evolved_variables_tags = tmpl::list<>;
+  using dg_interior_primitive_variables_tags = tmpl::list<>;
+  using dg_interior_temporary_tags = tmpl::list<>;
+  using dg_gridless_tags = tmpl::list<>;
+
+  [[noreturn]] static std::optional<std::string> dg_ghost(
+      gsl::not_null<Scalar<DataVector>*> /*tilde_d*/,
+      gsl::not_null<Scalar<DataVector>*> /*tilde_ye*/,
+      gsl::not_null<Scalar<DataVector>*> /*tilde_tau*/,
+      gsl::not_null<tnsr::i<DataVector, 3, Frame::Inertial>*> /*tilde_s*/,
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> /*tilde_b*/,
+      gsl::not_null<Scalar<DataVector>*> /*tilde_phi*/,
+
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> /*tilde_d_flux*/,
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> /*tilde_ye_flux*/,
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
+      /*tilde_tau_flux*/,
+      gsl::not_null<tnsr::Ij<DataVector, 3, Frame::Inertial>*> /*tilde_s_flux*/,
+      gsl::not_null<tnsr::IJ<DataVector, 3, Frame::Inertial>*> /*tilde_b_flux*/,
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
+      /*tilde_phi_flux*/,
+
+      gsl::not_null<Scalar<DataVector>*> /*lapse*/,
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> /*shift*/,
+      gsl::not_null<tnsr::i<DataVector, 3, Frame::Inertial>*>
+      /*spatial_velocity_one_form*/,
+      gsl::not_null<Scalar<DataVector>*> /*rest_mass_density*/,
+      gsl::not_null<Scalar<DataVector>*> /*electron_fraction*/,
+      gsl::not_null<Scalar<DataVector>*> /*temperature*/,
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
+      /*spatial_velocity*/,
+
+      gsl::not_null<tnsr::II<DataVector, 3, Frame::Inertial>*>
+      /*inv_spatial_metric*/,
+
+      const std::optional<
+          tnsr::I<DataVector, 3, Frame::Inertial>>& /*face_mesh_velocity*/,
+      const tnsr::i<DataVector, 3, Frame::Inertial>& /*normal_covector*/,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& /*normal_vector*/) {
+    ERROR(
+        "dg_ghost() should never be called: the boundary it would apply to "
+        "uses ZernikeB1 bases in DG evolution which do not need a boundary "
+        "condition. When applying DG boundary conditions this class should be "
+        "skipped as it is marked as Cartoon");
+  }
+
+  using fd_interior_evolved_variables_tags = tmpl::list<>;
+  using fd_interior_temporary_tags =
+      tmpl::list<evolution::dg::subcell::Tags::Mesh<3>, Shift, Lapse,
+                 SpatialMetric>;
+  using fd_interior_primitive_variables_tags =
+      tmpl::list<RestMassDensity, ElectronFraction, Temperature,
+                 hydro::Tags::Pressure<DataVector>,
+                 hydro::Tags::SpecificInternalEnergy<DataVector>,
+                 hydro::Tags::LorentzFactor<DataVector>,
+                 hydro::Tags::DivergenceCleaningField<DataVector>,
+                 hydro::Tags::SpatialVelocity<DataVector, 3>, MagneticField>;
+  using fd_gridless_tags = tmpl::list<fd::Tags::Reconstructor>;
+
+  static void fd_ghost(
+      gsl::not_null<Scalar<DataVector>*> rest_mass_density,
+      gsl::not_null<Scalar<DataVector>*> electron_fraction,
+      gsl::not_null<Scalar<DataVector>*> temperature,
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
+          lorentz_factor_times_spatial_velocity,
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> magnetic_field,
+      gsl::not_null<Scalar<DataVector>*> divergence_cleaning_field,
+
+      gsl::not_null<std::optional<Variables<db::wrap_tags_in<
+          Flux, typename grmhd::ValenciaDivClean::System::flux_variables>>>*>
+          cell_centered_ghost_fluxes,
+
+      const Direction<3>& direction,
+
+      // interior temporary tags
+      const Mesh<3>& subcell_mesh,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& interior_shift,
+      const Scalar<DataVector>& interior_lapse,
+      const tnsr::ii<DataVector, 3, Frame::Inertial>& interior_spatial_metric,
+
+      // interior prim vars tags
+      const Scalar<DataVector>& interior_rest_mass_density,
+      const Scalar<DataVector>& interior_electron_fraction,
+      const Scalar<DataVector>& interior_temperature,
+      const Scalar<DataVector>& interior_pressure,
+      const Scalar<DataVector>& interior_specific_internal_energy,
+      const Scalar<DataVector>& interior_lorentz_factor,
+      const Scalar<DataVector>& interior_divergence_cleaning_field,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& interior_spatial_velocity,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& interior_magnetic_field,
+
+      // fd_gridless_tags
+      const fd::Reconstructor& reconstructor);
+
+  // have an impl to make sharing code with GH+GRMHD easy
+  static void fd_ghost_impl(
+      gsl::not_null<Scalar<DataVector>*> rest_mass_density,
+      gsl::not_null<Scalar<DataVector>*> electron_fraction,
+      gsl::not_null<Scalar<DataVector>*> temperature,
+      gsl::not_null<Scalar<DataVector>*> pressure,
+      gsl::not_null<Scalar<DataVector>*> specific_internal_energy,
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*>
+          lorentz_factor_times_spatial_velocity,
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> spatial_velocity,
+      gsl::not_null<Scalar<DataVector>*> lorentz_factor,
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> magnetic_field,
+      gsl::not_null<Scalar<DataVector>*> divergence_cleaning_field,
+      gsl::not_null<tnsr::ii<DataVector, 3, Frame::Inertial>*> spatial_metric,
+      gsl::not_null<tnsr::II<DataVector, 3, Frame::Inertial>*>
+          inv_spatial_metric,
+      gsl::not_null<Scalar<DataVector>*> sqrt_det_spatial_metric,
+      gsl::not_null<Scalar<DataVector>*> lapse,
+      gsl::not_null<tnsr::I<DataVector, 3, Frame::Inertial>*> shift,
+
+      const Direction<3>& direction,
+
+      // fd_interior_temporary_tags
+      const Mesh<3>& subcell_mesh,
+
+      // fd_interior_primitive_variables_tags
+      const Scalar<DataVector>& interior_rest_mass_density,
+      const Scalar<DataVector>& interior_electron_fraction,
+      const Scalar<DataVector>& interior_temperature,
+      const Scalar<DataVector>& interior_pressure,
+      const Scalar<DataVector>& interior_specific_internal_energy,
+      const Scalar<DataVector>& interior_lorentz_factor,
+      const Scalar<DataVector>& interior_divergence_cleaning_field,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& interior_spatial_velocity,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& interior_magnetic_field,
+      const tnsr::ii<DataVector, 3, Frame::Inertial>& interior_spatial_metric,
+      const Scalar<DataVector>& interior_lapse,
+      const tnsr::I<DataVector, 3, Frame::Inertial>& interior_shift,
+
+      size_t ghost_zone_size, bool need_tags_for_fluxes);
+};
+}  // namespace grmhd::ValenciaDivClean::BoundaryConditions

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/Factory.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/Factory.hpp
@@ -5,6 +5,7 @@
 
 #include "Domain/BoundaryConditions/Periodic.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/BoundaryCondition.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/CartoonGhost.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/DemandOutgoingCharSpeeds.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/DirichletAnalytic.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/HydroFreeOutflow.hpp"
@@ -13,7 +14,7 @@
 namespace grmhd::ValenciaDivClean::BoundaryConditions {
 /// Typelist of standard BoundaryConditions
 using standard_boundary_conditions =
-    tmpl::list<DemandOutgoingCharSpeeds, DirichletAnalytic, HydroFreeOutflow,
-               Reflective,
+    tmpl::list<CartoonGhost, DemandOutgoingCharSpeeds, DirichletAnalytic,
+               HydroFreeOutflow, Reflective,
                domain::BoundaryConditions::Periodic<BoundaryCondition>>;
 }  // namespace grmhd::ValenciaDivClean::BoundaryConditions

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/Test_CartoonGhost.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/Test_CartoonGhost.cpp
@@ -1,0 +1,354 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <optional>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Expressions/Evaluate.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/BoundaryConditions/CartoonGhost.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Parity.hpp"
+#include "NumericalAlgorithms/Spectral/ParityFromSymmetry.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace {
+// The test fills every tensor component with a function of known parity:
+//   Even parity -> f(x) = x^2
+//   Odd  parity -> g(x) = x
+//
+// Ghost layer ig should mirror interior layer ix = ghost_zone_size - 1 - ig
+// with the correct parity sign.
+constexpr double h = 1.0;
+constexpr size_t num_x = 4;
+constexpr size_t num_y = 3;
+constexpr size_t num_z = 3;
+
+size_t interior_idx(const size_t ix, const size_t iy, const size_t iz) {
+  return ix + num_x * (iy + num_y * iz);
+}
+
+size_t ghost_idx(const size_t i_ghost, const size_t iy, const size_t iz,
+                 const size_t ghost_zone_size) {
+  return i_ghost + ghost_zone_size * (iy + num_y * iz);
+}
+
+double x_coord(const size_t ix) { return (static_cast<double>(ix) + 0.5) * h; }
+
+DataVector fill(const double power) {
+  DataVector result(num_x * num_y * num_z);
+  for (size_t iz = 0; iz < num_z; ++iz) {
+    for (size_t iy = 0; iy < num_y; ++iy) {
+      for (size_t ix = 0; ix < num_x; ++ix) {
+        result[interior_idx(ix, iy, iz)] = std::pow(x_coord(ix), power);
+      }
+    }
+  }
+  return result;
+}
+
+// Returns a tensor with each component filled according to its parity:
+// even -> x^2, odd -> x.
+template <typename TensorType>
+TensorType fill_by_parity() {
+  TensorType tensor(num_x * num_y * num_z);
+  constexpr auto parities = Spectral::make_component_parity_array<TensorType>();
+  for (size_t comp = 0; comp < TensorType::size(); ++comp) {
+    tensor[comp] = (gsl::at(parities, comp) == Spectral::Parity::Even)
+                       ? fill(2.0)
+                       : fill(1.0);
+  }
+  return tensor;
+}
+
+// Checks that every ghost layer ig mirrors interior layer
+// ix = ghost_zone_size - 1 - ig with the correct parity sign.
+template <typename TensorType>
+void check_all_ghost_layers(const TensorType& interior, const TensorType& ghost,
+                            const size_t ghost_zone_size,
+                            const std::string& name) {
+  CAPTURE(name);
+  constexpr auto parities = Spectral::make_component_parity_array<TensorType>();
+  for (size_t ig = 0; ig < ghost_zone_size; ++ig) {
+    const size_t mirror_ix = ghost_zone_size - 1 - ig;
+    for (size_t iy = 0; iy < num_y; ++iy) {
+      for (size_t iz = 0; iz < num_z; ++iz) {
+        const size_t gidx = ghost_idx(ig, iy, iz, ghost_zone_size);
+        const size_t iidx = interior_idx(mirror_ix, iy, iz);
+        for (size_t comp = 0; comp < TensorType::size(); ++comp) {
+          const double sign =
+              (gsl::at(parities, comp) == Spectral::Parity::Even) ? 1.0 : -1.0;
+          CHECK(ghost[comp][gidx] == approx(sign * interior[comp][iidx]));
+        }
+      }
+    }
+  }
+}
+
+// Verifies that ghost_inv_metric is the inverse of ghost_metric and that
+// ghost_sqrt_det equals sqrt(det(ghost_metric)) at every ghost point.
+void check_inv_metric_and_sqrt_det(const tnsr::ii<DataVector, 3>& metric,
+                                   const tnsr::II<DataVector, 3>& inv_metric,
+                                   const Scalar<DataVector>& sqrt_det) {
+  const size_t npts = get<0, 0>(metric).size();
+  for (size_t gi = 0; gi < npts; ++gi) {
+    const double g00 = get<0, 0>(metric)[gi];
+    const double g01 = get<0, 1>(metric)[gi];
+    const double g02 = get<0, 2>(metric)[gi];
+    const double g11 = get<1, 1>(metric)[gi];
+    const double g12 = get<1, 2>(metric)[gi];
+    const double g22 = get<2, 2>(metric)[gi];
+    const double det = g00 * (g11 * g22 - g12 * g12) -
+                       g01 * (g01 * g22 - g12 * g02) +
+                       g02 * (g01 * g12 - g11 * g02);
+    CHECK(get(sqrt_det)[gi] == approx(std::sqrt(det)));
+
+    for (size_t i = 0; i < 3; ++i) {
+      for (size_t k = 0; k < 3; ++k) {
+        double product = 0.0;
+        for (size_t j = 0; j < 3; ++j) {
+          product += inv_metric.get(i, j)[gi] * metric.get(j, k)[gi];
+        }
+        CHECK(product == approx(i == k ? 1.0 : 0.0));
+      }
+    }
+  }
+}
+
+// Test with  need_tags_for_fluxes=true fills fills ghost metric, lapse,
+// shift, pressure, eps and then computes LorentzFactor and SpatialVelocity.
+void test_fd_ghost_impl(const size_t ghost_zone_size,
+                        const bool need_tags_for_fluxes) {
+  CAPTURE(ghost_zone_size);
+  CAPTURE(need_tags_for_fluxes);
+
+  const Mesh<3> subcell_mesh{{{num_x, num_y, num_z}},
+                             Spectral::Basis::FiniteDifference,
+                             Spectral::Quadrature::CellCentered};
+
+  const size_t npts = num_x * num_y * num_z;
+  const auto interior_rho = fill_by_parity<Scalar<DataVector>>();
+  const auto interior_ye = fill_by_parity<Scalar<DataVector>>();
+  const auto interior_temp = fill_by_parity<Scalar<DataVector>>();
+  const auto interior_press = fill_by_parity<Scalar<DataVector>>();
+  const auto interior_eps = fill_by_parity<Scalar<DataVector>>();
+  const auto interior_div_phi = fill_by_parity<Scalar<DataVector>>();
+  const Scalar<DataVector> interior_lorentz{DataVector(npts, 1.56)};
+  const auto interior_vel = fill_by_parity<tnsr::I<DataVector, 3>>();
+  const auto interior_B = fill_by_parity<tnsr::I<DataVector, 3>>();
+
+  // Positive-definite metric with one non-trivial odd component (gamma_xy)
+  // to exercise the parity-negation logic for off-diagonal x-components.
+  // Diagonal entries are large constants; off-diagonal x entries are 0.1*x
+  // (small enough that the matrix stays positive definite for all test cells).
+  tnsr::ii<DataVector, 3> interior_metric(npts);
+  get<0, 0>(interior_metric) = DataVector(npts, 3.13);  // even, positive
+  get<1, 1>(interior_metric) = DataVector(npts, 2.22);  // even, positive
+  get<2, 2>(interior_metric) = DataVector(npts, 1.31);  // even, positive
+  get<0, 1>(interior_metric) = 0.1 * fill(1.0);         // odd: 0.1*x
+  get<0, 2>(interior_metric) = DataVector(npts, 0.0);   // odd: zero
+  get<1, 2>(interior_metric) = DataVector(npts, 0.0);   // even: zero
+
+  const Scalar<DataVector> interior_lapse{DataVector(npts, 1.5)};  // even
+  tnsr::I<DataVector, 3> interior_shift(npts);
+  get<0>(interior_shift) = 0.2 * fill(1.0);        // odd: 0.2*x
+  get<1>(interior_shift) = DataVector(npts, 0.0);  // even: zero
+  get<2>(interior_shift) = DataVector(npts, 0.0);  // even: zero
+
+  Scalar<DataVector> ghost_rho{};
+  Scalar<DataVector> ghost_ye{};
+  Scalar<DataVector> ghost_temp{};
+  Scalar<DataVector> ghost_press{};
+  Scalar<DataVector> ghost_eps{};
+  tnsr::I<DataVector, 3> ghost_lf_vel{};
+  tnsr::I<DataVector, 3> ghost_spatial_velocity{};
+  Scalar<DataVector> ghost_lorentz_factor{};
+  tnsr::I<DataVector, 3> ghost_B{};
+  Scalar<DataVector> ghost_phi{};
+  tnsr::ii<DataVector, 3> ghost_metric{};
+  tnsr::II<DataVector, 3> ghost_inv_metric{};
+  Scalar<DataVector> ghost_sqrt_det{};
+  Scalar<DataVector> ghost_lapse{};
+  tnsr::I<DataVector, 3> ghost_shift{};
+
+  grmhd::ValenciaDivClean::BoundaryConditions::CartoonGhost::fd_ghost_impl(
+      make_not_null(&ghost_rho), make_not_null(&ghost_ye),
+      make_not_null(&ghost_temp), make_not_null(&ghost_press),
+      make_not_null(&ghost_eps), make_not_null(&ghost_lf_vel),
+      make_not_null(&ghost_spatial_velocity),
+      make_not_null(&ghost_lorentz_factor), make_not_null(&ghost_B),
+      make_not_null(&ghost_phi), make_not_null(&ghost_metric),
+      make_not_null(&ghost_inv_metric), make_not_null(&ghost_sqrt_det),
+      make_not_null(&ghost_lapse), make_not_null(&ghost_shift),
+
+      Direction<3>::lower_xi(), subcell_mesh,
+
+      interior_rho, interior_ye, interior_temp, interior_press, interior_eps,
+      interior_lorentz, interior_div_phi, interior_vel, interior_B,
+      interior_metric, interior_lapse, interior_shift,
+
+      ghost_zone_size, need_tags_for_fluxes);
+
+  // Hydro prims: every ghost layer mirrors the correct interior layer.
+  check_all_ghost_layers(interior_rho, ghost_rho, ghost_zone_size, "rho");
+  check_all_ghost_layers(interior_ye, ghost_ye, ghost_zone_size, "ye");
+  check_all_ghost_layers(interior_temp, ghost_temp, ghost_zone_size, "temp");
+  check_all_ghost_layers(interior_div_phi, ghost_phi, ghost_zone_size, "phi");
+  tnsr::I<DataVector, 3> interior_lf_vel{};
+  tenex::evaluate<ti::I>(make_not_null(&interior_lf_vel),
+                         (interior_lorentz)() * (interior_vel)(ti::I));
+  check_all_ghost_layers(interior_lf_vel, ghost_lf_vel, ghost_zone_size,
+                         "lorentz_times_vel");
+  check_all_ghost_layers(interior_B, ghost_B, ghost_zone_size, "B");
+
+  // Metric variables — only populated when need_tags_for_fluxes=true.
+  if (need_tags_for_fluxes) {
+    check_all_ghost_layers(interior_press, ghost_press, ghost_zone_size,
+                           "pressure");
+    check_all_ghost_layers(interior_eps, ghost_eps, ghost_zone_size, "eps");
+    // Spatial metric: diagonal even components unchanged, off-diagonal x
+    // components (gamma_xy, gamma_xz) negated.
+    check_all_ghost_layers(interior_metric, ghost_metric, ghost_zone_size,
+                           "metric");
+    // Lapse is even (scalar), so ghost = interior at mirror.
+    check_all_ghost_layers(interior_lapse, ghost_lapse, ghost_zone_size,
+                           "lapse");
+    // Shift: x-component is odd (negated), y and z are even.
+    check_all_ghost_layers(interior_shift, ghost_shift, ghost_zone_size,
+                           "shift");
+
+    // Verify ghost_inv_metric is the inverse of ghost_metric and ghost_sqrt_det
+    // equals sqrt(det(ghost_metric)) at every ghost point.
+    check_inv_metric_and_sqrt_det(ghost_metric, ghost_inv_metric,
+                                  ghost_sqrt_det);
+
+    // LorentzFactor and SpatialVelocity are recomputed from the ghost metric
+    // and ghost Wv (not merely mirrored from the interior).  Verify the self-
+    // consistent relationships that the code implements:
+    //   W = sqrt(1 + gamma_ij * (Wv)^i * (Wv)^j)
+    //   v^i = (Wv)^i / W
+    const size_t ghost_npts = ghost_zone_size * num_y * num_z;
+    for (size_t gi = 0; gi < ghost_npts; ++gi) {
+      // gamma_ij * (Wv)^i * (Wv)^j — use upper-triangular storage of tnsr::ii
+      double contraction = 0.0;
+      for (size_t a = 0; a < 3; ++a) {
+        contraction += ghost_metric.get(a, a)[gi] * ghost_lf_vel.get(a)[gi] *
+                       ghost_lf_vel.get(a)[gi];
+        for (size_t b = a + 1; b < 3; ++b) {
+          contraction += 2.0 * ghost_metric.get(a, b)[gi] *
+                         ghost_lf_vel.get(a)[gi] * ghost_lf_vel.get(b)[gi];
+        }
+      }
+      CHECK(get(ghost_lorentz_factor)[gi] ==
+            approx(std::sqrt(1.0 + contraction)));
+      for (size_t a = 0; a < 3; ++a) {
+        CHECK(ghost_spatial_velocity.get(a)[gi] ==
+              approx(ghost_lf_vel.get(a)[gi] / get(ghost_lorentz_factor)[gi]));
+      }
+    }
+  }
+}
+
+void test_dg_ghost_error() {
+  const grmhd::ValenciaDivClean::BoundaryConditions::CartoonGhost bc{};
+  Scalar<DataVector> tilde_d{};
+  Scalar<DataVector> tilde_ye{};
+  Scalar<DataVector> tilde_tau{};
+  Scalar<DataVector> tilde_phi{};
+  tnsr::i<DataVector, 3> tilde_s{};
+  tnsr::i<DataVector, 3> svof{};
+  const tnsr::i<DataVector, 3> normal_cov{};
+  tnsr::I<DataVector, 3> tilde_b{};
+  tnsr::I<DataVector, 3> tilde_d_flux{};
+  tnsr::I<DataVector, 3> tilde_ye_flux{};
+  tnsr::I<DataVector, 3> tilde_tau_flux{};
+  tnsr::I<DataVector, 3> tilde_phi_flux{};
+  tnsr::I<DataVector, 3> shift{};
+  tnsr::I<DataVector, 3> vel{};
+  const tnsr::I<DataVector, 3> normal_vec{};
+  tnsr::Ij<DataVector, 3> tilde_s_flux{};
+  tnsr::IJ<DataVector, 3> tilde_b_flux{};
+  tnsr::II<DataVector, 3> inv_metric{};
+  Scalar<DataVector> lapse{};
+  Scalar<DataVector> rho{};
+  Scalar<DataVector> ye{};
+  Scalar<DataVector> temp{};
+  const std::optional<tnsr::I<DataVector, 3>> face_mesh_vel{};
+  CHECK_THROWS_WITH(
+      bc.dg_ghost(make_not_null(&tilde_d), make_not_null(&tilde_ye),
+                  make_not_null(&tilde_tau), make_not_null(&tilde_s),
+                  make_not_null(&tilde_b), make_not_null(&tilde_phi),
+                  make_not_null(&tilde_d_flux), make_not_null(&tilde_ye_flux),
+                  make_not_null(&tilde_tau_flux), make_not_null(&tilde_s_flux),
+                  make_not_null(&tilde_b_flux), make_not_null(&tilde_phi_flux),
+                  make_not_null(&lapse), make_not_null(&shift),
+                  make_not_null(&svof), make_not_null(&rho), make_not_null(&ye),
+                  make_not_null(&temp), make_not_null(&vel),
+                  make_not_null(&inv_metric), face_mesh_vel, normal_cov,
+                  normal_vec),
+      Catch::Matchers::ContainsSubstring("dg_ghost() should never be called"));
+}
+
+#ifdef SPECTRE_DEBUG
+void test_fd_ghost_impl_wrong_direction() {
+  Scalar<DataVector> out_rho{};
+  Scalar<DataVector> out_ye{};
+  Scalar<DataVector> out_temp{};
+  Scalar<DataVector> out_press{};
+  Scalar<DataVector> out_eps{};
+  Scalar<DataVector> out_lf{};
+  Scalar<DataVector> out_dcf{};
+  Scalar<DataVector> out_sqrt_det{};
+  Scalar<DataVector> out_lapse{};
+  tnsr::I<DataVector, 3> out_lf_vel{};
+  tnsr::I<DataVector, 3> out_vel{};
+  tnsr::I<DataVector, 3> out_B{};
+  tnsr::I<DataVector, 3> out_shift{};
+  tnsr::ii<DataVector, 3> out_metric{};
+  tnsr::II<DataVector, 3> out_inv_metric{};
+  const Scalar<DataVector> empty_scalar{};
+  const tnsr::I<DataVector, 3> empty_vec{};
+  const tnsr::ii<DataVector, 3> empty_metric{};
+  const Mesh<3> mesh{1, Spectral::Basis::FiniteDifference,
+                     Spectral::Quadrature::CellCentered};
+  CHECK_THROWS_WITH(
+      grmhd::ValenciaDivClean::BoundaryConditions::CartoonGhost::fd_ghost_impl(
+          make_not_null(&out_rho), make_not_null(&out_ye),
+          make_not_null(&out_temp), make_not_null(&out_press),
+          make_not_null(&out_eps), make_not_null(&out_lf_vel),
+          make_not_null(&out_vel), make_not_null(&out_lf),
+          make_not_null(&out_B), make_not_null(&out_dcf),
+          make_not_null(&out_metric), make_not_null(&out_inv_metric),
+          make_not_null(&out_sqrt_det), make_not_null(&out_lapse),
+          make_not_null(&out_shift), Direction<3>::lower_eta(), mesh,
+          empty_scalar, empty_scalar, empty_scalar, empty_scalar, empty_scalar,
+          empty_scalar, empty_scalar, empty_vec, empty_vec, empty_metric,
+          empty_scalar, empty_vec, 2, false),
+      Catch::Matchers::ContainsSubstring(
+          "Cartoon BC can only be applied in the x-direction"));
+}
+#endif
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.GrMhd.ValenciaDivClean.BoundaryConditions.CartoonGhost",
+                  "[Unit][GrMhd]") {
+  test_fd_ghost_impl(1, true);
+  test_fd_ghost_impl(2, true);
+  test_fd_ghost_impl(3, true);
+  // Not calculating fluxes just sets a subset of the variables; we only need
+  // to check once the subset is filled
+  test_fd_ghost_impl(2, false);
+  test_dg_ghost_error();
+#ifdef SPECTRE_DEBUG
+  test_fd_ghost_impl_wrong_direction();
+#endif
+}

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_ValenciaDivClean")
 
 set(LIBRARY_SOURCES
   Actions/Test_NumericInitialData.cpp
+  BoundaryConditions/Test_CartoonGhost.cpp
   BoundaryConditions/Test_DirichletAnalytic.cpp
   BoundaryConditions/Test_DemandOutgoingCharSpeeds.cpp
   BoundaryConditions/Test_HydroFreeOutflow.cpp


### PR DESCRIPTION
## Proposed changes

While DG does not need a BC at $x = 0$ because we use Zernike basis, FD does not have anything special happening and therefore does need ghost data. We fill this based on parity.

I don't think this filling can be made into generic code due to system-specific boundary condition handling. But the idea is generic (and will be repeated in a GhValenciaDivClean PR after this one)

I can't call the boundary condition `Cartoon` because that is the name of the default cartoon BC, but I am open to any suggestions

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
