### PR TITLE
B3 radial filtering

### DIFF
--- a/src/NumericalAlgorithms/Spectral/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Spectral/CMakeLists.txt
@@ -54,6 +54,8 @@ spectre_target_headers(
   FilteringB1.tpp
   FilteringB2.hpp
   FilteringB2.tpp
+  FilteringB3.hpp
+  FilteringB3.tpp
   GetSpectralQuantityForMesh.hpp
   IntegrationMatrix.hpp
   InterpolationWeights.hpp

--- a/src/NumericalAlgorithms/Spectral/FilteringB3.hpp
+++ b/src/NumericalAlgorithms/Spectral/FilteringB3.hpp
@@ -1,0 +1,62 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "Utilities/Gsl.hpp"
+
+/// \cond
+class DataVector;
+template <size_t Dim>
+class Mesh;
+template <typename TagsList>
+class Variables;
+/// \endcond
+
+namespace Spectral::filtering {
+/*!
+ * \brief Filters the radial components of tensors stored within a `Variables`
+ * represented by ZernikeB3 basis functions on a filled ball.
+ *
+ * \details Functions on a filled ball with angular degree $\ell$ behave as
+ * $r^\ell$ near the origin, so their radial profile lies in the even or
+ * odd parity ZernikeB3 subspace depending on whether $\ell$ is even or odd. The
+ * combined spectral space is therefore indexed by $(n_\mathrm{jac}, \ell, m)$,
+ * where $n_\mathrm{jac}$ is the radial Jacobi index. The exponential filter
+ * weight for mode $(n_\mathrm{jac}, \ell)$ is
+ *
+ * \f{align*}{
+ *   w = \exp\!\left(-\alpha \left(\frac{n_i}{N_r-1}\right)^{2p}\right),
+ * \f}
+ *
+ * where $n_i = \lfloor (\ell + 2 n_\mathrm{jac}) / 2 \rfloor$ and $N_r$ is the
+ * number of radial grid points.
+ *
+ * The mesh must have basis
+ * `(ZernikeB3, ZernikeB3, ZernikeB3)` with quadrature
+ * `(GaussRadauUpper, Gauss, Equiangular)` and extents
+ * `(n_r, l_max+1, 2*l_max+1)`.
+ *
+ * \see exponential_filter()
+ */
+template <typename VariablesTags>
+void zernike_b3_ball_radial_exponential_filter(
+    gsl::not_null<Variables<VariablesTags>*> u, const Mesh<3>& mesh,
+    double alpha, unsigned half_power);
+
+/*!
+ * \brief Filters the radial components of tensors stored within a `Variables`
+ * represented by ZernikeB3 basis functions on a filled ball.
+ *
+ * \details Overload taking a caller-managed working buffer. Avoids heap
+ * allocations when the filter is applied repeatedly (e.g. every volume call
+ * inside `Filters::Ball`).
+ */
+template <typename VariablesTags>
+void zernike_b3_ball_radial_exponential_filter(
+    gsl::not_null<Variables<VariablesTags>*> u, gsl::not_null<DataVector*> buf,
+    const Mesh<3>& mesh, double alpha, unsigned half_power);
+
+}  // namespace Spectral::filtering

--- a/src/NumericalAlgorithms/Spectral/FilteringB3.tpp
+++ b/src/NumericalAlgorithms/Spectral/FilteringB3.tpp
@@ -1,0 +1,197 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "NumericalAlgorithms/Spectral/FilteringB3.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+
+#include "DataStructures/Matrix.hpp"
+#include "DataStructures/Variables.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/ModalToNodalMatrix.hpp"
+#include "NumericalAlgorithms/Spectral/NodalToModalMatrix.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Spherepack.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/SpherepackCache.hpp"
+#include "Utilities/Blas.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Math.hpp"
+
+namespace Spectral::filtering {
+namespace b3_detail {
+[[maybe_unused]] inline void apply_matrix_in_first_dim(
+    double* result, const double* const input, const Matrix& matrix,
+    const size_t size) {
+  dgemm_<true>('N', 'N',
+               matrix.rows(),            // rows of matrix and result
+               size / matrix.columns(),  // columns of result and input
+               matrix.columns(),         // columns of matrix and rows of input
+               1.0,                      // overall multiplier
+               matrix.data(),            // matrix
+               matrix.spacing(),         // rows of matrix including padding
+               input,                    // input
+               matrix.columns(),         // rows of input
+               0.0,                      // overwrite output
+               result,                   // result
+               matrix.rows());           // rows of result
+}
+
+[[maybe_unused]] inline void check_valid_extents_b3(const size_t n_r,
+                                                    const size_t l_max) {
+  ASSERT(n_r > 1,
+         "At least 2 radial grid points are required to filter ZernikeB3, got "
+         "n_r = "
+             << n_r);
+  ASSERT(l_max >= 2,
+         "At least l_max=2 (3 latitudinal points) is required to filter "
+         "ZernikeB3, got l_max = "
+             << l_max);
+  ASSERT(l_max <= 2 * n_r - 2,
+         "ZernikeB3 radial resolution is insufficient for the requested "
+         "angular resolution. Need l_max <= 2*n_r-2, but l_max="
+             << l_max << " and n_r=" << n_r);
+}
+}  // namespace b3_detail
+
+template <typename TagsList>
+void zernike_b3_ball_radial_exponential_filter(
+    const gsl::not_null<Variables<TagsList>*> u,
+    const gsl::not_null<DataVector*> buf, const Mesh<3>& mesh,
+    const double alpha, const unsigned half_power) {
+  const size_t n_r = mesh.extents(0);
+  const size_t l_max = mesh.extents(1) - 1;
+  b3_detail::check_valid_extents_b3(n_r, l_max);
+  const size_t n_r_max = 2 * n_r - 2;
+  const size_t n_order = n_r - 1;
+
+  const auto& ylm = ylm::get_spherepack_cache(l_max);
+  const size_t n_spectral = ylm.spectral_size();
+  const size_t n_phys = mesh.number_of_grid_points();
+  constexpr size_t n_components =
+      Variables<TagsList>::number_of_independent_components;
+
+  const auto& modes = ylm::get_modes_by_degree_cache(l_max);
+
+  // Partition the caller-provided buffer into three contiguous regions:
+  //   spec_buf  : n_components * n_spectral * n_r  (SH spectral coefficients)
+  //   gathered  : max_batch * n_r                  (same-l radial profiles)
+  //   modal_buf : max_batch * n_r                  (ZernikeB3 modal space)
+  // where max_batch = (2*l_max+1) * n_components.
+  const size_t max_batch = (2 * l_max + 1) * n_components;
+  const size_t spec_buf_size = n_components * n_spectral * n_r;
+  const size_t buf_size = spec_buf_size + 2 * max_batch * n_r;
+  if (UNLIKELY(buf->size() < buf_size)) {
+    buf->destructive_resize(buf_size);
+  }
+  double* const spec_buf = buf->data();
+  double* const gathered = spec_buf + spec_buf_size;     // NOLINT
+  double* const modal_buf = gathered + max_batch * n_r;  // NOLINT
+
+  // SH analysis: physical space -> SH spectral space for all components.
+  // After this, spec_buf[comp*n_spectral*n_r + s*n_r + i_r] holds the SH
+  // spectral coefficient for mode s at radial collocation point i_r.
+  for (size_t comp = 0; comp < n_components; ++comp) {
+    ylm.phys_to_spec_all_offsets(
+        make_not_null(spec_buf + comp * n_spectral * n_r),  // NOLINT
+        make_not_null(u->data() + comp * n_phys), n_r);
+  }
+
+  // For each angular degree l: gather same-l SH modes, apply ZernikeB3
+  // nodal-to-modal, apply filter weights, apply modal-to-nodal, scatter back.
+  for (size_t l = 0; l <= l_max; ++l) {
+    const size_t* offsets = modes.offsets.data() + modes.l_start[l];  // NOLINT
+    const size_t n_modes_l = modes.l_start[l + 1] - modes.l_start[l];
+    // spectral_size_l = number of ZernikeB3 radial modes for this l
+    const size_t spectral_size_l = (n_r_max - l + 2) / 2;
+    const size_t n_batch = n_modes_l * n_components;
+
+    const auto& ntm =
+        Spectral::nodal_to_modal_matrix<Spectral::Basis::ZernikeB3,
+                                        Spectral::Quadrature::GaussRadauUpper>(
+            n_r, l, n_r_max);
+    const auto& mtn =
+        Spectral::modal_to_nodal_matrix<Spectral::Basis::ZernikeB3,
+                                        Spectral::Quadrature::GaussRadauUpper>(
+            n_r, l, n_r_max);
+
+    // Gather: copy radial profiles for all same-l modes across all components
+    // into the contiguous `gathered` buffer (layout: n_r × n_batch,
+    // column-major).
+    for (size_t comp = 0; comp < n_components; ++comp) {
+      const double* src = spec_buf + comp * n_spectral * n_r;  // NOLINT
+      for (size_t k = 0; k < n_modes_l; ++k) {
+        const size_t col = comp * n_modes_l + k;
+        std::copy(src + offsets[k] * n_r,        // NOLINT
+                  src + (offsets[k] + 1) * n_r,  // NOLINT
+                  gathered + col * n_r);         // NOLINT
+      }
+    }
+
+    // NTM: modal_buf (spectral_size_l × n_batch) = ntm x gathered (n_r ×
+    // n_batch)
+    b3_detail::apply_matrix_in_first_dim(modal_buf, gathered, ntm,
+                                         n_batch * n_r);
+
+    // Apply filter weights: w_r(n_jacobi, l), where
+    //   n_total = l + 2*n_jacobi,  n_i = n_total/2 (integer division)
+    //   w_r = exp(-alpha * (n_i / n_order)^(2p))
+    // The modal buffer is (spectral_size_l × n_batch) in column-major order,
+    // so modal_buf[k_spec + spectral_size_l * col] is element (k_spec, col).
+    for (size_t k_spec = 0; k_spec < spectral_size_l; ++k_spec) {
+      const auto n_i =
+          static_cast<double>(static_cast<size_t>((l + 2 * k_spec) / 2));
+      const double w_r =
+          std::exp(-alpha * integer_pow(n_i / static_cast<double>(n_order),
+                                        static_cast<int>(2 * half_power)));
+      for (size_t col = 0; col < n_batch; ++col) {
+        modal_buf[k_spec + spectral_size_l * col] *= w_r;  // NOLINT
+      }
+    }
+
+    // MTN: gathered (n_r × n_batch) = mtn x modal_buf (spectral_size_l ×
+    // n_batch)
+    b3_detail::apply_matrix_in_first_dim(gathered, modal_buf, mtn,
+                                         n_batch * spectral_size_l);
+
+    // Scatter: write filtered radial profiles back to the spectral buffer
+    for (size_t comp = 0; comp < n_components; ++comp) {
+      double* dst = spec_buf + comp * n_spectral * n_r;  // NOLINT
+      for (size_t k = 0; k < n_modes_l; ++k) {
+        const size_t col = comp * n_modes_l + k;
+        std::copy(gathered + col * n_r,        // NOLINT
+                  gathered + (col + 1) * n_r,  // NOLINT
+                  dst + offsets[k] * n_r);     // NOLINT
+      }
+    }
+  }
+
+  // SH synthesis: SH spectral space -> physical space for all components
+  for (size_t comp = 0; comp < n_components; ++comp) {
+    ylm.spec_to_phys_all_offsets(
+        make_not_null(u->data() + comp * n_phys),
+        make_not_null(spec_buf + comp * n_spectral * n_r), n_r);  // NOLINT
+  }
+}
+
+template <typename TagsList>
+void zernike_b3_ball_radial_exponential_filter(
+    const gsl::not_null<Variables<TagsList>*> u, const Mesh<3>& mesh,
+    const double alpha, const unsigned half_power) {
+  constexpr size_t n_components =
+      Variables<TagsList>::number_of_independent_components;
+  const size_t n_r = mesh.extents(0);
+  const size_t l_max = mesh.extents(1) - 1;
+  b3_detail::check_valid_extents_b3(n_r, l_max);
+  const size_t n_spectral = ylm::get_spherepack_cache(l_max).spectral_size();
+  const size_t max_batch = (2 * l_max + 1) * n_components;
+  DataVector buf(n_components * n_spectral * n_r + 2 * max_batch * n_r);
+  zernike_b3_ball_radial_exponential_filter(u, make_not_null(&buf), mesh, alpha,
+                                            half_power);
+}
+}  // namespace Spectral::filtering

--- a/src/NumericalAlgorithms/SphericalHarmonics/SpherepackCache.cpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/SpherepackCache.cpp
@@ -4,8 +4,10 @@
 #include "NumericalAlgorithms/SphericalHarmonics/SpherepackCache.hpp"
 
 #include <cstddef>
+#include <vector>
 
 #include "NumericalAlgorithms/SphericalHarmonics/Spherepack.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/SpherepackIterator.hpp"
 #include "Utilities/StaticCache.hpp"
 
 namespace ylm {
@@ -13,5 +15,38 @@ const Spherepack& get_spherepack_cache(const size_t l_max) {
   static const auto spherepack_cache = make_static_cache<CacheRange<2, 151>>(
       [](const size_t l) { return ylm::Spherepack(l, l); });
   return spherepack_cache(l_max);
+}
+
+const SphericalHarmonicModesByDegree& get_modes_by_degree_cache(
+    const size_t l_max) {
+  // Note the arbitrary max cache size
+  static const auto cache =
+      make_static_cache<CacheRange<2, 151>>([](const size_t l) {
+        SphericalHarmonicModesByDegree result;
+        result.l_start.assign(l + 2, 0);
+
+        // Count modes per degree
+        SpherepackIterator iter{l, l};
+        while (iter) {
+          ++result.l_start[iter.l() + 1];
+          ++iter;
+        }
+        // Build prefix sums
+        for (size_t ell = 1; ell <= l + 1; ++ell) {
+          result.l_start[ell] += result.l_start[ell - 1];
+        }
+        // Fill offsets using write positions initialised from the prefix sums
+        result.offsets.resize(result.l_start[l + 1]);
+        std::vector<size_t> write_pos(
+            result.l_start.begin(),
+            result.l_start.begin() + static_cast<std::ptrdiff_t>(l + 1));
+        iter.reset();
+        while (iter) {
+          result.offsets[write_pos[iter.l()]++] = iter();
+          ++iter;
+        }
+        return result;
+      });
+  return cache(l_max);
 }
 }  // namespace ylm

--- a/src/NumericalAlgorithms/SphericalHarmonics/SpherepackCache.hpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/SpherepackCache.hpp
@@ -4,10 +4,30 @@
 #pragma once
 
 #include <cstddef>
+#include <vector>
 
 namespace ylm {
 class Spherepack;
 
 /// Retrieves a cached Spherepack object with m_max equal to l_max
 const Spherepack& get_spherepack_cache(size_t l_max);
+
+/*!
+ * \brief SPHEREPACK spectral offsets grouped by angular degree \f$\ell\f$.
+ *
+ * \details `offsets` is a flat array of SPHEREPACK spectral offsets sorted
+ * by angular degree. The offsets for degree \f$\ell\f$ occupy the half-open
+ * range `[l_start[l], l_start[l+1])` within `offsets`.
+ */
+struct SphericalHarmonicModesByDegree {
+  /// Flat list of SPHEREPACK spectral offsets, grouped by angular degree
+  std::vector<size_t> offsets;
+  /// Prefix-sum array of length \f$\ell_\mathrm{max}+2\f$; the offsets for
+  /// degree \f$\ell\f$ are `offsets[l_start[l]..l_start[l+1])`
+  std::vector<size_t> l_start;
+};
+
+/// Retrieves cached SPHEREPACK spectral offsets grouped by angular degree for
+/// the given \p l_max.
+const SphericalHarmonicModesByDegree& get_modes_by_degree_cache(size_t l_max);
 }  // namespace ylm

--- a/tests/Unit/NumericalAlgorithms/Spectral/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Spectral/CMakeLists.txt
@@ -22,6 +22,7 @@ set(LIBRARY_SOURCES
   Test_Filtering.cpp
   Test_FilteringB1.cpp
   Test_FilteringB2.cpp
+  Test_FilteringB3.cpp
   Test_FiniteDifference.cpp
   Test_IndefiniteIntegral.cpp
   Test_IntegrationMatrix.cpp

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_FilteringB3.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_FilteringB3.cpp
@@ -1,0 +1,283 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cmath>
+#include <cstddef>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tags/TempTensor.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/BasisFunctionValue.hpp"
+#include "NumericalAlgorithms/Spectral/CollocationPoints.hpp"
+#include "NumericalAlgorithms/Spectral/FilteringB3.hpp"
+#include "NumericalAlgorithms/Spectral/FilteringB3.tpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Spherepack.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/SpherepackCache.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/SpherepackIterator.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace {
+// Build the physical-space DataVector for the pure B3 mode (n_jacobi, l) using
+// SPHEREPACK offset s (which encodes the (l, m, cos/sin) combination).
+DataVector pure_b3_mode_phys(const Mesh<3>& mesh, const size_t n_jacobi,
+                             const size_t l, const size_t s) {
+  const size_t n_r = mesh.extents(0);
+  const size_t l_max = mesh.extents(1) - 1;
+  const size_t n_phys = mesh.number_of_grid_points();
+
+  const auto& ylm = ylm::get_spherepack_cache(l_max);
+  const size_t n_spectral = ylm.spectral_size();
+
+  const DataVector& radial_pts =
+      Spectral::collocation_points<Spectral::Basis::ZernikeB3,
+                                   Spectral::Quadrature::GaussRadauUpper>(n_r);
+  const DataVector radial_profile =
+      Spectral::compute_basis_function_value<Spectral::Basis::ZernikeB3>(
+          l + 2 * n_jacobi, l, radial_pts);
+
+  // Construct a SH spectral buffer with just mode s active.
+  // Layout: spec_buf[s * n_r + i_r]
+  DataVector spec_buf(n_spectral * n_r, 0.0);
+  for (size_t i_r = 0; i_r < n_r; ++i_r) {
+    spec_buf[s * n_r + i_r] = radial_profile[i_r];
+  }
+
+  // Synthesize to physical space.
+  DataVector phys(n_phys);
+  ylm.spec_to_phys_all_offsets(make_not_null(phys.data()),
+                               make_not_null(spec_buf.data()), n_r);
+  return phys;
+}
+
+double expected_b3_radial_weight(const double alpha, const unsigned half_power,
+                                 const size_t n_r, const size_t n_jacobi,
+                                 const size_t l) {
+  const size_t n_order = n_r - 1;
+  const auto n_i =
+      static_cast<double>(static_cast<size_t>((l + 2 * n_jacobi) / 2));
+  return std::exp(-alpha *
+                  std::pow(n_i / static_cast<double>(n_order), 2 * half_power));
+}
+
+void test_ball_radial_filter() {
+  using TagsList = tmpl::list<::Tags::TempScalar<0>, ::Tags::TempI<1, 3>>;
+
+  // Mesh sizes: (n_r, l_max), satisfying l_max >= 2 and l_max <= 2*n_r-2
+  const std::vector<std::pair<size_t, size_t>> mesh_sizes{
+      {2, 2}, {3, 2}, {3, 3}, {3, 4}, {4, 5}, {4, 6}};
+
+  for (const auto& [n_r, l_max] : mesh_sizes) {
+    CAPTURE(n_r);
+    CAPTURE(l_max);
+    const Mesh<3> mesh{
+        {n_r, l_max + 1, 2 * l_max + 1},
+        {Spectral::Basis::ZernikeB3, Spectral::Basis::ZernikeB3,
+         Spectral::Basis::ZernikeB3},
+        {Spectral::Quadrature::GaussRadauUpper, Spectral::Quadrature::Gauss,
+         Spectral::Quadrature::Equiangular}};
+    const size_t n_phys = mesh.number_of_grid_points();
+
+    Variables<TagsList> u{n_phys};
+    Variables<TagsList> expected{n_phys};
+
+    // Find the SPHEREPACK offset for (l=0, m=0)
+    size_t s_l0_m0 = 0;
+    {
+      ylm::SpherepackIterator iter{l_max, l_max};
+      while (iter) {
+        if (iter.l() == 0) {
+          s_l0_m0 = iter();
+          break;
+        }
+        ++iter;
+      }
+    }
+
+    const DataVector top_radial = pure_b3_mode_phys(mesh, n_r - 1, 0, s_l0_m0);
+
+    // Test 1: alpha=0 is the identity.
+    {
+      get(get<::Tags::TempScalar<0>>(u)) = top_radial;
+      get<0>(get<::Tags::TempI<1, 3>>(u)) = top_radial;
+      get<1>(get<::Tags::TempI<1, 3>>(u)) = top_radial;
+      get<2>(get<::Tags::TempI<1, 3>>(u)) = top_radial;
+      expected = u;
+      Spectral::filtering::zernike_b3_ball_radial_exponential_filter(
+          make_not_null(&u), mesh, 0.0, 2);
+      CHECK_VARIABLES_APPROX(u, expected);
+    }
+
+    // Test 2: the constant function f=1 is unaffected by any filter.
+    // It occupies only the (l=0, n_jacobi=0) mode whose radial weight is
+    // always 1 (n_i=0 so w_r = exp(0) = 1).
+    {
+      get(get<::Tags::TempScalar<0>>(u)) = 1.0;
+      get<0>(get<::Tags::TempI<1, 3>>(u)) = 1.0;
+      get<1>(get<::Tags::TempI<1, 3>>(u)) = 1.0;
+      get<2>(get<::Tags::TempI<1, 3>>(u)) = 1.0;
+      expected = u;
+      Spectral::filtering::zernike_b3_ball_radial_exponential_filter(
+          make_not_null(&u), mesh, 36.0, 32);
+      CHECK_VARIABLES_APPROX(u, expected);
+    }
+
+    // Test 3: the top radial mode for l=0 (n_jacobi = n_r-1) is killed by
+    // heavy filtering.  n_i = n_r-1 = n_order, so
+    // w_r = exp(-36 * 1^64) = exp(-36) ~ 2e-16 ~ 0 to machine precision.
+    {
+      get(get<::Tags::TempScalar<0>>(u)) = top_radial;
+      get<0>(get<::Tags::TempI<1, 3>>(u)) = top_radial;
+      get<1>(get<::Tags::TempI<1, 3>>(u)) = top_radial;
+      get<2>(get<::Tags::TempI<1, 3>>(u)) = top_radial;
+      get(get<::Tags::TempScalar<0>>(expected)) = 0.0;
+      get<0>(get<::Tags::TempI<1, 3>>(expected)) = 0.0;
+      get<1>(get<::Tags::TempI<1, 3>>(expected)) = 0.0;
+      get<2>(get<::Tags::TempI<1, 3>>(expected)) = 0.0;
+      Spectral::filtering::zernike_b3_ball_radial_exponential_filter(
+          make_not_null(&u), mesh, 36.0, 32);
+      CHECK_VARIABLES_APPROX(u, expected);
+    }
+
+    // Test 4: constant + top radial mode: constant survives, top vanishes.
+    {
+      get(get<::Tags::TempScalar<0>>(u)) = 1.0 + top_radial;
+      get<0>(get<::Tags::TempI<1, 3>>(u)) = 1.0 + top_radial;
+      get<1>(get<::Tags::TempI<1, 3>>(u)) = 1.0 + top_radial;
+      get<2>(get<::Tags::TempI<1, 3>>(u)) = 1.0 + top_radial;
+      get(get<::Tags::TempScalar<0>>(expected)) = 1.0;
+      get<0>(get<::Tags::TempI<1, 3>>(expected)) = 1.0;
+      get<1>(get<::Tags::TempI<1, 3>>(expected)) = 1.0;
+      get<2>(get<::Tags::TempI<1, 3>>(expected)) = 1.0;
+      Spectral::filtering::zernike_b3_ball_radial_exponential_filter(
+          make_not_null(&u), mesh, 36.0, 32);
+      CHECK_VARIABLES_APPROX(u, expected);
+    }
+  }
+}
+
+// For each pure B3 spectral mode (n_jacobi, l, s), verify that
+// zernike_b3_ball_radial_exponential_filter scales the mode by w_r only
+// (no angular factor).
+void test_ball_radial_filter_weights() {
+  using TagsList = tmpl::list<::Tags::TempScalar<0>>;
+
+  const std::vector<std::pair<size_t, size_t>> mesh_sizes{
+      {2, 2}, {3, 3}, {3, 4}, {4, 5}};
+  const std::vector<std::pair<double, unsigned>> params{
+      {0.0, 1}, {10.0, 2}, {20.0, 4}, {36.0, 8}};
+
+  for (const auto& [n_r, l_max] : mesh_sizes) {
+    CAPTURE(n_r);
+    CAPTURE(l_max);
+    const Mesh<3> mesh{
+        {n_r, l_max + 1, 2 * l_max + 1},
+        {Spectral::Basis::ZernikeB3, Spectral::Basis::ZernikeB3,
+         Spectral::Basis::ZernikeB3},
+        {Spectral::Quadrature::GaussRadauUpper, Spectral::Quadrature::Gauss,
+         Spectral::Quadrature::Equiangular}};
+    const size_t n_phys = mesh.number_of_grid_points();
+    const size_t n_r_max = 2 * n_r - 2;
+    Variables<TagsList> u{n_phys};
+    Variables<TagsList> expected_result{n_phys};
+
+    for (const auto& [alpha, half_power] : params) {
+      CAPTURE(alpha);
+      CAPTURE(half_power);
+
+      ylm::SpherepackIterator iter{l_max, l_max};
+      while (iter) {
+        const size_t l = iter.l();
+        const size_t s = iter();
+        const size_t spectral_size_l = (n_r_max - l + 2) / 2;
+        CAPTURE(l);
+        CAPTURE(s);
+
+        for (size_t n_jacobi = 0; n_jacobi < spectral_size_l; ++n_jacobi) {
+          CAPTURE(n_jacobi);
+          const DataVector phys = pure_b3_mode_phys(mesh, n_jacobi, l, s);
+          get(get<::Tags::TempScalar<0>>(u)) = phys;
+
+          Spectral::filtering::zernike_b3_ball_radial_exponential_filter(
+              make_not_null(&u), mesh, alpha, half_power);
+
+          const double weight =
+              expected_b3_radial_weight(alpha, half_power, n_r, n_jacobi, l);
+          get(get<::Tags::TempScalar<0>>(expected_result)) = weight * phys;
+          CHECK_VARIABLES_APPROX(u, expected_result);
+        }
+        ++iter;
+      }
+    }
+  }
+}
+
+#ifdef SPECTRE_DEBUG
+void test_asserts() {
+  using TagsList = tmpl::list<::Tags::TempScalar<0>>;
+
+  {
+    INFO("n_r=1 triggers the min-radial-points assert");
+    const Mesh<3> mesh{
+        {1, 3, 5},
+        {Spectral::Basis::ZernikeB3, Spectral::Basis::ZernikeB3,
+         Spectral::Basis::ZernikeB3},
+        {Spectral::Quadrature::GaussRadauUpper, Spectral::Quadrature::Gauss,
+         Spectral::Quadrature::Equiangular}};
+    Variables<TagsList> u{mesh.number_of_grid_points()};
+    CHECK_THROWS_WITH(
+        Spectral::filtering::zernike_b3_ball_radial_exponential_filter(
+            make_not_null(&u), mesh, 1.0, 2),
+        Catch::Matchers::ContainsSubstring(
+            "At least 2 radial grid points are required to filter ZernikeB3"));
+  }
+  {
+    INFO("l_max=1 triggers the min-l_max assert");
+    const Mesh<3> mesh{
+        {3, 2, 3},
+        {Spectral::Basis::ZernikeB3, Spectral::Basis::ZernikeB3,
+         Spectral::Basis::ZernikeB3},
+        {Spectral::Quadrature::GaussRadauUpper, Spectral::Quadrature::Gauss,
+         Spectral::Quadrature::Equiangular}};
+    Variables<TagsList> u{mesh.number_of_grid_points()};
+    CHECK_THROWS_WITH(
+        Spectral::filtering::zernike_b3_ball_radial_exponential_filter(
+            make_not_null(&u), mesh, 1.0, 2),
+        Catch::Matchers::ContainsSubstring(
+            "At least l_max=2 (3 latitudinal points) is required"));
+  }
+  {
+    INFO("l_max > 2*n_r-2 triggers the angular-resolution assert");
+    const Mesh<3> mesh{
+        {2, 5, 9},
+        {Spectral::Basis::ZernikeB3, Spectral::Basis::ZernikeB3,
+         Spectral::Basis::ZernikeB3},
+        {Spectral::Quadrature::GaussRadauUpper, Spectral::Quadrature::Gauss,
+         Spectral::Quadrature::Equiangular}};
+    Variables<TagsList> u{mesh.number_of_grid_points()};
+    CHECK_THROWS_WITH(
+        Spectral::filtering::zernike_b3_ball_radial_exponential_filter(
+            make_not_null(&u), mesh, 1.0, 2),
+        Catch::Matchers::ContainsSubstring(
+            "ZernikeB3 radial resolution is insufficient for the requested "
+            "angular resolution"));
+  }
+}
+#endif  // SPECTRE_DEBUG
+
+SPECTRE_TEST_CASE("Unit.Numerical.Spectral.B3Filter",
+                  "[NumericalAlgorithms][Spectral][Unit]") {
+  test_ball_radial_filter();
+  test_ball_radial_filter_weights();
+#ifdef SPECTRE_DEBUG
+  test_asserts();
+#endif  // SPECTRE_DEBUG
+}
+}  // namespace

--- a/tests/Unit/NumericalAlgorithms/SphericalHarmonics/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/SphericalHarmonics/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LIBRARY_SOURCES
   Test_AngularOrdering.cpp
   Test_RealSphericalHarmonics.cpp
   Test_Spherepack.cpp
+  Test_SpherepackCache.cpp
   Test_SpherepackIterator.cpp
   Test_YlmToStf.cpp
   )

