### PR TITLE
Add zero_highest_modes spectral filter

### DIFF
--- a/src/NumericalAlgorithms/Spectral/Filtering.cpp
+++ b/src/NumericalAlgorithms/Spectral/Filtering.cpp
@@ -90,7 +90,7 @@ struct ZeroLowestModesImpl {
     for (size_t i = num_modes_to_zero; i < num_points; ++i) {
       filter_matrix(i, i) = 1.0;
     }
-    return Matrix(modal_to_nodal * filter_matrix * nodal_to_modal);
+    return {modal_to_nodal * filter_matrix * nodal_to_modal};
   }
 };
 
@@ -111,6 +111,48 @@ struct ZernikeB1ZeroLowestModesImpl {
       filter_matrix(i, i) = 1.0;
     }
     return modal_to_nodal * filter_matrix * nodal_to_modal;
+  }
+};
+
+template <Spectral::Basis BasisType, Spectral::Quadrature QuadratureType>
+struct ZeroHighestModesImpl {
+  Matrix operator()(const size_t num_points,
+                    const size_t num_modes_to_zero) const {
+    const Matrix& nodal_to_modal =
+        Spectral::nodal_to_modal_matrix<BasisType, QuadratureType>(num_points);
+    const Matrix& modal_to_nodal =
+        Spectral::modal_to_nodal_matrix<BasisType, QuadratureType>(num_points);
+    Matrix filter_matrix(num_points, num_points, 0.0);
+    for (size_t i = 0; i + num_modes_to_zero < num_points; ++i) {
+      filter_matrix(i, i) = 1.0;
+    }
+    return {modal_to_nodal * filter_matrix * nodal_to_modal};
+  }
+};
+
+struct FourierZeroHighestModesImpl {
+  Matrix operator()(const size_t num_points,
+                    const size_t num_modes_to_zero) const {
+    const Matrix& nodal_to_modal =
+        Spectral::nodal_to_modal_matrix<Spectral::Basis::Fourier,
+                                        Spectral::Quadrature::Equiangular>(
+            num_points);
+    const Matrix& modal_to_nodal =
+        Spectral::modal_to_nodal_matrix<Spectral::Basis::Fourier,
+                                        Spectral::Quadrature::Equiangular>(
+            num_points);
+    Matrix filter_matrix(num_points, num_points, 0.0);
+    // The constant (m = 0) mode is always retained.
+    filter_matrix(0, 0) = 1.0;
+    // Maximum mode
+    const size_t M = num_points / 2;
+    for (size_t i = 1; i < num_points; i += 2) {
+      const size_t m = (i + 1) / 2;
+      const double weight = (m + num_modes_to_zero <= M) ? 1.0 : 0.0;
+      filter_matrix(i, i) = weight;
+      filter_matrix(i + 1, i + 1) = weight;
+    }
+    return {modal_to_nodal * filter_matrix * nodal_to_modal};
   }
 };
 }  // namespace
