### PR TITLE
Optimize ReadH5

### DIFF
--- a/src/IO/H5/Python/ReadH5.py
+++ b/src/IO/H5/Python/ReadH5.py
@@ -40,16 +40,15 @@ def available_subfiles(
         h5files = [h5files]
     subfiles = set()
 
-    def visitor(name):
-        if name.endswith(extension):
-            subfiles.add(name)
-
     for h5file in h5files:
         if isinstance(h5file, h5py.File):
-            h5file.visit(visitor)
+            keys = h5file.keys()
         else:
             with h5py.File(h5file, "r") as open_h5_file:
-                open_h5_file.visit(visitor)
+                keys = list(open_h5_file.keys())
+        for name in keys:
+            if name.endswith(extension):
+                subfiles.add(name)
     return sorted(subfiles)
 
 


### PR DESCRIPTION
Subfiles (.vol, .dat) are always top-level HDF5 groups. Replace h5file.visit() with h5file.keys() to avoid recursively walking every dataset in the file, which is extremely slow on ZFS.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
