### PR TITLE
Add second covariant derivative of the coupling function in EsGB gravity

### DIFF
--- a/src/PointwiseFunctions/ScalarTensor/ScalarGaussBonnet/CMakeLists.txt
+++ b/src/PointwiseFunctions/ScalarTensor/ScalarGaussBonnet/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   CouplingParameters.cpp
+  DoubleCovariantDerivativeOfCoupling.cpp
   ScalarSource.cpp
   )
 
@@ -17,6 +18,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   CouplingParameters.hpp
+  DoubleCovariantDerivativeOfCoupling.hpp
   ScalarGaussBonnet.hpp
   ScalarSource.hpp
   Tags.hpp

--- a/src/PointwiseFunctions/ScalarTensor/ScalarGaussBonnet/DoubleCovariantDerivativeOfCoupling.cpp
+++ b/src/PointwiseFunctions/ScalarTensor/ScalarGaussBonnet/DoubleCovariantDerivativeOfCoupling.cpp
@@ -1,0 +1,150 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/ScalarTensor/ScalarGaussBonnet/DoubleCovariantDerivativeOfCoupling.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
+
+namespace ScalarTensor::sgb {
+
+template <typename DataType>
+void DDCoupling_normal_normal_projection(
+    const gsl::not_null<Scalar<DataType>*> DDCoupling_normal_normal_result,
+    const Scalar<DataType>& coupling_prime,
+    const Scalar<DataType>& coupling_prime_prime,
+    const Scalar<DataType>& pi_scalar,
+    const Scalar<DataType>& normal_normal_DD_scalar) {
+  get(*DDCoupling_normal_normal_result) =
+      get(coupling_prime_prime) * square(get(pi_scalar)) +
+      get(coupling_prime) * get(normal_normal_DD_scalar);
+}
+
+template <typename DataType>
+Scalar<DataType> DDCoupling_normal_normal_projection(
+    const Scalar<DataType>& coupling_prime,
+    const Scalar<DataType>& coupling_prime_prime,
+    const Scalar<DataType>& pi_scalar,
+    const Scalar<DataType>& normal_normal_DD_scalar) {
+  Scalar<DataType> result{};
+  DDCoupling_normal_normal_projection(make_not_null(&result), coupling_prime,
+                                      coupling_prime_prime, pi_scalar,
+                                      normal_normal_DD_scalar);
+  return result;
+}
+
+template <typename DataType, typename Frame>
+void DDCoupling_normal_spatial_projection(
+    const gsl::not_null<tnsr::i<DataType, 3, Frame>*>
+        DDCoupling_normal_spatial_result,
+    const Scalar<DataType>& coupling_prime,
+    const Scalar<DataType>& coupling_prime_prime,
+    const Scalar<DataType>& pi_scalar,
+    const tnsr::i<DataType, 3, Frame>& d_scalar_field,
+    const tnsr::i<DataType, 3, Frame>& normal_spatial_DD_scalar) {
+  tenex::evaluate<ti::i>(
+      DDCoupling_normal_spatial_result,
+      -coupling_prime_prime() * pi_scalar() * d_scalar_field(ti::i) +
+          coupling_prime() * normal_spatial_DD_scalar(ti::i));
+}
+
+template <typename DataType, typename Frame>
+tnsr::i<DataType, 3, Frame> DDCoupling_normal_spatial_projection(
+    const Scalar<DataType>& coupling_prime,
+    const Scalar<DataType>& coupling_prime_prime,
+    const Scalar<DataType>& pi_scalar,
+    const tnsr::i<DataType, 3, Frame>& d_scalar_field,
+    const tnsr::i<DataType, 3, Frame>& normal_spatial_DD_scalar) {
+  tnsr::i<DataType, 3, Frame> result{};
+  DDCoupling_normal_spatial_projection(
+      make_not_null(&result), coupling_prime, coupling_prime_prime, pi_scalar,
+      d_scalar_field, normal_spatial_DD_scalar);
+  return result;
+}
+
+template <typename DataType, typename Frame>
+void DDCoupling_spatial_spatial_projection(
+    const gsl::not_null<tnsr::ii<DataType, 3, Frame>*>
+        DDCoupling_spatial_spatial_result,
+    const Scalar<DataType>& coupling_prime,
+    const Scalar<DataType>& coupling_prime_prime,
+    const tnsr::i<DataType, 3, Frame>& d_scalar_field,
+    const tnsr::ii<DataType, 3, Frame>& spatial_spatial_DD_scalar) {
+  tenex::evaluate<ti::i, ti::j>(
+      DDCoupling_spatial_spatial_result,
+      coupling_prime_prime() * d_scalar_field(ti::i) * d_scalar_field(ti::j) +
+          coupling_prime() * spatial_spatial_DD_scalar(ti::i, ti::j));
+}
+
+template <typename DataType, typename Frame>
+tnsr::ii<DataType, 3, Frame> DDCoupling_spatial_spatial_projection(
+    const Scalar<DataType>& coupling_prime,
+    const Scalar<DataType>& coupling_prime_prime,
+    const tnsr::i<DataType, 3, Frame>& d_scalar_field,
+    const tnsr::ii<DataType, 3, Frame>& spatial_spatial_DD_scalar) {
+  tnsr::ii<DataType, 3, Frame> result{};
+  DDCoupling_spatial_spatial_projection(make_not_null(&result), coupling_prime,
+                                        coupling_prime_prime, d_scalar_field,
+                                        spatial_spatial_DD_scalar);
+  return result;
+}
+}  // namespace ScalarTensor::sgb
+
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define FRAME(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATE_SCALAR_FNS(_, data)                                    \
+  template void ScalarTensor::sgb::DDCoupling_normal_normal_projection(    \
+      gsl::not_null<Scalar<DTYPE(data)>*> DDCoupling_normal_normal_result, \
+      const Scalar<DTYPE(data)>& coupling_prime,                           \
+      const Scalar<DTYPE(data)>& coupling_prime_prime,                     \
+      const Scalar<DTYPE(data)>& pi_scalar,                                \
+      const Scalar<DTYPE(data)>& normal_normal_DD_scalar);                 \
+  template Scalar<DTYPE(data)>                                             \
+  ScalarTensor::sgb::DDCoupling_normal_normal_projection(                  \
+      const Scalar<DTYPE(data)>& coupling_prime,                           \
+      const Scalar<DTYPE(data)>& coupling_prime_prime,                     \
+      const Scalar<DTYPE(data)>& pi_scalar,                                \
+      const Scalar<DTYPE(data)>& normal_normal_DD_scalar);
+
+#define INSTANTIATE_TENSOR_FNS(_, data)                                        \
+  template void ScalarTensor::sgb::DDCoupling_normal_spatial_projection(       \
+      gsl::not_null<tnsr::i<DTYPE(data), 3, FRAME(data)>*>                     \
+          DDCoupling_normal_spatial_result,                                    \
+      const Scalar<DTYPE(data)>& coupling_prime,                               \
+      const Scalar<DTYPE(data)>& coupling_prime_prime,                         \
+      const Scalar<DTYPE(data)>& pi_scalar,                                    \
+      const tnsr::i<DTYPE(data), 3, FRAME(data)>& d_scalar_field,              \
+      const tnsr::i<DTYPE(data), 3, FRAME(data)>& normal_spatial_DD_scalar);   \
+  template tnsr::i<DTYPE(data), 3, FRAME(data)>                                \
+  ScalarTensor::sgb::DDCoupling_normal_spatial_projection(                     \
+      const Scalar<DTYPE(data)>& coupling_prime,                               \
+      const Scalar<DTYPE(data)>& coupling_prime_prime,                         \
+      const Scalar<DTYPE(data)>& pi_scalar,                                    \
+      const tnsr::i<DTYPE(data), 3, FRAME(data)>& d_scalar_field,              \
+      const tnsr::i<DTYPE(data), 3, FRAME(data)>& normal_spatial_DD_scalar);   \
+  template void ScalarTensor::sgb::DDCoupling_spatial_spatial_projection(      \
+      gsl::not_null<tnsr::ii<DTYPE(data), 3, FRAME(data)>*>                    \
+          DDCoupling_spatial_spatial_result,                                   \
+      const Scalar<DTYPE(data)>& coupling_prime,                               \
+      const Scalar<DTYPE(data)>& coupling_prime_prime,                         \
+      const tnsr::i<DTYPE(data), 3, FRAME(data)>& d_scalar_field,              \
+      const tnsr::ii<DTYPE(data), 3, FRAME(data)>& spatial_spatial_DD_scalar); \
+  template tnsr::ii<DTYPE(data), 3, FRAME(data)>                               \
+  ScalarTensor::sgb::DDCoupling_spatial_spatial_projection(                    \
+      const Scalar<DTYPE(data)>& coupling_prime,                               \
+      const Scalar<DTYPE(data)>& coupling_prime_prime,                         \
+      const tnsr::i<DTYPE(data), 3, FRAME(data)>& d_scalar_field,              \
+      const tnsr::ii<DTYPE(data), 3, FRAME(data)>& spatial_spatial_DD_scalar);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE_SCALAR_FNS, (double, DataVector))
+GENERATE_INSTANTIATIONS(INSTANTIATE_TENSOR_FNS, (double, DataVector),
+                        (Frame::Grid, Frame::Inertial))
+
+#undef DTYPE
+#undef FRAME
+#undef INSTANTIATE_SCALAR_FNS
+#undef INSTANTIATE_TENSOR_FNS

