### PR TITLE
Add KerrSchild initial guess to AH finder

### DIFF
--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -82,6 +82,8 @@
 #include "NumericalAlgorithms/DiscontinuousGalerkin/Tags.hpp"
 #include "NumericalAlgorithms/LinearOperators/Filters/Factory.hpp"
 #include "NumericalAlgorithms/LinearOperators/Filters/Tag.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/IO/InitialShapeFromFile.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/InitialShape.hpp"
 #include "Options/Options.hpp"
 #include "Options/ParseOptions.hpp"
 #include "Options/Protocols/FactoryCreation.hpp"
@@ -136,6 +138,7 @@
 #include "ParallelAlgorithms/ApparentHorizonFinder/Events/FindApparentHorizon.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Events/FindCommonHorizon.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/HorizonAliases.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/KerrSchild.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Protocols/HorizonMetavars.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Tags.hpp"
 #include "ParallelAlgorithms/Events/Completion.hpp"
@@ -462,6 +465,14 @@ struct EvolutionMetavars {
       : tt::ConformsTo<Options::protocols::FactoryCreation> {
     using factory_classes = tmpl::map<
         tmpl::pair<ah::Criterion, ah::Criteria::standard_criteria>,
+        tmpl::pair<ylm::InitialShape<Frame::Distorted>,
+                   tmpl::list<ylm::InitialShapes::Sphere<Frame::Distorted>,
+                              ylm::InitialShapes::FromFile<Frame::Distorted>,
+                              ah::InitialShapes::KerrSchild<Frame::Distorted>>>,
+        tmpl::pair<ylm::InitialShape<Frame::Inertial>,
+                   tmpl::list<ylm::InitialShapes::Sphere<Frame::Inertial>,
+                              ylm::InitialShapes::FromFile<Frame::Inertial>,
+                              ah::InitialShapes::KerrSchild<Frame::Inertial>>>,
         tmpl::pair<
             amr::Criterion,
             tmpl::push_back<

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhSingleBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhSingleBlackHole.hpp
@@ -26,6 +26,8 @@
 #include "Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp"
 #include "Evolution/Systems/Cce/Callbacks/DumpBondiSachsOnWorldtube.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Actions/SetInitialData.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/IO/InitialShapeFromFile.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/InitialShape.hpp"
 #include "Options/FactoryHelpers.hpp"
 #include "Options/Protocols/FactoryCreation.hpp"
 #include "Options/String.hpp"
@@ -49,6 +51,7 @@
 #include "ParallelAlgorithms/ApparentHorizonFinder/Criteria/Factory.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Events/FindApparentHorizon.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/HorizonAliases.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/KerrSchild.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Protocols/HorizonMetavars.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Actions/RunEventsOnFailure.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/ElementInitInterpPoints.hpp"
@@ -187,6 +190,14 @@ struct EvolutionMetavars : public GeneralizedHarmonicTemplateBase<3, UseLts> {
             tmpl::pair<LtsTimeStepper,
                        TimeSteppers::monotonic_lts_time_steppers>>,
         tmpl::pair<ah::Criterion, ah::Criteria::standard_criteria>,
+        tmpl::pair<ylm::InitialShape<Frame::Inertial>,
+                   tmpl::list<ylm::InitialShapes::Sphere<Frame::Inertial>,
+                              ylm::InitialShapes::FromFile<Frame::Inertial>,
+                              ah::InitialShapes::KerrSchild<Frame::Inertial>>>,
+        tmpl::pair<ylm::InitialShape<Frame::Distorted>,
+                   tmpl::list<ylm::InitialShapes::Sphere<Frame::Distorted>,
+                              ylm::InitialShapes::FromFile<Frame::Distorted>,
+                              ah::InitialShapes::KerrSchild<Frame::Distorted>>>,
         tmpl::pair<Event,
                    tmpl::flatten<tmpl::list<
                        ah::Events::FindApparentHorizon<ApparentHorizon>,

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/EvolveGhValenciaDivCleanWithHorizon.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/EvolveGhValenciaDivCleanWithHorizon.hpp
@@ -10,6 +10,8 @@
 #include "Evolution/Systems/GrMhd/GhValenciaDivClean/TimeDerivativeTerms.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
 #include "Evolution/VariableFixing/Tags.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/IO/InitialShapeFromFile.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/InitialShape.hpp"
 #include "Options/FactoryHelpers.hpp"
 #include "Options/Protocols/FactoryCreation.hpp"
 #include "Options/String.hpp"
@@ -21,6 +23,7 @@
 #include "ParallelAlgorithms/ApparentHorizonFinder/Criteria/Factory.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Events/FindApparentHorizon.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/HorizonAliases.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/KerrSchild.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Protocols/HorizonMetavars.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Surfaces/Tags.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/Factory.hpp"
@@ -92,7 +95,11 @@ struct EvolutionMetavars
     using factory_classes = Options::add_factory_classes<
         typename base::factory_creation::factory_classes,
         tmpl::pair<Event, tmpl::list<ah::Events::FindApparentHorizon<AhA>>>,
-        tmpl::pair<ah::Criterion, ah::Criteria::standard_criteria>>;
+        tmpl::pair<ah::Criterion, ah::Criteria::standard_criteria>,
+        tmpl::pair<ylm::InitialShape<domain_frame>,
+                   tmpl::list<ylm::InitialShapes::Sphere<domain_frame>,
+                              ylm::InitialShapes::FromFile<domain_frame>,
+                              ah::InitialShapes::KerrSchild<domain_frame>>>>;
   };
 
   using initial_data_tag = typename base::initial_data_tag;

--- a/src/Evolution/Executables/ScalarTensor/EvolveScalarTensorSingleBlackHole.hpp
+++ b/src/Evolution/Executables/ScalarTensor/EvolveScalarTensorSingleBlackHole.hpp
@@ -22,6 +22,8 @@
 #include "Evolution/Executables/ScalarTensor/ScalarTensorBase.hpp"
 #include "Evolution/Systems/Cce/Callbacks/DumpBondiSachsOnWorldtube.hpp"
 #include "Evolution/Systems/ScalarTensor/Actions/SetInitialData.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/IO/InitialShapeFromFile.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/InitialShape.hpp"
 #include "Options/FactoryHelpers.hpp"
 #include "Options/Protocols/FactoryCreation.hpp"
 #include "Options/String.hpp"
@@ -38,6 +40,7 @@
 #include "ParallelAlgorithms/ApparentHorizonFinder/Criteria/Factory.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Events/FindApparentHorizon.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/HorizonAliases.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/KerrSchild.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Protocols/HorizonMetavars.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Actions/RunEventsOnFailure.hpp"
 #include "ParallelAlgorithms/Interpolation/Actions/ElementInitInterpPoints.hpp"
@@ -196,6 +199,10 @@ struct EvolutionMetavars : public ScalarTensorTemplateBase<EvolutionMetavars> {
             tmpl::pair<LtsTimeStepper,
                        TimeSteppers::monotonic_lts_time_steppers>>,
         tmpl::pair<ah::Criterion, ah::Criteria::standard_criteria>,
+        tmpl::pair<ylm::InitialShape<Frame::Distorted>,
+                   tmpl::list<ylm::InitialShapes::Sphere<Frame::Distorted>,
+                              ylm::InitialShapes::FromFile<Frame::Distorted>,
+                              ah::InitialShapes::KerrSchild<Frame::Distorted>>>,
         tmpl::pair<
             Event,
             tmpl::flatten<tmpl::list<

--- a/src/NumericalAlgorithms/SphericalHarmonics/CMakeLists.txt
+++ b/src/NumericalAlgorithms/SphericalHarmonics/CMakeLists.txt
@@ -10,6 +10,7 @@ spectre_target_sources(
   PRIVATE
   AngularOrdering.cpp
   ChangeCenterOfStrahlkorper.cpp
+  InitialShape.cpp
   RealSphericalHarmonics.cpp
   SpherepackIterator.cpp
   Strahlkorper.cpp
@@ -34,6 +35,7 @@ spectre_target_headers(
   ApplyTensorYlmFilter.hpp
   ApplyTensorYlmFilter.tpp
   ChangeCenterOfStrahlkorper.hpp
+  InitialShape.hpp
   RealSphericalHarmonics.hpp
   SpherepackIterator.hpp
   Strahlkorper.hpp

--- a/src/NumericalAlgorithms/SphericalHarmonics/IO/CMakeLists.txt
+++ b/src/NumericalAlgorithms/SphericalHarmonics/IO/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   FillYlmLegendAndData.cpp
+  InitialShapeFromFile.cpp
   ReadSurfaceYlm.cpp
   StrahlkorperCoordsToTextFile.cpp
   StrahlkorperFromFile.cpp
@@ -19,6 +20,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   FillYlmLegendAndData.hpp
+  InitialShapeFromFile.hpp
   ReadSurfaceYlm.hpp
   StrahlkorperCoordsToTextFile.hpp
   )

--- a/src/NumericalAlgorithms/SphericalHarmonics/IO/InitialShapeFromFile.cpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/IO/InitialShapeFromFile.cpp
@@ -1,0 +1,64 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/SphericalHarmonics/IO/InitialShapeFromFile.hpp"
+
+#include <cstddef>
+#include <pup.h>
+#include <pup_stl.h>
+#include <string>
+#include <utility>
+
+#include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
+#include "Options/Context.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+namespace Frame {
+struct Distorted;
+struct Grid;
+struct Inertial;
+}  // namespace Frame
+
+namespace ylm::InitialShapes {
+template <typename Frame>
+FromFile<Frame>::FromFile(std::string h5_filename, std::string subfile_name,
+                          const double time, const double time_epsilon,
+                          const bool check_frame)
+    : h5_filename_(std::move(h5_filename)),
+      subfile_name_(std::move(subfile_name)),
+      time_(time),
+      time_epsilon_(time_epsilon),
+      check_frame_(check_frame) {}
+
+template <typename Frame>
+FromFile<Frame>::FromFile(CkMigrateMessage* msg) : InitialShape<Frame>(msg) {}
+
+template <typename Frame>
+Strahlkorper<Frame> FromFile<Frame>::strahlkorper(
+    const size_t l_max, const Options::Context& context) const {
+  return Strahlkorper<Frame>{l_max,         h5_filename_, subfile_name_, time_,
+                             time_epsilon_, check_frame_, context};
+}
+
+template <typename Frame>
+void FromFile<Frame>::pup(PUP::er& p) {
+  p | h5_filename_;
+  p | subfile_name_;
+  p | time_;
+  p | time_epsilon_;
+  p | check_frame_;
+}
+
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data) template class FromFile<FRAME(data)>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE,
+                        (::Frame::Grid, ::Frame::Distorted, ::Frame::Inertial))
+
+#undef FRAME
+#undef INSTANTIATE
+}  // namespace ylm::InitialShapes
+
+template <typename Frame>
+PUP::able::PUP_ID ylm::InitialShapes::FromFile<Frame>::my_PUP_ID = 0;  // NOLINT

--- a/src/NumericalAlgorithms/SphericalHarmonics/IO/InitialShapeFromFile.hpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/IO/InitialShapeFromFile.hpp
@@ -1,0 +1,86 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <pup.h>
+#include <string>
+
+#include "NumericalAlgorithms/SphericalHarmonics/InitialShape.hpp"
+#include "Options/Context.hpp"
+#include "Options/String.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace ylm {
+template <typename Frame>
+class Strahlkorper;
+
+namespace InitialShapes {
+/*!
+ * \ingroup SurfacesGroup
+ * \brief An initial Strahlkorper shape read from an H5 file.
+ */
+template <typename Frame>
+class FromFile : public InitialShape<Frame> {
+ public:
+  struct H5Filename {
+    using type = std::string;
+    static constexpr Options::String help = {
+        "H5 file containing the Strahlkorper coefficients"};
+  };
+  struct SubfileName {
+    using type = std::string;
+    static constexpr Options::String help = {
+        "Subfile (without leading slash or .dat extension) within "
+        "the H5 file that contains the Strahlkorper coefficients"};
+  };
+  struct Time {
+    using type = double;
+    static constexpr Options::String help = {
+        "Time at which to read the Strahlkorper coefficients"};
+  };
+  struct TimeEpsilon {
+    using type = double;
+    static constexpr Options::String help = {
+        "Tolerance for matching the requested time to read the Strahlkorper "
+        "coefficients"};
+  };
+  struct CheckFrame {
+    using type = bool;
+    static constexpr Options::String help = {
+        "Whether to check that the frame in the file matches the requested "
+        "frame"};
+  };
+
+  using options =
+      tmpl::list<H5Filename, SubfileName, Time, TimeEpsilon, CheckFrame>;
+  static constexpr Options::String help = {
+      "Construct a Strahlkorper from coefficients read from an H5 file."};
+  static std::string name() { return "FromFile"; }
+
+  FromFile() = default;
+  FromFile(std::string h5_filename, std::string subfile_name, double time,
+           double time_epsilon, bool check_frame);
+
+  /// \cond
+  explicit FromFile(CkMigrateMessage* msg);
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(FromFile);  // NOLINT
+  /// \endcond
+
+  Strahlkorper<Frame> strahlkorper(
+      size_t l_max, const Options::Context& context) const override;
+
+  void pup(PUP::er& p) override;
+
+ private:
+  std::string h5_filename_{};
+  std::string subfile_name_{};
+  double time_{};
+  double time_epsilon_{};
+  bool check_frame_{};
+};
+}  // namespace InitialShapes
+}  // namespace ylm

