### PR TITLE
Suppress compiler warning seen for Catch2 with clang22

### DIFF
--- a/cmake/EnableWarnings.cmake
+++ b/cmake/EnableWarnings.cmake
@@ -88,6 +88,19 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     )
 endif()
 
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang"
+    AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 22
+    AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 23)
+  create_cxx_flags_target(
+    "-Wno-c2y-extensions"
+    SpectreDisableClangCatchWarning)
+  target_link_libraries(
+    SpectreWarnings
+    INTERFACE
+    SpectreDisableClangCatchWarning
+  )
+endif()
+
 # Suppress CUDA warnings that we don't want
 create_cxx_flag_target(
   "-Xcudafe \"--diag_suppress=177,186,191,554,1301,1305,2189,3060,20012\""

--- a/cmake/SetupCatch.cmake
+++ b/cmake/SetupCatch.cmake
@@ -18,3 +18,5 @@ if (NOT Catch2_FOUND)
   )
   FetchContent_MakeAvailable(Catch2)
 endif()
+
+message(STATUS "Catch version: ${Catch2_VERSION}")

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_Sources.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_Sources.cpp
@@ -1079,7 +1079,7 @@ void test_cartoon_sources_x_zero_assert() {
 #endif  // SPECTRE_DEBUG
 }  // namespace
 
-// [[TimeOut, 10]]
+// [[TimeOut, 20]]
 SPECTRE_TEST_CASE("Unit.GrMhd.ValenciaDivClean.Sources", "[Unit][GrMhd]") {
   pypp::SetupLocalPythonEnvironment local_python_env{
       "Evolution/Systems/GrMhd/ValenciaDivClean"};


### PR DESCRIPTION
## Proposed changes

- Turn off warning for c2y-extensions when compiling with clang22
- Increase timeout for Test_Sources

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