--- a/src/PointwiseFunctions/ScalarTensor/ScalarGaussBonnet/DoubleCovariantDerivativeOfCoupling.hpp
+++ b/src/PointwiseFunctions/ScalarTensor/ScalarGaussBonnet/DoubleCovariantDerivativeOfCoupling.hpp
@@ -1,0 +1,111 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace ScalarTensor::sgb {
+/// @{
+/*!
+ * \brief Computes the projection of the second covariant derivative of the
+ * coupling function onto the normal vector.
+ *
+ * \details Computes the term
+ * \begin{equation}
+ *   n^a n^b \nabla_a\nabla_b F[\Psi]
+ *     = \frac{\delta^2 F[\Psi]}{\delta \Psi^2} \Pi^2
+ *     + \frac{\delta F[\Psi]}{\delta \Psi} n^a n^b \nabla_a \nabla_b \Psi,
+ * \end{equation}
+ * where $\Psi$ is the scalar field, $\Pi$ is its conjugate momentum, $F[\Psi]$
+ * is the coupling function and $n^a$ is the unit vector normal to
+ * the spatial hypersurfaces.
+ */
+template <typename DataType>
+void DDCoupling_normal_normal_projection(
+    gsl::not_null<Scalar<DataType>*> DDCoupling_normal_normal_result,
+    const Scalar<DataType>& coupling_prime,
+    const Scalar<DataType>& coupling_prime_prime,
+    const Scalar<DataType>& pi_scalar,
+    const Scalar<DataType>& normal_normal_DD_scalar);
+
+template <typename DataType>
+Scalar<DataType> DDCoupling_normal_normal_projection(
+    const Scalar<DataType>& coupling_prime,
+    const Scalar<DataType>& coupling_prime_prime,
+    const Scalar<DataType>& pi_scalar,
+    const Scalar<DataType>& normal_normal_DD_scalar);
+/// @}
+
+/// @{
+/*!
+ * \brief Computes the mixed projection of the second covariant derivative of
+ * the coupling function.
+ *
+ * \details Computes the term
+ * \begin{equation}
+ *   \gamma^a_i n^b \nabla_a \nabla_b F[\Psi]
+ *     = - \frac{\delta^2 F[\Psi]}{\delta \Psi^2} \Pi \partial_i \Psi
+ *     + \frac{\delta F[\Psi]}{\delta \Psi}
+ *       \gamma^a_i n^b \nabla_a \nabla_b \Psi,
+ * \end{equation}
+ * where $\Psi$ is the scalar field, $\Pi$ is its conjugate momentum and
+ * $F[\Psi]$ is the coupling function; $n^a$ is the unit vector normal to the
+ * spatial hypersurfaces and $\gamma^a_b = \delta^a_b + n^a n_b$ is the
+ * projection operator onto them.
+ */
+template <typename DataType, typename Frame>
+void DDCoupling_normal_spatial_projection(
+    gsl::not_null<tnsr::i<DataType, 3, Frame>*>
+        DDCoupling_normal_spatial_result,
+    const Scalar<DataType>& coupling_prime,
+    const Scalar<DataType>& coupling_prime_prime,
+    const Scalar<DataType>& pi_scalar,
+    const tnsr::i<DataType, 3, Frame>& d_scalar_field,
+    const tnsr::i<DataType, 3, Frame>& normal_spatial_DD_scalar);
+
+template <typename DataType, typename Frame>
+tnsr::i<DataType, 3, Frame> DDCoupling_normal_spatial_projection(
+    const Scalar<DataType>& coupling_prime,
+    const Scalar<DataType>& coupling_prime_prime,
+    const Scalar<DataType>& pi_scalar,
+    const tnsr::i<DataType, 3, Frame>& d_scalar_field,
+    const tnsr::i<DataType, 3, Frame>& normal_spatial_DD_scalar);
+/// @}
+
+/// @{
+/*!
+ * \brief Computes the spatial projection of the second covariant derivative of
+ * the coupling function.
+ *
+ * \details Computes the term
+ * \begin{equation}
+ *   \gamma^a_i \gamma^b_j \nabla_a \nabla_b F[\Psi]
+ *     = \frac{\delta^2 F[\Psi]}{\delta \Psi^2} (\partial_i \Psi)
+ *       (\partial_j \Psi)
+ *     + \frac{\delta F[\Psi]}{\delta \Psi}
+ *       \gamma^a_i \gamma^b_j \nabla_a \nabla_b \Psi,
+ * \end{equation}
+ * where $\Psi$ is the scalar field, $\Pi$ is its conjugate momentum and
+ * $F[\Psi]$ is the coupling function; $n^a$ is the unit vector normal to the
+ * spatial hypersurfaces and $\gamma^a_b = \delta^a_b + n^a n_b$ is the
+ * projection operator onto them.
+ */
+template <typename DataType, typename Frame>
+void DDCoupling_spatial_spatial_projection(
+    gsl::not_null<tnsr::ii<DataType, 3, Frame>*>
+        DDCoupling_spatial_spatial_result,
+    const Scalar<DataType>& coupling_prime,
+    const Scalar<DataType>& coupling_prime_prime,
+    const tnsr::i<DataType, 3, Frame>& d_scalar_field,
+    const tnsr::ii<DataType, 3, Frame>& spatial_spatial_DD_scalar);
+
+template <typename DataType, typename Frame>
+tnsr::ii<DataType, 3, Frame> DDCoupling_spatial_spatial_projection(
+    const Scalar<DataType>& coupling_prime,
+    const Scalar<DataType>& coupling_prime_prime,
+    const tnsr::i<DataType, 3, Frame>& d_scalar_field,
+    const tnsr::ii<DataType, 3, Frame>& spatial_spatial_DD_scalar);
+/// @}
+}  // namespace ScalarTensor::sgb