--- a/src/NumericalAlgorithms/SphericalHarmonics/InitialShape.cpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/InitialShape.cpp
@@ -1,0 +1,55 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/SphericalHarmonics/InitialShape.hpp"
+
+#include <array>
+#include <cstddef>
+#include <pup.h>
+#include <pup_stl.h>
+#include <utility>
+
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
+#include "Options/Context.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+namespace Frame {
+struct Distorted;
+struct Grid;
+struct Inertial;
+}  // namespace Frame
+
+namespace ylm::InitialShapes {
+template <typename Frame>
+Sphere<Frame>::Sphere(std::array<double, 3> center, const double radius)
+    : center_(std::move(center)), radius_(radius) {}
+
+template <typename Frame>
+Sphere<Frame>::Sphere(CkMigrateMessage* msg) : InitialShape<Frame>(msg) {}
+
+template <typename Frame>
+Strahlkorper<Frame> Sphere<Frame>::strahlkorper(
+    const size_t l_max, const Options::Context& /*context*/) const {
+  return Strahlkorper<Frame>{l_max, radius_, center_};
+}
+
+template <typename Frame>
+void Sphere<Frame>::pup(PUP::er& p) {
+  p | center_;
+  p | radius_;
+}
+
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data) template class Sphere<FRAME(data)>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE,
+                        (::Frame::Grid, ::Frame::Distorted, ::Frame::Inertial))
+
+#undef FRAME
+#undef INSTANTIATE
+}  // namespace ylm::InitialShapes
+
+template <typename Frame>
+PUP::able::PUP_ID ylm::InitialShapes::Sphere<Frame>::my_PUP_ID = 0;  // NOLINT

