### PR TITLE
Add second covariant derivative of scalar field in ScalarTensor.

### DIFF
--- a/src/PointwiseFunctions/ScalarTensor/CMakeLists.txt
+++ b/src/PointwiseFunctions/ScalarTensor/CMakeLists.txt
@@ -8,6 +8,7 @@ add_spectre_library(${LIBRARY})
 spectre_target_sources(
   ${LIBRARY}
   PRIVATE
+  DoubleCovariantDerivativeOfScalar.cpp
   RampUpFunction.cpp
   ScalarCharge.cpp
   ScalarSource.cpp
@@ -20,6 +21,7 @@ spectre_target_headers(
   HEADERS
   ConstraintDampingTags.hpp
   ConstraintGammas.hpp
+  DoubleCovariantDerivativeOfScalar.hpp
   RampUpFunction.hpp
   ScalarCharge.hpp
   SourceTags.hpp

--- a/src/PointwiseFunctions/ScalarTensor/DoubleCovariantDerivativeOfScalar.cpp
+++ b/src/PointwiseFunctions/ScalarTensor/DoubleCovariantDerivativeOfScalar.cpp
@@ -1,0 +1,171 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/ScalarTensor/DoubleCovariantDerivativeOfScalar.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace ScalarTensor {
+
+template <typename DataType, typename Frame>
+void DDKG_normal_normal_projection(
+    gsl::not_null<Scalar<DataType>*> DDKG_normal_normal_result,
+    const Scalar<DataType>& lapse, const tnsr::I<DataType, 3, Frame>& shift,
+    const tnsr::II<DataType, 3, Frame>& inverse_spatial_metric,
+    const tnsr::i<DataType, 3, Frame>& phi_scalar,
+    const tnsr::i<DataType, 3, Frame>& d_pi_scalar,
+    const Scalar<DataType>& dt_pi_scalar,
+    const tnsr::i<DataType, 3, Frame>& d_lapse) {
+  tenex::evaluate(
+      DDKG_normal_normal_result,
+      // - L_n Pi - (1/lapse) Phi^{i} partial_i lapse
+      -(1.0 / lapse()) * (dt_pi_scalar() - shift(ti::I) * d_pi_scalar(ti::i)
+
+                          + inverse_spatial_metric(ti::I, ti::J) *
+                                phi_scalar(ti::i) * d_lapse(ti::j)
+
+                              )
+
+  );
+}
+
+template <typename DataType, typename Frame>
+Scalar<DataType> DDKG_normal_normal_projection(
+    const Scalar<DataType>& lapse, const tnsr::I<DataType, 3, Frame>& shift,
+    const tnsr::II<DataType, 3, Frame>& inverse_spatial_metric,
+    const tnsr::i<DataType, 3, Frame>& phi_scalar,
+    const tnsr::i<DataType, 3, Frame>& d_pi_scalar,
+    const Scalar<DataType>& dt_pi_scalar,
+    const tnsr::i<DataType, 3, Frame>& d_lapse) {
+  Scalar<DataType> result{};
+  DDKG_normal_normal_projection(make_not_null(&result), lapse, shift,
+                                inverse_spatial_metric, phi_scalar, d_pi_scalar,
+                                dt_pi_scalar, d_lapse);
+  return result;
+}
+
+template <typename DataType, typename Frame>
+void DDKG_normal_spatial_projection(
+    gsl::not_null<tnsr::i<DataType, 3, Frame>*> DDKG_normal_spatial_result,
+    const tnsr::II<DataType, 3, Frame>& inverse_spatial_metric,
+    const tnsr::ii<DataType, 3, Frame>& extrinsic_curvature,
+    const tnsr::i<DataType, 3, Frame>& phi_scalar,
+    const tnsr::i<DataType, 3, Frame>& d_pi_scalar) {
+  tenex::evaluate<ti::i>(
+      DDKG_normal_spatial_result, extrinsic_curvature(ti::i, ti::j) *
+                                          inverse_spatial_metric(ti::J, ti::K) *
+                                          phi_scalar(ti::k)
+
+                                      - d_pi_scalar(ti::i)
+
+  );
+}
+
+template <typename DataType, typename Frame>
+tnsr::i<DataType, 3, Frame> DDKG_normal_spatial_projection(
+    const tnsr::II<DataType, 3, Frame>& inverse_spatial_metric,
+    const tnsr::ii<DataType, 3, Frame>& extrinsic_curvature,
+    const tnsr::i<DataType, 3, Frame>& phi_scalar,
+    const tnsr::i<DataType, 3, Frame>& d_pi_scalar) {
+  tnsr::i<DataType, 3, Frame> result{};
+  DDKG_normal_spatial_projection(make_not_null(&result), inverse_spatial_metric,
+                                 extrinsic_curvature, phi_scalar, d_pi_scalar);
+  return result;
+}
+
+template <typename DataType, typename Frame>
+void DDKG_spatial_spatial_projection(
+    gsl::not_null<tnsr::ii<DataType, 3, Frame>*> DDKG_spatial_spatial_result,
+    const tnsr::ii<DataType, 3, Frame>& extrinsic_curvature,
+    const tnsr::Ijj<DataType, 3, Frame>& spatial_christoffel_second_kind,
+    const Scalar<DataType>& pi_scalar,
+    const tnsr::i<DataType, 3, Frame>& phi_scalar,
+    const tnsr::ij<DataType, 3, Frame>& d_phi_scalar) {
+  // Note that D_phi is the covariant derivative and has Christoffel symbols
+  tenex::evaluate<ti::i, ti::j>(
+      DDKG_spatial_spatial_result,
+      -pi_scalar() * extrinsic_curvature(ti::i, ti::j)
+          // Note covariant derivative
+          // and symmetrize partial derivative of scalar
+          + 0.5 * (d_phi_scalar(ti::i, ti::j) + d_phi_scalar(ti::j, ti::i)) -
+          spatial_christoffel_second_kind(ti::K, ti::i, ti::j) *
+              phi_scalar(ti::k));
+}
+
+template <typename DataType, typename Frame>
+tnsr::ii<DataType, 3, Frame> DDKG_spatial_spatial_projection(
+    const tnsr::ii<DataType, 3, Frame>& extrinsic_curvature,
+    const tnsr::Ijj<DataType, 3, Frame>& spatial_christoffel_second_kind,
+    const Scalar<DataType>& pi_scalar,
+    const tnsr::i<DataType, 3, Frame>& phi_scalar,
+    const tnsr::ij<DataType, 3, Frame>& d_phi_scalar) {
+  tnsr::ii<DataType, 3, Frame> result{};
+  DDKG_spatial_spatial_projection(make_not_null(&result), extrinsic_curvature,
+                                  spatial_christoffel_second_kind, pi_scalar,
+                                  phi_scalar, d_phi_scalar);
+  return result;
+}
+}  // namespace ScalarTensor
+
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATE(_, data)                                                \
+  template void ScalarTensor::DDKG_normal_normal_projection(                \
+      gsl::not_null<Scalar<DTYPE(data)>*> DDKG_normal_normal_result,        \
+      const Scalar<DTYPE(data)>& lapse,                                     \
+      const tnsr::I<DTYPE(data), 3, FRAME(data)>& shift,                    \
+      const tnsr::II<DTYPE(data), 3, FRAME(data)>& inverse_spatial_metric,  \
+      const tnsr::i<DTYPE(data), 3, FRAME(data)>& phi_scalar,               \
+      const tnsr::i<DTYPE(data), 3, FRAME(data)>& d_pi_scalar,              \
+      const Scalar<DTYPE(data)>& dt_pi_scalar,                              \
+      const tnsr::i<DTYPE(data), 3, FRAME(data)>& d_lapse);                 \
+  template Scalar<DTYPE(data)> ScalarTensor::DDKG_normal_normal_projection( \
+      const Scalar<DTYPE(data)>& lapse,                                     \
+      const tnsr::I<DTYPE(data), 3, FRAME(data)>& shift,                    \
+      const tnsr::II<DTYPE(data), 3, FRAME(data)>& inverse_spatial_metric,  \
+      const tnsr::i<DTYPE(data), 3, FRAME(data)>& phi_scalar,               \
+      const tnsr::i<DTYPE(data), 3, FRAME(data)>& d_pi_scalar,              \
+      const Scalar<DTYPE(data)>& dt_pi_scalar,                              \
+      const tnsr::i<DTYPE(data), 3, FRAME(data)>& d_lapse);                 \
+  template void ScalarTensor::DDKG_normal_spatial_projection(               \
+      gsl::not_null<tnsr::i<DTYPE(data), 3, FRAME(data)>*>                  \
+          DDKG_normal_spatial_result,                                       \
+      const tnsr::II<DTYPE(data), 3, FRAME(data)>& inverse_spatial_metric,  \
+      const tnsr::ii<DTYPE(data), 3, FRAME(data)>& extrinsic_curvature,     \
+      const tnsr::i<DTYPE(data), 3, FRAME(data)>& phi_scalar,               \
+      const tnsr::i<DTYPE(data), 3, FRAME(data)>& d_pi_scalar);             \
+  template tnsr::i<DTYPE(data), 3, FRAME(data)>                             \
+  ScalarTensor::DDKG_normal_spatial_projection(                             \
+      const tnsr::II<DTYPE(data), 3, FRAME(data)>& inverse_spatial_metric,  \
+      const tnsr::ii<DTYPE(data), 3, FRAME(data)>& extrinsic_curvature,     \
+      const tnsr::i<DTYPE(data), 3, FRAME(data)>& phi_scalar,               \
+      const tnsr::i<DTYPE(data), 3, FRAME(data)>& d_pi_scalar);             \
+  template void ScalarTensor::DDKG_spatial_spatial_projection(              \
+      gsl::not_null<tnsr::ii<DTYPE(data), 3, FRAME(data)>*>                 \
+          DDKG_spatial_spatial_result,                                      \
+      const tnsr::ii<DTYPE(data), 3, FRAME(data)>& extrinsic_curvature,     \
+      const tnsr::Ijj<DTYPE(data), 3, FRAME(data)>&                         \
+          spatial_christoffel_second_kind,                                  \
+      const Scalar<DTYPE(data)>& pi_scalar,                                 \
+      const tnsr::i<DTYPE(data), 3, FRAME(data)>& phi_scalar,               \
+      const tnsr::ij<DTYPE(data), 3, FRAME(data)>& d_phi_scalar);           \
+  template tnsr::ii<DTYPE(data), 3, FRAME(data)>                            \
+  ScalarTensor::DDKG_spatial_spatial_projection(                            \
+      const tnsr::ii<DTYPE(data), 3, FRAME(data)>& extrinsic_curvature,     \
+      const tnsr::Ijj<DTYPE(data), 3, FRAME(data)>&                         \
+          spatial_christoffel_second_kind,                                  \
+      const Scalar<DTYPE(data)>& pi_scalar,                                 \
+      const tnsr::i<DTYPE(data), 3, FRAME(data)>& phi_scalar,               \
+      const tnsr::ij<DTYPE(data), 3, FRAME(data)>& d_phi_scalar);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector),
+                        (Frame::Grid, Frame::Inertial))
+
+#undef DTYPE
+#undef FRAME
+#undef INSTANTIATE

