### PR TITLE
Interpolation: add derivative method to SpanInterpolators

### DIFF
--- a/src/NumericalAlgorithms/Interpolation/BarycentricRationalSpanInterpolator.cpp
+++ b/src/NumericalAlgorithms/Interpolation/BarycentricRationalSpanInterpolator.cpp
@@ -41,5 +41,23 @@ double BarycentricRationalSpanInterpolator::interpolate(
   return interpolant(target_point);
 }
 
+double BarycentricRationalSpanInterpolator::derivative(
+    const gsl::span<const double>& source_points,
+    const gsl::span<const double>& values, const double target_point) const {
+  if (UNLIKELY(source_points.size() < min_order_ + 1)) {
+    ERROR("provided independent values for interpolation too small.");
+  }
+  // Boost moved barycentric_rational from boost::math to
+  // boost::math::interpolators in version 1.77.
+  // NOLINTNEXTLINE(google-build-using-namespace)
+  using namespace boost::math;
+  // NOLINTNEXTLINE(google-build-using-namespace)
+  using namespace boost::math::interpolators;
+  const barycentric_rational<double> interpolant(
+      source_points.data(), values.data(), source_points.size(),
+      std::min(source_points.size() - 1, max_order_));
+  return interpolant.prime(target_point);
+}
+
 PUP::able::PUP_ID intrp::BarycentricRationalSpanInterpolator::my_PUP_ID = 0;
 }  // namespace intrp

--- a/src/NumericalAlgorithms/Interpolation/BarycentricRationalSpanInterpolator.hpp
+++ b/src/NumericalAlgorithms/Interpolation/BarycentricRationalSpanInterpolator.hpp
@@ -69,12 +69,17 @@ class BarycentricRationalSpanInterpolator : public SpanInterpolator {
     return std::make_unique<BarycentricRationalSpanInterpolator>(*this);
   }
 
-  // to get the generic overload:
+  // to get the generic overloads:
+  using SpanInterpolator::derivative;
   using SpanInterpolator::interpolate;
 
   double interpolate(const gsl::span<const double>& source_points,
                      const gsl::span<const double>& values,
                      double target_point) const override;