--- a/src/PointwiseFunctions/ScalarTensor/ScalarGaussBonnet/Tags.hpp
+++ b/src/PointwiseFunctions/ScalarTensor/ScalarGaussBonnet/Tags.hpp
@@ -45,4 +45,56 @@ struct CouplingParameters : db::SimpleTag {
   }
 };
 }  // namespace Tags
+
+namespace sgb::Tags {
+/*!
+ * \brief Double normal projection of the second covariant derivative of the
+ * coupling function.
+ *
+ * \details Tag for the term $n^a n^b \nabla_a\nabla_b F[\Psi]$, where $F[\Psi]$
+ * is the coupling function, and $n^a$ is the unit vector normal to the spatial
+ * hypersurfaces.
+ */
+struct nnDDCoupling : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+/*!
+ * \brief Mixed projection of the second covariant derivative of the coupling
+ * function.
+ *
+ * \details Tag for the term $\gamma^a_i n^b \nabla_a \nabla_b F[\Psi]$, where
+ * $F[\Psi]$ is the coupling function, $n^a$ is the unit vector normal to the
+ * spatial hypersurfaces, and $\gamma^a_b = \delta^a_b + n^a n_b$ is the
+ * projection operator onto them.
+ */
+struct nsDDCoupling : db::SimpleTag {
+  using type = tnsr::i<DataVector, 3>;
+};
+
+/*!
+ * \brief Spatial projection of the second covariant derivative of the coupling
+ * function.
+ *
+ * \details Tag for the term $\gamma^a_i \gamma^b_j \nabla_a \nabla_b F[\Psi]$,
+ * where $F[\Psi]$ is the coupling function, $\gamma^a_b = \delta^a_b + n^a n_b$
+ * is the projection operator onto the spatial hypersurfaces, and $n^a$ is the
+ * unit vector normal to them.
+ */
+struct ssDDCoupling : db::SimpleTag {
+  using type = tnsr::ii<DataVector, 3>;
+};
+
+/*!
+ * \brief Spatial trace of the second covariant derivative of the coupling
+ * function.
+ *
+ * \details Tag for the term $\gamma^{ab} \nabla_a \nabla_b F[\Psi]$, where
+ * $F[\Psi]$ is the coupling function and $\gamma^{ab}$ is the inverse spatial
+ * metric.
+ */
+struct SpatialTraceDDCoupling : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+}  // namespace sgb::Tags
 }  // namespace ScalarTensor