--- a/src/PointwiseFunctions/ScalarTensor/DoubleCovariantDerivativeOfScalar.hpp
+++ b/src/PointwiseFunctions/ScalarTensor/DoubleCovariantDerivativeOfScalar.hpp
@@ -1,0 +1,109 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace ScalarTensor {
+/// @{
+/*!
+ * \brief Normal projection of the second covariant derivative of the scalar
+ * field.
+ *
+ * \details Computes the term
+ * \begin{equation}
+ *   n^a n^b \nabla_a \nabla_b \Psi = - \frac{1}{\alpha} \Bigl[ \partial_t \Pi
+ *      - \beta^i \partial_i \Pi
+ *      + \Phi^i \partial_i \alpha \Bigr],
+ * \end{equation}
+ * where $\Psi$ is the scalar field, $\Pi$ is its conjugate momentum and
+ * $\Phi_i = \partial_i \Psi$; $n^a$ is the unit vector normal to the spatial
+ * hypersurfaces, while $\alpha$ is the lapse and $\beta^i$ is the shift vector.
+ */
+template <typename DataType, typename Frame>
+void DDKG_normal_normal_projection(
+    gsl::not_null<Scalar<DataType>*> DDKG_normal_normal_result,
+    const Scalar<DataType>& lapse, const tnsr::I<DataType, 3, Frame>& shift,
+    const tnsr::II<DataType, 3, Frame>& inverse_spatial_metric,
+    const tnsr::i<DataType, 3, Frame>& phi_scalar,
+    const tnsr::i<DataType, 3, Frame>& d_pi_scalar,
+    const Scalar<DataType>& dt_pi_scalar,
+    const tnsr::i<DataType, 3, Frame>& d_lapse);
+
+template <typename DataType, typename Frame>
+Scalar<DataType> DDKG_normal_normal_projection(
+    const Scalar<DataType>& lapse, const tnsr::I<DataType, 3, Frame>& shift,
+    const tnsr::II<DataType, 3, Frame>& inverse_spatial_metric,
+    const tnsr::i<DataType, 3, Frame>& phi_scalar,
+    const tnsr::i<DataType, 3, Frame>& d_pi_scalar,
+    const Scalar<DataType>& dt_pi_scalar,
+    const tnsr::i<DataType, 3, Frame>& d_lapse);
+/// @}
+
+/// @{
+/*!
+ * \brief Mixed projection of the second covariant derivative of the scalar
+ * field.
+ *
+ * \details Computes the term
+ * \begin{equation}
+ *   \gamma^a_i n^b \nabla_a \nabla_b \Psi
+ *     = - \partial_i \Pi + K_{ij} \Phi^j,
+ * \end{equation}
+ * where $\Psi$ is the scalar field, $\Pi$ is its conjugate momentum and
+ * $\Phi_i = \partial_i \Psi$; $n^a$ is the unit vector normal to the spatial
+ * hypersurfaces, $\gamma^a_b = \delta^a_b + n^a n_b$ is the projection operator
+ * onto them and $K_{ij}$ is the extrinsic curvature.
+ */
+template <typename DataType, typename Frame>
+void DDKG_normal_spatial_projection(
+    gsl::not_null<tnsr::i<DataType, 3, Frame>*> DDKG_normal_spatial_result,
+    const tnsr::II<DataType, 3, Frame>& inverse_spatial_metric,
+    const tnsr::ii<DataType, 3, Frame>& extrinsic_curvature,
+    const tnsr::i<DataType, 3, Frame>& phi_scalar,
+    const tnsr::i<DataType, 3, Frame>& d_pi_scalar);
+
+template <typename DataType, typename Frame>
+tnsr::i<DataType, 3, Frame> DDKG_normal_spatial_projection(
+    const tnsr::II<DataType, 3, Frame>& inverse_spatial_metric,
+    const tnsr::ii<DataType, 3, Frame>& extrinsic_curvature,
+    const tnsr::i<DataType, 3, Frame>& phi_scalar,
+    const tnsr::i<DataType, 3, Frame>& d_pi_scalar);
+/// @}
+
+/// @{
+/*!
+ * \brief Spatial projection of the second covariant derivative of the scalar
+ * field.
+ *
+ * \details Computes the term
+ * \begin{equation}
+ *   \gamma^a_i \gamma^b_j \nabla_a \nabla_b \Psi =
+ *     - \Pi K_{ij} + D_{(i} \Phi_{j)},
+ * \end{equation}
+ * where $\Psi$ is the scalar field, $\Pi$ is its conjugate momentum and
+ * $\Phi_i = \partial_i \Psi$; $n^a$ is the unit vector normal to the spatial
+ * hypersurfaces and $\gamma^a_b = \delta^a_b + n^a n_b$ is the projection
+ * operator onto them; $K_{ij}$ is the extrinsic curvature and $D_i$ is the
+ * covariant derivative with respect to the spatial metric.
+ */
+template <typename DataType, typename Frame>
+void DDKG_spatial_spatial_projection(
+    gsl::not_null<tnsr::ii<DataType, 3, Frame>*> DDKG_spatial_spatial_result,
+    const tnsr::ii<DataType, 3, Frame>& extrinsic_curvature,
+    const tnsr::Ijj<DataType, 3, Frame>& spatial_christoffel_second_kind,
+    const Scalar<DataType>& pi_scalar,
+    const tnsr::i<DataType, 3, Frame>& phi_scalar,
+    const tnsr::ij<DataType, 3, Frame>& d_phi_scalar);
+
+template <typename DataType, typename Frame>
+tnsr::ii<DataType, 3, Frame> DDKG_spatial_spatial_projection(
+    const tnsr::ii<DataType, 3, Frame>& extrinsic_curvature,
+    const tnsr::Ijj<DataType, 3, Frame>& spatial_christoffel_second_kind,
+    const Scalar<DataType>& pi_scalar,
+    const tnsr::i<DataType, 3, Frame>& phi_scalar,
+    const tnsr::ij<DataType, 3, Frame>& d_phi_scalar);
+/// @}
+}  // namespace ScalarTensor