+
+  double derivative(const gsl::span<const double>& source_points,
+                    const gsl::span<const double>& values,
+                    double target_point) const override;
 
   size_t required_number_of_points_before_and_after() const override {
     return min_order_ / 2 + 1;

--- a/src/NumericalAlgorithms/Interpolation/CubicSpanInterpolator.cpp
+++ b/src/NumericalAlgorithms/Interpolation/CubicSpanInterpolator.cpp
@@ -35,6 +35,44 @@ SPECTRE_ALWAYS_INLINE ValueType interpolate_impl(
          ((t0 - t1) * (t0 - t2) * (t1 - t2) * (t0 - t3) * (t1 - t3) *
           (t2 - t3));
 }
+
+template <typename ValueType>
+SPECTRE_ALWAYS_INLINE ValueType derivative_impl(
+    const gsl::span<const double>& source_points,
+    const gsl::span<const ValueType>& values, const double target_point) {
+  const double t0 = source_points[0];
+  const double t1 = source_points[1];
+  const double t2 = source_points[2];
+  const double t3 = source_points[3];
+
+  const auto d0 = values[0];
+  const auto d1 = values[1];
+  const auto d2 = values[2];
+  const auto d3 = values[3];
+
+  const double x_minus_t0 = target_point - t0;
+  const double x_minus_t1 = target_point - t1;
+  const double x_minus_t2 = target_point - t2;
+  const double x_minus_t3 = target_point - t3;
+
+  // Sum-of-products derivative of each Lagrange basis numerator:
+  //   d/dx [(x - a)(x - b)(x - c)] = (x-b)(x-c) + (x-a)(x-c) + (x-a)(x-b)
+  const double s0 = (x_minus_t2 * x_minus_t3) + (x_minus_t1 * x_minus_t3) +
+                    (x_minus_t1 * x_minus_t2);
+  const double s1 = (x_minus_t2 * x_minus_t3) + (x_minus_t0 * x_minus_t3) +
+                    (x_minus_t0 * x_minus_t2);
+  const double s2 = (x_minus_t1 * x_minus_t3) + (x_minus_t0 * x_minus_t3) +
+                    (x_minus_t0 * x_minus_t1);
+  const double s3 = (x_minus_t1 * x_minus_t2) + (x_minus_t0 * x_minus_t2) +
+                    (x_minus_t0 * x_minus_t1);
+
+  return (d0 * s0 * (t1 - t2) * (t1 - t3) * (t2 - t3) -
+          d1 * s1 * (t0 - t2) * (t0 - t3) * (t2 - t3) +
+          d2 * s2 * (t0 - t1) * (t0 - t3) * (t1 - t3) -
+          d3 * s3 * (t0 - t1) * (t0 - t2) * (t1 - t2)) /
+         ((t0 - t1) * (t0 - t2) * (t1 - t2) * (t0 - t3) * (t1 - t3) *
+          (t2 - t3));
+}
 }  // namespace
 
 double CubicSpanInterpolator::interpolate(
@@ -48,6 +86,19 @@ std::complex<double> CubicSpanInterpolator::interpolate(
     const gsl::span<const std::complex<double>>& values,
     double target_point) const {
   return interpolate_impl(source_points, values, target_point);
+}
+
+double CubicSpanInterpolator::derivative(
+    const gsl::span<const double>& source_points,
+    const gsl::span<const double>& values, double target_point) const {
+  return derivative_impl(source_points, values, target_point);
+}
+
+std::complex<double> CubicSpanInterpolator::derivative(
+    const gsl::span<const double>& source_points,
+    const gsl::span<const std::complex<double>>& values,
+    double target_point) const {
+  return derivative_impl(source_points, values, target_point);
 }
 
 PUP::able::PUP_ID intrp::CubicSpanInterpolator::my_PUP_ID = 0;

--- a/src/NumericalAlgorithms/Interpolation/CubicSpanInterpolator.hpp
+++ b/src/NumericalAlgorithms/Interpolation/CubicSpanInterpolator.hpp
@@ -54,6 +54,15 @@ class CubicSpanInterpolator : public SpanInterpolator {
       const gsl::span<const std::complex<double>>& values,
       double target_point) const;
 
+  double derivative(const gsl::span<const double>& source_points,
+                    const gsl::span<const double>& values,
+                    double target_point) const override;
+
+  std::complex<double> derivative(
+      const gsl::span<const double>& source_points,
+      const gsl::span<const std::complex<double>>& values,
+      double target_point) const override;
+
   size_t required_number_of_points_before_and_after() const override {
     return 2;
   }

--- a/src/NumericalAlgorithms/Interpolation/LinearSpanInterpolator.cpp
+++ b/src/NumericalAlgorithms/Interpolation/LinearSpanInterpolator.cpp
@@ -20,6 +20,13 @@ SPECTRE_ALWAYS_INLINE ValueType interpolate_impl(
                          (source_points[1] - source_points[0]) *
                          (target_point - source_points[0]);
 }
+
+template <typename ValueType>
+SPECTRE_ALWAYS_INLINE ValueType
+derivative_impl(const gsl::span<const double>& source_points,
+                const gsl::span<const ValueType>& values) {
+  return (values[1] - values[0]) / (source_points[1] - source_points[0]);
+}
 }  // namespace
 
 double LinearSpanInterpolator::interpolate(
@@ -33,6 +40,20 @@ std::complex<double> LinearSpanInterpolator::interpolate(
     const gsl::span<const std::complex<double>>& values,
     const double target_point) const {
   return interpolate_impl(source_points, values, target_point);
+}
+
+double LinearSpanInterpolator::derivative(
+    const gsl::span<const double>& source_points,
+    const gsl::span<const double>& values,
+    const double /*target_point*/) const {
+  return derivative_impl(source_points, values);
+}
+
+std::complex<double> LinearSpanInterpolator::derivative(
+    const gsl::span<const double>& source_points,
+    const gsl::span<const std::complex<double>>& values,
+    const double /*target_point*/) const {
+  return derivative_impl(source_points, values);
 }
 
 PUP::able::PUP_ID intrp::LinearSpanInterpolator::my_PUP_ID = 0;

--- a/src/NumericalAlgorithms/Interpolation/LinearSpanInterpolator.hpp
+++ b/src/NumericalAlgorithms/Interpolation/LinearSpanInterpolator.hpp
@@ -50,6 +50,15 @@ class LinearSpanInterpolator : public SpanInterpolator {
       const gsl::span<const std::complex<double>>& values,
       double target_point) const;
 
+  double derivative(const gsl::span<const double>& source_points,
+                    const gsl::span<const double>& values,
+                    double target_point) const override;
+
+  std::complex<double> derivative(
+      const gsl::span<const double>& source_points,
+      const gsl::span<const std::complex<double>>& values,
+      double target_point) const override;
+
   size_t required_number_of_points_before_and_after() const override {
     return 1;
   }

--- a/src/NumericalAlgorithms/Interpolation/SpanInterpolator.cpp
+++ b/src/NumericalAlgorithms/Interpolation/SpanInterpolator.cpp
@@ -31,4 +31,24 @@ std::complex<double> SpanInterpolator::interpolate(
                   gsl::span<const double>(imag_part.data(), imag_part.size()),
                   target_point)};
 }