--- a/tests/Unit/PointwiseFunctions/ScalarTensor/ScalarGaussBonnet/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/ScalarTensor/ScalarGaussBonnet/CMakeLists.txt
@@ -4,6 +4,7 @@ set(LIBRARY "Test_ScalarGaussBonnetPointwise")
 
 set(LIBRARY_SOURCES
   Test_CouplingParameters.cpp
+  Test_DoubleCovariantDerivativeOfCoupling.cpp
   Test_ScalarSource.cpp
   Test_Tags.cpp
   )

--- a/tests/Unit/PointwiseFunctions/ScalarTensor/ScalarGaussBonnet/DoubleCovariantDerivativeOfCoupling.py
+++ b/tests/Unit/PointwiseFunctions/ScalarTensor/ScalarGaussBonnet/DoubleCovariantDerivativeOfCoupling.py
@@ -1,0 +1,29 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def DDCoupling_normal_normal_projection(
+    coupling_prime, coupling_prime_prime, Pi, nnDDPsi
+):
+    return coupling_prime_prime * Pi**2 + coupling_prime * (nnDDPsi)
+
+
+def DDCoupling_normal_spatial_projection(
+    coupling_prime, coupling_prime_prime, Pi, DPsi, nsDDPsi
+):
+    return -coupling_prime_prime * Pi * DPsi + coupling_prime * nsDDPsi
+
+
+def DDCoupling_spatial_spatial_projection(
+    coupling_prime, coupling_prime_prime, DPsi, ssDDPsi
+):
+    return (
+        coupling_prime_prime * np.tensordot(DPsi, DPsi, axes=0)
+        + coupling_prime * ssDDPsi
+    )
+
+
+def DDCoupling_spatial_trace(inverse_spatial_metric, ssDDFPsi):
+    return np.einsum("ij,ji->", inverse_spatial_metric, ssDDFPsi)