--- a/src/NumericalAlgorithms/SphericalHarmonics/InitialShape.hpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/InitialShape.hpp
@@ -1,0 +1,99 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <pup.h>
+
+#include "Options/Context.hpp"
+#include "Options/String.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace ylm {
+template <typename Frame>
+class Strahlkorper;
+
+/*!
+ * \ingroup SurfacesGroup
+ * \brief Base class for constructing initial Strahlkorper shapes.
+ * \details When constructing a Stahlkorper from options (such as the
+ * initial guess for an apparent horizon), the user can specify a resolution
+ * and a shape (such as spherical, or read from file).
+ */
+template <typename Frame>
+class InitialShape : public PUP::able {
+ protected:
+  /// \cond
+  InitialShape() = default;
+  InitialShape(const InitialShape&) = default;
+  InitialShape(InitialShape&&) = default;
+  InitialShape& operator=(const InitialShape&) = default;
+  InitialShape& operator=(InitialShape&&) = default;
+  /// \endcond
+
+ public:
+  ~InitialShape() override = default;
+  explicit InitialShape(CkMigrateMessage* msg) : PUP::able(msg) {}
+
+  WRAPPED_PUPable_abstract(InitialShape);
+
+  /// Construct a Strahlkorper with both `l_max` and `m_max` set to `l_max`.
+  /// The `context` is used to report option-parsing errors.
+  virtual Strahlkorper<Frame> strahlkorper(
+      size_t l_max, const Options::Context& context) const = 0;
+};
+
+namespace InitialShapes {
+/*!
+ * \ingroup SurfacesGroup
+ * \brief A spherical initial Strahlkorper shape.
+ */
+template <typename Frame>
+class Sphere : public InitialShape<Frame> {
+ public:
+  struct Center {
+    using type = std::array<double, 3>;
+    static constexpr Options::String help = {
+        "Center of the Strahlkorper expansion"};
+  };
+  struct Radius {
+    using type = double;
+    static constexpr Options::String help = {
+        "Radius of spherical Strahlkorper"};
+  };
+
+  using options = tmpl::list<Center, Radius>;
+  static constexpr Options::String help = {
+      "Construct a spherical Strahlkorper."};
+  static std::string name() { return "Sphere"; }
+
+  Sphere() = default;
+  Sphere(std::array<double, 3> center, double radius);
+
+  /// \cond
+  explicit Sphere(CkMigrateMessage* msg);
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(Sphere);  // NOLINT
+  /// \endcond
+
+  Strahlkorper<Frame> strahlkorper(
+      size_t l_max, const Options::Context& context) const override;
+
+  void pup(PUP::er& p) override;
+
+ private:
+  std::array<double, 3> center_{};
+  double radius_{};
+};
+
+}  // namespace InitialShapes
+}  // namespace ylm

--- a/src/NumericalAlgorithms/SphericalHarmonics/Strahlkorper.cpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/Strahlkorper.cpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <memory>
 #include <ostream>
 #include <pup.h>
 #include <pup_stl.h>
@@ -13,6 +14,7 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/ModalVector.hpp"
 #include "DataStructures/VectorImpl.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/InitialShape.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/SpherepackIterator.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/StdArrayHelpers.hpp"