@@ -215,6 +257,109 @@ const Matrix& zero_lowest_modes(const Mesh<1>& mesh,
         }
         default:
           ERROR("Unsupported quadrature type in filtering lowest modes: "
+                << mesh.quadrature(0));
+      };
+    default:
+      ERROR("Cannot filter basis type: " << mesh.basis(0));
+  };
+}
+
+const Matrix& zero_highest_modes(const Mesh<1>& mesh,
+                                 const size_t number_of_modes_to_zero) {
+  switch (mesh.basis(0)) {
+    case Basis::Legendre:
+      ASSERT(number_of_modes_to_zero < mesh.extents(0),
+             "For a 1d mesh with " << mesh.extents(0)
+                                   << " grid points, you cannot zero "
+                                   << number_of_modes_to_zero << " modes.");
+      switch (mesh.quadrature(0)) {
+        case Spectral::Quadrature::GaussLobatto: {
+          constexpr size_t max_num_points =
+              Spectral::maximum_number_of_points<Spectral::Basis::Legendre>;
+          constexpr size_t min_num_points = Spectral::minimum_number_of_points<
+              Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto>;
+          const auto cache =
+              make_static_cache<CacheRange<min_num_points, max_num_points + 1>,
+                                CacheRange<0_st, max_num_points>>(
+                  ZeroHighestModesImpl<Spectral::Basis::Legendre,
+                                       Spectral::Quadrature::GaussLobatto>{});
+          return cache(mesh.number_of_grid_points(), number_of_modes_to_zero);
+        }
+        case Spectral::Quadrature::Gauss: {
+          constexpr size_t max_num_points =
+              Spectral::maximum_number_of_points<Spectral::Basis::Legendre>;
+          constexpr size_t min_num_points =
+              Spectral::minimum_number_of_points<Spectral::Basis::Legendre,
+                                                 Spectral::Quadrature::Gauss>;
+          const auto cache =
+              make_static_cache<CacheRange<min_num_points, max_num_points + 1>,
+                                CacheRange<0_st, max_num_points>>(
+                  ZeroHighestModesImpl<Spectral::Basis::Legendre,
+                                       Spectral::Quadrature::Gauss>{});
+          return cache(mesh.number_of_grid_points(), number_of_modes_to_zero);
+        }
+        default:
+          ERROR("Unsupported quadrature type in filtering highest modes: "
+                << mesh.quadrature(0));
+      };
+    case Basis::Chebyshev:
+      ASSERT(number_of_modes_to_zero < mesh.extents(0),
+             "For a 1d mesh with " << mesh.extents(0)
+                                   << " grid points, you cannot zero "
+                                   << number_of_modes_to_zero << " modes.");
+      switch (mesh.quadrature(0)) {
+        case Spectral::Quadrature::GaussLobatto: {
+          constexpr size_t max_num_points =
+              Spectral::maximum_number_of_points<Spectral::Basis::Chebyshev>;
+          constexpr size_t min_num_points = Spectral::minimum_number_of_points<
+              Spectral::Basis::Chebyshev, Spectral::Quadrature::GaussLobatto>;
+          const auto cache =
+              make_static_cache<CacheRange<min_num_points, max_num_points + 1>,
+                                CacheRange<0_st, max_num_points>>(
+                  ZeroHighestModesImpl<Spectral::Basis::Chebyshev,
+                                       Spectral::Quadrature::GaussLobatto>{});
+          return cache(mesh.number_of_grid_points(), number_of_modes_to_zero);
+        }
+        case Spectral::Quadrature::Gauss: {
+          constexpr size_t max_num_points =
+              Spectral::maximum_number_of_points<Spectral::Basis::Chebyshev>;
+          constexpr size_t min_num_points =
+              Spectral::minimum_number_of_points<Spectral::Basis::Chebyshev,
+                                                 Spectral::Quadrature::Gauss>;
+          const auto cache =
+              make_static_cache<CacheRange<min_num_points, max_num_points + 1>,
+                                CacheRange<0_st, max_num_points>>(
+                  ZeroHighestModesImpl<Spectral::Basis::Chebyshev,
+                                       Spectral::Quadrature::Gauss>{});
+          return cache(mesh.number_of_grid_points(), number_of_modes_to_zero);
+        }
+        default:
+          ERROR("Unsupported quadrature type in filtering highest modes: "
+                << mesh.quadrature(0));
+      };
+    case Basis::Fourier:
+      switch (mesh.quadrature(0)) {
+        case Spectral::Quadrature::Equiangular: {
+          ASSERT(mesh.number_of_grid_points() % 2 == 1,
+                 "The Fourier basis is required to have an odd number of grid "
+                 "points for stability, got "
+                     << mesh.number_of_grid_points());
+          ASSERT(number_of_modes_to_zero <= mesh.number_of_grid_points() / 2,
+                 "For a Fourier mesh with "
+                     << mesh.number_of_grid_points() << " grid points ("
+                     << mesh.number_of_grid_points() / 2
+                     << " m-modes), you cannot zero " << number_of_modes_to_zero
+                     << " modes.");
+          constexpr size_t max_num_points =
+              Spectral::maximum_number_of_points<Spectral::Basis::Fourier>;
+          const auto cache =
+              make_static_cache<CacheRange<1_st, max_num_points + 1>,
+                                CacheRange<0_st, max_num_points / 2 + 1>>(
+                  FourierZeroHighestModesImpl{});
+          return cache(mesh.number_of_grid_points(), number_of_modes_to_zero);
+        }
+        default:
+          ERROR("Unsupported quadrature type in filtering highest modes: "
                 << mesh.quadrature(0));
       };
     default:

--- a/src/NumericalAlgorithms/Spectral/Filtering.hpp
+++ b/src/NumericalAlgorithms/Spectral/Filtering.hpp
@@ -79,5 +79,39 @@ Matrix exponential_filter(const Mesh<1>& mesh, double alpha,
 const Matrix& zero_lowest_modes(
     const Mesh<1>& mesh, size_t number_of_modes_to_zero,
     Spectral::Parity parity = Spectral::Parity::Uninitialized);
+
+/*!
+ * \brief Zeros the highest `number_of_modes_to_zero` modal coefficients. Note
+ * that the matrix must be applied to a nodal representation.
+ *
+ * Given a function \f$u\f$
+ *
+ * \f{align}{
+ *   u(x)=\sum_{i=0}^N c_i P_i(x),
+ * \f}
+ *
+ * where \f$c_i\f$ are the modal coefficients and \f$P_i(x)\f$ is the basis
+ * (e.g. Legendre polynomials), the filter matrix will take the *nodal*
+ * representation of \f$u\f$ and zero out the highest `number_of_modes_to_zero`
+ * modal coefficients. That is, after the filter is applied \f$u\to\bar{u}\f$ is
+ *
+ * \f{align}{
+ *   \bar{u}(x)=\sum_{i=0}^{N-k} c_i P_i(x),
+ * \f}
+ *
+ * where \f$k\f$ is the number of modes set to zero. The output \f$\bar{u}\f$ is
+ * also in the *nodal* representation. The constant (\f$i=0\f$) mode is never
+ * removed for any basis.
+ *
+ * For the Fourier basis the "modes" are the \f$m\f$-modes: the highest
+ * `number_of_modes_to_zero` \f$m\f$-modes are zeroed, with both the \f$\cos\f$
+ * and \f$\sin\f$ contributions to a given \f$m\f$-mode treated identically.
+ *
+ * \note Only the Legendre, Chebyshev, and Fourier bases are supported. Unlike
+ * `zero_lowest_modes`, there is no parity argument and the ZernikeB1 basis is
+ * not supported.
+ */
+const Matrix& zero_highest_modes(const Mesh<1>& mesh,
+                                 size_t number_of_modes_to_zero);
 }  // namespace filtering
 }  // namespace Spectral

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_Filtering.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_Filtering.cpp
@@ -38,7 +38,7 @@ void test_exponential_filter(const double alpha, const unsigned half_power,
     const Mesh<1> mesh{num_pts, BasisType, QuadratureType};
     ModalVector initial_modal_coeffs(num_pts);
     for (size_t i = 0; i < num_pts; ++i) {
-      initial_modal_coeffs = i + 1.0;
+      initial_modal_coeffs[i] = static_cast<double>(i) + 1.0;
     }
     const DataVector initial_nodal_coeffs =
         to_nodal_coefficients(initial_modal_coeffs, mesh);
@@ -160,7 +160,7 @@ void test_zero_lowest_modes() {
       const Mesh<1> mesh{num_pts, BasisType, QuadratureType};
       ModalVector initial_modal_coeffs(num_pts);
       for (size_t i = 0; i < num_pts; ++i) {
-        initial_modal_coeffs = i + 1.0;
+        initial_modal_coeffs[i] = static_cast<double>(i) + 1.0;
       }
       const DataVector initial_nodal_coeffs =
           to_nodal_coefficients(initial_modal_coeffs, mesh);
@@ -238,5 +238,129 @@ SPECTRE_TEST_CASE("Unit.Numerical.Spectral.ZeroLowestModesFilter",
   test_zero_lowest_modes<Spectral::Basis::Chebyshev,
                          Spectral::Quadrature::Gauss>();
   test_zero_lowest_modes_zernike_b1();
+}
+
+template <Spectral::Basis BasisType, Spectral::Quadrature QuadratureType>
+void test_zero_highest_modes() {
+  CAPTURE(BasisType);
+  CAPTURE(QuadratureType);
+  for (size_t num_pts =
+           Spectral::minimum_number_of_points<BasisType, QuadratureType>;
+       num_pts <= Spectral::maximum_number_of_points<BasisType>; ++num_pts) {
+    CAPTURE(num_pts);
+    // Zeroing modes is a round trip through the modal<->nodal transforms, so
+    // the retained modes are reproduced and the dropped modes vanish to
+    // roundoff. The roundoff accumulates with the number of points (chained
+    // transforms) and scales with the data magnitude, whose largest modal
+    // coefficient is `num_pts`.
+    const Approx local_approx =
+        Approx::custom().epsilon(1.0e-13).scale(static_cast<double>(num_pts));
+    for (size_t number_of_modes_to_filter = 0;
+         number_of_modes_to_filter < num_pts; ++number_of_modes_to_filter) {
+      CAPTURE(number_of_modes_to_filter);
+      const Mesh<1> mesh{num_pts, BasisType, QuadratureType};
+      ModalVector initial_modal_coeffs(num_pts);
+      for (size_t i = 0; i < num_pts; ++i) {
+        initial_modal_coeffs[i] = static_cast<double>(i) + 1.0;
+      }
+      const DataVector initial_nodal_coeffs =
+          to_nodal_coefficients(initial_modal_coeffs, mesh);
+      DataVector filtered_nodal_coeffs(num_pts);
+      const Matrix& filter_matrix = Spectral::filtering::zero_highest_modes(
+          mesh, number_of_modes_to_filter);
+      dgemv_('N', num_pts, num_pts, 1., filter_matrix.data(),
+             filter_matrix.spacing(), initial_nodal_coeffs.data(), 1, 0.0,
+             filtered_nodal_coeffs.data(), 1);
+      const ModalVector filtered_modal_coeffs =
+          to_modal_coefficients(filtered_nodal_coeffs, mesh);
+      for (size_t i = 0; i < num_pts; ++i) {
+        CAPTURE(i);
+        if (i + number_of_modes_to_filter >= num_pts) {
+          CHECK(filtered_modal_coeffs[i] == local_approx(0.0));
+        } else {
+          CHECK(local_approx(filtered_modal_coeffs[i]) ==
+                initial_modal_coeffs[i]);
+        }
+      }
+    }
+  }
+}
+
+void test_fourier_zero_highest_modes() {
+  Approx local_approx = approx;
+  local_approx.scale(1.0);
+  const std::vector<size_t> num_pts_list{1, 3, 5, 15};
+  for (const size_t num_pts : num_pts_list) {
+    CAPTURE(num_pts);
+    const Mesh<1> mesh{num_pts, Spectral::Basis::Fourier,
+                       Spectral::Quadrature::Equiangular};
+    const DataVector& x = Spectral::collocation_points<
+        Spectral::Basis::Fourier, Spectral::Quadrature::Equiangular>(num_pts);
+    const size_t M = (num_pts - 1) / 2;
+    for (size_t number_of_modes_to_filter = 0; number_of_modes_to_filter <= M;
+         ++number_of_modes_to_filter) {
+      CAPTURE(number_of_modes_to_filter);
+      const Matrix& filter = Spectral::filtering::zero_highest_modes(
+          mesh, number_of_modes_to_filter);
+      // The constant mode is always retained.
+      const DataVector constant_vals(num_pts, 1.0);
+      DataVector filtered_constant(num_pts, 0.0);
+      dgemv_('N', num_pts, num_pts, 1., filter.data(), filter.spacing(),
+             constant_vals.data(), 1, 0.0, filtered_constant.data(), 1);
+      CHECK_ITERABLE_CUSTOM_APPROX(filtered_constant, constant_vals,
+                                   local_approx);
+      for (size_t m = 1; m <= M; ++m) {
+        CAPTURE(m);
+        const DataVector cos_vals = cos(static_cast<double>(m) * x);
+        const DataVector sin_vals = sin(static_cast<double>(m) * x);
+        DataVector filtered_cos(num_pts, 0.0);
+        DataVector filtered_sin(num_pts, 0.0);
+        dgemv_('N', num_pts, num_pts, 1., filter.data(), filter.spacing(),
+               cos_vals.data(), 1, 0.0, filtered_cos.data(), 1);
+        dgemv_('N', num_pts, num_pts, 1., filter.data(), filter.spacing(),
+               sin_vals.data(), 1, 0.0, filtered_sin.data(), 1);
+        // The top number_of_modes_to_filter m-modes are zeroed.
+        const bool keep = m + number_of_modes_to_filter <= M;
+        const DataVector expected_cos =
+            keep ? cos_vals : DataVector(num_pts, 0.0);
+        const DataVector expected_sin =
+            keep ? sin_vals : DataVector(num_pts, 0.0);
+        CHECK_ITERABLE_CUSTOM_APPROX(filtered_cos, expected_cos, local_approx);
+        CHECK_ITERABLE_CUSTOM_APPROX(filtered_sin, expected_sin, local_approx);
+      }
+    }
+  }
+}
+
+SPECTRE_TEST_CASE("Unit.Numerical.Spectral.ZeroHighestModesFilter",
+                  "[NumericalAlgorithms][Spectral][Unit]") {
+  test_zero_highest_modes<Spectral::Basis::Legendre,
+                          Spectral::Quadrature::GaussLobatto>();
+  test_zero_highest_modes<Spectral::Basis::Legendre,
+                          Spectral::Quadrature::Gauss>();
+  test_zero_highest_modes<Spectral::Basis::Chebyshev,
+                          Spectral::Quadrature::GaussLobatto>();
+  test_zero_highest_modes<Spectral::Basis::Chebyshev,
+                          Spectral::Quadrature::Gauss>();
+  test_fourier_zero_highest_modes();
+#ifdef SPECTRE_DEBUG
+  CHECK_THROWS_WITH(
+      Spectral::filtering::zero_highest_modes(
+          Mesh<1>{4, Spectral::Basis::Fourier,
+                  Spectral::Quadrature::Equiangular},
+          1),
+      Catch::Matchers::ContainsSubstring("The Fourier basis is required to "
+                                         "have an odd number of grid points"));
+  CHECK_THROWS_WITH(Spectral::filtering::zero_highest_modes(
+                        Mesh<1>{5, Spectral::Basis::Fourier,
+                                Spectral::Quadrature::Equiangular},
+                        3),
+                    Catch::Matchers::ContainsSubstring("you cannot zero"));
+  CHECK_THROWS_WITH(Spectral::filtering::zero_highest_modes(
+                        Mesh<1>{4, Spectral::Basis::Legendre,
+                                Spectral::Quadrature::GaussLobatto},
+                        4),
+                    Catch::Matchers::ContainsSubstring("you cannot zero"));
+#endif  // SPECTRE_DEBUG
 }
 }  // namespace


### PR DESCRIPTION
## Proposed changes

Zeros the highest modal coefficients of a nodal field for the Legendre, Chebyshev, and Fourier bases. For Fourier, the highest m-modes are zeroed and the constant mode is always retained.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
