### PR TITLE
Add computation of constraint equations in vacuum GR

### DIFF
--- a/src/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
+++ b/src/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
@@ -21,6 +21,7 @@ spectre_target_sources(
   KerrHorizon.cpp
   KerrSchildCoords.cpp
   Lapse.cpp
+  MomentumConstraint.cpp
   ProjectionOperators.cpp
   Psi4.cpp
   Psi4Real.cpp
@@ -59,6 +60,7 @@ spectre_target_headers(
   KerrHorizon.hpp
   KerrSchildCoords.hpp
   Lapse.hpp
+  MomentumConstraint.hpp
   ProjectionOperators.hpp
   Ricci.hpp
   Psi4.hpp

--- a/src/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
+++ b/src/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
@@ -15,6 +15,7 @@ spectre_target_sources(
   ExtrinsicCurvature.cpp
   GeodesicAcceleration.cpp
   GeodesicEquation.cpp
+  HamiltonianConstraint.cpp
   InterfaceNullNormal.cpp
   InverseSpacetimeMetric.cpp
   KerrHorizon.cpp
@@ -52,6 +53,7 @@ spectre_target_headers(
   ExtrinsicCurvature.hpp
   GeodesicAcceleration.hpp
   GeodesicEquation.hpp
+  HamiltonianConstraint.hpp
   InterfaceNullNormal.hpp
   InverseSpacetimeMetric.hpp
   KerrHorizon.hpp

--- a/src/PointwiseFunctions/GeneralRelativity/HamiltonianConstraint.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/HamiltonianConstraint.cpp
@@ -1,0 +1,70 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/GeneralRelativity/HamiltonianConstraint.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
+
+namespace gr {
+template <typename DataType, size_t SpatialDim, typename Frame>
+void hamiltonian_constraint_in_vacuum(
+    const gsl::not_null<Scalar<DataType>*> hamiltonian_constraint,
+    const Scalar<DataType>& ricci_scalar,
+    const Scalar<DataType>& trace_extrinsic_curvature,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const tnsr::ii<DataType, SpatialDim, Frame>& extrinsic_curvature) {
+  set_number_of_grid_points(hamiltonian_constraint, ricci_scalar);
+  tenex::evaluate(hamiltonian_constraint,
+                  ricci_scalar() + square(trace_extrinsic_curvature()) -
+                      extrinsic_curvature(ti::i, ti::j) *
+                          inverse_spatial_metric(ti::I, ti::K) *
+                          inverse_spatial_metric(ti::J, ti::L) *
+                          extrinsic_curvature(ti::k, ti::l));
+}
+
+template <typename DataType, size_t SpatialDim, typename Frame>
+Scalar<DataType> hamiltonian_constraint_in_vacuum(
+    const Scalar<DataType>& ricci_scalar,
+    const Scalar<DataType>& trace_extrinsic_curvature,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const tnsr::ii<DataType, SpatialDim, Frame>& extrinsic_curvature) {
+  Scalar<DataType> result{};
+  hamiltonian_constraint_in_vacuum(make_not_null(&result), ricci_scalar,
+                                   trace_extrinsic_curvature,
+                                   inverse_spatial_metric, extrinsic_curvature);
+  return result;
+}
+}  // namespace gr
+
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DIM(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)
+
+#define INSTANTIATE(_, data)                                         \
+  template void gr::hamiltonian_constraint_in_vacuum(                \
+      gsl::not_null<Scalar<DTYPE(data)>*> hamiltonian_constraint,    \
+      const Scalar<DTYPE(data)>& ricci_scalar,                       \
+      const Scalar<DTYPE(data)>& trace_extrinsic_curvature,          \
+      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&           \
+          inverse_spatial_metric,                                    \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>&           \
+          extrinsic_curvature);                                      \
+  template Scalar<DTYPE(data)> gr::hamiltonian_constraint_in_vacuum( \
+      const Scalar<DTYPE(data)>& ricci_scalar,                       \
+      const Scalar<DTYPE(data)>& trace_extrinsic_curvature,          \
+      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&           \
+          inverse_spatial_metric,                                    \
+      const tnsr::ii<DTYPE(data), DIM(data), FRAME(data)>&           \
+          extrinsic_curvature);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector), (1, 2, 3),
+                        (Frame::Grid, Frame::Inertial))
+
+#undef DTYPE
+#undef DIM
+#undef FRAME
+#undef INSTANTIATE

--- a/src/PointwiseFunctions/GeneralRelativity/HamiltonianConstraint.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/HamiltonianConstraint.hpp
@@ -1,0 +1,37 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace gr {
+/// @{
+/*!
+ * \brief Computes the hamiltonian constraint in vacuum.
+ *
+ * \details The hamiltonian constraint in vacuum GR reads (cf. Eq. (2.90) in
+ * \cite BaumgarteShapiro)
+ * \begin{equation}
+ *   \mathcal{H} = R + K^2 - K_{ij}K^{ij} = 0,
+ * \end{equation}
+ * where $R$ is the spatial Ricci scalar, $K_{ij}$ is the extrinsic curvature
+ * and $K$ is its trace.
+ */
+template <typename DataType, size_t SpatialDim, typename Frame>
+void hamiltonian_constraint_in_vacuum(
+    gsl::not_null<Scalar<DataType>*> hamiltonian_constraint,
+    const Scalar<DataType>& ricci_scalar,
+    const Scalar<DataType>& trace_extrinsic_curvature,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const tnsr::ii<DataType, SpatialDim, Frame>& extrinsic_curvature);
+
+template <typename DataType, size_t SpatialDim, typename Frame>
+Scalar<DataType> hamiltonian_constraint_in_vacuum(
+    const Scalar<DataType>& ricci_scalar,
+    const Scalar<DataType>& trace_extrinsic_curvature,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
+    const tnsr::ii<DataType, SpatialDim, Frame>& extrinsic_curvature);
+/// @}
+}  // namespace gr

--- a/src/PointwiseFunctions/GeneralRelativity/MomentumConstraint.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/MomentumConstraint.cpp
@@ -1,0 +1,68 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/GeneralRelativity/MomentumConstraint.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
+
+namespace gr {
+template <typename DataType, size_t SpatialDim, typename Frame>
+void momentum_constraint_in_vacuum(
+    const gsl::not_null<tnsr::i<DataType, SpatialDim, Frame>*>
+        momentum_constraint,
+    const tnsr::ijj<DataType, SpatialDim, Frame>& d_extrinsic_curvature,
+    const tnsr::i<DataType, SpatialDim, Frame>& d_trace_extrinsic_curvature,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric) {
+  set_number_of_grid_points(momentum_constraint, d_trace_extrinsic_curvature);
+  tenex::evaluate<ti::i>(momentum_constraint,
+                         inverse_spatial_metric(ti::J, ti::K) *
+                                 d_extrinsic_curvature(ti::j, ti::k, ti::i) -
+                             d_trace_extrinsic_curvature(ti::i));
+}
+
+template <typename DataType, size_t SpatialDim, typename Frame>
+tnsr::i<DataType, SpatialDim, Frame> momentum_constraint_in_vacuum(
+    const tnsr::ijj<DataType, SpatialDim, Frame>& d_extrinsic_curvature,
+    const tnsr::i<DataType, SpatialDim, Frame>& d_trace_extrinsic_curvature,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric) {
+  tnsr::i<DataType, SpatialDim, Frame> result{};
+  momentum_constraint_in_vacuum(make_not_null(&result), d_extrinsic_curvature,
+                                d_trace_extrinsic_curvature,
+                                inverse_spatial_metric);
+  return result;
+}
+}  // namespace gr
+
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define DIM(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(2, data)
+
+#define INSTANTIATE(_, data)                                       \
+  template void gr::momentum_constraint_in_vacuum(                 \
+      gsl::not_null<tnsr::i<DTYPE(data), DIM(data), FRAME(data)>*> \
+          momentum_constraint,                                     \
+      const tnsr::ijj<DTYPE(data), DIM(data), FRAME(data)>&        \
+          d_extrinsic_curvature,                                   \
+      const tnsr::i<DTYPE(data), DIM(data), FRAME(data)>&          \
+          d_trace_extrinsic_curvature,                             \
+      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&         \
+          inverse_spatial_metric);                                 \
+  template tnsr::i<DTYPE(data), DIM(data), FRAME(data)>            \
+  gr::momentum_constraint_in_vacuum(                               \
+      const tnsr::ijj<DTYPE(data), DIM(data), FRAME(data)>&        \
+          d_extrinsic_curvature,                                   \
+      const tnsr::i<DTYPE(data), DIM(data), FRAME(data)>&          \
+          d_trace_extrinsic_curvature,                             \
+      const tnsr::II<DTYPE(data), DIM(data), FRAME(data)>&         \
+          inverse_spatial_metric);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector), (1, 2, 3),
+                        (Frame::Grid, Frame::Inertial))
+
+#undef DTYPE
+#undef DIM
+#undef FRAME
+#undef INSTANTIATE

--- a/src/PointwiseFunctions/GeneralRelativity/MomentumConstraint.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/MomentumConstraint.hpp
@@ -1,0 +1,36 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace gr {
+/// @{
+/*!
+ * \brief Computes the momentum constraint in vacuum.
+ *
+ * \details The momentum constraint in vacuum GR reads (cf. Eq. (2.96) in
+ * \cite BaumgarteShapiro)
+ * \begin{equation}
+ *   \mathcal{M}_i = D_j {K^j}_i - D_i K = 0,
+ * \end{equation}
+ * where $D_i$ is the covariant derivative with respect to the spatial metric,
+ * $K_{ij}$ is the extrinsic curvature and $K$ is its trace.
+ */
+template <typename DataType, size_t SpatialDim, typename Frame>
+void momentum_constraint_in_vacuum(
+    gsl::not_null<tnsr::i<DataType, SpatialDim, Frame>*> momentum_constraint,
+    const tnsr::ijj<DataType, SpatialDim, Frame>& d_extrinsic_curvature,
+    const tnsr::i<DataType, SpatialDim, Frame>& d_trace_extrinsic_curvature,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric);
+
+template <typename DataType, size_t SpatialDim, typename Frame>
+tnsr::i<DataType, SpatialDim, Frame> momentum_constraint_in_vacuum(
+    const tnsr::ijj<DataType, SpatialDim, Frame>& d_extrinsic_curvature,
+    const tnsr::i<DataType, SpatialDim, Frame>& d_trace_extrinsic_curvature,
+    const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric);
+/// @}
+
+}  // namespace gr

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
@@ -11,6 +11,7 @@ set(LIBRARY_SOURCES
   Test_CurvatureScalars.cpp
   Test_GeodesicAcceleration.cpp
   Test_GeodesicEquation.cpp
+  Test_HamiltonianConstraint.cpp
   Test_InterfaceNullNormal.cpp
   Test_KerrHorizon.cpp
   Test_KerrSchildCoords.cpp

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/CMakeLists.txt
@@ -15,6 +15,7 @@ set(LIBRARY_SOURCES
   Test_InterfaceNullNormal.cpp
   Test_KerrHorizon.cpp
   Test_KerrSchildCoords.cpp
+  Test_MomentumConstraint.cpp
   Test_ProjectionOperators.cpp
   Test_Psi4.cpp
   Test_Ricci.cpp

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/HamiltonianConstraint.py
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/HamiltonianConstraint.py
@@ -1,0 +1,24 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def hamiltonian_constraint_in_vacuum(
+    ricci_scalar,
+    trace_extrinsic_curvature,
+    inverse_spatial_metric,
+    extrinsic_curvature,
+):
+    extrinsic_curvature_square = np.einsum(
+        "ij,ik,jl,kl->",
+        extrinsic_curvature,
+        inverse_spatial_metric,
+        inverse_spatial_metric,
+        extrinsic_curvature,
+    )
+    return (
+        ricci_scalar
+        + trace_extrinsic_curvature**2
+        - extrinsic_curvature_square
+    )

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/MomentumConstraint.py
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/MomentumConstraint.py
@@ -1,0 +1,13 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def momentum_constraint_in_vacuum(
+    d_extrinsic_curvature, d_trace_extrinsic_curvature, inverse_spatial_metric
+):
+    return (
+        np.einsum("jk,jki->i", inverse_spatial_metric, d_extrinsic_curvature)
+        - d_trace_extrinsic_curvature
+    )

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_HamiltonianConstraint.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_HamiltonianConstraint.cpp
@@ -1,0 +1,36 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "PointwiseFunctions/GeneralRelativity/HamiltonianConstraint.hpp"
+
+namespace {
+template <size_t SpatialDim, typename Frame, typename DataType>
+void test_hamiltonian_constraint_in_vacuum(const DataType& used_for_size) {
+  Scalar<DataType> (*f)(const Scalar<DataType>&, const Scalar<DataType>&,
+                        const tnsr::II<DataType, SpatialDim, Frame>&,
+                        const tnsr::ii<DataType, SpatialDim, Frame>&) =
+      &gr::hamiltonian_constraint_in_vacuum<DataType, SpatialDim, Frame>;
+  pypp::check_with_random_values<1>(f, "HamiltonianConstraint",
+                                    "hamiltonian_constraint_in_vacuum",
+                                    {{{-1., 1.}}}, used_for_size);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.PointwiseFunctions.GeneralRelativity.HamiltonianConstraint",
+    "[Unit][PointwiseFunctions]") {
+  const pypp::SetupLocalPythonEnvironment local_python_env{
+      "PointwiseFunctions/GeneralRelativity"};
+
+  GENERATE_UNINITIALIZED_DOUBLE_AND_DATAVECTOR;
+
+  CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_hamiltonian_constraint_in_vacuum,
+                                    (1, 2, 3), (Frame::Inertial, Frame::Grid));
+}

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_MomentumConstraint.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Test_MomentumConstraint.cpp
@@ -1,0 +1,37 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "PointwiseFunctions/GeneralRelativity/MomentumConstraint.hpp"
+
+namespace {
+template <size_t SpatialDim, typename Frame, typename DataType>
+void test_momentum_constraint_in_vacuum(const DataType& used_for_size) {
+  tnsr::i<DataType, SpatialDim, Frame> (*f)(
+      const tnsr::ijj<DataType, SpatialDim, Frame>&,
+      const tnsr::i<DataType, SpatialDim, Frame>&,
+      const tnsr::II<DataType, SpatialDim, Frame>&) =
+      &gr::momentum_constraint_in_vacuum<DataType, SpatialDim, Frame>;
+  pypp::check_with_random_values<1>(f, "MomentumConstraint",
+                                    "momentum_constraint_in_vacuum",
+                                    {{{-1., 1.}}}, used_for_size);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.PointwiseFunctions.GeneralRelativity.MomentumConstraint",
+    "[Unit][PointwiseFunctions]") {
+  const pypp::SetupLocalPythonEnvironment local_python_env{
+      "PointwiseFunctions/GeneralRelativity"};
+
+  GENERATE_UNINITIALIZED_DOUBLE_AND_DATAVECTOR;
+
+  CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_momentum_constraint_in_vacuum,
+                                    (1, 2, 3), (Frame::Inertial, Frame::Grid));
+}


### PR DESCRIPTION
## Proposed changes

Add functions that compute the hamiltonian and momentum constraint in vacuum GR, using the generic 3+1 expressions.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
