### PR TITLE
Reduce CI disk usage by deleting Android SDK, etc. Re-enable code coverage

### DIFF
--- a/.github/workflows/Tests.yaml
+++ b/.github/workflows/Tests.yaml
@@ -535,6 +535,10 @@ jobs:
 
     container:
       image: ${{ inputs.container || 'sxscollaboration/spectre:dev' }}
+      volumes:
+        - /usr/local:/mnt/host-usr-local
+        - /usr/share:/mnt/host-usr-share
+        - /opt:/mnt/host-opt
       env:
         # We make sure to use a fixed absolute path for the ccache directory
         CCACHE_DIR: /work/ccache
@@ -565,6 +569,18 @@ jobs:
       # for why we need this
       options: --privileged
     steps:
+      - name: Free host disk space
+        run: |
+          df -h /
+          rm -rf /mnt/host-usr-local/lib/android \
+                 /mnt/host-usr-local/.ghcup \
+                 /mnt/host-usr-local/julia* \
+                 /mnt/host-opt/hostedtoolcache \
+                 /mnt/host-usr-share/dotnet \
+                 /mnt/host-usr-share/swift \
+                 /mnt/host-usr-share/miniconda \
+                 /mnt/host-opt/microsoft /mnt/host-opt/google || true
+          df -h /
       - name: Record start time
         id: start
         run: |


### PR DESCRIPTION
## Proposed changes

While GitHub only guarantees 14GB of space, it turns out the host has a whole bunch of features installed we don't use like Android SDK, Swift, dotnet, etc. And these are all outside the container so we can't use them anyway. Removing them gains us about 31GB of disk space. I'm doing doing this for the testing builds since the others don't use a lot of disk space anyway. This also lets us enable code coverage again. I tested what I easily could on my branch, but since we haven't had coverage on in a couple years there may be other things like secrets that need updating.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