--- a/tests/Unit/PointwiseFunctions/ScalarTensor/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/ScalarTensor/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_ScalarTensorPointwise")
 set(LIBRARY_SOURCES
   Test_ConstraintDampingTags.cpp
   Test_ConstraintGammas.cpp
+  Test_DoubleCovariantDerivativeOfScalar.cpp
   Test_RampUpFunction.cpp
   Test_ScalarCharge.cpp
   Test_ScalarSource.cpp

--- a/tests/Unit/PointwiseFunctions/ScalarTensor/DoubleCovariantDerivativeOfScalar.py
+++ b/tests/Unit/PointwiseFunctions/ScalarTensor/DoubleCovariantDerivativeOfScalar.py
@@ -1,0 +1,56 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def DDKG_normal_normal_projection(
+    lapse,
+    shift,
+    inverse_spatial_metric,
+    phi_scalar,
+    d_pi_scalar,
+    dt_pi_scalar,
+    d_lapse,
+):
+    lie_pi = dt_pi_scalar - np.dot(shift, d_pi_scalar)
+    lie_pi *= 1.0 / lapse
+
+    acc_dot_phi = np.transpose(phi_scalar) @ inverse_spatial_metric @ d_lapse
+    acc_dot_phi *= 1.0 / lapse
+
+    result = -lie_pi - acc_dot_phi
+
+    return result
+
+
+def DDKG_normal_spatial_projection(
+    inverse_spatial_metric, extrinsic_curvature, phi_scalar, d_pi_scalar
+):
+    result = (
+        extrinsic_curvature @ inverse_spatial_metric @ phi_scalar
+    ) - d_pi_scalar
+
+    return result
+
+
+def DDKG_spatial_spatial_projection(
+    extrinsic_curvature,
+    spatial_christoffel_second_kind,
+    pi_scalar,
+    phi_scalar,
+    d_phi_scalar,
+):
+    chris_times_phi = np.einsum(
+        "kij, k->ij", spatial_christoffel_second_kind, phi_scalar
+    )
+
+    # Random number test does not impose symmetry of d_phi
+    # D_phi = d_phi_scalar - chris_times_phi
+
+    # Symmetrizing
+    D_phi = 0.5 * (d_phi_scalar + np.transpose(d_phi_scalar)) - chris_times_phi
+
+    result = D_phi - pi_scalar * extrinsic_curvature
+
+    return result

--- a/tests/Unit/PointwiseFunctions/ScalarTensor/Test_DoubleCovariantDerivativeOfScalar.cpp
+++ b/tests/Unit/PointwiseFunctions/ScalarTensor/Test_DoubleCovariantDerivativeOfScalar.cpp
@@ -1,0 +1,60 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "PointwiseFunctions/ScalarTensor/DoubleCovariantDerivativeOfScalar.hpp"
+
+namespace {
+template <typename Frame, typename DataType>
+void test_DDKG_normal_normal_projection(const DataType& used_for_size) {
+  Scalar<DataType> (*f)(
+      const Scalar<DataType>&, const tnsr::I<DataType, 3, Frame>&,
+      const tnsr::II<DataType, 3, Frame>&, const tnsr::i<DataType, 3, Frame>&,
+      const tnsr::i<DataType, 3, Frame>&, const Scalar<DataType>&,
+      const tnsr::i<DataType, 3, Frame>&) =
+      ScalarTensor::DDKG_normal_normal_projection;
+  pypp::check_with_random_values<1>(f, "DoubleCovariantDerivativeOfScalar",
+                                    "DDKG_normal_normal_projection",
+                                    {{{1.0e-2, 0.5}}}, used_for_size);
+}
+
+template <typename Frame, typename DataType>
+void test_DDKG_normal_spatial_projection(const DataType& used_for_size) {
+  tnsr::i<DataType, 3, Frame> (*f)(
+      const tnsr::II<DataType, 3, Frame>&, const tnsr::ii<DataType, 3, Frame>&,
+      const tnsr::i<DataType, 3, Frame>&, const tnsr::i<DataType, 3, Frame>&) =
+      ScalarTensor::DDKG_normal_spatial_projection;
+  pypp::check_with_random_values<1>(f, "DoubleCovariantDerivativeOfScalar",
+                                    "DDKG_normal_spatial_projection",
+                                    {{{1.0e-2, 0.5}}}, used_for_size);
+}
+
+template <typename Frame, typename DataType>
+void test_DDKG_spatial_spatial_projection(const DataType& used_for_size) {
+  tnsr::ii<DataType, 3, Frame> (*f)(
+      const tnsr::ii<DataType, 3, Frame>&, const tnsr::Ijj<DataType, 3, Frame>&,
+      const Scalar<DataType>&, const tnsr::i<DataType, 3, Frame>&,
+      const tnsr::ij<DataType, 3, Frame>&) =
+      ScalarTensor::DDKG_spatial_spatial_projection;
+  pypp::check_with_random_values<1>(f, "DoubleCovariantDerivativeOfScalar",
+                                    "DDKG_spatial_spatial_projection",
+                                    {{{1.0e-2, 0.5}}}, used_for_size);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.ScalarTensor.DDScalar",
+                  "[Unit][PointwiseFunctions]") {
+  const pypp::SetupLocalPythonEnvironment local_python_env{
+      "PointwiseFunctions/ScalarTensor"};
+
+  GENERATE_UNINITIALIZED_DOUBLE_AND_DATAVECTOR;
+
+  CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_DDKG_normal_normal_projection,
+                                    (Frame::Inertial, Frame::Grid))
+}


### PR DESCRIPTION
## Proposed changes

Computes the projections of $\nabla_\mu \nabla_\nu \Psi$, where $\Psi$ is the scalar field of Scalar-Tensor theories.

@guilara 

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
