### PR TITLE
Add option for number of shells in distorted frame

### DIFF
--- a/src/Domain/Creators/Sphere.cpp
+++ b/src/Domain/Creators/Sphere.cpp
@@ -320,26 +320,23 @@ Domain<3> Sphere::create_domain() const {
             fill_interior_ and (block_id == num_blocks_ - 1);
         // Correct for 'which_wedges' option
         const size_t shell = block_id / num_blocks_per_shell_;
-        const size_t block_number = shell * 6 +
-                                    which_wedge_index(which_wedges_) +
-                                    block_id % num_blocks_per_shell_;
+        const size_t shape_map_index =
+            which_wedge_index(which_wedges_) + block_id % num_blocks_per_shell_;
         block_maps_grid_to_distorted[block_id] =
-            hard_coded_options.grid_to_distorted_map(
-                block_number, is_inner_cube, num_blocks_per_shell_);
+            hard_coded_options.grid_to_distorted_map(shell, shape_map_index,
+                                                     is_inner_cube);
         block_maps_distorted_to_inertial[block_id] =
-            hard_coded_options.distorted_to_inertial_map(
-                block_number, is_inner_cube, num_blocks_per_shell_);
+            hard_coded_options.distorted_to_inertial_map(shell, is_inner_cube);
         block_maps_grid_to_inertial[block_id] =
             hard_coded_options.grid_to_inertial_map(
-                block_number, is_outer_shell, is_inner_cube,
-                num_blocks_per_shell_);
+                shell, shape_map_index, is_outer_shell, is_inner_cube);
       }
 
       // Inject time dependent map into the excision
       if (not fill_interior_ and which_wedges_ == ShellWedges::All) {
         domain.inject_time_dependent_map_for_excision_sphere(
-            "ExcisionSphere", hard_coded_options.grid_to_inertial_map(
-                                  0, false, true, num_blocks_per_shell_));
+            "ExcisionSphere",
+            hard_coded_options.grid_to_inertial_map(0, 0, false, true));
       }
     } else {
       const auto& time_dependence = std::get<std::unique_ptr<

--- a/src/Domain/Creators/Sphere.hpp
+++ b/src/Domain/Creators/Sphere.hpp
@@ -157,16 +157,19 @@ namespace domain::creators {
  * The Sphere domain creator also has the option to use some hard coded time
  * dependent maps that may be useful in certain scenarios. This method adds the
  * maps in `domain::creators::sphere::TimeDependentMapOptions` to the domain.
- * Currently, the first (inner-most) shell has maps between `Frame::Grid`,
- * `Frame::Distorted`, and `Frame::Inertial` while all subsequent shells only
- * have maps between `Frame::Grid` and `Frame::Inertial`.
- *
- * \note You can only use hard-coded time dependent maps if you have an excision
- * surface. You cannot have a inner cube.
+ * When a shape map is specified, an excised sphere uses it on the innermost
+ * radial shell by default. A filled sphere with multiple radial shells uses it
+ * on at least the two innermost shells: the first shell turns on the
+ * deformation away from the central cube, and the subsequent selected shells
+ * roll it off. At least one outer shell must remain without a shape map, so
+ * this filled configuration requires at least three radial shells. The
+ * `NumberOfRadialShellsWithShapeMap` option can be used to choose more inner
+ * shells. With only one radial shell, a filled sphere does not roll off the
+ * shape map, while an excised sphere rolls it off at the outer boundary.
  *
  * ##### None
- * To not have any time dependent maps, pass a `std::nullopt` to appropriate
- * argument in the constructor. In the input file, simple have
+ * To not have any time dependent maps, pass a `std::nullopt` to the appropriate
+ * argument in the constructor. In the input file, simply have
  * `TimeDependentMaps: None`.
  *
  */

--- a/src/Domain/Creators/SphericalShells.cpp
+++ b/src/Domain/Creators/SphericalShells.cpp
@@ -127,6 +127,11 @@ SphericalShells::SphericalShells(
         std::holds_alternative<sphere::TimeDependentMapOptions>(
             time_dependent_options_.value());
     if (use_hard_coded_maps_) {
+      if (not excise_center_) {
+        PARSE_ERROR(context,
+                    "Hard-coded time-dependent maps are not supported when the "
+                    "SphericalShells center is filled (InnerRadius is zero).");
+      }
       std::get<sphere::TimeDependentMapOptions>(time_dependent_options_.value())
           .build_maps(std::array{0.0, 0.0, 0.0}, false, inner_radius_,
                       radial_partitioning_, outer_radius_);
@@ -198,17 +203,17 @@ Domain<3> SphericalShells::create_domain() const {
       for (size_t block_id = 0; block_id < num_blocks_; block_id++) {
         const bool is_outer_shell = block_id == num_blocks_ - 1;
         block_maps_grid_to_distorted[block_id] =
-            hard_coded_options.grid_to_distorted_map(block_id, false, 1);
+            hard_coded_options.grid_to_distorted_map(block_id, 0, false);
         block_maps_distorted_to_inertial[block_id] =
-            hard_coded_options.distorted_to_inertial_map(block_id, false, 1);
+            hard_coded_options.distorted_to_inertial_map(block_id, false);
         block_maps_grid_to_inertial[block_id] =
-            hard_coded_options.grid_to_inertial_map(block_id, is_outer_shell,
-                                                    false, 1);
+            hard_coded_options.grid_to_inertial_map(block_id, 0, is_outer_shell,
+                                                    false);
       }
 
       domain.inject_time_dependent_map_for_excision_sphere(
           "ExcisionSphere",
-          hard_coded_options.grid_to_inertial_map(0, false, true, 1));
+          hard_coded_options.grid_to_inertial_map(0, 0, false, true));
     } else {
       const auto& time_dependence = std::get<std::unique_ptr<
           domain::creators::time_dependence::TimeDependence<3>>>(

--- a/src/Domain/Creators/SphericalShells.hpp
+++ b/src/Domain/Creators/SphericalShells.hpp
@@ -72,10 +72,14 @@ namespace domain::creators {
 /// The SphericalShells domain creator also has the option to use some hard
 /// coded time dependent maps that may be useful in certain scenarios. This
 /// method adds the maps in `domain::creators::sphere::TimeDependentMapOptions`
-/// to the domain. Currently, the first (inner-most) shell has maps between
-/// `Frame::Grid`, `Frame::Distorted`, and `Frame::Inertial` while all
-/// subsequent shells only have maps between `Frame::Grid` and
-/// `Frame::Inertial`.
+/// to the domain. Hard-coded time-dependent maps are currently supported only
+/// for excised domains, i.e. when `InnerRadius` is positive. When a shape map
+/// is specified, the innermost radial shell uses it by default, while
+/// subsequent shells have maps only between `Frame::Grid` and
+/// `Frame::Inertial`. The `NumberOfRadialShellsWithShapeMap` option can add
+/// distorted-frame maps to more inner shells. For domains with multiple radial
+/// shells, the final radial shell cannot use the shape map. With only one
+/// radial shell, the shape map rolls off at the outer boundary.
 ///
 /// ##### None
 /// To not have any time dependent maps, pass a `std::nullopt` as the

--- a/src/Domain/Creators/TimeDependentOptions/Sphere.cpp
+++ b/src/Domain/Creators/TimeDependentOptions/Sphere.cpp
@@ -35,13 +35,16 @@ TimeDependentMapOptions::TimeDependentMapOptions(
     RotationMapOptionType rotation_map_options,
     ExpansionMapOptionType expansion_map_options,
     TranslationMapOptionType translation_map_options,
-    const bool transition_rot_scale_trans)
+    const bool transition_rot_scale_trans,
+    std::optional<size_t> number_of_radial_shells_with_shape_map)
     : initial_time_(initial_time),
       shape_map_options_(std::move(shape_map_options)),
       rotation_map_options_(std::move(rotation_map_options)),
       expansion_map_options_(std::move(expansion_map_options)),
       translation_map_options_(std::move(translation_map_options)),
-      transition_rot_scale_trans_(transition_rot_scale_trans) {}
+      transition_rot_scale_trans_(transition_rot_scale_trans),
+      number_of_radial_shells_with_shape_map_(
+          std::move(number_of_radial_shells_with_shape_map)) {}
 
 std::unordered_map<std::string,
                    std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
@@ -108,6 +111,44 @@ void TimeDependentMapOptions::build_maps(
     const double outer_radius) {
   filled_ = filled;
   if (shape_map_options_.has_value()) {
+    const size_t number_of_radial_shells = radial_partitions.size() + 1;
+    number_of_radial_shells_with_shape_map_ =
+        number_of_radial_shells_with_shape_map_.value_or(
+            filled_ and not radial_partitions.empty() ? 2 : 1);
+    if (number_of_radial_shells_with_shape_map_.value() == 0) {
+      ERROR(
+          "The number of radial shells with a shape map must be at least one.");
+    }
+    if (filled_ and not radial_partitions.empty() and
+        number_of_radial_shells < 3) {
+      ERROR(
+          "A filled sphere with multiple radial shells and a shape map must "
+          "have at least three radial shells: at least two with the shape map "
+          "and an outer shell without it, but there are only "
+          << number_of_radial_shells << " radial shells.");
+    }
+    if (filled_ and not radial_partitions.empty() and
+        number_of_radial_shells_with_shape_map_.value() < 2) {
+      ERROR(
+          "At least two radial shells must have a shape map when the interior "
+          "is filled, but "
+          << number_of_radial_shells_with_shape_map_.value()
+          << " was requested.");
+    }
+    if (number_of_radial_shells_with_shape_map_.value() >
+            number_of_radial_shells or
+        (number_of_radial_shells_with_shape_map_.value() ==
+             number_of_radial_shells and
+         not radial_partitions.empty())) {
+      ERROR(
+          "The number of radial shells with a shape map must be smaller than "
+          "the total number of radial shells for domains with multiple radial "
+          "shells, but there are "
+          << number_of_radial_shells << " radial shells and "
+          << number_of_radial_shells_with_shape_map_.value()
+          << " were requested.");
+    }
+
     const double coefficient_truncation_limit =
         time_dependent_options::coefficient_truncation_limit_from_shape_options(
             shape_map_options_.value());
@@ -126,11 +167,14 @@ void TimeDependentMapOptions::build_maps(
       // Shape map transitions from 0 to 1 from the inner cube to this surface
       deformed_radius_ =
           radial_partitions.empty() ? outer_radius : radial_partitions.front();
-      // Shape map transitions from 1 to 0 from the deformed surface to the next
-      // radial partition or to the outer radius
+      // Shape map transitions from 1 to 0 from the deformed surface to the
+      // outer boundary of the last shell with a shape map.
       const bool has_shape_rolloff = not radial_partitions.empty();
       const double shape_outer_radius =
-          radial_partitions.size() > 1 ? radial_partitions[1] : outer_radius;
+          radial_partitions.empty()
+              ? outer_radius
+              : gsl::at(radial_partitions,
+                        number_of_radial_shells_with_shape_map_.value() - 1);
       // These must match the order of orientations_for_sphere_wrappings() in
       // DomainHelpers.hpp. The values must match that of Wedge::Axis
       const std::array<int, 6> axes{3, -3, 2, -2, 1, -1};
@@ -157,10 +201,13 @@ void TimeDependentMapOptions::build_maps(
       }
     } else {
       // Shape map transitions from 1 to 0 from the inner radius to the first
-      // radial partition or to the outer radius
+      // radial shell boundary outside the shape-map region
       deformed_radius_ = inner_radius;
       const double shape_outer_radius =
-          radial_partitions.empty() ? outer_radius : radial_partitions.front();
+          radial_partitions.empty()
+              ? outer_radius
+              : gsl::at(radial_partitions,
+                        number_of_radial_shells_with_shape_map_.value() - 1);
       transition_func =
           std::make_unique<domain::CoordinateMaps::ShapeMapTransitionFunctions::
                                SphereTransition>(inner_radius,
@@ -227,12 +274,10 @@ void TimeDependentMapOptions::build_maps(
 // in the Sphere domain creator as well as this class' documentation.
 TimeDependentMapOptions::MapType<Frame::Distorted, Frame::Inertial>
 TimeDependentMapOptions::distorted_to_inertial_map(
-    const size_t block_number, const bool is_inner_cube,
-    const size_t num_blocks_per_shell) const {
+    const size_t radial_shell, const bool is_inner_cube) const {
   const bool block_has_shape_map =
       shape_map_options_.has_value() and
-      block_number <
-          (filled_ ? 2 * num_blocks_per_shell : num_blocks_per_shell) and
+      radial_shell < number_of_radial_shells_with_shape_map_.value() and
       not is_inner_cube;
   if (block_has_shape_map) {
     return std::make_unique<DistortedToInertialComposition>(
@@ -243,22 +288,23 @@ TimeDependentMapOptions::distorted_to_inertial_map(
 }
 
 TimeDependentMapOptions::MapType<Frame::Grid, Frame::Distorted>
-TimeDependentMapOptions::grid_to_distorted_map(
-    const size_t block_number, const bool is_inner_cube,
-    const size_t num_blocks_per_shell) const {
+TimeDependentMapOptions::grid_to_distorted_map(const size_t radial_shell,
+                                               const size_t shape_map_index,
+                                               const bool is_inner_cube) const {
   const bool block_has_shape_map =
       shape_map_options_.has_value() and
-      block_number <
-          (filled_ ? 2 * num_blocks_per_shell : num_blocks_per_shell) and
+      radial_shell < number_of_radial_shells_with_shape_map_.value() and
       not is_inner_cube;
   if (block_has_shape_map) {
     // If the interior is not filled we use the SphereTransition function and
     // build only one shape map at index 0 (see `build_maps` above). Otherwise,
-    // we use the Wedge transition function and build a shape map for each
-    // direction, so we have to use the block number here to get the correct
-    // shape map.
-    return std::make_unique<GridToDistortedComposition>(
-        gsl::at(shape_maps_, filled_ ? block_number : 0));
+    // we use the Wedge transition function and build two sets of shape maps for
+    // the six canonical wedge directions: indices 0..5 deform the innermost
+    // shell and indices 6..11 roll off the deformation in outer shells.
+    return std::make_unique<GridToDistortedComposition>(gsl::at(
+        shape_maps_,
+        filled_ ? (radial_shell == 0 ? shape_map_index : 6 + shape_map_index)
+                : 0));
   } else {
     return nullptr;
   }
@@ -266,22 +312,22 @@ TimeDependentMapOptions::grid_to_distorted_map(
 
 TimeDependentMapOptions::MapType<Frame::Grid, Frame::Inertial>
 TimeDependentMapOptions::grid_to_inertial_map(
-    const size_t block_number, const bool is_outer_shell,
-    const bool is_central_region, const size_t num_blocks_per_shell) const {
+    const size_t radial_shell, const size_t shape_map_index,
+    const bool is_outer_shell, const bool is_central_region) const {
   const bool block_has_shape_map =
       shape_map_options_.has_value() and
-      block_number <
-          (filled_ ? 2 * num_blocks_per_shell : num_blocks_per_shell) and
+      radial_shell < number_of_radial_shells_with_shape_map_.value() and
       not(is_central_region and filled_);
   if (block_has_shape_map) {
     // If the interior is not filled we use the SphereTransition function and
     // build only one shape map at index 0 (see `build_maps` above). Otherwise,
-    // we use the Wedge transition function and build a shape map for each
-    // direction, so we have to use the block number here to get the correct
-    // shape map.
+    // we use the Wedge transition function and build two sets of shape maps for
+    // the six canonical wedge directions: indices 0..5 deform the innermost
+    // shell and indices 6..11 roll off the deformation in outer shells.
     return std::make_unique<GridToInertialComposition>(
-        gsl::at(shape_maps_,
-                filled_ ? block_number : (is_central_region ? 1 : 0)),
+        gsl::at(shape_maps_, filled_ ? (radial_shell == 0 ? shape_map_index
+                                                          : 6 + shape_map_index)
+                                     : (is_central_region ? 1 : 0)),
         inner_rot_scale_trans_map_);
   } else if (is_outer_shell and transition_rot_scale_trans_) {
     return std::make_unique<GridToInertialSimple>(

--- a/src/Domain/Creators/TimeDependentOptions/Sphere.hpp
+++ b/src/Domain/Creators/TimeDependentOptions/Sphere.hpp
@@ -104,21 +104,33 @@ struct TimeDependentMapOptions {
         "shell"};
   };
 
-  using options = tmpl::list<InitialTime, ShapeMapOptions, RotationMapOptions,
-                             ExpansionMapOptions, TranslationMapOptions,
-                             TransitionRotScaleTrans>;
+  struct NumberOfRadialShellsWithShapeMap {
+    using type = Options::Auto<size_t>;
+    static constexpr Options::String help = {
+        "Number of innermost radial shells that use the shape map. This must "
+        "be at least one. A filled Sphere with multiple radial shells requires "
+        "at least two shells with a shape map. For any domain with multiple "
+        "radial shells, at least one outer shell must remain without a shape "
+        "map. Specify 'Auto' to use the default for the domain."};
+  };
+
+  using options =
+      tmpl::list<InitialTime, ShapeMapOptions, RotationMapOptions,
+                 ExpansionMapOptions, TranslationMapOptions,
+                 TransitionRotScaleTrans, NumberOfRadialShellsWithShapeMap>;
   static constexpr Options::String help{
       "The options for all the hard-coded time dependent maps in the "
       "Sphere domain."};
 
   TimeDependentMapOptions() = default;
 
-  TimeDependentMapOptions(double initial_time,
-                          ShapeMapOptionType shape_map_options,
-                          RotationMapOptionType rotation_map_options,
-                          ExpansionMapOptionType expansion_map_options,
-                          TranslationMapOptionType translation_map_options,
-                          bool transition_rot_scale_trans);
+  TimeDependentMapOptions(
+      double initial_time, ShapeMapOptionType shape_map_options,
+      RotationMapOptionType rotation_map_options,
+      ExpansionMapOptionType expansion_map_options,
+      TranslationMapOptionType translation_map_options,
+      bool transition_rot_scale_trans,
+      std::optional<size_t> number_of_radial_shells_with_shape_map);
 
   /*!
    * \brief Create the function of time map using the options that were
@@ -160,10 +172,14 @@ struct TimeDependentMapOptions {
    *
    * For blocks with a shape map, this will be a RotScaleTrans map. For other
    * blocks, this returns `nullptr`.
+   *
+   * \param radial_shell Zero-based index specifying a shell in the `Sphere`
+   * or `SphericalShells` domain, starting at the innermost shell.
+   * \param is_inner_cube Whether the block is the central cube of a filled
+   * sphere.
    */
   MapType<Frame::Distorted, Frame::Inertial> distorted_to_inertial_map(
-      size_t block_number, bool is_inner_cube,
-      size_t num_blocks_per_shell) const;
+      size_t radial_shell, bool is_inner_cube) const;
 
   /*!
    * \brief This will construct the map from `Frame::Grid` to
@@ -171,10 +187,22 @@ struct TimeDependentMapOptions {
    *
    * For blocks with a shape map, this will return the `Shape` map (with a size
    * function of time). For other blocks, this returns `nullptr`.
+   *
+   * \param radial_shell Zero-based index specifying a shell in the `Sphere`
+   * or `SphericalShells` domain, starting at the innermost shell.
+   * \param shape_map_index Index of the wedge direction in the order returned
+   * by `orientations_for_sphere_wrappings`. This is only used for filled
+   * spheres. In that case, the implementation uses the Wedge transition
+   * function and builds two sets of shape maps for the six canonical wedge
+   * directions: indices 0..5 deform the innermost shell and indices 6..11 roll
+   * off the deformation in outer shells. If the sphere is not filled, then
+   * the implementation uses the SphereTransition function and builds only one
+   * shape map, leaving this option unused.
+   * \param is_inner_cube Whether the block is the central cube of a filled
+   * sphere.
    */
   MapType<Frame::Grid, Frame::Distorted> grid_to_distorted_map(
-      size_t block_number, bool is_inner_cube,
-      size_t num_blocks_per_shell) const;
+      size_t radial_shell, size_t shape_map_index, bool is_inner_cube) const;
 
   /*!
    * \brief This will construct the map from `Frame::Grid` to `Frame::Inertial`.
@@ -183,10 +211,24 @@ struct TimeDependentMapOptions {
    * `RotScaleTrans` composition. For other blocks, this returns just the
    * `RotScaleTrans` map. In the outer shell, the `RotScaleTrans` map will
    * transition to zero.
+   *
+   * \param radial_shell Zero-based index specifying a shell in the `Sphere`
+   * or `SphericalShells` domain, starting at the innermost shell.
+   * \param shape_map_index Index of the wedge direction in the order returned
+   * by `orientations_for_sphere_wrappings`. This is only used for filled
+   * spheres. In that case, the implementation uses the Wedge transition
+   * function and builds two sets of shape maps for the six canonical wedge
+   * directions: indices 0..5 deform the innermost shell and indices 6..11 roll
+   * off the deformation in outer shells. If the sphere is not filled, then
+   * the implementation uses the SphereTransition function and builds only one
+   * shape map, leaving this option unused.
+   * \param is_outer_shell Whether the block is in the outermost radial shell.
+   * \param is_central_region Whether the map is for the central cube of a
+   * filled sphere or the excision boundary of an excised sphere.
    */
   MapType<Frame::Grid, Frame::Inertial> grid_to_inertial_map(
-      size_t block_number, bool is_outer_shell, bool is_central_region,
-      size_t num_blocks_per_shell) const;
+      size_t radial_shell, size_t shape_map_index, bool is_outer_shell,
+      bool is_central_region) const;
 
   /*!
    * \brief Whether or not the distorted frame is being used. I.e. whether or
@@ -215,5 +257,6 @@ struct TimeDependentMapOptions {
   ExpansionMapOptionType expansion_map_options_;
   TranslationMapOptionType translation_map_options_;
   bool transition_rot_scale_trans_{false};
+  std::optional<size_t> number_of_radial_shells_with_shape_map_{};
 };
 }  // namespace domain::creators::sphere

--- a/src/Evolution/Ringdown/MinimumAhCExcisionRadius.cpp
+++ b/src/Evolution/Ringdown/MinimumAhCExcisionRadius.cpp
@@ -102,8 +102,7 @@ double minimum_ahc_excision_radius(
   const size_t obs_id_at_match_time =
       volume_data.find_observation_id(match_time, match_time_tol);
 
-  const auto serialized_inspiral_domain =
-      volume_data.get_domain();
+  const auto serialized_inspiral_domain = volume_data.get_domain();
   if (not serialized_inspiral_domain.has_value()) {
     ERROR("No domain found in volume files at the specified match time.");
   }
@@ -155,7 +154,8 @@ double minimum_ahc_excision_radius(
                                           rotation_map_options,
                                           expansion_map_options,
                                           translation_map_options,
-                                          true};
+                                          true,
+                                          std::nullopt};
 
   const double ahc_average_radius = ahc_inertial_at_match_time.average_radius();
   const std::array<double, 3> ahc_ringdown_center =

--- a/src/Evolution/Ringdown/StrahlkorperCoefsAndCenters.cpp
+++ b/src/Evolution/Ringdown/StrahlkorperCoefsAndCenters.cpp
@@ -44,8 +44,8 @@ std::vector<std::array<double, 4>> extract_rotation_func_and_2_derivs(
     const domain::FunctionsOfTimeMap& functions_of_time, const double time) {
   const auto function_of_time = functions_of_time.find("Rotation");
   if (function_of_time == functions_of_time.end()) {
-    ERROR("Rotation function of time could not be found at " << "time " << time
-                                                             << "M.");
+    ERROR("Rotation function of time could not be found at "
+          << "time " << time << "M.");
   }
   const auto values = function_of_time->second->func_and_2_derivs(time);
   std::vector<std::array<double, 4>> result(3);
@@ -182,7 +182,8 @@ strahlkorper_coefs_and_centers(
                                      rotation_map_options_from_volume,
                                      expansion_map_options_from_volume,
                                      translation_map_options_from_volume,
-                                     true};
+                                     true,
+                                     std::nullopt};
       // We construct a temporary ringdown domain that will be used to transform
       // the common horizon from the inspiral inertial frame to the temporary
       // frame (ringdown intermediate frame in SpEC) for shape coefficients and

--- a/support/Pipelines/Bbh/Ringdown.yaml
+++ b/support/Pipelines/Bbh/Ringdown.yaml
@@ -78,6 +78,7 @@ DomainCreator:
       TranslationMap:
         InitialValues: {{ Translation }}
       TransitionRotScaleTrans: True
+      NumberOfRadialShellsWithShapeMap: Auto
     OuterBoundaryCondition:
       ConstraintPreservingBjorhus:
         Type: ConstraintPreservingPhysical

--- a/tests/Unit/Domain/Creators/Test_Sphere.cpp
+++ b/tests/Unit/Domain/Creators/Test_Sphere.cpp
@@ -8,6 +8,7 @@
 #include <cstddef>
 #include <limits>
 #include <memory>
+#include <optional>
 #include <pup.h>
 #include <random>
 #include <string>
@@ -113,7 +114,9 @@ std::string option_string(
     const std::vector<CoordinateMaps::Distribution>& radial_distribution,
     const ShellWedges which_wedges, const bool time_dependent,
     const bool hard_coded_time_dependent_maps,
-    const bool with_boundary_conditions) {
+    const bool with_boundary_conditions,
+    const std::optional<std::string>& number_of_radial_shells_with_shape_map =
+        std::string{"Auto"}) {
   const std::string interior_option =
       [&interior, &with_boundary_conditions]() -> std::string {
     if (std::holds_alternative<creators::Sphere::Excision>(interior)) {
@@ -143,6 +146,11 @@ std::string option_string(
                 "    IndexPolarAxis: " +
                 std::to_string(equatorial_compression->index_polar_axis) + "\n"
           : "  EquatorialCompression: None\n";
+  const std::string number_of_radial_shells_with_shape_map_option =
+      number_of_radial_shells_with_shape_map.has_value()
+          ? "    NumberOfRadialShellsWithShapeMap: " +
+                number_of_radial_shells_with_shape_map.value() + "\n"
+          : "";
   const std::string time_dependent_option =
       time_dependent ? (hard_coded_time_dependent_maps
                             ? "  TimeDependentMaps:\n"
@@ -157,7 +165,8 @@ std::string option_string(
                               "    TranslationMap:\n"
                               "      InitialValues: [[0.0, 0.0, 0.0],"
                               " [0.001, -0.003, 0.005], [0.0, 0.0, 0.0]]\n"
-                              "    TransitionRotScaleTrans: False\n"
+                              "    TransitionRotScaleTrans: False\n" +
+                                  number_of_radial_shells_with_shape_map_option
                             : "  TimeDependentMaps:\n"
                               "    UniformTranslation:\n"
                               "      InitialTime: 1.0\n"
@@ -424,6 +433,15 @@ void test_parse_errors() {
   const std::vector<domain::CoordinateMaps::Distribution> radial_distribution{
       domain::CoordinateMaps::Distribution::Linear};
   const std::vector<domain::CoordinateMaps::Distribution>
+      radial_distribution_two_shells{
+          domain::CoordinateMaps::Distribution::Linear,
+          domain::CoordinateMaps::Distribution::Linear};
+  const std::vector<domain::CoordinateMaps::Distribution>
+      radial_distribution_three_shells{
+          domain::CoordinateMaps::Distribution::Linear,
+          domain::CoordinateMaps::Distribution::Linear,
+          domain::CoordinateMaps::Distribution::Linear};
+  const std::vector<domain::CoordinateMaps::Distribution>
       radial_distribution_too_many{
           domain::CoordinateMaps::Distribution::Linear,
           domain::CoordinateMaps::Distribution::Logarithmic};
@@ -504,6 +522,34 @@ void test_parse_errors() {
       Catch::Matchers::ContainsSubstring(
           "None boundary condition is not supported. If you would like "
           "an outflow-type boundary condition, you must use that."));
+
+  CHECK_THROWS_WITH(
+      creators::Sphere(
+          inner_radius, outer_radius, inner_cube, refinement, initial_extents,
+          use_equiangular_map, equatorial_compression, std::vector{1.3},
+          radial_distribution_two_shells, which_wedges,
+          creators::sphere::TimeDependentMapOptions{
+              1.0,
+              creators::time_dependent_options::ShapeMapOptions<
+                  false, domain::ObjectLabel::None>{8, std::nullopt},
+              std::nullopt, std::nullopt, std::nullopt, false, std::nullopt},
+          nullptr, Options::Context{false, {}, 1, 1}),
+      Catch::Matchers::ContainsSubstring(
+          "must have at least three radial shells"));
+
+  CHECK_THROWS_WITH(
+      creators::Sphere(
+          inner_radius, outer_radius, creators::Sphere::Excision{}, refinement,
+          initial_extents, use_equiangular_map, equatorial_compression,
+          std::vector{1.3, 1.6}, radial_distribution_three_shells, which_wedges,
+          creators::sphere::TimeDependentMapOptions{
+              1.0,
+              creators::time_dependent_options::ShapeMapOptions<
+                  false, domain::ObjectLabel::None>{8, std::nullopt},
+              std::nullopt, std::nullopt, std::nullopt, false, 3},
+          nullptr, Options::Context{false, {}, 1, 1}),
+      Catch::Matchers::ContainsSubstring(
+          "must be smaller than the total number of radial shells"));
 }
 
 template <typename Generator>
@@ -570,12 +616,12 @@ void test_sphere(const gsl::not_null<Generator*> gen) {
     }
     CAPTURE(use_hard_coded_time_dep_options);
 
-    // If we are using hard coded maps, we need at least two shells (or one
-    // radial partition) for the translation map.
-    auto array_index = (use_hard_coded_time_dep_options and
-                                gsl::at(radial_partitioning, index).empty()
-                            ? index + 1
-                            : index);
+    // If we are using hard coded maps, the final radial shell cannot have the
+    // shape map. Filled spheres also need two inner shells with the shape map.
+    const auto array_index =
+        use_hard_coded_time_dep_options
+            ? (fill_interior ? std::max(index, 2_st) : std::max(index, 1_st))
+            : index;
     CAPTURE(gsl::at(radial_partitioning, array_index));
     CAPTURE(gsl::at(radial_distribution, array_index));
 
@@ -608,7 +654,8 @@ void test_sphere(const gsl::not_null<Generator*> gen) {
             TranslationMapOptions<3>{std::array{
                 std::array<double, 3>{0.0, 0.0, 0.0}, translation_velocity,
                 std::array<double, 3>{0.0, 0.0, 0.0}}},
-            false};
+            false,
+            std::nullopt};
       } else {
         time_dependent_options = std::make_unique<
             domain::creators::time_dependence::UniformTranslation<3, 0>>(
@@ -646,6 +693,205 @@ void test_sphere(const gsl::not_null<Generator*> gen) {
   }
 }
 
+void test_number_of_radial_shells_with_shape_map() {
+  const Interior interior{creators::Sphere::Excision{}};
+  const auto make_time_dependent_options =
+      [](const std::optional<size_t> number_of_radial_shells_with_shape_map) {
+        return creators::sphere::TimeDependentMapOptions{
+            1.0,
+            domain::creators::time_dependent_options::ShapeMapOptions<
+                false, domain::ObjectLabel::None>{10, std::nullopt},
+            std::nullopt,
+            std::nullopt,
+            domain::creators::time_dependent_options::TranslationMapOptions<3>{
+                std::array{std::array<double, 3>{0.0, 0.0, 0.0},
+                           std::array<double, 3>{0.001, -0.003, 0.005},
+                           std::array<double, 3>{0.0, 0.0, 0.0}}},
+            false,
+            number_of_radial_shells_with_shape_map};
+      };
+  const creators::Sphere sphere{1.0,
+                                5.0,
+                                creators::Sphere::Excision{},
+                                0_st,
+                                std::array{5_st, 6_st, 7_st},
+                                true,
+                                std::nullopt,
+                                std::vector{2.0, 3.0, 4.0},
+                                domain::CoordinateMaps::Distribution::Linear,
+                                ShellWedges::All,
+                                make_time_dependent_options(2)};
+
+  const auto domain = sphere.create_domain();
+  const auto& blocks = domain.blocks();
+  REQUIRE(blocks.size() == 24);
+  for (size_t block_id = 0; block_id < blocks.size(); ++block_id) {
+    CAPTURE(block_id);
+    CHECK(blocks[block_id].has_distorted_frame() == (block_id / 6 < 2));
+  }
+  TestHelpers::domain::creators::test_creation(
+      option_string(1.0, 5.0, interior, 0_st, std::array{5_st, 6_st, 7_st},
+                    true, std::nullopt, std::vector{2.0, 3.0, 4.0},
+                    std::vector{domain::CoordinateMaps::Distribution::Linear},
+                    ShellWedges::All, true, true, false, "2"),
+      sphere, false);
+
+  const creators::Sphere auto_sphere{
+      1.0,
+      5.0,
+      creators::Sphere::Excision{},
+      0_st,
+      std::array{5_st, 6_st, 7_st},
+      true,
+      std::nullopt,
+      std::vector{2.0, 3.0, 4.0},
+      domain::CoordinateMaps::Distribution::Linear,
+      ShellWedges::All,
+      make_time_dependent_options(std::nullopt)};
+  TestHelpers::domain::creators::test_creation(
+      option_string(1.0, 5.0, interior, 0_st, std::array{5_st, 6_st, 7_st},
+                    true, std::nullopt, std::vector{2.0, 3.0, 4.0},
+                    std::vector{domain::CoordinateMaps::Distribution::Linear},
+                    ShellWedges::All, true, true, false, "Auto"),
+      auto_sphere, false);
+
+  const auto make_deformed_time_dependent_options = []() {
+    return creators::sphere::TimeDependentMapOptions{
+        1.0,
+        domain::creators::time_dependent_options::ShapeMapOptions<
+            false, domain::ObjectLabel::None>{10, std::nullopt,
+                                              std::array{0.1, 0.0, 0.0}},
+        std::nullopt,
+        std::nullopt,
+        std::nullopt,
+        false,
+        2};
+  };
+  const creators::Sphere full_filled_sphere{
+      1.0,
+      5.0,
+      creators::Sphere::InnerCube{0.0},
+      0_st,
+      std::array{5_st, 6_st, 7_st},
+      true,
+      std::nullopt,
+      std::vector{2.0, 3.0, 4.0},
+      domain::CoordinateMaps::Distribution::Linear,
+      ShellWedges::All,
+      make_deformed_time_dependent_options()};
+  const auto full_filled_domain = full_filled_sphere.create_domain();
+  const auto& full_filled_blocks = full_filled_domain.blocks();
+  const auto full_functions_of_time = full_filled_sphere.functions_of_time();
+  REQUIRE(full_filled_blocks.size() == 25);
+  const tnsr::I<double, 3, Frame::BlockLogical> block_logical_coords{
+      {{0.1, -0.2, 0.3}}};
+
+  for (const auto which_wedges :
+       std::array{ShellWedges::FourOnEquator, ShellWedges::OneAlongMinusX}) {
+    CAPTURE(which_wedges);
+    const size_t blocks_per_shell =
+        which_wedges == ShellWedges::FourOnEquator ? 4 : 1;
+    const size_t first_wedge =
+        which_wedges == ShellWedges::FourOnEquator ? 2 : 5;
+    const creators::Sphere partial_sphere{
+        1.0,
+        5.0,
+        creators::Sphere::InnerCube{0.0},
+        0_st,
+        std::array{5_st, 6_st, 7_st},
+        true,
+        std::nullopt,
+        std::vector{2.0, 3.0, 4.0},
+        domain::CoordinateMaps::Distribution::Linear,
+        which_wedges,
+        make_deformed_time_dependent_options()};
+    const auto partial_domain = partial_sphere.create_domain();
+    const auto& partial_blocks = partial_domain.blocks();
+    const auto partial_functions_of_time = partial_sphere.functions_of_time();
+    REQUIRE(partial_blocks.size() == 4 * blocks_per_shell + 1);
+    CHECK_FALSE(partial_blocks.back().has_distorted_frame());
+    for (size_t shell = 0; shell < 4; ++shell) {
+      CAPTURE(shell);
+      for (size_t wedge = 0; wedge < blocks_per_shell; ++wedge) {
+        CAPTURE(wedge);
+        const size_t partial_block_id = shell * blocks_per_shell + wedge;
+        const size_t full_block_id = shell * 6 + first_wedge + wedge;
+        const auto& partial_block = gsl::at(partial_blocks, partial_block_id);
+        const auto& full_block = gsl::at(full_filled_blocks, full_block_id);
+        CHECK(partial_block.has_distorted_frame() == (shell < 2));
+        if (shell < 2) {
+          CHECK(partial_block.moving_mesh_grid_to_distorted_map() ==
+                full_block.moving_mesh_grid_to_distorted_map());
+          CHECK(partial_block.moving_mesh_distorted_to_inertial_map() ==
+                full_block.moving_mesh_distorted_to_inertial_map());
+          CHECK(partial_block.moving_mesh_grid_to_inertial_map() ==
+                full_block.moving_mesh_grid_to_inertial_map());
+
+          const auto partial_grid_coords =
+              partial_block.moving_mesh_logical_to_grid_map()(
+                  block_logical_coords);
+          const auto full_grid_coords =
+              full_block.moving_mesh_logical_to_grid_map()(
+                  block_logical_coords);
+          CHECK_ITERABLE_APPROX(partial_grid_coords, full_grid_coords);
+          const auto partial_distorted_coords =
+              partial_block.moving_mesh_grid_to_distorted_map()(
+                  partial_grid_coords, 1.0, partial_functions_of_time);
+          const auto full_distorted_coords =
+              full_block.moving_mesh_grid_to_distorted_map()(
+                  full_grid_coords, 1.0, full_functions_of_time);
+          CHECK_ITERABLE_APPROX(partial_distorted_coords,
+                                full_distorted_coords);
+          CHECK(not(get<0>(partial_distorted_coords) ==
+                        approx(get<0>(partial_grid_coords)) and
+                    get<1>(partial_distorted_coords) ==
+                        approx(get<1>(partial_grid_coords)) and
+                    get<2>(partial_distorted_coords) ==
+                        approx(get<2>(partial_grid_coords))));
+        }
+      }
+    }
+  }
+
+  const creators::Sphere single_excised_shell{
+      1.0,
+      5.0,
+      creators::Sphere::Excision{},
+      0_st,
+      std::array{5_st, 6_st, 7_st},
+      true,
+      std::nullopt,
+      {},
+      domain::CoordinateMaps::Distribution::Linear,
+      ShellWedges::OneAlongMinusX,
+      make_time_dependent_options(std::nullopt)};
+  const auto single_excised_domain = single_excised_shell.create_domain();
+  REQUIRE(single_excised_domain.blocks().size() == 1);
+  CHECK(single_excised_domain.blocks()[0].has_distorted_frame());
+
+  const creators::Sphere single_filled_shell{
+      1.0,
+      5.0,
+      creators::Sphere::InnerCube{0.0},
+      0_st,
+      std::array{5_st, 6_st, 7_st},
+      true,
+      std::nullopt,
+      {},
+      domain::CoordinateMaps::Distribution::Linear,
+      ShellWedges::FourOnEquator,
+      make_time_dependent_options(std::nullopt)};
+  const auto single_filled_domain = single_filled_shell.create_domain();
+  const auto& single_filled_blocks = single_filled_domain.blocks();
+  REQUIRE(single_filled_blocks.size() == 5);
+  for (size_t block_id = 0; block_id < single_filled_blocks.size();
+       ++block_id) {
+    CAPTURE(block_id);
+    CHECK(single_filled_blocks[block_id].has_distorted_frame() ==
+          (block_id < 4));
+  }
+}
+
 void test_shape_distortion_general(
     const double time,
     domain::creators::Sphere::TimeDepOptionType time_dependent_options,
@@ -661,7 +907,7 @@ void test_shape_distortion_general(
       6_st,
       true,
       std::nullopt,
-      {fill_interior ? deformed_radius : 4.},
+      fill_interior ? std::vector{deformed_radius, 4.} : std::vector{4.},
       domain::CoordinateMaps::Distribution::Linear,
       ShellWedges::All,
       std::move(time_dependent_options)};
@@ -728,7 +974,8 @@ void test_shape_distortion() {
               std::nullopt,
               std::nullopt,
               std::nullopt,
-              not fill_interior};
+              not fill_interior,
+              std::nullopt};
       test_shape_distortion_general(time, std::move(time_dependent_options),
                                     inner_radius, fill_interior, x);
     }
@@ -771,7 +1018,8 @@ void test_shape_distortion() {
         std::nullopt,
         std::nullopt,
         std::nullopt,
-        true};
+        true,
+        std::nullopt};
 
     test_shape_distortion_general(time, std::move(time_dependent_options),
                                   inner_radius, false, x);
@@ -789,6 +1037,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.Sphere", "[Domain][Unit]") {
   domain::creators::time_dependence::register_derived_with_charm();
   test_parse_errors();
   test_sphere(make_not_null(&gen));
+  test_number_of_radial_shells_with_shape_map();
   test_shape_distortion();
 }
 }  // namespace domain

--- a/tests/Unit/Domain/Creators/Test_SphericalShells.cpp
+++ b/tests/Unit/Domain/Creators/Test_SphericalShells.cpp
@@ -6,6 +6,7 @@
 #include <array>
 #include <cstddef>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -64,7 +65,15 @@ std::string option_string(
     const std::vector<domain::CoordinateMaps::Distribution>&
         radial_distribution,
     const bool time_dependent, const bool hard_coded_time_dependent_maps,
-    const bool with_boundary_conditions, const bool inner_bc_is_none = false) {
+    const bool with_boundary_conditions, const bool inner_bc_is_none = false,
+    const std::optional<std::string>& number_of_radial_shells_with_shape_map =
+        std::string{"Auto"}) {
+  const std::string number_of_radial_shells_with_shape_map_option =
+      number_of_radial_shells_with_shape_map.has_value()
+          ? "    NumberOfRadialShellsWithShapeMap: " +
+                number_of_radial_shells_with_shape_map.value() + "\n"
+          : "";
+
   const std::string time_dependent_option =
       time_dependent ? (hard_coded_time_dependent_maps
                             ? "  TimeDependentMaps:\n"
@@ -79,7 +88,8 @@ std::string option_string(
                               "    TranslationMap:\n"
                               "      InitialValues: [[0.0, 0.0, 0.0],"
                               " [0.001, -0.003, 0.005], [0.0, 0.0, 0.0]]\n"
-                              "    TransitionRotScaleTrans: False\n"
+                              "    TransitionRotScaleTrans: False\n" +
+                                  number_of_radial_shells_with_shape_map_option
                             : "  TimeDependentMaps:\n"
                               "    UniformTranslation:\n"
                               "      InitialTime: 1.0\n"
@@ -138,6 +148,11 @@ void test_parse_errors() {
       {2.1 * outer_radius, 2.2 * outer_radius}};
   const std::vector<domain::CoordinateMaps::Distribution> radial_distribution{
       domain::CoordinateMaps::Distribution::Linear};
+  const std::vector<domain::CoordinateMaps::Distribution>
+      radial_distribution_three_shells{
+          domain::CoordinateMaps::Distribution::Linear,
+          domain::CoordinateMaps::Distribution::Linear,
+          domain::CoordinateMaps::Distribution::Linear};
   const std::vector<domain::CoordinateMaps::Distribution>
       radial_distribution_too_many{
           domain::CoordinateMaps::Distribution::Linear,
@@ -252,6 +267,33 @@ void test_parse_errors() {
       std::make_unique<TestHelpers::domain::BoundaryConditions::
                            TestNoneBoundaryCondition<3>>(),
       create_boundary_condition(true), Options::Context{false, {}, 1, 1}));
+
+  CHECK_THROWS_WITH(
+      domain::creators::SphericalShells(
+          0.0, outer_radius, radial_refinement, radial_extents, l,
+          radial_partitioning, radial_distribution,
+          domain::creators::sphere::TimeDependentMapOptions{
+              1.0,
+              domain::creators::time_dependent_options::ShapeMapOptions<
+                  false, domain::ObjectLabel::None>{8, std::nullopt},
+              std::nullopt, std::nullopt, std::nullopt, false, std::nullopt},
+          nullptr, nullptr, Options::Context{false, {}, 1, 1}),
+      Catch::Matchers::ContainsSubstring(
+          "Hard-coded time-dependent maps are not supported when the "
+          "SphericalShells center is filled"));
+
+  CHECK_THROWS_WITH(
+      domain::creators::SphericalShells(
+          inner_radius, outer_radius, radial_refinement, radial_extents, l,
+          std::vector{1.3, 1.6}, radial_distribution_three_shells,
+          domain::creators::sphere::TimeDependentMapOptions{
+              1.0,
+              domain::creators::time_dependent_options::ShapeMapOptions<
+                  false, domain::ObjectLabel::None>{8, std::nullopt},
+              std::nullopt, std::nullopt, std::nullopt, false, 3},
+          nullptr, nullptr, Options::Context{false, {}, 1, 1}),
+      Catch::Matchers::ContainsSubstring(
+          "must be smaller than the total number of radial shells"));
 }
 
 template <typename Generator>
@@ -490,7 +532,8 @@ void test_sphere(const gsl::not_null<Generator*> gen) {
                 TranslationMapOptions<3>{std::array{
                     std::array<double, 3>{0.0, 0.0, 0.0}, translation_velocity,
                     std::array<double, 3>{0.0, 0.0, 0.0}}},
-                false};
+                false,
+                std::nullopt};
       } else {
         time_dependent_options = std::make_unique<
             domain::creators::time_dependence::UniformTranslation<3, 0>>(
@@ -521,6 +564,116 @@ void test_sphere(const gsl::not_null<Generator*> gen) {
             gsl::at(radial_distribution, array_index), time_dependent,
             use_hard_coded_time_dep_options, with_boundary_conditions),
         spherical_shells, with_boundary_conditions);
+  }
+}
+
+void test_number_of_radial_shells_with_shape_map() {
+  const auto make_time_dependent_options =
+      [](const std::optional<size_t> number_of_shells) {
+        return domain::creators::sphere::TimeDependentMapOptions{
+            1.0,
+            domain::creators::time_dependent_options::ShapeMapOptions<
+                false, domain::ObjectLabel::None>{10, std::nullopt},
+            std::nullopt,
+            std::nullopt,
+            domain::creators::time_dependent_options::TranslationMapOptions<3>{
+                std::array{std::array<double, 3>{0.0, 0.0, 0.0},
+                           std::array<double, 3>{0.001, -0.003, 0.005},
+                           std::array<double, 3>{0.0, 0.0, 0.0}}},
+            false,
+            number_of_shells};
+      };
+  const auto check_distorted_frames =
+      [](const domain::creators::SphericalShells& domain_creator,
+         const size_t number_of_shells_with_shape_map) {
+        const auto domain = domain_creator.create_domain();
+        const auto& blocks = domain.blocks();
+        for (size_t shell = 0; shell < blocks.size(); ++shell) {
+          CAPTURE(shell);
+          CHECK(blocks[shell].has_distorted_frame() ==
+                (shell < number_of_shells_with_shape_map));
+        }
+      };
+
+  {
+    INFO("Single radial shell with shape map");
+    const domain::creators::SphericalShells domain_creator{
+        1.0,
+        5.0,
+        0_st,
+        5_st,
+        6_st,
+        {},
+        domain::CoordinateMaps::Distribution::Linear,
+        make_time_dependent_options(std::nullopt)};
+    check_distorted_frames(domain_creator, 1);
+    TestHelpers::domain::creators::test_creation(
+        option_string(1.0, 5.0, 0_st, 5_st, 6_st, {},
+                      std::vector{domain::CoordinateMaps::Distribution::Linear},
+                      true, true, false, false, "Auto"),
+        domain_creator, false);
+  }
+
+  {
+    INFO("Two radial shells with shape map");
+    const domain::creators::SphericalShells domain_creator{
+        1.0,
+        5.0,
+        0_st,
+        5_st,
+        6_st,
+        {2.0, 3.0, 4.0},
+        domain::CoordinateMaps::Distribution::Linear,
+        make_time_dependent_options(2)};
+    check_distorted_frames(domain_creator, 2);
+    TestHelpers::domain::creators::test_creation(
+        option_string(1.0, 5.0, 0_st, 5_st, 6_st, {2.0, 3.0, 4.0},
+                      std::vector{domain::CoordinateMaps::Distribution::Linear},
+                      true, true, false, false, "2"),
+        domain_creator, false);
+    const domain::creators::SphericalShells auto_domain_creator{
+        1.0,
+        5.0,
+        0_st,
+        5_st,
+        6_st,
+        {2.0, 3.0, 4.0},
+        domain::CoordinateMaps::Distribution::Linear,
+        domain::creators::sphere::TimeDependentMapOptions{
+            1.0,
+            domain::creators::time_dependent_options::ShapeMapOptions<
+                false, domain::ObjectLabel::None>{10, std::nullopt},
+            std::nullopt, std::nullopt,
+            domain::creators::time_dependent_options::TranslationMapOptions<3>{
+                std::array{std::array<double, 3>{0.0, 0.0, 0.0},
+                           std::array<double, 3>{0.001, -0.003, 0.005},
+                           std::array<double, 3>{0.0, 0.0, 0.0}}},
+            false, std::nullopt}};
+    TestHelpers::domain::creators::test_creation(
+        option_string(1.0, 5.0, 0_st, 5_st, 6_st, {2.0, 3.0, 4.0},
+                      std::vector{domain::CoordinateMaps::Distribution::Linear},
+                      true, true, false, false, "Auto"),
+        auto_domain_creator, false);
+  }
+
+  {
+    INFO("Five of eight radial shells with shape maps");
+    const domain::creators::SphericalShells domain_creator{
+        1.0,
+        9.0,
+        0_st,
+        5_st,
+        6_st,
+        {2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0},
+        domain::CoordinateMaps::Distribution::Linear,
+        make_time_dependent_options(5)};
+    check_distorted_frames(domain_creator, 5);
+    TestHelpers::domain::creators::test_creation(
+        option_string(1.0, 9.0, 0_st, 5_st, 6_st,
+                      {2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0},
+                      std::vector{domain::CoordinateMaps::Distribution::Linear},
+                      true, true, false, false, "5"),
+        domain_creator, false);
   }
 }
 
@@ -596,7 +749,8 @@ void test_shape_distortion() {
         std::nullopt,
         std::nullopt,
         std::nullopt,
-        true};
+        true,
+        std::nullopt};
     test_shape_distortion_general(time, std::move(time_dependent_options),
                                   inner_radius, x);
   }
@@ -638,7 +792,8 @@ void test_shape_distortion() {
         std::nullopt,
         std::nullopt,
         std::nullopt,
-        true};
+        true,
+        std::nullopt};
 
     test_shape_distortion_general(time, std::move(time_dependent_options),
                                   inner_radius, x);
@@ -727,5 +882,6 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.SphericalShells", "[Domain][Unit]") {
   test_parse_errors();
   test_sphere(make_not_null(&gen));
   test_filled_sphere(make_not_null(&gen));
+  test_number_of_radial_shells_with_shape_map();
   test_shape_distortion();
 }

--- a/tests/Unit/Domain/Creators/TimeDependentOptions/Test_Sphere.cpp
+++ b/tests/Unit/Domain/Creators/TimeDependentOptions/Test_Sphere.cpp
@@ -49,7 +49,8 @@ std::string create_option_string(const std::optional<bool> use_non_zero_shape) {
          "TranslationMap:\n"
          "  InitialValues: [[0.1, -3.2, 1.1], [-0.3, 0.5, -0.7],"
          " [0.1, -0.4, 0.02]]\n"
-         "TransitionRotScaleTrans: True"s;
+         "TransitionRotScaleTrans: True\n"
+         "NumberOfRadialShellsWithShapeMap: Auto"s;
 }
 // nullopt implies no shape map at all
 void test(const std::optional<bool> use_non_zero_shape) {
@@ -134,63 +135,130 @@ void test(const std::optional<bool> use_non_zero_shape) {
     time_dep_options.build_maps(center, /* filled */ false, inner_radius,
                                 radial_partitions, outer_radius);
     // Inner shell with shape
-    check_map(time_dep_options.grid_to_distorted_map(0, false, 6),
+    check_map(time_dep_options.grid_to_distorted_map(0, 0, false),
               not use_non_zero_shape.has_value(), false);
-    check_map(time_dep_options.distorted_to_inertial_map(0, false, 6),
+    check_map(time_dep_options.distorted_to_inertial_map(0, false),
               not use_non_zero_shape.has_value(), false);
-    check_map(time_dep_options.grid_to_inertial_map(0, false, false, 6), false,
+    check_map(time_dep_options.grid_to_inertial_map(0, 0, false, false), false,
               false);
     // Shell without shape
-    check_map(time_dep_options.grid_to_distorted_map(6, false, 6), true, false);
-    check_map(time_dep_options.distorted_to_inertial_map(6, false, 6), true,
+    check_map(time_dep_options.grid_to_distorted_map(1, 0, false), true, false);
+    check_map(time_dep_options.distorted_to_inertial_map(1, false), true,
               false);
-    check_map(time_dep_options.grid_to_inertial_map(6, false, false, 6), false,
+    check_map(time_dep_options.grid_to_inertial_map(1, 0, false, false), false,
               false);
     // Inner S2 shell with shape
-    check_map(time_dep_options.grid_to_distorted_map(0, false, 1),
+    check_map(time_dep_options.grid_to_distorted_map(0, 0, false),
               not use_non_zero_shape.has_value(), false);
-    check_map(time_dep_options.distorted_to_inertial_map(0, false, 1),
+    check_map(time_dep_options.distorted_to_inertial_map(0, false),
               not use_non_zero_shape.has_value(), false);
-    check_map(time_dep_options.grid_to_inertial_map(0, false, false, 1), false,
+    check_map(time_dep_options.grid_to_inertial_map(0, 0, false, false), false,
               false);
     // S2 Shell without shape
-    check_map(time_dep_options.grid_to_distorted_map(1, false, 1), true, false);
-    check_map(time_dep_options.distorted_to_inertial_map(1, false, 1), true,
+    check_map(time_dep_options.grid_to_distorted_map(1, 0, false), true, false);
+    check_map(time_dep_options.distorted_to_inertial_map(1, false), true,
               false);
-    check_map(time_dep_options.grid_to_inertial_map(1, false, false, 1), false,
+    check_map(time_dep_options.grid_to_inertial_map(1, 0, false, false), false,
               false);
   }
   {
     INFO("Filled");
-    time_dep_options.build_maps(center, /* filled */ true, inner_radius,
-                                radial_partitions, outer_radius);
+    auto filled_time_dep_options =
+        TestHelpers::test_creation<TimeDependentMapOptions>(
+            create_option_string(use_non_zero_shape));
+    filled_time_dep_options.build_maps(center, /* filled */ true, inner_radius,
+                                       radial_partitions, outer_radius);
     // Inner shell: cube to sphere
-    check_map(time_dep_options.grid_to_distorted_map(0, false, 6),
+    check_map(filled_time_dep_options.grid_to_distorted_map(0, 0, false),
               not use_non_zero_shape.has_value(), false);
-    check_map(time_dep_options.distorted_to_inertial_map(0, false, 6),
+    check_map(filled_time_dep_options.distorted_to_inertial_map(0, false),
               not use_non_zero_shape.has_value(), false);
-    check_map(time_dep_options.grid_to_inertial_map(0, false, false, 6), false,
-              false);
+    check_map(filled_time_dep_options.grid_to_inertial_map(0, 0, false, false),
+              false, false);
     // Shape rolloff region
-    check_map(time_dep_options.grid_to_distorted_map(6, false, 6),
+    check_map(filled_time_dep_options.grid_to_distorted_map(1, 0, false),
               not use_non_zero_shape.has_value(), false);
-    check_map(time_dep_options.distorted_to_inertial_map(6, false, 6),
+    check_map(filled_time_dep_options.distorted_to_inertial_map(1, false),
               not use_non_zero_shape.has_value(), false);
-    check_map(time_dep_options.grid_to_inertial_map(0, false, false, 6), false,
-              false);
+    check_map(filled_time_dep_options.grid_to_inertial_map(1, 0, false, false),
+              false, false);
     // Shell without shape
-    check_map(time_dep_options.grid_to_distorted_map(12, false, 6), true,
+    check_map(filled_time_dep_options.grid_to_distorted_map(2, 0, false), true,
               false);
-    check_map(time_dep_options.distorted_to_inertial_map(12, false, 6), true,
+    check_map(filled_time_dep_options.distorted_to_inertial_map(2, false), true,
               false);
-    check_map(time_dep_options.grid_to_inertial_map(12, false, false, 6), false,
-              false);
+    check_map(filled_time_dep_options.grid_to_inertial_map(2, 0, false, false),
+              false, false);
     // Inner cube
-    check_map(time_dep_options.grid_to_distorted_map(12, true, 6), true, false);
-    check_map(time_dep_options.distorted_to_inertial_map(12, true, 6), true,
+    check_map(filled_time_dep_options.grid_to_distorted_map(2, 0, true), true,
               false);
-    check_map(time_dep_options.grid_to_inertial_map(12, false, true, 6), false,
+    check_map(filled_time_dep_options.distorted_to_inertial_map(2, true), true,
               false);
+    check_map(filled_time_dep_options.grid_to_inertial_map(2, 0, false, true),
+              false, false);
+  }
+
+  {
+    INFO("Explicit shell count");
+    TimeDependentMapOptions time_dep_options_with_two_shape_shells{
+        initial_time,
+        time_dependent_options::ShapeMapOptions<false,
+                                                domain::ObjectLabel::None>{
+            l_max, std::nullopt},
+        std::nullopt,
+        std::nullopt,
+        time_dependent_options::TranslationMapOptions<3>{
+            std::array{std::array<double, 3>{0.1, -3.2, 1.1},
+                       std::array<double, 3>{-0.3, 0.5, -0.7},
+                       std::array<double, 3>{0.1, -0.4, 0.02}}},
+        true,
+        2};
+    time_dep_options_with_two_shape_shells.build_maps(
+        center, /* filled */ false, inner_radius, radial_partitions,
+        outer_radius);
+    for (size_t shell = 0; shell < 3; ++shell) {
+      const bool has_shape = shell < 2;
+      CAPTURE(shell);
+      check_map(time_dep_options_with_two_shape_shells.grid_to_distorted_map(
+                    shell, 0, false),
+                not has_shape, false);
+      check_map(
+          time_dep_options_with_two_shape_shells.distorted_to_inertial_map(
+              shell, false),
+          not has_shape, false);
+    }
+  }
+
+  {
+    INFO("Five of eight shells with shape maps");
+    const std::vector<double> many_radial_partitions{1.0, 1.5, 2.0, 2.5,
+                                                     3.0, 3.5, 3.7};
+    TimeDependentMapOptions many_shell_time_dep_options{
+        initial_time,
+        time_dependent_options::ShapeMapOptions<false,
+                                                domain::ObjectLabel::None>{
+            l_max, std::nullopt},
+        std::nullopt,
+        std::nullopt,
+        time_dependent_options::TranslationMapOptions<3>{
+            std::array{std::array<double, 3>{0.1, -3.2, 1.1},
+                       std::array<double, 3>{-0.3, 0.5, -0.7},
+                       std::array<double, 3>{0.1, -0.4, 0.02}}},
+        true,
+        5};
+    many_shell_time_dep_options.build_maps(center, /* filled */ false,
+                                           inner_radius, many_radial_partitions,
+                                           outer_radius);
+    for (size_t shell = 0; shell < 8; ++shell) {
+      const bool has_shape = shell < 5;
+      CAPTURE(shell);
+      check_map(
+          many_shell_time_dep_options.grid_to_distorted_map(shell, 0, false),
+          not has_shape, false);
+      check_map(
+          many_shell_time_dep_options.distorted_to_inertial_map(shell, false),
+          not has_shape, false);
+    }
   }
 
   const auto functions_of_time =
@@ -213,6 +281,18 @@ void test(const std::optional<bool> use_non_zero_shape) {
                    .get()) == translation_non_zero);
   }
 }
+
+void test_parse_errors() {
+  CHECK_THROWS_WITH(
+      TestHelpers::test_creation<TimeDependentMapOptions>(
+          "InitialTime: 1.5\n"
+          "ShapeMap: None\n"
+          "RotationMap: None\n"
+          "ExpansionMap: None\n"
+          "TranslationMap: None\n"
+          "TransitionRotScaleTrans: True\n"),
+      Catch::Matchers::ContainsSubstring("NumberOfRadialShellsWithShapeMap"));
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Domain.Creators.TimeDependentOptions.Sphere",
@@ -220,5 +300,6 @@ SPECTRE_TEST_CASE("Unit.Domain.Creators.TimeDependentOptions.Sphere",
   test({true});
   test({false});
   test(std::nullopt);
+  test_parse_errors();
 }
 }  // namespace domain::creators::sphere

--- a/tests/Unit/Evolution/Ringdown/Test_MinimumAhCExcisionRadius.cpp
+++ b/tests/Unit/Evolution/Ringdown/Test_MinimumAhCExcisionRadius.cpp
@@ -131,7 +131,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Ringdown.MinimumAhCExcisionRadius",
   const domain::creators::sphere::TimeDependentMapOptions
       time_dependent_map_options{times.at(0),          shape_map_options,
                                  rotation_map_options, expansion_map_options,
-                                 std::nullopt,         true};
+                                 std::nullopt,         true,
+                                 std::nullopt};
 
   const domain::creators::Sphere domain_creator{
       0.01,

--- a/tests/Unit/Evolution/Ringdown/Test_StrahlkorperCoefsAndCenters.cpp
+++ b/tests/Unit/Evolution/Ringdown/Test_StrahlkorperCoefsAndCenters.cpp
@@ -128,7 +128,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Ringdown.StrahlkorperCoefsAndCenters",
   const domain::creators::sphere::TimeDependentMapOptions
       time_dependent_map_options{times.at(0),          shape_map_options,
                                  rotation_map_options, expansion_map_options,
-                                 std::nullopt,         true};
+                                 std::nullopt,         true,
+                                 std::nullopt};
 
   const domain::creators::Sphere domain_creator{
       0.01,

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_ComputeVarsToInterpolateToTarget.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_ComputeVarsToInterpolateToTarget.cpp
@@ -74,7 +74,7 @@ void test_compute_horizon_volume_quantities(const bool is_time_dependent) {
                     3>{std::array{std::array{0.0, 0.0, 0.0},
                                   std::array{0.0, 0.0, 0.0},
                                   std::array{0.0, 0.0, 0.0}}},
-                true}}
+                true, std::nullopt}}
           : std::nullopt};
   const auto domain = domain_creator.create_domain();
   const auto& functions_of_time = domain_creator.functions_of_time();

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_FindApparentHorizon.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_FindApparentHorizon.cpp
@@ -245,7 +245,7 @@ void test_apparent_horizon(
                     3>{std::array{std::array{0.0, 0.0, 0.0},
                                   std::array{0.0, 0.01, 0.0},
                                   std::array{0.0, 0.0, 0.0}}},
-                true}}
+                true, std::nullopt}}
           : std::nullopt);
 
   {


### PR DESCRIPTION
## Proposed changes

Currently, in the `Sphere` and `SphericalShell` domain, only the innermost radial partition gets the hard-coded shape map. This PR adds a new option to `TimeDependentMapOptions` that chooses how many radial partitions get the shape map. This is necessary to reproduce SpEC domains, with the same radial partitioning and same shape map as the domains spec uses. In particular, during a ringdown or perturbed black-hole run, one often wants to have the shape map extend far from the horizon (out to say r=60M or so), but have much smaller radial partitions near the horzion, where the spacetime is changing on much smaller length scales.

Note: I used codex to assist with this PR. I reviewed every line in this PR myself, and I also had codex review with the spectre-review skill.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
The `Sphere` and `SphericalShell` domains now contain a new option under `TimeDependentMaps` called `NumberOfRadialShellsWithShapeMap`. Set it to auto to keep the old behavior (only the innermost radial partition gets the shape map`. You can also choose to set this it to a nonnegative integer no greater than one less than the number of partitions (the outermost partition is not allowed to have a shape map in this implementation, becauase in practice we always want the outer boundary to be a sphere, not a deformed sphere...that's the whole reason for the shape map rolling off to the identity).

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [x] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

This PR is especially helpful for ringdowns or perturbed black holes using shape and size control.