--- a/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Test_SpherepackCache.cpp
+++ b/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Test_SpherepackCache.cpp
@@ -1,0 +1,89 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <vector>
+
+#include "NumericalAlgorithms/SphericalHarmonics/SpherepackCache.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/SpherepackIterator.hpp"
+
+namespace {
+void test_modes_by_degree(const size_t l_max) {
+  const auto& modes = ylm::get_modes_by_degree_cache(l_max);
+
+  // l_start has length l_max+2 and begins at zero
+  CHECK(modes.l_start.size() == l_max + 2);
+  CHECK(modes.l_start[0] == 0);
+
+  // Each degree l has exactly 2*l+1 modes (one m=0 entry plus two for each
+  // m=1..l), which is the standard count for m_max == l_max with
+  // zero_m_is_real=true.
+  for (size_t l = 0; l <= l_max; ++l) {
+    CHECK(modes.l_start[l + 1] - modes.l_start[l] == 2 * l + 1);
+  }
+
+  // Total mode count matches the number of entries visited by
+  // SpherepackIterator
+  ylm::SpherepackIterator iter{l_max, l_max};
+  size_t total_modes = 0;
+  while (iter) {
+    ++total_modes;
+    ++iter;
+  }
+  CHECK(modes.offsets.size() == total_modes);
+  CHECK(modes.l_start[l_max + 1] == total_modes);
+
+  // Build an offset->l reference map from the iterator.
+  // Use l_max+1 as a sentinel for "not a valid mode offset".
+  std::vector<size_t> offset_to_l(iter.spherepack_array_size(), l_max + 1);
+  iter.reset();
+  while (iter) {
+    offset_to_l[iter()] = iter.l();
+    ++iter;
+  }
+
+  // Every entry in offsets[l_start[l]..l_start[l+1]) has degree l
+  for (size_t l = 0; l <= l_max; ++l) {
+    for (size_t k = modes.l_start[l]; k < modes.l_start[l + 1]; ++k) {
+      CHECK(offset_to_l[modes.offsets[k]] == l);
+    }
+  }
+
+  // The full set of offsets matches the iterator exactly (no duplicates, no
+  // gaps)
+  std::vector<size_t> sorted_cache_offsets = modes.offsets;
+  std::sort(sorted_cache_offsets.begin(), sorted_cache_offsets.end());
+
+  std::vector<size_t> sorted_iter_offsets;
+  sorted_iter_offsets.reserve(total_modes);
+  iter.reset();
+  while (iter) {
+    sorted_iter_offsets.push_back(iter());
+    ++iter;
+  }
+  std::sort(sorted_iter_offsets.begin(), sorted_iter_offsets.end());
+
+  CHECK(sorted_cache_offsets == sorted_iter_offsets);
+}
+
+void test_cache_identity() {
+  // Same l_max must return the same object
+  CHECK(&ylm::get_modes_by_degree_cache(4) ==
+        &ylm::get_modes_by_degree_cache(4));
+  // Different l_max must return different objects
+  CHECK(&ylm::get_modes_by_degree_cache(2) !=
+        &ylm::get_modes_by_degree_cache(4));
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.SphericalHarmonics.SpherepackCache",
+                  "[NumericalAlgorithms][Unit]") {
+  // Testing the SphericalHarmonicModesByDegree cache, NOT the Spherepack cache
+  test_modes_by_degree(2);
+  test_modes_by_degree(5);
+  test_modes_by_degree(10);
+  test_cache_identity();
+}


### PR DESCRIPTION
## Proposed changes

Add radial filtering for B3.

This is the only new filtering needed for filled spheres: the angular part can use the existing TensorYlm infrastructure, which will be bundled with this in a Filters::Ball class.

Depends on
 - [x] #7264 for logical coordinates

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