--- a/tests/Unit/PointwiseFunctions/ScalarTensor/ScalarGaussBonnet/Test_DoubleCovariantDerivativeOfCoupling.cpp
+++ b/tests/Unit/PointwiseFunctions/ScalarTensor/ScalarGaussBonnet/Test_DoubleCovariantDerivativeOfCoupling.cpp
@@ -1,0 +1,61 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "PointwiseFunctions/ScalarTensor/ScalarGaussBonnet/DoubleCovariantDerivativeOfCoupling.hpp"
+
+namespace {
+template <typename DataType>
+void test_DDCoupling_normal_normal_projection(const DataType& used_for_size) {
+  Scalar<DataType> (*f)(const Scalar<DataType>&, const Scalar<DataType>&,
+                        const Scalar<DataType>&, const Scalar<DataType>&) =
+      &ScalarTensor::sgb::DDCoupling_normal_normal_projection;
+  pypp::check_with_random_values<1>(f, "DoubleCovariantDerivativeOfCoupling",
+                                    "DDCoupling_normal_normal_projection",
+                                    {{{-1., 1.}}}, used_for_size);
+}
+
+template <typename Frame, typename DataType>
+void test_DDCoupling_normal_spatial_projection(const DataType& used_for_size) {
+  tnsr::i<DataType, 3, Frame> (*f)(
+      const Scalar<DataType>&, const Scalar<DataType>&, const Scalar<DataType>&,
+      const tnsr::i<DataType, 3, Frame>&, const tnsr::i<DataType, 3, Frame>&) =
+      &ScalarTensor::sgb::DDCoupling_normal_spatial_projection;
+  pypp::check_with_random_values<1>(f, "DoubleCovariantDerivativeOfCoupling",
+                                    "DDCoupling_normal_spatial_projection",
+                                    {{{-1., 1.}}}, used_for_size);
+}
+
+template <typename Frame, typename DataType>
+void test_DDCoupling_spatial_spatial_projection(const DataType& used_for_size) {
+  tnsr::ii<DataType, 3, Frame> (*f)(
+      const Scalar<DataType>&, const Scalar<DataType>&,
+      const tnsr::i<DataType, 3, Frame>&, const tnsr::ii<DataType, 3, Frame>&) =
+      &ScalarTensor::sgb::DDCoupling_spatial_spatial_projection;
+  pypp::check_with_random_values<1>(f, "DoubleCovariantDerivativeOfCoupling",
+                                    "DDCoupling_spatial_spatial_projection",
+                                    {{{-1., 1.}}}, used_for_size);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.ScalarTensor.sgb.DDCoupling",
+                  "[Unit][PointwiseFunctions]") {
+  const pypp::SetupLocalPythonEnvironment local_python_env{
+      "PointwiseFunctions/ScalarTensor/ScalarGaussBonnet"};
+
+  GENERATE_UNINITIALIZED_DOUBLE_AND_DATAVECTOR;
+
+  test_DDCoupling_normal_normal_projection(d);
+  test_DDCoupling_normal_normal_projection(dv);
+
+  CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_DDCoupling_normal_spatial_projection,
+                                    (Frame::Inertial, Frame::Grid));
+  CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_DDCoupling_spatial_spatial_projection,
+                                    (Frame::Inertial, Frame::Grid));
+}

