### PR TITLE
CCE: switch InitializeJ dispatch to call_with_dynamic_type

### DIFF
--- a/src/Evolution/Systems/Cce/Actions/InitializeFirstHypersurface.hpp
+++ b/src/Evolution/Systems/Cce/Actions/InitializeFirstHypersurface.hpp
@@ -75,17 +75,15 @@ struct InitializeFirstHypersurface {
                          ->template local_synchronous_action<
                              observers::Actions::GetLockPointer<
                                  observers::Tags::H5FileLock>>();
+    // Box-based dispatch (see `InitializeJ::InitializeJ::operator()`): the
+    // generator picks the right derived-class `return_tags`/`argument_tags`
+    // via `call_with_dynamic_type` and forwards to `db::mutate_apply`.
     if constexpr (tt::is_a_v<AnalyticWorldtubeBoundary, BoundaryComponent>) {
-      db::mutate_apply<typename InitializeJ::InitializeJ<false>::mutate_tags,
-                       typename InitializeJ::InitializeJ<false>::argument_tags>(
-          db::get<Tags::InitializeJ<false>>(box), make_not_null(&box),
-          make_not_null(hdf5_lock));
+      db::get<Tags::InitializeJ<false>>(box)(make_not_null(&box),
+                                             make_not_null(hdf5_lock));
     } else {
-      db::mutate_apply<
-          typename InitializeJ::InitializeJ<EvolveCcm>::mutate_tags,
-          typename InitializeJ::InitializeJ<EvolveCcm>::argument_tags>(
-          db::get<Tags::InitializeJ<EvolveCcm>>(box), make_not_null(&box),
-          make_not_null(hdf5_lock));
+      db::get<Tags::InitializeJ<EvolveCcm>>(box)(make_not_null(&box),
+                                                 make_not_null(hdf5_lock));
     }
     db::mutate_apply<InitializeScriPlusValue<Tags::InertialRetardedTime>>(
         make_not_null(&box), db::get<::Tags::TimeStepId>(box).substep_time());

--- a/src/Evolution/Systems/Cce/AnalyticSolutions/CMakeLists.txt
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/CMakeLists.txt
@@ -20,6 +20,7 @@ spectre_target_headers(
   HEADERS
   BouncingBlackHole.hpp
   LinearizedBondiSachs.hpp
+  LinearizedBondiSachsInitializeJ.hpp
   GaugeWave.hpp
   RobinsonTrautman.hpp
   RotatingSchwarzschild.hpp

--- a/src/Evolution/Systems/Cce/AnalyticSolutions/LinearizedBondiSachs.cpp
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/LinearizedBondiSachs.cpp
@@ -15,6 +15,7 @@
 #include "DataStructures/Tags/TempTensor.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
+#include "Evolution/Systems/Cce/AnalyticSolutions/LinearizedBondiSachsInitializeJ.hpp"
 #include "Evolution/Systems/Cce/Tags.hpp"
 #include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "NumericalAlgorithms/Spectral/CollocationPoints.hpp"

--- a/src/Evolution/Systems/Cce/AnalyticSolutions/LinearizedBondiSachs.hpp
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/LinearizedBondiSachs.hpp
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "DataStructures/SpinWeighted.hpp"
+#include "Evolution/Systems/Cce/AnalyticSolutions/LinearizedBondiSachsInitializeJ.hpp"
 #include "Evolution/Systems/Cce/AnalyticSolutions/SphericalMetricData.hpp"
 #include "Evolution/Systems/Cce/AnalyticSolutions/WorldtubeData.hpp"
 #include "Evolution/Systems/Cce/Initialize/InitializeJ.hpp"
@@ -27,51 +28,6 @@ class ComplexDataVector;
 
 namespace Cce::Solutions {
 namespace LinearizedBondiSachs_detail {
-namespace InitializeJ {
-// First hypersurface Initialization for the
-// `Cce::Solutions::LinearizedBondiSachs` analytic solution.
-//
-// This initialization procedure should not be used except when the
-// `Cce::Solutions::LinearizedBondiSachs` analytic solution is used,
-// as a consequence, this initial data generator is deliberately not
-// option-creatable; it should only be obtained from the `get_initialize_j`
-// function of `Cce::InitializeJ::LinearizedBondiSachs`.
-struct LinearizedBondiSachs : ::Cce::InitializeJ::InitializeJ<false> {
-  WRAPPED_PUPable_decl_template(LinearizedBondiSachs);  // NOLINT
-  explicit LinearizedBondiSachs(CkMigrateMessage* /*unused*/) {}
-
-  LinearizedBondiSachs() = default;
-
-  LinearizedBondiSachs(double start_time, double frequency,
-                       std::complex<double> c_2a, std::complex<double> c_2b,
-                       std::complex<double> c_3a, std::complex<double> c_3b);
-
-  std::unique_ptr<InitializeJ> get_clone() const override;
-
-  void operator()(
-      gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 2>>*> j,
-      gsl::not_null<tnsr::i<DataVector, 3>*> cartesian_cauchy_coordinates,
-      gsl::not_null<
-          tnsr::i<DataVector, 2, ::Frame::Spherical<::Frame::Inertial>>*>
-          angular_cauchy_coordinates,
-      const Scalar<SpinWeighted<ComplexDataVector, 2>>& boundary_j,
-      const Scalar<SpinWeighted<ComplexDataVector, 2>>& boundary_dr_j,
-      const Scalar<SpinWeighted<ComplexDataVector, 0>>& r,
-      const Scalar<SpinWeighted<ComplexDataVector, 0>>& beta, size_t l_max,
-      size_t number_of_radial_points,
-      gsl::not_null<Parallel::NodeLock*> hdf5_lock) const override;
-
-  void pup(PUP::er& /*p*/) override;
-
- private:
-  std::complex<double> c_2a_ = std::numeric_limits<double>::signaling_NaN();
-  std::complex<double> c_2b_ = std::numeric_limits<double>::signaling_NaN();
-  std::complex<double> c_3a_ = std::numeric_limits<double>::signaling_NaN();
-  std::complex<double> c_3b_ = std::numeric_limits<double>::signaling_NaN();
-  double frequency_ = std::numeric_limits<double>::signaling_NaN();
-  double time_ = std::numeric_limits<double>::signaling_NaN();
-};
-}  // namespace InitializeJ
 
 // combine the (2,2) and (3,3) modes to collocation values for
 // `bondi_quantity`

--- a/src/Evolution/Systems/Cce/AnalyticSolutions/LinearizedBondiSachsInitializeJ.hpp
+++ b/src/Evolution/Systems/Cce/AnalyticSolutions/LinearizedBondiSachsInitializeJ.hpp
@@ -1,0 +1,80 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <complex>
+#include <cstddef>
+#include <limits>
+#include <memory>
+
+#include "DataStructures/SpinWeighted.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/Cce/Initialize/InitializeJ.hpp"
+#include "Parallel/NodeLock.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+
+/// \cond
+class DataVector;
+class ComplexDataVector;
+/// \endcond
+
+namespace Cce::Solutions::LinearizedBondiSachs_detail::InitializeJ {
+// First hypersurface Initialization for the
+// `Cce::Solutions::LinearizedBondiSachs` analytic solution.
+//
+// This initialization procedure should not be used except when the
+// `Cce::Solutions::LinearizedBondiSachs` analytic solution is used,
+// as a consequence, this initial data generator is deliberately not
+// option-creatable; it should only be obtained from the `get_initialize_j`
+// function of `Cce::InitializeJ::LinearizedBondiSachs`.
+//
+// It lives in its own lightweight header (depending only on `InitializeJ.hpp`,
+// not the heavy `LinearizedBondiSachs.hpp`/`SphericalMetricData.hpp`) so that
+// `InitializeJ.hpp` can bottom-include it for the `call_with_dynamic_type`
+// dispatch over `InitializeJ<false>::creatable_classes` without an include
+// cycle.
+struct LinearizedBondiSachs : ::Cce::InitializeJ::InitializeJ<false> {
+  WRAPPED_PUPable_decl_template(LinearizedBondiSachs);  // NOLINT
+  explicit LinearizedBondiSachs(CkMigrateMessage* /*unused*/) {}
+
+  LinearizedBondiSachs() = default;
+
+  LinearizedBondiSachs(double start_time, double frequency,
+                       std::complex<double> c_2a, std::complex<double> c_2b,
+                       std::complex<double> c_3a, std::complex<double> c_3b);
+
+  // Deliberately not option-creatable (see note above); obtained only via
+  // `Cce::Solutions::LinearizedBondiSachs::get_initialize_j`. It is still in
+  // `InitializeJ<false>::creatable_classes` so the dispatch and charm
+  // registration see it; `factory_creatable = false` keeps it out of the
+  // option factory.
+  static constexpr bool factory_creatable = false;
+
+  std::unique_ptr<InitializeJ> get_clone() const override;
+
+  void operator()(
+      gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 2>>*> j,
+      gsl::not_null<tnsr::i<DataVector, 3>*> cartesian_cauchy_coordinates,
+      gsl::not_null<
+          tnsr::i<DataVector, 2, ::Frame::Spherical<::Frame::Inertial>>*>
+          angular_cauchy_coordinates,
+      const Scalar<SpinWeighted<ComplexDataVector, 2>>& boundary_j,
+      const Scalar<SpinWeighted<ComplexDataVector, 2>>& boundary_dr_j,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>& r,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>& beta, size_t l_max,
+      size_t number_of_radial_points,
+      gsl::not_null<Parallel::NodeLock*> hdf5_lock) const;
+
+  void pup(PUP::er& /*p*/) override;
+
+ private:
+  std::complex<double> c_2a_ = std::numeric_limits<double>::signaling_NaN();
+  std::complex<double> c_2b_ = std::numeric_limits<double>::signaling_NaN();
+  std::complex<double> c_3a_ = std::numeric_limits<double>::signaling_NaN();
+  std::complex<double> c_3b_ = std::numeric_limits<double>::signaling_NaN();
+  double frequency_ = std::numeric_limits<double>::signaling_NaN();
+  double time_ = std::numeric_limits<double>::signaling_NaN();
+};
+}  // namespace Cce::Solutions::LinearizedBondiSachs_detail::InitializeJ

--- a/src/Evolution/Systems/Cce/Initialize/ConformalFactor.hpp
+++ b/src/Evolution/Systems/Cce/Initialize/ConformalFactor.hpp
@@ -183,7 +183,7 @@ struct ConformalFactor : InitializeJ<false> {
       const Scalar<SpinWeighted<ComplexDataVector, 0>>& r,
       const Scalar<SpinWeighted<ComplexDataVector, 0>>& beta, size_t l_max,
       size_t number_of_radial_points,
-      gsl::not_null<Parallel::NodeLock*> hdf5_lock) const override;
+      gsl::not_null<Parallel::NodeLock*> hdf5_lock) const;
 
   void pup(PUP::er& p) override;
 

--- a/src/Evolution/Systems/Cce/Initialize/InitializeJ.hpp
+++ b/src/Evolution/Systems/Cce/Initialize/InitializeJ.hpp
@@ -7,6 +7,7 @@
 #include <memory>
 #include <string>
 
+#include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/SpinWeighted.hpp"
 #include "DataStructures/Tags.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
@@ -18,12 +19,16 @@
 #include "Options/String.hpp"
 #include "Parallel/NodeLock.hpp"
 #include "Parallel/Printf/Printf.hpp"
+#include "Utilities/CallWithDynamicType.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Serialization/CharmPupable.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
 class ComplexDataVector;
+namespace Cce::Solutions::LinearizedBondiSachs_detail::InitializeJ {
+struct LinearizedBondiSachs;
+}  // namespace Cce::Solutions::LinearizedBondiSachs_detail::InitializeJ
 /// \endcond
 
 namespace Cce {
@@ -40,8 +45,7 @@ struct NoOpFinalize {
       const Scalar<SpinWeighted<ComplexDataVector, 0>>& /*gauge_d*/,
       const tnsr::i<DataVector, 2, ::Frame::Spherical<::Frame::Inertial>>&
       /*angular_cauchy_coordinates*/,
-      const Spectral::Swsh::SwshInterpolator& /*interpolator*/) const {
-  }
+      const Spectral::Swsh::SwshInterpolator& /*interpolator*/) const {}
 };
 
 // perform an iterative solve for the set of angular coordinates. The iteration
@@ -348,6 +352,7 @@ struct InitializeJ<true> : public PUP::able {
       tmpl::list<Tags::BondiJ, Tags::CauchyCartesianCoords,
                  Tags::CauchyAngularCoords, Tags::PartiallyFlatCartesianCoords,
                  Tags::PartiallyFlatAngularCoords>;
+  using return_tags = mutate_tags;
   using argument_tags =
       tmpl::push_back<boundary_tags, Tags::LMax, Tags::NumberOfRadialPoints>;
 
@@ -362,22 +367,17 @@ struct InitializeJ<true> : public PUP::able {
 
   virtual std::unique_ptr<InitializeJ<true>> get_clone() const = 0;
 
-  virtual void operator()(
-      gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 2>>*> j,
-      gsl::not_null<tnsr::i<DataVector, 3>*> cartesian_cauchy_coordinates,
-      gsl::not_null<
-          tnsr::i<DataVector, 2, ::Frame::Spherical<::Frame::Inertial>>*>
-          angular_cauchy_coordinates,
-      gsl::not_null<tnsr::i<DataVector, 3>*> cartesian_inertial_coordinates,
-      gsl::not_null<
-          tnsr::i<DataVector, 2, ::Frame::Spherical<::Frame::Inertial>>*>
-          angular_inertial_coordinates,
-      const Scalar<SpinWeighted<ComplexDataVector, 2>>& boundary_j,
-      const Scalar<SpinWeighted<ComplexDataVector, 2>>& boundary_dr_j,
-      const Scalar<SpinWeighted<ComplexDataVector, 0>>& r,
-      const Scalar<SpinWeighted<ComplexDataVector, 0>>& beta, size_t l_max,
-      size_t number_of_radial_points,
-      gsl::not_null<Parallel::NodeLock*> hdf5_lock) const = 0;
+  // Each derived class declares its own `return_tags` and `argument_tags` and
+  // implements a non-virtual `operator()`; the dispatch below picks the
+  // correct dynamic type and forwards through `db::mutate_apply`.
+  template <typename DbTags>
+  void operator()(const gsl::not_null<db::DataBox<DbTags>*> box,
+                  const gsl::not_null<Parallel::NodeLock*> hdf5_lock) const {
+    call_with_dynamic_type<void, creatable_classes>(
+        this, [&](auto* const derived) {
+          db::mutate_apply(*derived, box, hdf5_lock);
+        });
+  }
 };
 
 /*!
@@ -398,6 +398,10 @@ struct InitializeJ<true> : public PUP::able {
  */
 template <>
 struct InitializeJ<false> : public PUP::able {
+  // Default boundary/mutate/argument tags used by the simple derived classes
+  // (ConformalFactor, InverseCubic<false>, NoIncomingRadiation, ZeroNonSmooth).
+  // A derived class may shadow these with its own list, in which case the
+  // per-class list is used during dispatch.
   using boundary_tags = tmpl::list<Tags::BoundaryValue<Tags::BondiJ>,
                                    Tags::BoundaryValue<Tags::Dr<Tags::BondiJ>>,
                                    Tags::BoundaryValue<Tags::BondiR>,
@@ -405,11 +409,15 @@ struct InitializeJ<false> : public PUP::able {
 
   using mutate_tags = tmpl::list<Tags::BondiJ, Tags::CauchyCartesianCoords,
                                  Tags::CauchyAngularCoords>;
+  using return_tags = mutate_tags;
   using argument_tags =
       tmpl::push_back<boundary_tags, Tags::LMax, Tags::NumberOfRadialPoints>;
 
-  using creatable_classes = tmpl::list<ConformalFactor, InverseCubic<false>,
-                                       NoIncomingRadiation, ZeroNonSmooth>;
+  using creatable_classes =
+      tmpl::list<ConformalFactor, InverseCubic<false>, NoIncomingRadiation,
+                 ZeroNonSmooth,
+                 ::Cce::Solutions::LinearizedBondiSachs_detail::InitializeJ::
+                     LinearizedBondiSachs>;
 
   InitializeJ() = default;
   explicit InitializeJ(CkMigrateMessage* /*msg*/) {}
@@ -418,22 +426,24 @@ struct InitializeJ<false> : public PUP::able {
 
   virtual std::unique_ptr<InitializeJ<false>> get_clone() const = 0;
 
-  virtual void operator()(
-      gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 2>>*> j,
-      gsl::not_null<tnsr::i<DataVector, 3>*> cartesian_cauchy_coordinates,
-      gsl::not_null<
-          tnsr::i<DataVector, 2, ::Frame::Spherical<::Frame::Inertial>>*>
-          angular_cauchy_coordinates,
-      const Scalar<SpinWeighted<ComplexDataVector, 2>>& boundary_j,
-      const Scalar<SpinWeighted<ComplexDataVector, 2>>& boundary_dr_j,
-      const Scalar<SpinWeighted<ComplexDataVector, 0>>& r,
-      const Scalar<SpinWeighted<ComplexDataVector, 0>>& beta, size_t l_max,
-      size_t number_of_radial_points,
-      gsl::not_null<Parallel::NodeLock*> hdf5_lock) const = 0;
+  // Each derived class declares its own `return_tags` and `argument_tags` and
+  // implements a non-virtual `operator()` whose signature matches those tags.
+  // The dispatch below picks the correct dynamic type and forwards through
+  // `db::mutate_apply` so the per-class tag lists are honored.
+  template <typename DbTags>
+  void operator()(const gsl::not_null<db::DataBox<DbTags>*> box,
+                  const gsl::not_null<Parallel::NodeLock*> hdf5_lock) const {
+    call_with_dynamic_type<void, creatable_classes>(
+        this, [&](auto* const derived) {
+          db::mutate_apply(*derived, box, hdf5_lock);
+        });
+  }
 };
 }  // namespace InitializeJ
 }  // namespace Cce
 
+#include "Evolution/Systems/Cce/AnalyticSolutions/LinearizedBondiSachsInitializeJ.hpp"
+#include "Evolution/Systems/Cce/Initialize/ConformalFactor.hpp"
 #include "Evolution/Systems/Cce/Initialize/InverseCubic.hpp"
 #include "Evolution/Systems/Cce/Initialize/NoIncomingRadiation.hpp"
 #include "Evolution/Systems/Cce/Initialize/ZeroNonSmooth.hpp"

--- a/src/Evolution/Systems/Cce/Initialize/InverseCubic.hpp
+++ b/src/Evolution/Systems/Cce/Initialize/InverseCubic.hpp
@@ -67,7 +67,7 @@ struct InverseCubic<true> : InitializeJ<true> {
       const Scalar<SpinWeighted<ComplexDataVector, 0>>& r,
       const Scalar<SpinWeighted<ComplexDataVector, 0>>& beta, size_t l_max,
       size_t number_of_radial_points,
-      gsl::not_null<Parallel::NodeLock*> hdf5_lock) const override;
+      gsl::not_null<Parallel::NodeLock*> hdf5_lock) const;
 
   void pup(PUP::er& /*p*/) override;
 };
@@ -114,7 +114,7 @@ struct InverseCubic<false> : InitializeJ<false> {
       const Scalar<SpinWeighted<ComplexDataVector, 0>>& r,
       const Scalar<SpinWeighted<ComplexDataVector, 0>>& beta, size_t l_max,
       size_t number_of_radial_points,
-      gsl::not_null<Parallel::NodeLock*> hdf5_lock) const override;
+      gsl::not_null<Parallel::NodeLock*> hdf5_lock) const;
 
   void pup(PUP::er& /*p*/) override;
 };

