### PR TITLE
Fix macOS cache misses in CI

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -1060,7 +1060,7 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
         uses: actions/cache/restore@v5
         id: restore-dependencies
         env:
-          CACHE_KEY_PREFIX: "dependencies-${{ matrix.os }}"
+          CACHE_KEY_PREFIX: "dependencies-${{ matrix.os }}-${{ runner.arch }}"
         with:
           path: ~/dependencies
           key: "${{ env.CACHE_KEY_PREFIX }}-${{ github.run_id }}"
@@ -1138,7 +1138,7 @@ ${{ matrix.build_type }}-pch-${{ matrix.use_pch || 'ON' }}"
         uses: actions/cache/restore@v5
         id: restore-ccache
         env:
-          CACHE_KEY_PREFIX: "ccache-${{ matrix.os }}"
+          CACHE_KEY_PREFIX: "ccache-${{ matrix.os }}-${{ runner.arch }}"
         with:
           path: ~/ccache
           key: "${{ env.CACHE_KEY_PREFIX }}-${{ github.run_id }}"


### PR DESCRIPTION
## Proposed changes

The caches are restored based on prefix matching since the end may include date as a wildcard. The cache prefixes were:
ccache-macos-15-intel- # For Intel x86
ccache-macos-15-       # For ARM-64
this meant that the ARM builds could match the Intel builds and therefore grab
the completely wrong cache, causing 0% cache hit rate. This change makes the
prefixes be:
ccache-macos-15-intel-X64-
ccache-macos-15-ARM64-
which should fix the cache misses.

**Note**: I hope this fixes it, and that there isn't some other issue, but I we won't know until we try.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