--- a/tests/Unit/PointwiseFunctions/ScalarTensor/ScalarGaussBonnet/Test_Tags.cpp
+++ b/tests/Unit/PointwiseFunctions/ScalarTensor/ScalarGaussBonnet/Test_Tags.cpp
@@ -11,7 +11,7 @@
 #include "PointwiseFunctions/ScalarTensor/RampUpFunction.hpp"
 #include "PointwiseFunctions/ScalarTensor/ScalarGaussBonnet/Tags.hpp"
 
-SPECTRE_TEST_CASE("Unit.PointwiseFunctions.ScalarTensor.Sgb.Tags",
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.ScalarTensor.sgb.Tags",
                   "[Unit][PointwiseFunctions]") {
   TestHelpers::db::test_simple_tag<ScalarTensor::Tags::CouplingParameters>(
       "CouplingParameters");
@@ -19,4 +19,14 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.ScalarTensor.Sgb.Tags",
       "Linear: 2.0\n"
       "Quadratic: 0.1\n"
       "Quartic: 0.5\n");
+
+  TestHelpers::db::test_simple_tag<ScalarTensor::sgb::Tags::nnDDCoupling>(
+      "nnDDCoupling");
+  TestHelpers::db::test_simple_tag<ScalarTensor::sgb::Tags::nsDDCoupling>(
+      "nsDDCoupling");
+  TestHelpers::db::test_simple_tag<ScalarTensor::sgb::Tags::ssDDCoupling>(
+      "ssDDCoupling");
+  TestHelpers::db::test_simple_tag<
+      ScalarTensor::sgb::Tags::SpatialTraceDDCoupling>(
+      "SpatialTraceDDCoupling");
 }


### PR DESCRIPTION
## Proposed changes

Add the functions that compute the projections of $\nabla_\mu \nabla_\nu F[\Psi]$, where $F[\Psi]$ is the coupling function appearing in EsGB gravity.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