--- a/src/Evolution/Systems/Cce/Initialize/NoIncomingRadiation.hpp
+++ b/src/Evolution/Systems/Cce/Initialize/NoIncomingRadiation.hpp
@@ -86,7 +86,7 @@ struct NoIncomingRadiation : InitializeJ<false> {
       const Scalar<SpinWeighted<ComplexDataVector, 0>>& r,
       const Scalar<SpinWeighted<ComplexDataVector, 0>>& beta, size_t l_max,
       size_t number_of_radial_points,
-      gsl::not_null<Parallel::NodeLock*> hdf5_lock) const override;
+      gsl::not_null<Parallel::NodeLock*> hdf5_lock) const;
 
   void pup(PUP::er& p) override;
 

--- a/src/Evolution/Systems/Cce/Initialize/RegisterInitializeJWithCharm.hpp
+++ b/src/Evolution/Systems/Cce/Initialize/RegisterInitializeJWithCharm.hpp
@@ -3,24 +3,18 @@
 
 #pragma once
 
-#include "Evolution/Systems/Cce/AnalyticSolutions/LinearizedBondiSachs.hpp"
+#include "Evolution/Systems/Cce/Components/WorldtubeBoundary.hpp"
 #include "Evolution/Systems/Cce/Initialize/InitializeJ.hpp"
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
 