@@ -34,6 +36,19 @@ Strahlkorper<Frame>::Strahlkorper(const size_t l_max, const size_t m_max,
       strahlkorper_coefs_(ylm_.spectral_size(), 0.0) {
   ylm::Spherepack::add_constant(&strahlkorper_coefs_, radius);
 }
+
+template <typename Frame>
+Strahlkorper<Frame>::Strahlkorper(const size_t initial_l,
+                                  const InitialShape<Frame>& initial_shape,
+                                  const Options::Context& context)
+    : Strahlkorper(initial_shape.strahlkorper(initial_l, context)) {}
+
+template <typename Frame>
+Strahlkorper<Frame>::Strahlkorper(
+    const size_t initial_l,
+    const std::unique_ptr<InitialShape<Frame>>& initial_shape,
+    const Options::Context& context)
+    : Strahlkorper(initial_l, *initial_shape, context) {}
 
 template <typename Frame>
 Strahlkorper<Frame>::Strahlkorper(

--- a/src/NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp
@@ -5,10 +5,12 @@
 
 #include <array>
 #include <cstddef>
+#include <memory>
 #include <string>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/ModalVector.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/InitialShape.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Spherepack.hpp"
 #include "Options/Context.hpp"
 #include "Options/String.hpp"
@@ -33,65 +35,23 @@ namespace ylm {
 template <typename Frame>
 class Strahlkorper {
  public:
-  struct LMax {
+  struct InitialL {
     using type = size_t;
     static constexpr Options::String help = {
-        "Strahlkorper is expanded in Ylms up to l=LMax"};
+        "Initial Strahlkorper resolution. Sets both l_max and m_max."};
   };
-  struct Radius {
-    using type = double;
-    static constexpr Options::String help = {
-        "Radius of spherical Strahlkorper"};
+  struct InitialShapeOption {
+    using type = std::unique_ptr<InitialShape<Frame>>;
+    static constexpr Options::String help = {"Initial Strahlkorper shape."};
+    static std::string name() { return "InitialShape"; }
   };
-  struct Center {
-    using type = std::array<double, 3>;
-    static constexpr Options::String help = {
-        "Center of spherical Strahlkorper"};
-  };
-  struct H5Filename {
-    using type = std::string;
-    static constexpr Options::String help = {
-        "H5 file containing the Strahlkorper coefficients"};
-  };
-  struct SubfileName {
-    using type = std::string;
-    static constexpr Options::String help = {
-        "Subfile (without leading slash or .dat extension) within "
-        "the H5 file that contains the Strahlkorper coefficients"};
-  };
-  struct Time {
-    using type = double;
-    static constexpr Options::String help = {
-        "Time at which to read the Strahlkorper coefficients"};
-  };
-  struct TimeEpsilon {
-    using type = double;
-    static constexpr Options::String help = {
-        "Tolerance for matching the requested time to read the Strahlkorper "
-        "coefficients"};
-  };
-  struct CheckFrame {
-    using type = bool;
-    static constexpr Options::String help = {
-        "Whether to check that the frame in the file matches the requested "
-        "frame"};
-  };
-  using options =
-      tmpl::list<LMax,
-                 Options::Alternatives<tmpl::list<Radius, Center>,
-                                       tmpl::list<H5Filename, SubfileName, Time,
-                                                  TimeEpsilon, CheckFrame>>>;
+  using options = tmpl::list<InitialL, InitialShapeOption>;
 
   static constexpr Options::String help{
       "A star-shaped surface expressed as an expansion in spherical "
       "harmonics.\n"
-      "A Strahlkorper can be constructed from Options in two ways:\n"
-      "1. Specify LMax, Center, and Radius to construct a spherical "
-      "Strahlkorper.\n"
-      "2. Specify LMax, H5Filename, SubfileName, Time, TimeEpsilon, and "
-      "CheckFrame to construct a Strahlkorper from coefficients read from an "
-      "H5 file. The Strahlkorper will be prolonged or restricted to the "
-      "specified LMax."};
+      "A Strahlkorper can be constructed from options by specifying InitialL "
+      "and an InitialShape. InitialL sets both l_max and m_max."};
 
   // Pup needs default constructor
   Strahlkorper() = default;
@@ -114,6 +74,15 @@ class Strahlkorper {
                const std::string& subfile_name, double time,
                double time_epsilon, bool check_frame,
                const Options::Context& context);
+
+  /// Construct from options from an initial shape.
+  /// @{
+  Strahlkorper(size_t initial_l, const InitialShape<Frame>& initial_shape,
+               const Options::Context& context);
+  Strahlkorper(size_t initial_l,
+               const std::unique_ptr<InitialShape<Frame>>& initial_shape,
+               const Options::Context& context);
+  /// @}
 
   /// Construct a Strahlkorper from a DataVector containing the radius
   /// at the collocation points.

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/CMakeLists.txt
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/CMakeLists.txt
@@ -15,6 +15,7 @@ spectre_target_sources(
   Destination.cpp
   FastFlow.cpp
   InterpolateVolumeVars.cpp
+  KerrSchild.cpp
   OptionTags.cpp
   Storage.cpp
   )
@@ -35,6 +36,7 @@ spectre_target_headers(
   HorizonAliases.hpp
   Initialization.hpp
   InterpolateVolumeVars.hpp
+  KerrSchild.hpp
   OptionTags.hpp
   PrintDeadlockAnalysis.hpp
   Storage.hpp
@@ -55,6 +57,7 @@ target_link_libraries(
   Options
   Printf
   SphericalHarmonics
+  SphericalHarmonicsIO
   PRIVATE
   CoordinateMaps
   Domain

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/KerrSchild.cpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/KerrSchild.cpp
@@ -1,0 +1,75 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "ParallelAlgorithms/ApparentHorizonFinder/KerrSchild.hpp"
+
+#include <array>
+#include <cstddef>
+#include <pup.h>
+#include <utility>
+
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Spherepack.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
+#include "Options/Context.hpp"
+#include "Options/ParseError.hpp"
+#include "PointwiseFunctions/GeneralRelativity/KerrHorizon.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/StdArrayHelpers.hpp"
+
+namespace Frame {
+struct Distorted;
+struct Grid;
+struct Inertial;
+}  // namespace Frame
+
+namespace ah::InitialShapes {
+template <typename Frame>
+KerrSchild<Frame>::KerrSchild(std::array<double, 3> center, const double mass,
+                              std::array<double, 3> spin)
+    : center_(std::move(center)), mass_(mass), spin_(std::move(spin)) {}
+
+template <typename Frame>
+KerrSchild<Frame>::KerrSchild(CkMigrateMessage* msg)
+    : ylm::InitialShape<Frame>(msg) {}
+
+template <typename Frame>
+ylm::Strahlkorper<Frame> KerrSchild<Frame>::strahlkorper(
+    const size_t l_max, const Options::Context& context) const {
+  if (mass_ <= 0.0) {
+    PARSE_ERROR(context, "KerrSchild expects Mass > 0, not " << mass_);
+  }
+  if (magnitude(spin_) > 1.0) {
+    PARSE_ERROR(context,
+                "KerrSchild expects |Spin| <= 1, not " << magnitude(spin_));
+  }
+  const auto ylm = ylm::Spherepack{l_max, l_max};
+  return ylm::Strahlkorper<Frame>{l_max, l_max,
+                                  get(gr::Solutions::kerr_horizon_radius(
+                                      ylm.theta_phi_points(), mass_, spin_)),
+                                  center_};
+}
+
+template <typename Frame>
+void KerrSchild<Frame>::pup(PUP::er& p) {
+  p | center_;
+  p | mass_;
+  p | spin_;
+}
+
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data) template class KerrSchild<FRAME(data)>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE,
+                        (::Frame::Grid, ::Frame::Distorted, ::Frame::Inertial))
+
+#undef FRAME
+#undef INSTANTIATE
+}  // namespace ah::InitialShapes
+
+template <typename Frame>
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+PUP::able::PUP_ID ah::InitialShapes::KerrSchild<Frame>::my_PUP_ID =
+    0;  // NOLINT

--- a/src/ParallelAlgorithms/ApparentHorizonFinder/KerrSchild.hpp
+++ b/src/ParallelAlgorithms/ApparentHorizonFinder/KerrSchild.hpp
@@ -1,0 +1,66 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <pup.h>
+
+#include "NumericalAlgorithms/SphericalHarmonics/InitialShape.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
+#include "Options/Context.hpp"
+#include "Options/String.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace ah::InitialShapes {
+/*!
+ * \ingroup SurfacesGroup
+ * \brief An initial shape for a Strahlkorper corersponding to a Kerr-Schild
+ * black hole.
+ */
+template <typename Frame>
+class KerrSchild : public ylm::InitialShape<Frame> {
+ public:
+  struct Center {
+    using type = std::array<double, 3>;
+    static constexpr Options::String help = {
+        "Center of the Strahlkorper expansion"};
+  };
+  struct Mass {
+    using type = double;
+    static constexpr Options::String help = {"Mass of the black hole"};
+  };
+  struct Spin {
+    using type = std::array<double, 3>;
+    static constexpr Options::String help = {"Dimensionless spin vector"};
+  };
+
+  using options = tmpl::list<Center, Mass, Spin>;
+  static constexpr Options::String help = {
+      "Construct a Kerr-Schild horizon for the given mass and dimensionless "
+      "spin vector."};
+  static std::string name() { return "KerrSchild"; }
+
+  KerrSchild() = default;
+  KerrSchild(std::array<double, 3> center, double mass,
+             std::array<double, 3> spin);
+
+  /// \cond
+  explicit KerrSchild(CkMigrateMessage* msg);
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(KerrSchild);  // NOLINT
+  /// \endcond
+
+  ylm::Strahlkorper<Frame> strahlkorper(
+      size_t l_max, const Options::Context& context) const override;
+
+  void pup(PUP::er& p) override;
+
+ private:
+  std::array<double, 3> center_{};
+  double mass_{};
+  std::array<double, 3> spin_{};
+};
+}  // namespace ah::InitialShapes

--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -528,9 +528,11 @@ ApparentHorizons:
   ObservationAhA: &AhA
     Criteria:
     InitialGuess:
-      LMax: &ObsLMax 10
-      Radius: {{ ExcisionRadiusA * 1.5 }}
-      Center: [*XCoordA, *YOffset, *ZOffset]
+      InitialL: &ObsLMax 10
+      InitialShape:
+        Sphere:
+          Radius: {{ ExcisionRadiusA * 1.5 }}
+          Center: [*XCoordA, *YOffset, *ZOffset]
     FastFlow: &DefaultFastFlow
       Flow: Fast
       Alpha: 1.0
@@ -546,9 +548,11 @@ ApparentHorizons:
   ObservationAhB: &AhB
     Criteria:
     InitialGuess:
-      LMax: *ObsLMax
-      Radius: {{ ExcisionRadiusB * 1.5 }}
-      Center: [*XCoordB, *YOffset, *ZOffset]
+      InitialL: *ObsLMax
+      InitialShape:
+        Sphere:
+          Radius: {{ ExcisionRadiusB * 1.5 }}
+          Center: [*XCoordB, *YOffset, *ZOffset]
     FastFlow: *DefaultFastFlow
     Verbosity: Quiet
     MaxComputeCoordsRetries: 3
@@ -556,9 +560,11 @@ ApparentHorizons:
   ObservationAhC:
     Criteria:
     InitialGuess:
-      LMax: 33
-      Radius: 10.0
-      Center: [0.0, 0.0, 0.0]
+      InitialL: 33
+      InitialShape:
+        Sphere:
+          Radius: 10.0
+          Center: [0.0, 0.0, 0.0]
     FastFlow: *DefaultFastFlow
     Verbosity: Quiet
     MaxComputeCoordsRetries: 3

--- a/support/Pipelines/Bbh/Ringdown.yaml
+++ b/support/Pipelines/Bbh/Ringdown.yaml
@@ -332,9 +332,11 @@ ApparentHorizons:
   ApparentHorizon: &Ah
     Criteria:
     InitialGuess:
-      LMax: *MaximumL
-      Radius: 2.2
-      Center: [0., 0., 0.]
+      InitialL: *MaximumL
+      InitialShape:
+        Sphere:
+          Radius: 2.2
+          Center: [0., 0., 0.]
     FastFlow:
       Flow: Fast
       Alpha: 1.0

--- a/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
@@ -318,9 +318,11 @@ ApparentHorizons:
   ObservationAhA: &AhA
     Criteria:
     InitialGuess:
-      LMax: *LMax
-      Radius: 2.2
-      Center: [*XCoordA, 0.0, 0.0]
+      InitialL: *LMax
+      InitialShape:
+        Sphere:
+          Radius: 2.2
+          Center: [*XCoordA, 0.0, 0.0]
     FastFlow: &DefaultFastFlow
       Flow: Fast
       Alpha: 1.0
@@ -336,9 +338,11 @@ ApparentHorizons:
   ObservationAhB: &AhB
     Criteria:
     InitialGuess:
-      LMax: *LMax
-      Radius: 2.2
-      Center: [*XCoordB, 0.0, 0.0]
+      InitialL: *LMax
+      InitialShape:
+        Sphere:
+          Radius: 2.2
+          Center: [*XCoordB, 0.0, 0.0]
     FastFlow: *DefaultFastFlow
     Verbosity: Verbose
     MaxComputeCoordsRetries: 3
@@ -346,9 +350,11 @@ ApparentHorizons:
   ObservationAhC:
     Criteria:
     InitialGuess:
-      LMax: 20
-      Radius: 10.0
-      Center: [0.0, 0.0, 0.0]
+      InitialL: 20
+      InitialShape:
+        Sphere:
+          Radius: 10.0
+          Center: [0.0, 0.0, 0.0]
     FastFlow: *DefaultFastFlow
     Verbosity: Verbose
     MaxComputeCoordsRetries: 3

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -250,9 +250,11 @@ ApparentHorizons:
           MaxResidual: 1.e-1
           MinResolutionL: 4
     InitialGuess:
-      LMax: &LMax 8
-      Radius: 2.2
-      Center: *Center
+      InitialL: &LMax 8
+      InitialShape:
+        Sphere:
+          Radius: 2.2
+          Center: *Center
     FastFlow:
       Flow: Fast
       Alpha: 1.0

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
@@ -242,9 +242,11 @@ ApparentHorizons:
   AhA:
     Criteria:
     InitialGuess:
-      LMax: 4
-      Radius: 2.2
-      Center: [0.0, 0.0, 0.0]
+      InitialL: 4
+      InitialShape:
+        Sphere:
+          Radius: 2.2
+          Center: [0.0, 0.0, 0.0]
     FastFlow:
       Flow: Fast
       Alpha: 1.0

--- a/tests/InputFiles/ScalarTensor/KerrSchildSphericalHarmonic.yaml
+++ b/tests/InputFiles/ScalarTensor/KerrSchildSphericalHarmonic.yaml
@@ -234,9 +234,11 @@ ApparentHorizons:
   ApparentHorizon: &Ah
     Criteria:
     InitialGuess:
-      LMax: *LMax
-      Radius: 2.2
-      Center: [0., 0., 0.]
+      InitialL: *LMax
+      InitialShape:
+        Sphere:
+          Radius: 2.2
+          Center: [0., 0., 0.]
     FastFlow:
       Flow: Fast
       Alpha: 1.0

--- a/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Test_Strahlkorper.cpp
+++ b/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Test_Strahlkorper.cpp
@@ -21,13 +21,17 @@
 #include "IO/H5/File.hpp"
 #include "NumericalAlgorithms/RootFinding/QuadraticEquation.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/IO/FillYlmLegendAndData.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/IO/InitialShapeFromFile.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/InitialShape.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Spherepack.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/SpherepackIterator.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
 #include "Options/ParseOptions.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/FileSystem.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace Frame {
@@ -36,6 +40,16 @@ struct Inertial;
 
 namespace ylm {
 namespace {
+struct TestCreationMetavariables {
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes = tmpl::map<
+        tmpl::pair<ylm::InitialShape<Frame::Inertial>,
+                   tmpl::list<ylm::InitialShapes::Sphere<Frame::Inertial>,
+                              ylm::InitialShapes::FromFile<Frame::Inertial>>>>;
+  };
+};
+
 void test_invert_spec_phys_transform() {
   const double avg_radius = 1.0;
   const double delta_radius = 0.1;
@@ -220,16 +234,19 @@ Strahlkorper<Frame::Inertial> parse_strahlkorper_from_options(
   Options::Parser<tmpl::list<OptionTags::Strahlkorper<Frame::Inertial>>> opts(
       "");
   opts.parse(options_string);
-  return opts.get<OptionTags::Strahlkorper<Frame::Inertial>>();
+  return opts.get<OptionTags::Strahlkorper<Frame::Inertial>,
+                  TestCreationMetavariables>();
 }
 
 void test_construct_from_options() {
   // Test construction from Radius and Center
   {
     CHECK(parse_strahlkorper_from_options("Strahlkorper:\n"
-                                          " LMax : 6\n"
-                                          " Center: [1.,2.,3.]\n"
-                                          " Radius: 4.5\n") ==
+                                          " InitialL : 6\n"
+                                          " InitialShape:\n"
+                                          "   Sphere:\n"
+                                          "     Center: [1.,2.,3.]\n"
+                                          "     Radius: 4.5\n") ==
           Strahlkorper<Frame::Inertial>(6, 6, 4.5, {{1., 2., 3.}}));
   }
 
@@ -252,12 +269,14 @@ void test_construct_from_options() {
     {
       const auto read_strahlkorper = parse_strahlkorper_from_options(
           "Strahlkorper:\n"
-          " LMax : 4\n"
-          " H5Filename: TestStrahlkorperOptions.h5\n"
-          " SubfileName: TestSurface_Ylm\n"
-          " Time: 1.23\n"
-          " TimeEpsilon: 1.0e-10\n"
-          " CheckFrame: true\n");
+          " InitialL : 4\n"
+          " InitialShape:\n"
+          "   FromFile:\n"
+          "     H5Filename: TestStrahlkorperOptions.h5\n"
+          "     SubfileName: TestSurface_Ylm\n"
+          "     Time: 1.23\n"
+          "     TimeEpsilon: 1.0e-10\n"
+          "     CheckFrame: true\n");
 
       CHECK(read_strahlkorper.l_max() == l_max_original);
       CHECK(read_strahlkorper.m_max() == l_max_original);
@@ -271,12 +290,14 @@ void test_construct_from_options() {
       const size_t l_max_requested = 6;
       const auto read_strahlkorper = parse_strahlkorper_from_options(
           "Strahlkorper:\n"
-          " LMax : 6\n"
-          " H5Filename: TestStrahlkorperOptions.h5\n"
-          " SubfileName: TestSurface_Ylm\n"
-          " Time: 1.23\n"
-          " TimeEpsilon: 1.0e-10\n"
-          " CheckFrame: true\n");
+          " InitialL : 6\n"
+          " InitialShape:\n"
+          "   FromFile:\n"
+          "     H5Filename: TestStrahlkorperOptions.h5\n"
+          "     SubfileName: TestSurface_Ylm\n"
+          "     Time: 1.23\n"
+          "     TimeEpsilon: 1.0e-10\n"
+          "     CheckFrame: true\n");
 
       CHECK(read_strahlkorper.l_max() == l_max_requested);
       CHECK(read_strahlkorper.m_max() == l_max_requested);
@@ -292,12 +313,14 @@ void test_construct_from_options() {
     {
       const auto read_strahlkorper = parse_strahlkorper_from_options(
           "Strahlkorper:\n"
-          " LMax : 2\n"
-          " H5Filename: TestStrahlkorperOptions.h5\n"
-          " SubfileName: TestSurface_Ylm\n"
-          " Time: 1.23\n"
-          " TimeEpsilon: 1.0e-10\n"
-          " CheckFrame: true\n");
+          " InitialL : 2\n"
+          " InitialShape:\n"
+          "   FromFile:\n"
+          "     H5Filename: TestStrahlkorperOptions.h5\n"
+          "     SubfileName: TestSurface_Ylm\n"
+          "     Time: 1.23\n"
+          "     TimeEpsilon: 1.0e-10\n"
+          "     CheckFrame: true\n");
 
       CHECK(read_strahlkorper.l_max() == 2);
       CHECK(read_strahlkorper.m_max() == 2);
@@ -318,13 +341,16 @@ void test_construct_from_options() {
         "");
     opts.parse(
         "Strahlkorper:\n"
-        " LMax : 4\n"
-        " H5Filename: NonexistentFile.h5\n"
-        " SubfileName: TestSurface_Ylm\n"
-        " Time: 1.23\n"
-        " TimeEpsilon: 1.0e-10\n"
-        " CheckFrame: true\n");
-    CHECK_THROWS_WITH(opts.get<OptionTags::Strahlkorper<Frame::Inertial>>(),
+        " InitialL : 4\n"
+        " InitialShape:\n"
+        "   FromFile:\n"
+        "     H5Filename: NonexistentFile.h5\n"
+        "     SubfileName: TestSurface_Ylm\n"
+        "     Time: 1.23\n"
+        "     TimeEpsilon: 1.0e-10\n"
+        "     CheckFrame: true\n");
+    CHECK_THROWS_WITH((opts.get<OptionTags::Strahlkorper<Frame::Inertial>,
+                                TestCreationMetavariables>()),
                       Catch::Matchers::ContainsSubstring(
                           "Trying to open the file 'NonexistentFile.h5'") &&
                           Catch::Matchers::ContainsSubstring("does not exist"));
@@ -345,14 +371,17 @@ void test_construct_from_options() {
         "");
     opts.parse(
         "Strahlkorper:\n"
-        " LMax : 4\n"
-        " H5Filename: TestStrahlkorperOptionsFailure.h5\n"
-        " SubfileName: InvalidSurface\n"
-        " Time: 1.23\n"
-        " TimeEpsilon: 1.0e-10\n"
-        " CheckFrame: true\n");
+        " InitialL : 4\n"
+        " InitialShape:\n"
+        "   FromFile:\n"
+        "     H5Filename: TestStrahlkorperOptionsFailure.h5\n"
+        "     SubfileName: InvalidSurface\n"
+        "     Time: 1.23\n"
+        "     TimeEpsilon: 1.0e-10\n"
+        "     CheckFrame: true\n");
     CHECK_THROWS_WITH(
-        opts.get<OptionTags::Strahlkorper<Frame::Inertial>>(),
+        (opts.get<OptionTags::Strahlkorper<Frame::Inertial>,
+                  TestCreationMetavariables>()),
         Catch::Matchers::ContainsSubstring("Cannot open the object"));
 
     file_system::rm(test_filename, true);
@@ -373,14 +402,17 @@ void test_construct_from_options() {
         "");
     opts.parse(
         "Strahlkorper:\n"
-        " LMax : 4\n"
-        " H5Filename: TestStrahlkorperOptionsTimeEpsilon.h5\n"
-        " SubfileName: TestSurface_Ylm\n"
-        " Time: 1.2300000003\n"  // Differs by 3.0e-10 from actual time
-        " TimeEpsilon: 1.0e-10\n"
-        " CheckFrame: true\n");
+        " InitialL : 4\n"
+        " InitialShape:\n"
+        "   FromFile:\n"
+        "     H5Filename: TestStrahlkorperOptionsTimeEpsilon.h5\n"
+        "     SubfileName: TestSurface_Ylm\n"
+        "     Time: 1.2300000003\n"  // Differs by 3.0e-10 from actual time
+        "     TimeEpsilon: 1.0e-10\n"
+        "     CheckFrame: true\n");
     CHECK_THROWS_WITH(
-        opts.get<OptionTags::Strahlkorper<Frame::Inertial>>(),
+        (opts.get<OptionTags::Strahlkorper<Frame::Inertial>,
+                  TestCreationMetavariables>()),
         Catch::Matchers::ContainsSubstring("Could not find time"));
 
     file_system::rm(test_filename, true);

--- a/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_OptionTags.cpp
+++ b/tests/Unit/ParallelAlgorithms/ApparentHorizonFinder/Test_OptionTags.cpp
@@ -18,6 +18,8 @@
 #include "Domain/Domain.hpp"
 #include "Framework/TestCreation.hpp"
 #include "IO/Logging/Verbosity.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/IO/InitialShapeFromFile.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/InitialShape.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Strahlkorper.hpp"
 #include "Options/Auto.hpp"
 #include "Options/Protocols/FactoryCreation.hpp"
@@ -27,9 +29,11 @@
 #include "ParallelAlgorithms/ApparentHorizonFinder/Criteria/Residual.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Destination.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/FastFlow.hpp"
+#include "ParallelAlgorithms/ApparentHorizonFinder/KerrSchild.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/OptionTags.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Protocols/HorizonMetavars.hpp"
 #include "ParallelAlgorithms/ApparentHorizonFinder/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/KerrHorizon.hpp"
 #include "Time/Tags/TimeAndPrevious.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
@@ -61,8 +65,12 @@ struct MockMetavariables {
 struct TestCreationMetavariables {
   struct factory_creation
       : tt::ConformsTo<Options::protocols::FactoryCreation> {
-    using factory_classes =
-        tmpl::map<tmpl::pair<ah::Criterion, ah::Criteria::standard_criteria>>;
+    using factory_classes = tmpl::map<
+        tmpl::pair<ah::Criterion, ah::Criteria::standard_criteria>,
+        tmpl::pair<ylm::InitialShape<Frame::Grid>,
+                   tmpl::list<ylm::InitialShapes::Sphere<Frame::Grid>,
+                              ylm::InitialShapes::FromFile<Frame::Grid>,
+                              ah::InitialShapes::KerrSchild<Frame::Grid>>>>;
   };
 };
 }  // namespace
@@ -106,9 +114,11 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizonFinder.OptionTags",
           "  MaxIts: 100\n"
           "Verbosity: Verbose\n"
           "InitialGuess:\n"
-          "  Center: [0.05, 0.06, 0.07]\n"
-          "  Radius: 2.0\n"
-          "  LMax: 12\n"
+          "  InitialL: 12\n"
+          "  InitialShape:\n"
+          "    Sphere:\n"
+          "      Center: [0.05, 0.06, 0.07]\n"
+          "      Radius: 2.0\n"
           "MaxComputeCoordsRetries: 3\n"
           "BlocksForHorizonFind: All");
   CHECK(created_opts == apparent_horizon_opts);
@@ -130,6 +140,57 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizonFinder.OptionTags",
                                           block_names.end()});
   }
   {
+    const auto kerr_schild_shape = TestHelpers::test_factory_creation<
+        ylm::InitialShape<Frame::Grid>,
+        ah::InitialShapes::KerrSchild<Frame::Grid>>(
+        "KerrSchild:\n"
+        "  Center: [0.1, -0.2, 0.3]\n"
+        "  Mass: 0.5\n"
+        "  Spin: [0.0, 0.0, 0.7]\n");
+    const size_t kerr_schild_l_max = 16;
+    const std::array<double, 3> kerr_schild_center{{0.1, -0.2, 0.3}};
+    const double mass = 0.5;
+    const std::array<double, 3> dimensionless_spin{{0.0, 0.0, 0.7}};
+    const ylm::Spherepack ylm{kerr_schild_l_max, kerr_schild_l_max};
+    const ylm::Strahlkorper<Frame::Grid> expected_kerr_schild_horizon{
+        kerr_schild_l_max, kerr_schild_l_max,
+        get(gr::Solutions::kerr_horizon_radius(ylm.theta_phi_points(), mass,
+                                               dimensionless_spin)),
+        kerr_schild_center};
+    CHECK(kerr_schild_shape->strahlkorper(kerr_schild_l_max, {}) ==
+          expected_kerr_schild_horizon);
+
+    const auto kerr_schild_created_opts =
+        TestHelpers::test_creation<ah::HorizonOptions<Frame::Grid>,
+                                   TestCreationMetavariables>(
+            "Criteria:\n"
+            "FastFlow:\n"
+            "  Flow: Fast\n"
+            "  Alpha: 1.0\n"
+            "  Beta: 0.5\n"
+            "  AbsTol: 1e-12\n"
+            "  TruncationTol: 1e-2\n"
+            "  DivergenceTol: 1.2\n"
+            "  DivergenceIter: 5\n"
+            "  MaxIts: 100\n"
+            "Verbosity: Verbose\n"
+            "InitialGuess:\n"
+            "  InitialL: 16\n"
+            "  InitialShape:\n"
+            "    KerrSchild:\n"
+            "      Center: [0.1, -0.2, 0.3]\n"
+            "      Mass: 0.5\n"
+            "      Spin: [0.0, 0.0, 0.7]\n"
+            "MaxComputeCoordsRetries: 3\n"
+            "BlocksForHorizonFind: All");
+
+    CHECK(kerr_schild_created_opts.initial_guess.l_max() == kerr_schild_l_max);
+    CHECK(kerr_schild_created_opts.initial_guess.expansion_center() ==
+          kerr_schild_center);
+    CHECK_ITERABLE_APPROX(kerr_schild_created_opts.initial_guess.coefficients(),
+                          expected_kerr_schild_horizon.coefficients());
+  }
+  {
     const auto new_created_opts =
         TestHelpers::test_creation<ah::HorizonOptions<Frame::Grid>,
                                    TestCreationMetavariables>(
@@ -145,9 +206,11 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizonFinder.OptionTags",
             "  MaxIts: 100\n"
             "Verbosity: Verbose\n"
             "InitialGuess:\n"
-            "  Center: [0.05, 0.06, 0.07]\n"
-            "  Radius: 2.0\n"
-            "  LMax: 12\n"
+            "  InitialL: 12\n"
+            "  InitialShape:\n"
+            "    Sphere:\n"
+            "      Center: [0.05, 0.06, 0.07]\n"
+            "      Radius: 2.0\n"
             "MaxComputeCoordsRetries: 3\n"
             "BlocksForHorizonFind: [Shell0]");
     const auto blocks_for_horizon_find =


### PR DESCRIPTION
## Proposed changes

Enables 3 initial guesses for the horizon finder, including the existing two:
- Specify `Lmax`, `Radius`, and `Center` for a spherical extraction surface
- Specify `Lmax` and options pointing to surface coefs in an H5 file

This PR adds a third:
- Specify `Lmax`, and mass and spin of a KerrSchild black hole 

The motivation for this PR is to be able to start with a better initial guess to reduce time spent finding the initial horizon in simulations of high-spin perturbed black holes. I've found that for spin=0.999 the horizon finder initially takes hundreds of iterations.

Note: Codex assisted in preparing this PR. I reviewed every line.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
To specify an initial guess for the apparent horizon finder, now specify `InitialL` and `InitialShape` in one of three ways:

1. Initial shape is a coordinate sphere. Example:
```yaml
InitialGuess:
  InitialL: 10
  InitialShape:
    Sphere:
      Radius: 2.5
      Center: [0.0, 0.0, 0.0]
```

2. Initial shape is read from a file, then prolonged or extended to `InitialL`:
```yaml
InitialGuess:
  InitialL: 10
  InitialShape:
    FromFile:
      H5Filename: TestStrahlkorperOptions.h5
      SubfileName: TestSurface_Ylm
      Time: 1.23
      TimeEpsilon: 1.0e-10
      CheckFrame: true
```

3. Initial shape is that of a Kerr-Schild black hole. Example:
```yaml
InitialGuess:
  InitialL: 10
  InitialShape:
    KerrSchild:
      Center: [0.1, -0.2, 0.3]
      Mass: 0.5
      Spin: [0.0, 0.0, 0.7]
```
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [x] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
