### PR TITLE
Give better error for parse errors caused by tabs

### DIFF
--- a/src/Options/ParseOptions.hpp
+++ b/src/Options/ParseOptions.hpp
@@ -990,17 +990,24 @@ template <typename OptionList, typename Group>
   auto context = context_;
   context.line = e.mark.line;
   context.column = e.mark.column;
+
+  std::string hint =
+      "This is often due to placing a suboption on the same line as an "
+      "option, e.g.:\nDomainCreator: CreateInterval:\n  IsPeriodicIn: "
+      "[false]\n\nShould be:\nDomainCreator:\n  CreateInterval:\n    "
+      "IsPeriodicIn: [true]\n\nSee an example input file for help.";
+  if (input_source_.back().find('\t') != std::string::npos) {
+    hint = "This may be due to indenting with tabs.";
+  }
   // Inline the top_level branch of PARSE_ERROR to avoid warning that
   // the other branch would call terminate.  (Parser errors can only
   // be generated at top level.)
-  ERROR(
+  ERROR_NO_TRACE(
       "\n"
       << context
-      << "Unable to correctly parse the input file because of a syntax error.\n"
-         "This is often due to placing a suboption on the same line as an "
-         "option, e.g.:\nDomainCreator: CreateInterval:\n  IsPeriodicIn: "
-         "[false]\n\nShould be:\nDomainCreator:\n  CreateInterval:\n    "
-         "IsPeriodicIn: [true]\n\nSee an example input file for help.");
+      << "Unable to correctly parse the input file because of a syntax error:\n"
+      << "  " << e.msg << "\n"
+      << hint);
 }
 
 template <typename OptionList, typename Group>

--- a/tests/Unit/Options/Test_Options.cpp
+++ b/tests/Unit/Options/Test_Options.cpp
@@ -51,20 +51,6 @@ void test_options_empty() {
       Catch::Matchers::ContainsSubstring("\n'4' does not look like options"));
 }
 
-void test_options_syntax_error() {
-  INFO("Syntax error");
-  CHECK_THROWS_WITH(
-      []() {
-        Options::Parser<tmpl::list<>> opts("");
-        opts.parse(
-            "DomainCreator: CreateInterval:\n"
-            "  IsPeriodicIn: [false]");
-      }(),
-      Catch::Matchers::ContainsSubstring(
-          "At line 1 column 30:\nUnable to correctly parse the "
-          "input file because of a syntax error"));
-}
-
 struct Simple {
   using type = int;
   static constexpr Options::String help = {"halp"};
@@ -918,6 +904,38 @@ void test_options_complex_containers() {
                                                                 {{2}, {"B"}}}));
 }
 
+void test_options_syntax_error() {
+  INFO("Syntax error");
+  CHECK_THROWS_WITH(
+      []() {
+        Options::Parser<tmpl::list<>> opts("");
+        opts.parse(
+            "DomainCreator: CreateInterval:\n"
+            "  IsPeriodicIn: [false]");
+      }(),
+      Catch::Matchers::ContainsSubstring(
+          "At line 1 column 30:\nUnable to correctly parse the "
+          "input file because of a syntax error") and
+          not Catch::Matchers::ContainsSubstring("tabs"));
+  CHECK_THROWS_WITH(
+      []() {
+        Options::Parser<tmpl::list<UnorderedMap>> opts("");
+        opts.parse(
+            "UnorderedMap:\n"
+            "\tA: 3");
+      }(),
+      Catch::Matchers::ContainsSubstring("Unable to correctly parse the input "
+                                         "file because of a syntax error") and
+          Catch::Matchers::ContainsSubstring("indenting with tabs"));
+  // Check that tabs don't cause an error if the input file is valid.
+  {
+    Options::Parser<tmpl::list<UnorderedMap>> opts("");
+    opts.parse(
+        "UnorderedMap:\n"
+        "  A:\t3");
+  }
+}
+
 #ifdef SPECTRE_DEBUG
 struct Duplicate {
   using type = int;
@@ -1698,7 +1716,6 @@ void test_integer_scientific() {
 
 SPECTRE_TEST_CASE("Unit.Options", "[Unit][Options]") {
   test_options_empty();
-  test_options_syntax_error();
   test_options_simple();
   test_options_print_long_help();
   test_options_grouped();
@@ -1710,6 +1727,7 @@ SPECTRE_TEST_CASE("Unit.Options", "[Unit][Options]") {
   test_options_unordered_map();
   test_options_variant();
   test_options_complex_containers();
+  test_options_syntax_error();
   test_options_invalid_calls();
   test_options_apply();
   test_options_option_context_default_stream();


### PR DESCRIPTION
Also include the YAML message for parser errors.  It's often not very informative, but it might help in some cases.

Fixes #2928 

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