+
+std::complex<double> SpanInterpolator::derivative(
+    const gsl::span<const double>& source_points,
+    const gsl::span<const std::complex<double>>& values,
+    const double target_point) const {
+  // the operation below to get the real and imag parts does not alter the
+  // contents of the span, so the const-cast is safe.
+  const ComplexDataVector view{
+      const_cast<std::complex<double>*>(values.data()),  // NOLINT
+      values.size()};
+  const DataVector real_part = real(view);
+  const DataVector imag_part = imag(view);
+  return std::complex<double>{
+      derivative(source_points,
+                 gsl::span<const double>(real_part.data(), real_part.size()),
+                 target_point),
+      derivative(source_points,
+                 gsl::span<const double>(imag_part.data(), imag_part.size()),
+                 target_point)};
+}
 }  // namespace intrp

--- a/src/NumericalAlgorithms/Interpolation/SpanInterpolator.hpp
+++ b/src/NumericalAlgorithms/Interpolation/SpanInterpolator.hpp
@@ -55,6 +55,23 @@ class SpanInterpolator : public PUP::able {
       const gsl::span<const std::complex<double>>& values,
       double target_point) const;
 
+  /// Evaluate the derivative of the interpolant of the function represented by
+  /// `values` at `source_points`, evaluated at the requested `target_point`.
+  virtual double derivative(const gsl::span<const double>& source_points,
+                            const gsl::span<const double>& values,
+                            double target_point) const = 0;
+
+  /// Evaluate the derivative of the interpolant of the function represented by
+  /// complex `values` at `source_points`, evaluated at the requested
+  /// `target_point`. This generic implementation calls the real version on the
+  /// real and imaginary parts separately; derived classes should override it
+  /// when a specialized complex implementation that avoids the split is more
+  /// efficient.
+  virtual std::complex<double> derivative(
+      const gsl::span<const double>& source_points,
+      const gsl::span<const std::complex<double>>& values,
+      double target_point) const;
+
   /// The number of domain points that should be both before and after the
   /// requested target point for best interpolation. For instance, for a linear
   /// interpolator, this function would return `1` to request that the target is

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_SpanInterpolators.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_SpanInterpolators.cpp
@@ -27,7 +27,11 @@ void test_linear_interpolator(const gsl::not_null<Generator*> gen) {
   auto linear_interpolator_complex_values =
       make_with_random_values<ComplexDataVector>(gen, value_dist,
                                                  static_cast<size_t>(2));
-  const DataVector linear_interpolator_points = {{0.0, 1.0}};
+  // Use source points whose spacing is not 1 and that do not start at 0 so the
+  // interpolation denominator and offset are genuinely exercised.
+  const DataVector linear_interpolator_points = {{0.5, 2.0}};
+  const double point_spacing =
+      linear_interpolator_points[1] - linear_interpolator_points[0];
   const double target_point = value_dist(*gen);
   const LinearSpanInterpolator test_linear_interpolator{};
   const double real_linear_interpolation = test_linear_interpolator.interpolate(
@@ -37,8 +41,10 @@ void test_linear_interpolator(const gsl::not_null<Generator*> gen) {
                               linear_interpolator_values.size()},
       target_point);
   CHECK(real_linear_interpolation ==
-        approx(target_point * linear_interpolator_values[1] +
-               (1.0 - target_point) * linear_interpolator_values[0]));
+        approx(linear_interpolator_values[0] +
+               (linear_interpolator_values[1] - linear_interpolator_values[0]) /
+                   point_spacing *
+                   (target_point - linear_interpolator_points[0])));
   const std::complex<double> complex_linear_interpolation =
       test_linear_interpolator.interpolate(
           gsl::span<const double>{linear_interpolator_points.data(),
@@ -49,8 +55,34 @@ void test_linear_interpolator(const gsl::not_null<Generator*> gen) {
           target_point);
   CHECK_ITERABLE_APPROX(
       complex_linear_interpolation,
-      target_point * linear_interpolator_complex_values[1] +
-          (1.0 - target_point) * linear_interpolator_complex_values[0]);
+      linear_interpolator_complex_values[0] +
+          (linear_interpolator_complex_values[1] -
+           linear_interpolator_complex_values[0]) /
+              point_spacing * (target_point - linear_interpolator_points[0]));
+
+  // The linear derivative is the constant slope between the two source
+  // points; verify both the real and complex overloads.
+  const double real_linear_derivative = test_linear_interpolator.derivative(
+      gsl::span<const double>{linear_interpolator_points.data(),
+                              linear_interpolator_points.size()},
+      gsl::span<const double>{linear_interpolator_values.data(),
+                              linear_interpolator_values.size()},
+      target_point);
+  CHECK(real_linear_derivative ==
+        approx((linear_interpolator_values[1] - linear_interpolator_values[0]) /
+               point_spacing));
+  const std::complex<double> complex_linear_derivative =
+      test_linear_interpolator.derivative(
+          gsl::span<const double>{linear_interpolator_points.data(),
+                                  linear_interpolator_points.size()},
+          gsl::span<const std::complex<double>>{
+              linear_interpolator_complex_values.data(),
+              linear_interpolator_complex_values.size()},
+          target_point);
+  CHECK_ITERABLE_APPROX(complex_linear_derivative,
+                        (linear_interpolator_complex_values[1] -
+                         linear_interpolator_complex_values[0]) /
+                            point_spacing);
 }
 
 template <typename VectorType, typename InterpolatorType, typename Generator>
