### PR TITLE
Fix overlay logic when tag-options are not 1-to-1

### DIFF
--- a/src/Parallel/GlobalCache.ci
+++ b/src/Parallel/GlobalCache.ci
@@ -33,7 +33,7 @@ module GlobalCache {
         const Parallel::ResourceInfo<Metavariables>& resource_info);
     entry void overlay_cache_data(
         tuples::tagged_tuple_from_typelist<
-            Parallel::get_overlayable_option_list<Metavariables>>&);
+            Parallel::get_overlayable_tag_list<Metavariables>>);
     entry void print_mutable_cache_callbacks(const std::string& file_name);
   }
   }  // namespace Parallel

--- a/src/Parallel/GlobalCache.hpp
+++ b/src/Parallel/GlobalCache.hpp
@@ -364,8 +364,8 @@ class GlobalCache
   ///
   /// This is used when reparsing an input file to update option values during
   /// a restart from a checkpoint.
-  void overlay_cache_data(const tuples::tagged_tuple_from_typelist<
-                          Parallel::get_overlayable_option_list<Metavariables>>&
+  void overlay_cache_data(tuples::tagged_tuple_from_typelist<
+                          Parallel::get_overlayable_tag_list<Metavariables>>
                               data_to_overlay);
 
   /// Retrieve the proxy to the global cache
@@ -653,21 +653,13 @@ void GlobalCache<Metavariables>::mutate(const std::tuple<Args...>& args) {
 
 template <typename Metavariables>
 void GlobalCache<Metavariables>::overlay_cache_data(
-    const tuples::tagged_tuple_from_typelist<
-        Parallel::get_overlayable_option_list<Metavariables>>&
+    tuples::tagged_tuple_from_typelist<
+        Parallel::get_overlayable_tag_list<Metavariables>>
         data_to_overlay) {
-  // Entries in `get_overlayable_tag_list` and `get_overlayable_option_list`
-  // have a 1-to-1 mapping: one is the option tag for the other. We loop
-  // over the tag because it's easy to call tag::option_tag but not vice versa.
   tmpl::for_each<Parallel::get_overlayable_tag_list<Metavariables>>(
-      [this, &data_to_overlay](auto tag) {
-        using Tag = typename decltype(tag)::type;
-        static_assert(tmpl::size<typename Tag::option_tags>::value == 1,
-                      "The current implementation can only update tags "
-                      "constructed from a single option tag.");
-        using OptionTag = tmpl::front<typename Tag::option_tags>;
+      [this, &data_to_overlay]<typename Tag>(tmpl::type_<Tag> /*meta*/) {
         tuples::get<Tag>(const_global_cache_) =
-            Tag::create_from_options(tuples::get<OptionTag>(data_to_overlay));
+            std::move(tuples::get<Tag>(data_to_overlay));
       });
 }
 

--- a/src/Parallel/Main.hpp
+++ b/src/Parallel/Main.hpp
@@ -184,22 +184,10 @@ class Main : public CBase_Main<Metavariables> {
   using singleton_component_list =
       tmpl::filter<component_list, Parallel::is_singleton<tmpl::_1>>;
 
-  template <typename ParallelComponent>
-  using parallel_component_options = Parallel::get_option_tags<
-      typename ParallelComponent::simple_tags_from_options, Metavariables>;
-  template <typename ArrayComponent>
-  using array_component_allocation_options =
-      Parallel::get_option_tags<typename ArrayComponent::array_allocation_tags,
-                                Metavariables>;
-  using option_list = tmpl::remove_duplicates<tmpl::flatten<tmpl::list<
-      Parallel::OptionTags::ResourceInfo<Metavariables>,
-      Parallel::get_option_tags<const_global_cache_tags, Metavariables>,
-      Parallel::get_option_tags<mutable_global_cache_tags, Metavariables>,
-      tmpl::transform<component_list,
-                      tmpl::bind<parallel_component_options, tmpl::_1>>,
-      tmpl::transform<
-          all_array_component_list,
-          tmpl::bind<array_component_allocation_options, tmpl::_1>>>>>;
+  using option_list = tmpl::push_front<
+      Parallel::get_option_tags<
+          Parallel::all_initialization_tags_t<Metavariables>, Metavariables>,
+      Parallel::OptionTags::ResourceInfo<Metavariables>>;
   using overlayable_option_list =
       Parallel::get_overlayable_option_list<Metavariables>;
 
@@ -1076,13 +1064,14 @@ void Main<Metavariables>::update_const_global_cache_from_input_file() {
   if (file_system::check_if_file_exists(input_file_for_reparse)) {
     parser_.template overlay_file<overlayable_option_list>(
         input_file_for_reparse);
-    const auto data_to_overlay =
-        parser_.template apply<overlayable_option_list,
-                               Metavariables>([](auto... args) {
-          return tuples::tagged_tuple_from_typelist<overlayable_option_list>(
+    const auto updated_options =
+        parser_.template apply<option_list, Metavariables>([](auto... args) {
+          return tuples::tagged_tuple_from_typelist<option_list>(
               std::move(args)...);
         });
-    global_cache_proxy_.overlay_cache_data(data_to_overlay);
+    auto new_global_cache_values = Parallel::create_from_options<Metavariables>(
+        updated_options, Parallel::get_overlayable_tag_list<Metavariables>{});
+    global_cache_proxy_.overlay_cache_data(std::move(new_global_cache_values));
     Parallel::printf("... success!\n");
   } else {
     Parallel::printf(

--- a/src/Parallel/ParallelComponentHelpers.hpp
+++ b/src/Parallel/ParallelComponentHelpers.hpp
@@ -12,6 +12,7 @@
 #include "Parallel/Callback.hpp"
 #include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
+#include "Parallel/TypeTraits.hpp"
 #include "Utilities/PrettyType.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TypeTraits.hpp"
@@ -297,6 +298,37 @@ using get_simple_tags_from_options =
         InitializationActionsList,
         detail::get_simple_tags_from_options_from_action<tmpl::_1>>>>;
 
+/// Collect all initialization tags required by the metavariables.
+///
+/// Initialization tags are the tags in the global cache, the
+/// `simple_tags_from_options` from each component, and the
+/// `array_allocation_tags` from each array component.
+template <typename Metavariables>
+struct all_initialization_tags {
+ private:
+  template <typename T>
+  using simple_tags_from_options = typename T::simple_tags_from_options;
+  template <typename T>
+  using array_allocation_tags = typename T::array_allocation_tags;
+
+ public:
+  using type = tmpl::remove_duplicates<tmpl::append<
+      get_const_global_cache_tags<Metavariables>,
+      get_mutable_global_cache_tags<Metavariables>,
+      tmpl::join<
+          tmpl::transform<typename Metavariables::component_list,
+                          tmpl::bind<simple_tags_from_options, tmpl::_1>>>,
+      tmpl::join<
+          tmpl::transform<tmpl::filter<typename Metavariables::component_list,
+                                       Parallel::is_array<tmpl::_1>>,
+                          tmpl::bind<array_allocation_tags, tmpl::_1>>>>>;
+};
+
+/// \copydoc all_initialization_tags
+template <typename Metavariables>
+using all_initialization_tags_t =
+    typename all_initialization_tags<Metavariables>::type;
+
 namespace detail {
 template <typename SimpleTag, typename Metavariables,
           bool PassMetavariables = SimpleTag::pass_metavariables>
@@ -331,17 +363,12 @@ struct is_tag_overlayable : std::false_type {};
 template <typename Tag>
 struct is_tag_overlayable<Tag, std::void_t<decltype(Tag::is_overlayable)>>
     : std::bool_constant<Tag::is_overlayable> {};
-
-template <typename Tag>
-struct GetUniqueOptionTag {
-  using type = tmpl::front<typename Tag::option_tags>;
-};
 }  // namespace detail
 
 /// Get the subset of `const_global_cache_tags` that are overlayable.
 ///
 /// Note this is a list of tags in the GlobalCache, but is not a list of option
-/// tags. However, each tag in the list will have a corresponding option tag.
+/// tags.
 ///
 /// By default, tags are not overlayable, i.e., can not be reparsed to update
 /// a simulation value after a restart from checkpoint. Any tag can "opt in"
@@ -358,12 +385,21 @@ using get_overlayable_tag_list =
     tmpl::filter<get_const_global_cache_tags<Metavariables>,
                  detail::is_tag_overlayable<tmpl::_1>>;
 
-/// Get the option tags corresponding to the output of
-/// `get_overlayable_tag_list`.
+/// Get the overlayable option tags.
+///
+/// These are the option tags that are only used to construct things
+/// in `get_overlayable_tag_list`.
 template <typename Metavariables>
-using get_overlayable_option_list =
-    tmpl::transform<get_overlayable_tag_list<Metavariables>,
-                    detail::GetUniqueOptionTag<tmpl::_1>>;
+using get_overlayable_option_list = tmpl::list_difference<
+    get_option_tags<get_const_global_cache_tags<Metavariables>, Metavariables>,
+    get_option_tags<
+        tmpl::remove_if<all_initialization_tags_t<Metavariables>,
+                        tmpl::and_<tmpl::lazy::list_contains<
+                                       tmpl::pin<get_const_global_cache_tags<
+                                           Metavariables>>,
+                                       tmpl::_1>,
+                                   detail::is_tag_overlayable<tmpl::_1>>>,
+        Metavariables>>;
 
 /// \cond
 namespace Algorithms {

--- a/tests/Unit/Parallel/Test_ParallelComponentHelpers.cpp
+++ b/tests/Unit/Parallel/Test_ParallelComponentHelpers.cpp
@@ -348,6 +348,73 @@ void check_initialization_items(
   CHECK(Parallel::create_from_options<Metavariables>(
             options, simple_tags_from_options{}) == expected_items);
 }
+
+namespace overlay {
+template <size_t Label>
+struct Option {
+  static constexpr size_t value = Label;
+};
+
+template <bool Overlayable, typename Options>
+struct Tag : db::SimpleTag {
+  using type = int;
+  static constexpr bool pass_metavariables = false;
+  using option_tags = Options;
+  static constexpr bool is_overlayable = Overlayable;
+};
+
+template <typename ConstTags, typename OtherTags>
+struct Metavariables {
+  using const_global_cache_tags = ConstTags;
+  using mutable_global_cache_tags = OtherTags;
+  using component_list = tmpl::list<>;
+};
+
+using over12 = Tag<true, tmpl::list<Option<1>, Option<2>>>;
+using not13 = Tag<false, tmpl::list<Option<1>, Option<3>>>;
+using over1 = Tag<true, tmpl::list<Option<1>>>;
+static_assert(
+    std::is_same_v<Parallel::get_overlayable_tag_list<
+                       Metavariables<tmpl::list<over12>, tmpl::list<>>>,
+                   tmpl::list<over12>>);
+static_assert(
+    std::is_same_v<Parallel::get_overlayable_tag_list<
+                       Metavariables<tmpl::list<not13>, tmpl::list<over12>>>,
+                   tmpl::list<>>);
+static_assert(
+    std::is_same_v<Parallel::get_overlayable_tag_list<
+                       Metavariables<tmpl::list<over12, not13>, tmpl::list<>>>,
+                   tmpl::list<over12>>);
+static_assert(
+    std::is_same_v<Parallel::get_overlayable_tag_list<
+                       Metavariables<tmpl::list<over12, over1>, tmpl::list<>>>,
+                   tmpl::list<over12, over1>>);
+
+static_assert(
+    std::is_same_v<tmpl::sort<Parallel::get_overlayable_option_list<
+                       Metavariables<tmpl::list<over12>, tmpl::list<>>>>,
+                   tmpl::list<Option<1>, Option<2>>>);
+static_assert(
+    std::is_same_v<tmpl::sort<Parallel::get_overlayable_option_list<
+                       Metavariables<tmpl::list<not13>, tmpl::list<over12>>>>,
+                   tmpl::list<>>);
+static_assert(
+    std::is_same_v<tmpl::sort<Parallel::get_overlayable_option_list<
+                       Metavariables<tmpl::list<over12, not13>, tmpl::list<>>>>,
+                   tmpl::list<Option<2>>>);
+static_assert(
+    std::is_same_v<tmpl::sort<Parallel::get_overlayable_option_list<
+                       Metavariables<tmpl::list<over12>, tmpl::list<not13>>>>,
+                   tmpl::list<Option<2>>>);
+static_assert(
+    std::is_same_v<tmpl::sort<Parallel::get_overlayable_option_list<
+                       Metavariables<tmpl::list<over12, over1>, tmpl::list<>>>>,
+                   tmpl::list<Option<1>, Option<2>>>);
+static_assert(
+    std::is_same_v<tmpl::sort<Parallel::get_overlayable_option_list<
+                       Metavariables<tmpl::list<over12>, tmpl::list<over1>>>>,
+                   tmpl::list<Option<2>>>);
+}  // namespace overlay
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Parallel.ComponentHelpers", "[Unit][Parallel]") {


### PR DESCRIPTION
It is now possible to mark tags parsed from multiple options as overlayable.

Options that are used in both overlayable and non-overlayable tags are no longer considered overlayable.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
