### PR TITLE
CCE: compute boundary Du<Dr<J>> by time-differentiating Dr<J>

### DIFF
--- a/src/Evolution/Systems/Cce/BoundaryData.hpp
+++ b/src/Evolution/Systems/Cce/BoundaryData.hpp
@@ -587,7 +587,8 @@ using characteristic_worldtube_boundary_tags = db::wrap_tags_in<
         tmpl::list<Tags::BondiBeta, Tags::BondiU, Tags::Dr<Tags::BondiU>,
                    Tags::BondiQ, Tags::BondiW, Tags::BondiJ,
                    Tags::Dr<Tags::BondiJ>, Tags::BondiH, Tags::Du<Tags::BondiJ>,
-                   Tags::BondiR, Tags::Du<Tags::BondiR>, Tags::DuRDividedByR>,
+                   Tags::BondiR, Tags::Du<Tags::BondiR>, Tags::DuRDividedByR,
+                   Tags::Du<Tags::Dr<Tags::BondiJ>>>,
         tmpl::conditional_t<
             IncludeKleinGordon,
             tmpl::list<Cce::Tags::KleinGordonPsi, Cce::Tags::KleinGordonPi>,

--- a/src/Evolution/Systems/Cce/Tags.hpp
+++ b/src/Evolution/Systems/Cce/Tags.hpp
@@ -156,7 +156,15 @@ struct Dlambda : db::PrefixTag, db::SimpleTag {
   using tag = Tag;
 };
 
-/// The derivative with respect to Bondi retarded time \f$u\f$
+/// The derivative with respect to Bondi retarded time \f$u\f$.
+///
+/// \note The worldtube boundary tag `Du<Dr<BondiJ>>` is the time derivative
+/// *following the worldtube* (at constant numerical coordinate
+/// \f$\breve y = -1\f$), i.e.
+/// \f$\partial_{\breve u}\partial_r J = \frac{d}{d u}(\partial_r J)\f$, not a
+/// derivative at constant Bondi \f$r\f$. See
+/// `BondiWorldtubeDataManager::populate_boundary_du_dr_j` and the fixed-\f$y\f$
+/// vs. fixed-\f$r\f$ notes in `BoundaryData.hpp`.
 template <typename Tag>
 struct Du : db::PrefixTag, db::SimpleTag {
   using type = Scalar<SpinWeighted<ComplexDataVector, Tag::type::type::spin>>;

--- a/src/Evolution/Systems/Cce/WorldtubeDataManager.cpp
+++ b/src/Evolution/Systems/Cce/WorldtubeDataManager.cpp
@@ -430,7 +430,94 @@ bool BondiWorldtubeDataManager::populate_hypersurface_boundary_data(
       *boundary_data_variables)) =
       exp(2.0 * bondi_beta.data()) / square(bondi_r.data()) *
       (bondi_k.data() * bondi_q.data() - bondi_j.data() * conj(bondi_q.data()));
+
+  populate_boundary_du_dr_j(boundary_data_variables, time);
   return true;