@@ -58,19 +90,24 @@ void test_interpolator_approximate_fidelity(
     const gsl::not_null<Generator*> gen, const InterpolatorType& interpolator,
     Approx interpolator_approx) {
   UniformCustomDistribution<double> value_dist{0.1, 1.0};
-  DataVector interpolator_points{
-      2 * interpolator.required_number_of_points_before_and_after()};
-  VectorType interpolator_values{
-      2 * interpolator.required_number_of_points_before_and_after()};
+  const size_t points_on_each_side =
+      interpolator.required_number_of_points_before_and_after();
+  DataVector interpolator_points{2 * points_on_each_side};
+  VectorType interpolator_values{2 * points_on_each_side};
   const double frequency = value_dist(*gen);
   const typename VectorType::value_type amplitude = value_dist(*gen);
-  // only sample a small span to give the low-order interpolators an easier time
+  // Sample a small, uniformly spaced span so the low-order interpolators stay
+  // accurate.
+  const double point_spacing = 0.01;
   for (size_t i = 0; i < interpolator_points.size(); ++i) {
-    interpolator_points[i] = 0.01 * i / interpolator_points.size();
+    interpolator_points[i] = point_spacing * static_cast<double>(i);
     interpolator_values[i] =
         amplitude * cos(frequency * interpolator_points[i]);
   }
-  const double target_time = value_dist(*gen) / 100.0;
+  // Keep the target in the central interval so the requested number of points
+  // lies on each side of it (as required by the interpolator).
+  const double target_time = interpolator_points[points_on_each_side - 1] +
+                             value_dist(*gen) * point_spacing;
   const auto interpolator_result = interpolator.interpolate(
       gsl::span<const double>{interpolator_points.data(),
                               interpolator_points.size()},
@@ -83,20 +120,126 @@ void test_interpolator_approximate_fidelity(
                                interpolator_approx);
 }
 
+template <typename VectorType, typename InterpolatorType, typename Generator>
+void test_interpolator_derivative_approximate_fidelity(
+    const gsl::not_null<Generator*> gen, const InterpolatorType& interpolator,
+    Approx interpolator_approx) {
+  // NOLINTNEXTLINE(misc-const-correctness) - operator() is non-const
+  UniformCustomDistribution<double> value_dist{0.1, 1.0};
+  const size_t points_on_each_side =
+      interpolator.required_number_of_points_before_and_after();
+  DataVector interpolator_points{2 * points_on_each_side};
+  VectorType interpolator_values{2 * points_on_each_side};
+  const double frequency = value_dist(*gen);
+  const typename VectorType::value_type amplitude = value_dist(*gen);
+  // Sample a small, uniformly spaced span so the low-order interpolators stay
+  // accurate.
+  const double point_spacing = 0.01;
+  for (size_t i = 0; i < interpolator_points.size(); ++i) {
+    interpolator_points[i] = point_spacing * static_cast<double>(i);
+    interpolator_values[i] =
+        amplitude * cos(frequency * interpolator_points[i]);
+  }
+  // Keep the target in the central interval so the requested number of points
+  // lies on each side of it (as required by the interpolator).
+  const double target_time = interpolator_points[points_on_each_side - 1] +
+                             value_dist(*gen) * point_spacing;
+  const auto interpolator_derivative_result = interpolator.derivative(
+      gsl::span<const double>{interpolator_points.data(),
+                              interpolator_points.size()},
+      gsl::span<const typename VectorType::value_type>{
+          interpolator_values.data(), interpolator_points.size()},
+      target_time);
+
+  CHECK_ITERABLE_CUSTOM_APPROX(
+      interpolator_derivative_result,
+      -amplitude * frequency * sin(frequency * target_time),
+      interpolator_approx);
+}
+
+template <typename VectorType, typename InterpolatorType, typename Generator>
+void test_interpolator_derivative_is_exact(
+    const gsl::not_null<Generator*> gen, const InterpolatorType& interpolator) {
+  // An order-N interpolant reproduces a degree-N polynomial exactly, so its
+  // derivative equals the analytic polynomial derivative to roundoff (a small
+  // multiple of machine epsilon). This is a much tighter accuracy check than
+  // the fidelity test above, whose tolerance is dominated by the interpolant's
+  // truncation error on a transcendental function.
+  using ValueType = typename VectorType::value_type;
+  const size_t number_of_points =
+      2 * interpolator.required_number_of_points_before_and_after();
+  const size_t degree = number_of_points - 1;
+  const UniformCustomDistribution<double> coefficient_dist{0.1, 1.0};
+  const auto coefficients = make_with_random_values<VectorType>(
+      gen, coefficient_dist, number_of_points);
+  // Horner evaluation of the polynomial and of its analytic derivative.
+  const auto polynomial = [&coefficients, degree](const double x) {
+    ValueType result = coefficients[degree];
+    for (size_t i = degree; i > 0; --i) {
+      result = result * x + coefficients[i - 1];
+    }
+    return result;
+  };
+  const auto polynomial_derivative = [&coefficients, degree](const double x) {
+    ValueType result = static_cast<double>(degree) * coefficients[degree];
+    // loop on `i > 1` and index with `i - 1` so the size_t cannot underflow
+    // for a degree-0 polynomial.
+    for (size_t i = degree; i > 1; --i) {
+      result = result * x + static_cast<double>(i - 1) * coefficients[i - 1];
+    }
+    return result;
+  };
+  // Place the points near integer positions but randomly perturbed, so the
+  // test does not rely on a special exactly-uniform grid. The perturbation
+  // stays well below the unit spacing, keeping the points well separated and
+  // the interpolation well conditioned.
+  // NOLINTNEXTLINE(misc-const-correctness) - operator() is non-const
+  UniformCustomDistribution<double> perturbation_dist{-0.1, 0.1};
+  DataVector points{number_of_points};
+  VectorType values{number_of_points};
+  for (size_t i = 0; i < number_of_points; ++i) {
+    points[i] = static_cast<double>(i) + perturbation_dist(*gen);
+    values[i] = polynomial(points[i]);
+  }
+  const double target_point = 0.5 * static_cast<double>(degree);
+  const auto interpolator_derivative_result = interpolator.derivative(
+      gsl::span<const double>{points.data(), points.size()},
+      gsl::span<const ValueType>{values.data(), values.size()}, target_point);
+  const Approx exact_approx = Approx::custom().epsilon(1.0e-13).scale(1.0);
+  CHECK_ITERABLE_CUSTOM_APPROX(interpolator_derivative_result,
+                               polynomial_derivative(target_point),
+                               exact_approx);
+}
+
 SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolation.SpanInterpolators",
                   "[Unit][NumericalAlgorithms]") {
   MAKE_GENERATOR(gen);
   test_linear_interpolator(make_not_null(&gen));
 
   {
-    // Linear interpolator will not get terribly close, but that's okay.
-    Approx interpolator_approx = Approx::custom().epsilon(1.0e-2).scale(1.0);
+    // Over the small sampled span the test function is nearly linear, so even
+    // the linear interpolator resolves the value well; its derivative is a
+    // finite-difference slope that loses one factor of h in accuracy.
+    const Approx interpolator_approx =
+        Approx::custom().epsilon(1.0e-4).scale(1.0);
+    const Approx derivative_approx =
+        Approx::custom().epsilon(1.0e-2).scale(1.0);
 
     INFO("testing LinearSpanInterpolator");
     test_interpolator_approximate_fidelity<DataVector>(
         make_not_null(&gen), LinearSpanInterpolator{}, interpolator_approx);
     test_interpolator_approximate_fidelity<ComplexDataVector>(
         make_not_null(&gen), LinearSpanInterpolator{}, interpolator_approx);
+    test_interpolator_derivative_approximate_fidelity<DataVector>(
+        make_not_null(&gen), LinearSpanInterpolator{}, derivative_approx);
+    test_interpolator_derivative_approximate_fidelity<ComplexDataVector>(
+        make_not_null(&gen), LinearSpanInterpolator{}, derivative_approx);
+    // a linear interpolant reproduces a degree-1 polynomial exactly, so its
+    // derivative is exact -- a tight check the fidelity test cannot provide
+    test_interpolator_derivative_is_exact<DataVector>(make_not_null(&gen),
+                                                      LinearSpanInterpolator{});
+    test_interpolator_derivative_is_exact<ComplexDataVector>(
+        make_not_null(&gen), LinearSpanInterpolator{});
 
     // verify the the construction from options is successful
     const auto option_created_linear_interpolator =
@@ -108,6 +251,12 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolation.SpanInterpolators",
     test_interpolator_approximate_fidelity<ComplexDataVector>(
         make_not_null(&gen), *option_created_linear_interpolator,
         interpolator_approx);
+    test_interpolator_derivative_approximate_fidelity<DataVector>(
+        make_not_null(&gen), *option_created_linear_interpolator,
+        derivative_approx);
+    test_interpolator_derivative_approximate_fidelity<ComplexDataVector>(
+        make_not_null(&gen), *option_created_linear_interpolator,
+        derivative_approx);
 
     // verify that the interpolator can be serialized and deserialized
     test_interpolator_approximate_fidelity<DataVector>(
@@ -118,19 +267,39 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolation.SpanInterpolators",
         make_not_null(&gen),
         serialize_and_deserialize(LinearSpanInterpolator{}),
         interpolator_approx);
+    test_interpolator_derivative_approximate_fidelity<DataVector>(
+        make_not_null(&gen),
+        serialize_and_deserialize(LinearSpanInterpolator{}), derivative_approx);
+    test_interpolator_derivative_approximate_fidelity<ComplexDataVector>(
+        make_not_null(&gen),
+        serialize_and_deserialize(LinearSpanInterpolator{}), derivative_approx);
   }
 
   {
-    Approx interpolator_approx =
+    const Approx interpolator_approx =
         Approx::custom()
             .epsilon(std::numeric_limits<double>::epsilon() * 1.0e8)
             .scale(1.0);
+    // The cubic-Lagrange derivative loses one factor of h in accuracy
+    // compared to the value of the interpolant.
+    const Approx derivative_approx =
+        Approx::custom().epsilon(1.0e-5).scale(1.0);
 
     INFO("testing CubicSpanInterpolator");
     test_interpolator_approximate_fidelity<DataVector>(
         make_not_null(&gen), CubicSpanInterpolator{}, interpolator_approx);
     test_interpolator_approximate_fidelity<ComplexDataVector>(
         make_not_null(&gen), CubicSpanInterpolator{}, interpolator_approx);
+    test_interpolator_derivative_approximate_fidelity<DataVector>(
+        make_not_null(&gen), CubicSpanInterpolator{}, derivative_approx);
+    test_interpolator_derivative_approximate_fidelity<ComplexDataVector>(
+        make_not_null(&gen), CubicSpanInterpolator{}, derivative_approx);
+    // a cubic interpolant reproduces a cubic exactly, so its derivative is also
+    // exact -- a tight check the fidelity test above cannot provide
+    test_interpolator_derivative_is_exact<DataVector>(make_not_null(&gen),
+                                                      CubicSpanInterpolator{});
+    test_interpolator_derivative_is_exact<ComplexDataVector>(
+        make_not_null(&gen), CubicSpanInterpolator{});
 
     // verify the the construction from options is successful
     const auto option_created_cubic_interpolator =
@@ -142,6 +311,12 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolation.SpanInterpolators",
     test_interpolator_approximate_fidelity<ComplexDataVector>(
         make_not_null(&gen), *option_created_cubic_interpolator,
         interpolator_approx);
+    test_interpolator_derivative_approximate_fidelity<DataVector>(
+        make_not_null(&gen), *option_created_cubic_interpolator,
+        derivative_approx);
+    test_interpolator_derivative_approximate_fidelity<ComplexDataVector>(
+        make_not_null(&gen), *option_created_cubic_interpolator,
+        derivative_approx);
 
     // verify that the interpolator can be serialized and deserialized
     test_interpolator_approximate_fidelity<DataVector>(
@@ -150,13 +325,23 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolation.SpanInterpolators",
     test_interpolator_approximate_fidelity<ComplexDataVector>(
         make_not_null(&gen), serialize_and_deserialize(CubicSpanInterpolator{}),
         interpolator_approx);
+    test_interpolator_derivative_approximate_fidelity<DataVector>(
+        make_not_null(&gen), serialize_and_deserialize(CubicSpanInterpolator{}),
+        derivative_approx);
+    test_interpolator_derivative_approximate_fidelity<ComplexDataVector>(
+        make_not_null(&gen), serialize_and_deserialize(CubicSpanInterpolator{}),
+        derivative_approx);
   }
 
   {
-    Approx interpolator_approx =
+    const Approx interpolator_approx =
         Approx::custom()
             .epsilon(std::numeric_limits<double>::epsilon() * 1.0e5)
             .scale(1.0);
+    // The barycentric-rational derivative is one order less accurate than the
+    // value of the interpolant.
+    const Approx derivative_approx =
+        Approx::custom().epsilon(1.0e-8).scale(1.0);
 
     INFO("testing BarycentricRationalSpanInterpolator");
     test_interpolator_approximate_fidelity<DataVector>(
@@ -165,6 +350,18 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolation.SpanInterpolators",
     test_interpolator_approximate_fidelity<ComplexDataVector>(
         make_not_null(&gen), BarycentricRationalSpanInterpolator{5u, 6u},
         interpolator_approx);
+    test_interpolator_derivative_approximate_fidelity<DataVector>(
+        make_not_null(&gen), BarycentricRationalSpanInterpolator{5u, 6u},
+        derivative_approx);
+    test_interpolator_derivative_approximate_fidelity<ComplexDataVector>(
+        make_not_null(&gen), BarycentricRationalSpanInterpolator{5u, 6u},
+        derivative_approx);
+    // with 6 points and order 5 the interpolant reproduces a degree-5
+    // polynomial exactly, so its derivative is exact as well
+    test_interpolator_derivative_is_exact<DataVector>(
+        make_not_null(&gen), BarycentricRationalSpanInterpolator{5u, 6u});
+    test_interpolator_derivative_is_exact<ComplexDataVector>(
+        make_not_null(&gen), BarycentricRationalSpanInterpolator{5u, 6u});
 
     // verify the the construction from options is successful
     const auto option_created_barycentric_interpolator =
@@ -178,6 +375,12 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolation.SpanInterpolators",
     test_interpolator_approximate_fidelity<ComplexDataVector>(
         make_not_null(&gen), *option_created_barycentric_interpolator,
         interpolator_approx);
+    test_interpolator_derivative_approximate_fidelity<DataVector>(
+        make_not_null(&gen), *option_created_barycentric_interpolator,
+        derivative_approx);
+    test_interpolator_derivative_approximate_fidelity<ComplexDataVector>(
+        make_not_null(&gen), *option_created_barycentric_interpolator,
+        derivative_approx);
 
     // verify that the interpolator can be serialized and deserialized
     test_interpolator_approximate_fidelity<DataVector>(
@@ -188,6 +391,14 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Interpolation.SpanInterpolators",
         make_not_null(&gen),
         serialize_and_deserialize(BarycentricRationalSpanInterpolator{5u, 6u}),
         interpolator_approx);
+    test_interpolator_derivative_approximate_fidelity<DataVector>(
+        make_not_null(&gen),
+        serialize_and_deserialize(BarycentricRationalSpanInterpolator{5u, 6u}),
+        derivative_approx);
+    test_interpolator_derivative_approximate_fidelity<ComplexDataVector>(
+        make_not_null(&gen),
+        serialize_and_deserialize(BarycentricRationalSpanInterpolator{5u, 6u}),
+        derivative_approx);
   }
 }
 }  // namespace intrp


### PR DESCRIPTION
Adds a `derivative(source_points, values, target_point)` method to the `intrp::SpanInterpolator` interface and its derived classes, returning the derivative of the interpolant at the requested point (the analogue of the existing `interpolate`). This is needed by downstream code that must time-differentiate an interpolated worldtube quantity.

- `SpanInterpolator` declares the pure-virtual real overload and a virtual complex overload; the base implementation of the complex overload splits the values into real/imaginary parts and calls the real overload. Derived classes override the complex overload when a specialized version is more efficient.
- `LinearSpanInterpolator` returns the constant slope between the two points.
- `CubicSpanInterpolator` adds `derivative_impl`, the analytic derivative of the cubic Lagrange interpolant.
- `BarycentricRationalSpanInterpolator` uses boost's `barycentric_rational::prime`.

Tested with an approximate-fidelity check against the analytic derivative of `A cos(w t)`, and -- since a degree-N interpolant reproduces a degree-N polynomial exactly -- with exact-polynomial derivative checks for the linear, cubic, and barycentric interpolators.

Co-Authored-By: Claude Opus 4.8 [noreply@anthropic.com](mailto:noreply@anthropic.com)

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

Part of the CauchySecondOrder initial-data stack.

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