-/// \cond
 namespace Cce {
-namespace Solutions::LinearizedBondiSachs_detail::InitializeJ {
-struct LinearizedBondiSachs;
-}
-/// \endcond
-
 /// A function for registering all of the InitializeJ derived classes with
-/// charm, including the ones not intended to be directly option-creatable
+/// charm, including the ones not intended to be directly option-creatable.
+/// `LinearizedBondiSachs` is registered through
+/// `InitializeJ<false>::creatable_classes` (it sets `factory_creatable = false`
+/// so it stays out of the option factory).
 template <bool EvolveCcm, typename BoundaryComponent>
 void register_initialize_j_with_charm() {
-  PUPable_reg(SINGLE_ARG(Solutions::LinearizedBondiSachs_detail::InitializeJ::
-                         LinearizedBondiSachs));
-
   if constexpr (tt::is_a_v<AnalyticWorldtubeBoundary, BoundaryComponent>) {
     register_derived_classes_with_charm<Cce::InitializeJ::InitializeJ<false>>();
   } else {

--- a/src/Evolution/Systems/Cce/Initialize/ZeroNonSmooth.hpp
+++ b/src/Evolution/Systems/Cce/Initialize/ZeroNonSmooth.hpp
@@ -88,7 +88,7 @@ struct ZeroNonSmooth : InitializeJ<false> {
       const Scalar<SpinWeighted<ComplexDataVector, 0>>& r,
       const Scalar<SpinWeighted<ComplexDataVector, 0>>& beta, size_t l_max,
       size_t number_of_radial_points,
-      gsl::not_null<Parallel::NodeLock*> hdf5_lock) const override;
+      gsl::not_null<Parallel::NodeLock*> hdf5_lock) const;
 
   void pup(PUP::er& p) override;
 

--- a/tests/Unit/Helpers/Evolution/Systems/Cce/AnalyticSolutions/AnalyticDataHelpers.cpp
+++ b/tests/Unit/Helpers/Evolution/Systems/Cce/AnalyticSolutions/AnalyticDataHelpers.cpp
@@ -7,6 +7,7 @@
 #include <cstddef>
 
 #include "DataStructures/ComplexDataVector.hpp"
+#include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/SpinWeighted.hpp"
 #include "DataStructures/TaggedTuple.hpp"
@@ -331,23 +332,49 @@ void test_initialize_j(const size_t l_max, const size_t number_of_radial_points,
   tnsr::i<DataVector, 2, ::Frame::Spherical<::Frame::Inertial>>
       test_angular_coordinates{number_of_angular_points};
   auto node_lock = Parallel::NodeLock{};
-  (*(analytic_solution->get_initialize_j(time)))(
-      make_not_null(&test_j), make_not_null(&test_cartesian_coordinates),
-      make_not_null(&test_angular_coordinates),
-      get<Tags::BoundaryValue<Tags::BondiJ>>(boundary_variables),
-      get<Tags::BoundaryValue<Tags::Dr<Tags::BondiJ>>>(boundary_variables),
-      get<Tags::BoundaryValue<Tags::BondiR>>(boundary_variables),
-      get<Tags::BoundaryValue<Tags::BondiBeta>>(boundary_variables), l_max,
-      number_of_radial_points, make_not_null(&node_lock));
-  (*expected_initialize_j)(
-      make_not_null(&expected_j),
-      make_not_null(&expected_cartesian_coordinates),
-      make_not_null(&expected_angular_coordinates),
-      get<Tags::BoundaryValue<Tags::BondiJ>>(boundary_variables),
-      get<Tags::BoundaryValue<Tags::Dr<Tags::BondiJ>>>(boundary_variables),
-      get<Tags::BoundaryValue<Tags::BondiR>>(boundary_variables),
-      get<Tags::BoundaryValue<Tags::BondiBeta>>(boundary_variables), l_max,
-      number_of_radial_points, make_not_null(&node_lock));
+  // Invoke the generator through the box-based dispatch (the path used by
+  // `InitializeFirstHypersurface`); the base no longer exposes a direct
+  // `operator()`. The box holds the generator's `mutate_tags` (outputs) and
+  // `argument_tags` (boundary values, `LMax`, `NumberOfRadialPoints`).
+  const auto run_initialize_j =
+      [&boundary_variables, &node_lock, l_max, number_of_radial_points,
+       number_of_angular_points](
+          const std::unique_ptr<InitializeJ::InitializeJ<false>>& generator,
+          const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 2>>*> j,
+          const gsl::not_null<tnsr::i<DataVector, 3>*> cartesian_coordinates,
+          const gsl::not_null<
+              tnsr::i<DataVector, 2, ::Frame::Spherical<::Frame::Inertial>>*>
+              angular_coordinates) {
+        auto box = db::create<db::AddSimpleTags<
+            Tags::BondiJ, Tags::CauchyCartesianCoords,
+            Tags::CauchyAngularCoords, Tags::BoundaryValue<Tags::BondiJ>,
+            Tags::BoundaryValue<Tags::Dr<Tags::BondiJ>>,
+            Tags::BoundaryValue<Tags::BondiR>,
+            Tags::BoundaryValue<Tags::BondiBeta>, Tags::LMax,
+            Tags::NumberOfRadialPoints>>(
+            Scalar<SpinWeighted<ComplexDataVector, 2>>{
+                number_of_angular_points * number_of_radial_points},
+            tnsr::i<DataVector, 3>{number_of_angular_points},
+            tnsr::i<DataVector, 2, ::Frame::Spherical<::Frame::Inertial>>{
+                number_of_angular_points},
+            get<Tags::BoundaryValue<Tags::BondiJ>>(boundary_variables),
+            get<Tags::BoundaryValue<Tags::Dr<Tags::BondiJ>>>(
+                boundary_variables),
+            get<Tags::BoundaryValue<Tags::BondiR>>(boundary_variables),
+            get<Tags::BoundaryValue<Tags::BondiBeta>>(boundary_variables),
+            l_max, number_of_radial_points);
+        (*generator)(make_not_null(&box), make_not_null(&node_lock));
+        *j = db::get<Tags::BondiJ>(box);
+        *cartesian_coordinates = db::get<Tags::CauchyCartesianCoords>(box);
+        *angular_coordinates = db::get<Tags::CauchyAngularCoords>(box);
+      };
+  run_initialize_j(analytic_solution->get_initialize_j(time),
+                   make_not_null(&test_j),
+                   make_not_null(&test_cartesian_coordinates),
+                   make_not_null(&test_angular_coordinates));
+  run_initialize_j(expected_initialize_j, make_not_null(&expected_j),
+                   make_not_null(&expected_cartesian_coordinates),
+                   make_not_null(&expected_angular_coordinates));
   CHECK(test_j == expected_j);
   CHECK(test_cartesian_coordinates == expected_cartesian_coordinates);
   CHECK(test_angular_coordinates == expected_angular_coordinates);


### PR DESCRIPTION
Replaces the rigid pure-virtual `operator()` on `InitializeJ<true>` and `InitializeJ<false>` with a templated `operator()(box, hdf5_lock)` that dispatches through `call_with_dynamic_type` + `db::mutate_apply`. Each derived class can now expose its own `return_tags` / `argument_tags` (shadowing the base-class defaults), so future generators that need more worldtube boundary inputs no longer require widening every sibling class's signature.

The action `InitializeFirstHypersurface` invokes the generator through the new box-based form. The existing simple schemes (ConformalFactor, InverseCubic, NoIncomingRadiation, ZeroNonSmooth, LinearizedBondiSachs) inherit their default tag lists from the base class; `override` is dropped from their `operator()` declarations now that the base call is no longer virtual.

So the `call_with_dynamic_type` dispatch can resolve every derived type, `InitializeJ.hpp` bottom-includes each generator header and lists them all in `creatable_classes`. The LinearizedBondiSachs generator is not option-creatable (`factory_creatable = false`) but is still listed so it can be dispatched and charm-registered; it is split out into the lightweight `LinearizedBondiSachsInitializeJ.hpp` to avoid the `SphericalMetricData` include cycle. The `test_initialize_j` helper invokes the generator through the box-based form as well.

Co-Authored-By: Claude Opus 4.8 [noreply@anthropic.com](mailto:noreply@anthropic.com)

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

No user-facing or input-file changes. Developer note for anyone adding an InitializeJ generator: the base class no longer has a virtual operator(). A generator now declares its own return_tags/argument_tags, implements a non-virtual operator() matching them, and is added to InitializeJ<...>::creatable_classes. Set static constexpr bool factory_creatable = false; if it should be dispatchable/charm-registered but not option-creatable (as LinearizedBondiSachs does).

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

Part 1 of a 4-PR stack building toward the CauchySecondOrder initial-data scheme. Review/merge in order: (1) this dispatch refactor → (2) SpanInterpolator::derivative → (3) Du<Dy<J>> worldtube boundary value → (4) CauchySecondOrder. PRs 2–4 follow once this lands. PR 4 might need further splitting.

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