+}
+
+void BondiWorldtubeDataManager::populate_boundary_du_dr_j(
+    const gsl::not_null<Variables<
+        Tags::characteristic_worldtube_boundary_tags<Tags::BoundaryValue>>*>
+        boundary_data_variables,
+    const double time) const {
+  // The previous detail::populate_hypersurface_boundary_data call already
+  // refreshed time_span_start_ / time_span_end_ for the current target time.
+  // The interpolation sub-window we use for the time derivative must match the
+  // one used for value interpolation above.
+  const auto interpolation_time_span = detail::create_span_for_time_value(
+      time, 0, interpolator_->required_number_of_points_before_and_after(),
+      time_span_start_, time_span_end_, buffer_updater_->get_time_buffer());
+  const size_t interpolation_span_size =
+      interpolation_time_span.second - interpolation_time_span.first;
+  const size_t buffer_span_size = time_span_end_ - time_span_start_;
+  const size_t offset_in_buffer =
+      interpolation_time_span.first - time_span_start_;
+
+  const DataVector time_points{
+      buffer_updater_->get_time_buffer().data() +  // NOLINT
+          interpolation_time_span.first,
+      interpolation_span_size};
+
+  const size_t number_of_libsharp_coefficients =
+      Spectral::Swsh::size_of_libsharp_coefficient_vector(l_max_);
+  const size_t number_of_angular_points =
+      Spectral::Swsh::number_of_swsh_collocation_points(l_max_);
+
+  SpinWeighted<ComplexModalVector, 2> dr_j_libsharp_modes{
+      number_of_libsharp_coefficients};
+  SpinWeighted<ComplexDataVector, 2> dr_j_nodal{};
+
+  // Dr<J> over time, laid out so the nodal slice at buffer time `ti` lives in
+  // [ti * num_points, (ti + 1) * num_points).
+  ComplexDataVector dr_j_over_time{interpolation_span_size *
+                                   number_of_angular_points};
+
+  const auto& dr_j_modes_buffer =
+      get(get<Spectral::Swsh::Tags::SwshTransform<Tags::Dr<Tags::BondiJ>>>(
+              coefficients_buffers_))
+          .data();
+
+  for (size_t ti = 0; ti < interpolation_span_size; ++ti) {
+    const size_t time_index_in_buffer = offset_in_buffer + ti;
+    dr_j_libsharp_modes.data() = 0.0;
+    for (const auto libsharp_mode :
+         Spectral::Swsh::cached_coefficients_metadata(l_max_)) {
+      const size_t plus_m_goldberg_index = Spectral::Swsh::goldberg_mode_index(
+          l_max_, libsharp_mode.l, static_cast<int>(libsharp_mode.m));
+      const size_t minus_m_goldberg_index = Spectral::Swsh::goldberg_mode_index(
+          l_max_, libsharp_mode.l, -static_cast<int>(libsharp_mode.m));
+      Spectral::Swsh::goldberg_modes_to_libsharp_modes_single_pair(
+          libsharp_mode, make_not_null(&dr_j_libsharp_modes), 0,
+          dr_j_modes_buffer[(plus_m_goldberg_index * buffer_span_size) +
+                            time_index_in_buffer],
+          dr_j_modes_buffer[(minus_m_goldberg_index * buffer_span_size) +
+                            time_index_in_buffer]);
+    }
+    dr_j_nodal.data().set_data_ref(
+        dr_j_over_time.data() + (ti * number_of_angular_points),  // NOLINT
+        number_of_angular_points);
+    Spectral::Swsh::inverse_swsh_transform(
+        l_max_, 1, make_not_null(&dr_j_nodal), dr_j_libsharp_modes);
+  }
+
+  // Time derivative (at constant y, i.e. following the worldtube) of the
+  // boundary Dr<J>, i.e. Du<Dr<J>>. The conversion to Du<Dy<J>> via the
+  // worldtube Jacobian is performed by the consumer of this boundary value.
+  auto& du_dr_j =
+      get(get<Tags::BoundaryValue<Tags::Du<Tags::Dr<Tags::BondiJ>>>>(
+              *boundary_data_variables))
+          .data();
+  ComplexDataVector dr_j_at_point{interpolation_span_size};
+  for (size_t i = 0; i < number_of_angular_points; ++i) {
+    for (size_t ti = 0; ti < interpolation_span_size; ++ti) {
+      dr_j_at_point[ti] = dr_j_over_time[(ti * number_of_angular_points) + i];
+    }
+    du_dr_j[i] = interpolator_->derivative(
+        gsl::span<const double>(time_points.data(), time_points.size()),
+        gsl::span<const std::complex<double>>(dr_j_at_point.data(),
+                                              dr_j_at_point.size()),
+        time);
+  }
 }
 
 std::unique_ptr<WorldtubeDataManager<

--- a/src/Evolution/Systems/Cce/WorldtubeDataManager.hpp
+++ b/src/Evolution/Systems/Cce/WorldtubeDataManager.hpp
@@ -263,6 +263,18 @@ class BondiWorldtubeDataManager
   void pup(PUP::er& p) override;  // NOLINT
 
  private:
+  // Compute the boundary value of `Du<Dr<BondiJ>>` at the requested time by
+  // numerically time-differentiating the buffered `Dr<BondiJ>` with
+  // `interpolator_`, holding the angular coordinate fixed (i.e. following the
+  // worldtube). This is the time derivative at constant numerical coordinate
+  // y = -1, i.e. d_ubreve d_r J|_Gamma = d/du (d_r J|_Gamma), and is *not* a
+  // derivative at constant Bondi r.
+  void populate_boundary_du_dr_j(
+      gsl::not_null<Variables<
+          Tags::characteristic_worldtube_boundary_tags<Tags::BoundaryValue>>*>
+          boundary_data_variables,
+      double time) const;
+
   std::unique_ptr<
       WorldtubeBufferUpdater<Tags::worldtube_boundary_tags_for_writing<
           Spectral::Swsh::Tags::SwshTransform>>>

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_AnalyticBoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_AnalyticBoundaryCommunication.cpp
@@ -236,8 +236,12 @@ SPECTRE_TEST_CASE(
   analytic_manager.populate_hypersurface_boundary_data(
       make_not_null(&expected_boundary_variables), target_time);
 
-  tmpl::for_each<
-      Tags::characteristic_worldtube_boundary_tags<Tags::BoundaryValue>>(
+  // `Du<Dr<BondiJ>>` is not populated by `create_bondi_boundary_data` (the
+  // "expected" side here), so it would compare NaN-vs-NaN; exclude it.
+  using tags_to_compare = tmpl::list_difference<
+      Tags::characteristic_worldtube_boundary_tags<Tags::BoundaryValue>,
+      tmpl::list<Tags::BoundaryValue<Tags::Du<Tags::Dr<Tags::BondiJ>>>>>;
+  tmpl::for_each<tags_to_compare>(
       [&expected_boundary_variables, &runner](auto tag_v) {
         using tag = typename decltype(tag_v)::type;
         INFO(db::tag_name<tag>());

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_GhBoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_GhBoundaryCommunication.cpp
@@ -286,17 +286,19 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.GhBoundaryCommunication",
           .epsilon(std::numeric_limits<double>::epsilon() * 1.0e4)
           .scale(1.0);
 
-  tmpl::for_each<
-      Tags::characteristic_worldtube_boundary_tags<Tags::BoundaryValue>>(
-      [&expected_boundary_variables, &runner,
-       &angular_derivative_approx](auto tag_v) {
-        using tag = typename decltype(tag_v)::type;
-        INFO(db::tag_name<tag>());
-        const auto& test_lhs =
-            ActionTesting::get_databox_tag<evolution_component, tag>(runner, 0);
-        const auto& test_rhs = get<tag>(expected_boundary_variables);
-        CHECK_ITERABLE_CUSTOM_APPROX(test_lhs, test_rhs,
-                                     angular_derivative_approx);
-      });
+  // `Du<Dr<BondiJ>>` is not populated by `create_bondi_boundary_data` (the
+  // "expected" side here), so it would compare NaN-vs-NaN; exclude it.
+  using tags_to_compare = tmpl::list_difference<
+      Tags::characteristic_worldtube_boundary_tags<Tags::BoundaryValue>,
+      tmpl::list<Tags::BoundaryValue<Tags::Du<Tags::Dr<Tags::BondiJ>>>>>;
+  tmpl::for_each<tags_to_compare>([&expected_boundary_variables, &runner,
+                                   &angular_derivative_approx](auto tag_v) {
+    using tag = typename decltype(tag_v)::type;
+    INFO(db::tag_name<tag>());
+    const auto& test_lhs =
+        ActionTesting::get_databox_tag<evolution_component, tag>(runner, 0);
+    const auto& test_rhs = get<tag>(expected_boundary_variables);
+    CHECK_ITERABLE_CUSTOM_APPROX(test_lhs, test_rhs, angular_derivative_approx);
+  });
 }
 }  // namespace Cce

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_H5BoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_H5BoundaryCommunication.cpp
@@ -317,18 +317,20 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.H5BoundaryCommunication",
           .epsilon(std::numeric_limits<double>::epsilon() * 1.0e4)
           .scale(1.0);
 
-  tmpl::for_each<
-      Tags::characteristic_worldtube_boundary_tags<Tags::BoundaryValue>>(
-      [&expected_boundary_variables, &runner,
-       &angular_derivative_approx](auto tag_v) {
-        using tag = typename decltype(tag_v)::type;
-        INFO(db::tag_name<tag>());
-        const auto& test_lhs =
-            ActionTesting::get_databox_tag<evolution_component, tag>(runner, 0);
-        const auto& test_rhs = get<tag>(expected_boundary_variables);
-        CHECK_ITERABLE_CUSTOM_APPROX(test_lhs, test_rhs,
-                                     angular_derivative_approx);
-      });
+  // `Du<Dr<BondiJ>>` is not populated by `create_bondi_boundary_data` (the
+  // "expected" side here), so it would compare NaN-vs-NaN; exclude it.
+  using tags_to_compare = tmpl::list_difference<
+      Tags::characteristic_worldtube_boundary_tags<Tags::BoundaryValue>,
+      tmpl::list<Tags::BoundaryValue<Tags::Du<Tags::Dr<Tags::BondiJ>>>>>;
+  tmpl::for_each<tags_to_compare>([&expected_boundary_variables, &runner,
+                                   &angular_derivative_approx](auto tag_v) {
+    using tag = typename decltype(tag_v)::type;
+    INFO(db::tag_name<tag>());
+    const auto& test_lhs =
+        ActionTesting::get_databox_tag<evolution_component, tag>(runner, 0);
+    const auto& test_rhs = get<tag>(expected_boundary_variables);
+    CHECK_ITERABLE_CUSTOM_APPROX(test_lhs, test_rhs, angular_derivative_approx);
+  });
   if (file_system::check_if_file_exists(filename)) {
     file_system::rm(filename, true);
   }

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_KleinGordonH5BoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_KleinGordonH5BoundaryCommunication.cpp
@@ -308,18 +308,20 @@ void test_klein_gordon_h5_boundary_communication(
           .epsilon(std::numeric_limits<double>::epsilon() * 1.0e4)
           .scale(1.0);
 
-  tmpl::for_each<
-      Tags::characteristic_worldtube_boundary_tags<Tags::BoundaryValue>>(
-      [&expected_boundary_variables, &runner,
-       &angular_derivative_approx](auto tag_v) {
-        using tag = typename decltype(tag_v)::type;
-        INFO(db::tag_name<tag>());
-        const auto& test_lhs =
-            ActionTesting::get_databox_tag<evolution_component, tag>(runner, 0);
-        const auto& test_rhs = get<tag>(expected_boundary_variables);
-        CHECK_ITERABLE_CUSTOM_APPROX(test_lhs, test_rhs,
-                                     angular_derivative_approx);
-      });
+  // `Du<Dr<BondiJ>>` is not populated by `create_bondi_boundary_data` (the
+  // "expected" side here), so it would compare NaN-vs-NaN; exclude it.
+  using tags_to_compare = tmpl::list_difference<
+      Tags::characteristic_worldtube_boundary_tags<Tags::BoundaryValue>,
+      tmpl::list<Tags::BoundaryValue<Tags::Du<Tags::Dr<Tags::BondiJ>>>>>;
+  tmpl::for_each<tags_to_compare>([&expected_boundary_variables, &runner,
+                                   &angular_derivative_approx](auto tag_v) {
+    using tag = typename decltype(tag_v)::type;
+    INFO(db::tag_name<tag>());
+    const auto& test_lhs =
+        ActionTesting::get_databox_tag<evolution_component, tag>(runner, 0);
+    const auto& test_rhs = get<tag>(expected_boundary_variables);
+    CHECK_ITERABLE_CUSTOM_APPROX(test_lhs, test_rhs, angular_derivative_approx);
+  });
 
   // then the scalar variables
   Scalar<ComplexModalVector> expected_kg_psi_modal;

--- a/tests/Unit/Evolution/Systems/Cce/Test_AnalyticBoundaryDataManager.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_AnalyticBoundaryDataManager.cpp
@@ -140,14 +140,20 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.AnalyticBoundaryDataManager",
       get<gr::Tags::SpacetimeMetric<DataVector, 3>>(
           analytic_solution_gh_variables),
       extraction_radius, l_max);
-  tmpl::for_each<
-      Tags::characteristic_worldtube_boundary_tags<Tags::BoundaryValue>>(
-      [&boundary_variables_from_manager,
-       &expected_boundary_variables](auto tag_v) {
-        using tag = typename decltype(tag_v)::type;
-        CHECK_ITERABLE_APPROX(get<tag>(boundary_variables_from_manager),
-                              get<tag>(expected_boundary_variables));
-      });
+  // `Du<Dr<BondiJ>>` is not set by `create_bondi_boundary_data` (it is
+  // computed in `BondiWorldtubeDataManager` by time-differentiating the
+  // buffered `Dr<BondiJ>` and has no single-time analogue here).
+  // Both sides remain default-initialized at that tag, so comparing them
+  // would be NaN-vs-NaN with `SPECTRE_NAN_INIT`.
+  using tags_to_compare = tmpl::list_difference<
+      Tags::characteristic_worldtube_boundary_tags<Tags::BoundaryValue>,
+      tmpl::list<Tags::BoundaryValue<Tags::Du<Tags::Dr<Tags::BondiJ>>>>>;
+  tmpl::for_each<tags_to_compare>([&boundary_variables_from_manager,
+                                   &expected_boundary_variables](auto tag_v) {
+    using tag = typename decltype(tag_v)::type;
+    CHECK_ITERABLE_APPROX(get<tag>(boundary_variables_from_manager),
+                          get<tag>(expected_boundary_variables));
+  });
 
   // test writing news
   ActionTesting::MockRuntimeSystem<metavariables> runner{{l_max}};

--- a/tests/Unit/Evolution/Systems/Cce/Test_BoundaryData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_BoundaryData.cpp
@@ -12,6 +12,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Evolution/Systems/Cce/BoundaryData.hpp"
+#include "Evolution/Systems/Cce/Tags.hpp"
 #include "Framework/CheckWithRandomValues.hpp"
 #include "Framework/SetupLocalPythonEnvironment.hpp"
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
@@ -22,6 +23,7 @@
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/Pi.hpp"
 #include "PointwiseFunctions/GeneralRelativity/SpacetimeMetric.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
 
 namespace Cce {
 namespace {
@@ -614,19 +616,24 @@ void test_kerr_schild_boundary_consistency(
           .epsilon(std::numeric_limits<double>::epsilon() * 1.0e5)
           .scale(1.0);
 
-  tmpl::for_each<
-      Tags::characteristic_worldtube_boundary_tags<Tags::BoundaryValue>>(
-      [&](auto tag_v) {
-        using tag = typename decltype(tag_v)::type;
-        INFO(db::tag_name<tag>());
-        const auto& test_nodal = get<tag>(modal_boundary_variables);
-        const auto& test_gh = get<tag>(gh_boundary_variables);
-        const auto& test_modal = get<tag>(modal_boundary_variables);
-        CHECK_ITERABLE_CUSTOM_APPROX(test_nodal, test_gh,
-                                     angular_derivative_approx);
-        CHECK_ITERABLE_CUSTOM_APPROX(test_nodal, test_modal,
-                                     angular_derivative_approx);
-      });
+  // `Du<Dr<BondiJ>>` is not populated by these single-time analytic worldtube
+  // computations (it is computed in `BondiWorldtubeDataManager` by
+  // time-differentiating buffered `Dr<BondiJ>`), so it stays NaN-initialized
+  // here; exclude it from the comparison.
+  using tags_to_compare = tmpl::list_difference<
+      Tags::characteristic_worldtube_boundary_tags<Tags::BoundaryValue>,
+      tmpl::list<Tags::BoundaryValue<Tags::Du<Tags::Dr<Tags::BondiJ>>>>>;
+  tmpl::for_each<tags_to_compare>([&](auto tag_v) {
+    using tag = typename decltype(tag_v)::type;
+    INFO(db::tag_name<tag>());
+    const auto& test_nodal = get<tag>(modal_boundary_variables);
+    const auto& test_gh = get<tag>(gh_boundary_variables);
+    const auto& test_modal = get<tag>(modal_boundary_variables);
+    CHECK_ITERABLE_CUSTOM_APPROX(test_nodal, test_gh,
+                                 angular_derivative_approx);
+    CHECK_ITERABLE_CUSTOM_APPROX(test_nodal, test_modal,
+                                 angular_derivative_approx);
+  });
 }
 
 // this tests that both execution pathways in Schwarzschild produce the expected
@@ -678,23 +685,27 @@ void test_schwarzschild_solution(const gsl::not_null<Generator*> gen) {
           .epsilon(std::numeric_limits<double>::epsilon() * 1.0e4)
           .scale(1.0);
 
-  tmpl::for_each<
-      Tags::characteristic_worldtube_boundary_tags<Tags::BoundaryValue>>(
-      [&](auto tag_v) {
-        using tag = typename decltype(tag_v)::type;
-        INFO(db::tag_name<tag>());
-        const auto& expected = get<tag>(expected_variables);
-        const auto& test_nodal = get<tag>(nodal_boundary_variables);
-        const auto& test_gh = get<tag>(gh_boundary_variables);
-        const auto& test_modal = get<tag>(modal_boundary_variables);
+  // `Du<Dr<BondiJ>>` is not populated by these single-time analytic worldtube
+  // computations (it is computed in `BondiWorldtubeDataManager` by
+  // time-differentiating buffered `Dr<BondiJ>`), so it stays NaN-initialized
+  // here; exclude it from the comparison.
+  using tags_to_compare = tmpl::list_difference<
+      Tags::characteristic_worldtube_boundary_tags<Tags::BoundaryValue>,
+      tmpl::list<Tags::BoundaryValue<Tags::Du<Tags::Dr<Tags::BondiJ>>>>>;
+  tmpl::for_each<tags_to_compare>([&](auto tag_v) {
+    using tag = typename decltype(tag_v)::type;
+    INFO(db::tag_name<tag>());
+    const auto& expected = get<tag>(expected_variables);
+    const auto& test_nodal = get<tag>(nodal_boundary_variables);
+    const auto& test_gh = get<tag>(gh_boundary_variables);
+    const auto& test_modal = get<tag>(modal_boundary_variables);
 
-        CHECK_ITERABLE_CUSTOM_APPROX(expected, test_nodal,
-                                     angular_derivative_approx);
-        CHECK_ITERABLE_CUSTOM_APPROX(expected, test_gh,
-                                     angular_derivative_approx);
-        CHECK_ITERABLE_CUSTOM_APPROX(expected, test_modal,
-                                     angular_derivative_approx);
-      });
+    CHECK_ITERABLE_CUSTOM_APPROX(expected, test_nodal,
+                                 angular_derivative_approx);
+    CHECK_ITERABLE_CUSTOM_APPROX(expected, test_gh, angular_derivative_approx);
+    CHECK_ITERABLE_CUSTOM_APPROX(expected, test_modal,
+                                 angular_derivative_approx);
+  });
 }
 }  // namespace
 

--- a/tests/Unit/Evolution/Systems/Cce/Test_WorldtubeData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_WorldtubeData.cpp
@@ -411,16 +411,185 @@ class BondiBufferUpdater
   size_t l_max_ = 0;
 };
 
+// Fake buffer updater that fills only two Goldberg modes with simple
+// polynomial-in-time signals:
+//   * `R` lives entirely in the (l=0, m=0) mode and is constant in time.
+//   * `Dr<BondiJ>` lives entirely in the (l=2, m=0) mode and is linear in time
+//     (no constant offset). Linear-in-time means
+//        Dr<BondiJ>(t, theta, phi)
+//          = (t / target_time) * Dr<BondiJ>(target_time, theta, phi),
+//     so the time derivative of `dy_j = 0.5 R Dr<BondiJ>` at any target time
+//     is exactly `0.5 R Dr<BondiJ>(target_time) / target_time` at every
+//     angular collocation point. This lets the test compare the data
+//     manager's `Du<Dy<BondiJ>>` directly against
+//     `0.5 R Dr<BondiJ> / target_time` read off the boundary variables.
+// All other writing tags are zero. `BondiR` is set to a positive constant so
+// the existing post-processing in `BondiWorldtubeDataManager::populate...`
+// does not divide by zero.
+class SimplePolyBondiBufferUpdater
+    : public WorldtubeBufferUpdater<Tags::worldtube_boundary_tags_for_writing<
+          Spectral::Swsh::Tags::SwshTransform>> {
+ public:
+  using tags_for_writing = Tags::worldtube_boundary_tags_for_writing<
+      Spectral::Swsh::Tags::SwshTransform>;
+
+  SimplePolyBondiBufferUpdater() = default;
+  SimplePolyBondiBufferUpdater(DataVector time_buffer, const size_t l_max,
+                               const double r_amplitude,
+                               const double dr_j_slope,
+                               const double extraction_radius)
+      : time_buffer_{std::move(time_buffer)},
+        l_max_{l_max},
+        r_amplitude_{r_amplitude},
+        dr_j_slope_{dr_j_slope},
+        extraction_radius_{extraction_radius} {}
+
+  // NOLINTNEXTLINE
+  WRAPPED_PUPable_decl_base_template(WorldtubeBufferUpdater<tags_for_writing>,
+                                     SimplePolyBondiBufferUpdater);
+
+  explicit SimplePolyBondiBufferUpdater(CkMigrateMessage* /*unused*/) {}
+
+  double update_buffers_for_time(
+      const gsl::not_null<Variables<tags_for_writing>*> buffers,
+      const gsl::not_null<size_t*> time_span_start,
+      const gsl::not_null<size_t*> time_span_end, const double time,
+      const size_t /*computation_l_max*/, const size_t interpolator_length,
+      const size_t buffer_depth,
+      const bool /*time_varies_fastest*/ = true) const override {
+    if (*time_span_end > interpolator_length and
+        time_buffer_[*time_span_end - interpolator_length + 1] > time) {
+      return time_buffer_[*time_span_end - interpolator_length + 1];
+    }
+    const auto new_span = detail::create_span_for_time_value(
+        time, buffer_depth, interpolator_length, 0, time_buffer_.size(),
+        time_buffer_);
+    *time_span_start = new_span.first;
+    *time_span_end = new_span.second;
+    const size_t span_size = *time_span_end - *time_span_start;
+
+    tmpl::for_each<tags_for_writing>([&buffers](auto tag_v) {
+      using tag = typename decltype(tag_v)::type;
+      get(get<tag>(*buffers)).data() = std::complex<double>{0.0, 0.0};
+    });
+
+    auto& r_buffer =
+        get(get<Spectral::Swsh::Tags::SwshTransform<Tags::BondiR>>(*buffers))
+            .data();
+    const size_t r_mode_index =
+        Spectral::Swsh::goldberg_mode_index(l_max_, 0_st, 0);
+    for (size_t ti = 0; ti < span_size; ++ti) {
+      r_buffer[(r_mode_index * span_size) + ti] =
+          std::complex<double>{r_amplitude_, 0.0};
+    }
+
+    auto& dr_j_buffer =
+        get(get<Spectral::Swsh::Tags::SwshTransform<Tags::Dr<Tags::BondiJ>>>(
+                *buffers))
+            .data();
+    const size_t dr_j_mode_index =
+        Spectral::Swsh::goldberg_mode_index(l_max_, 2_st, 0);
+    for (size_t ti = 0; ti < span_size; ++ti) {
+      dr_j_buffer[(dr_j_mode_index * span_size) + ti] = std::complex<double>{
+          dr_j_slope_ * time_buffer_[(*time_span_start) + ti], 0.0};
+    }
+
+    return time_buffer_[std::min(*time_span_end - interpolator_length + 1,
+                                 time_buffer_.size() - 1)];
+  }
+
+  std::unique_ptr<WorldtubeBufferUpdater<tags_for_writing>> get_clone()
+      const override {
+    return std::make_unique<SimplePolyBondiBufferUpdater>(*this);
+  }
+
+  bool time_is_outside_range(const double time) const override {
+    return time < time_buffer_[0] or
+           time > time_buffer_[time_buffer_.size() - 1];
+  }
+
+  size_t get_l_max() const override { return l_max_; }
+
+  double get_extraction_radius() const override { return extraction_radius_; }
+
+  DataVector& get_time_buffer() override { return time_buffer_; }
+
+  bool has_version_history() const override { return true; }
+
+  void pup(PUP::er& p) override {
+    p | time_buffer_;
+    p | l_max_;
+    p | r_amplitude_;
+    p | dr_j_slope_;
+    p | extraction_radius_;
+  }
+
+ private:
+  DataVector time_buffer_;
+  size_t l_max_ = 0;
+  double r_amplitude_ = 0.0;
+  double dr_j_slope_ = 0.0;
+  double extraction_radius_ = 100.0;
+};
+
 template <typename T>
 PUP::able::PUP_ID Cce::DummyBufferUpdater<T>::my_PUP_ID = 0;  // NOLINT
 template <typename T>
-PUP::able::PUP_ID Cce::BondiBufferUpdater<T>::my_PUP_ID = 0;  // NOLINT
+PUP::able::PUP_ID Cce::BondiBufferUpdater<T>::my_PUP_ID = 0;         // NOLINT
+PUP::able::PUP_ID Cce::SimplePolyBondiBufferUpdater::my_PUP_ID = 0;  // NOLINT
 
 template class Cce::DummyBufferUpdater<ComplexModalVector>;
 template class Cce::DummyBufferUpdater<DataVector>;
 template class Cce::BondiBufferUpdater<ComplexModalVector>;
 
 namespace {
+
+void test_bondi_data_manager_du_dr_j() {
+  INFO("BondiWorldtubeDataManager::populate_boundary_du_dr_j");
+  const size_t l_max = 8;
+  const size_t buffer_size = 4;
+  const double r_amplitude = 100.0;
+  const double dr_j_slope = 0.25;
+  const double extraction_radius = 100.0;
+
+  DataVector time_buffer{30};
+  for (size_t i = 0; i < time_buffer.size(); ++i) {
+    time_buffer[i] = 1.0 + 0.1 * static_cast<double>(i);
+  }
+  const double target_time = 1.5 + 1.0e-3;
+
+  const BondiWorldtubeDataManager data_manager{
+      std::make_unique<SimplePolyBondiBufferUpdater>(
+          time_buffer, l_max, r_amplitude, dr_j_slope, extraction_radius),
+      l_max, buffer_size,
+      std::make_unique<intrp::BarycentricRationalSpanInterpolator>(3u, 4u)};
+
+  Variables<Tags::characteristic_worldtube_boundary_tags<Tags::BoundaryValue>>
+      boundary_variables{
+          Spectral::Swsh::number_of_swsh_collocation_points(l_max)};
+  Parallel::NodeLock hdf5_lock{};
+  data_manager.populate_hypersurface_boundary_data(
+      make_not_null(&boundary_variables), target_time,
+      make_not_null(&hdf5_lock));
+
+  // With Dr<BondiJ>(t) = (t / target_time) * Dr<BondiJ>(target_time), the
+  // analytic time derivative of Dr<BondiJ> at the target time is exactly
+  // Dr<BondiJ>(target_time) / target_time at every angular collocation point.
+  const auto& dr_bondi_j =
+      get(get<Tags::BoundaryValue<Tags::Dr<Tags::BondiJ>>>(boundary_variables))
+          .data();
+  const ComplexDataVector expected_du_dr_j = dr_bondi_j / target_time;
+  const auto& computed_du_dr_j =
+      get(get<Tags::BoundaryValue<Tags::Du<Tags::Dr<Tags::BondiJ>>>>(
+              boundary_variables))
+          .data();
+  const Approx interpolator_approx =
+      Approx::custom()
+          .epsilon(std::numeric_limits<double>::epsilon() * 1.0e5)
+          .scale(1.0);
+  CHECK_ITERABLE_CUSTOM_APPROX(computed_du_dr_j, expected_du_dr_j,
+                               interpolator_approx);
+}
 
 template <typename DataManager, typename DummyUpdater, typename Generator>
 void test_data_manager_with_bondi_buffer_updater(
@@ -532,17 +701,22 @@ void test_data_manager_with_bondi_buffer_updater(
           .epsilon(std::numeric_limits<double>::epsilon() * 1.0e4)
           .scale(1.0);
 
-  tmpl::for_each<
-      Tags::characteristic_worldtube_boundary_tags<Tags::BoundaryValue>>(
-      [&expected_boundary_variables, &interpolated_boundary_variables,
-       &angular_derivative_approx](auto tag_v) {
-        using tag = typename decltype(tag_v)::type;
-        INFO(db::tag_name<tag>());
-        const auto& test_lhs = get<tag>(expected_boundary_variables);
-        const auto& test_rhs = get<tag>(interpolated_boundary_variables);
-        CHECK_ITERABLE_CUSTOM_APPROX(test_lhs, test_rhs,
-                                     angular_derivative_approx);
-      });
+  // The expected variables are built from `create_bondi_boundary_data` at a
+  // single time, which does not populate `Du<Dr<BondiJ>>` (that boundary value
+  // is computed in `BondiWorldtubeDataManager` by time-differentiating the
+  // buffered `Dr<BondiJ>` and so has no single-time analogue here).
+  using tags_to_compare = tmpl::list_difference<
+      Tags::characteristic_worldtube_boundary_tags<Tags::BoundaryValue>,
+      tmpl::list<Tags::BoundaryValue<Tags::Du<Tags::Dr<Tags::BondiJ>>>>>;
+  tmpl::for_each<tags_to_compare>([&expected_boundary_variables,
+                                   &interpolated_boundary_variables,
+                                   &angular_derivative_approx](auto tag_v) {
+    using tag = typename decltype(tag_v)::type;
+    INFO(db::tag_name<tag>());
+    const auto& test_lhs = get<tag>(expected_boundary_variables);
+    const auto& test_rhs = get<tag>(interpolated_boundary_variables);
+    CHECK_ITERABLE_CUSTOM_APPROX(test_lhs, test_rhs, angular_derivative_approx);
+  });
 }
 
 template <typename T, typename Generator>
@@ -1020,6 +1194,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.ReadBoundaryDataH5",
     test_data_manager_with_bondi_buffer_updater<BondiWorldtubeDataManager,
                                                 BondiBufferUpdater>(
         make_not_null(&gen));
+    test_bondi_data_manager_du_dr_j();
   }
 }
 }  // namespace Cce


### PR DESCRIPTION
Adds `Tags::Du<Tags::Dr<Tags::BondiJ>>` to
`characteristic_worldtube_boundary_tags` (needed by `CauchySecondOrder`) and computes its boundary value.

`BondiWorldtubeDataManager` time-differentiates the buffered boundary `Dr<BondiJ>` over the current interpolation sub-window (using the new `SpanInterpolator::derivative`), holding the angular coordinate fixed (i.e. following the worldtube), to obtain `Du<Dr<BondiJ>>` at the target time. 

Note: The tag `Du<Dr<BondiJ>>` really refers to the numerical time derivative  at constant $`y = -1`$ $`\partial_{\breve u}\partial_r J|_{\Gamma} = \frac{d}{d u} \partial_r J (u, r = R(u))`$

`create_bondi_boundary_data` does not populate `Du<Dr<BondiJ>>`, so the boundary-comparison loops that build their "expected" Variables from it exclude that tag via `tmpl::list_difference` (with a comment explaining why): `Test_WorldtubeData`, `Test_AnalyticBoundaryDataManager`, and the H5 / KleinGordonH5 / Gh / Analytic `*BoundaryCommunication` tests.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
