### PR TITLE
Use CMake presets

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,9 @@
+{
+  "version": 7,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 27,
+    "patch": 0
+  },
+  "include": ["support/Environments/$penv{SPECTRE_MACHINE}Presets.json"]
+}

--- a/cmake/SetupFormaline.cmake
+++ b/cmake/SetupFormaline.cmake
@@ -22,6 +22,7 @@ set(SPECTRE_FORMALINE_LOCATIONS
   CLAUDE.md
   cmake
   CMakeLists.txt
+  CMakePresets.json
   containers
   docs
   external

--- a/docs/Installation/BuildSystem.md
+++ b/docs/Installation/BuildSystem.md
@@ -50,6 +50,75 @@ instructions. If you are on a cluster we support, we will already have an
 environment setup and an easy way for you to configure the build without having
 to specify flags yourself.
 
+## Configuring with CMake presets {#cmake_presets}
+
+Instead of passing flags on the command line every time, you can use
+[CMake presets](https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html)
+to capture a configuration once and select it with `cmake --preset <name>`. The
+build directory of a preset defaults to `build-<name>` in the source tree.
+
+We provide a few standard presets that you can reuse on any machine:
+
+- `debug`: a `Debug` build (`-O0`, all `ASSERT`s and sanity checks enabled),
+  used while actively developing and debugging.
+- `release-debug`: a `Release` build with `SPECTRE_DEBUG=ON`, so it keeps the
+  `ASSERT`s and sanity checks but is optimized. **This is the preferred default
+  for most runs**: the checks catch subtle bugs that only surface in long
+  simulations and cost very little performance.
+- `release`: a fully optimized `Release` build with no debug checks. Use this
+  only when full performance is absolutely necessary.
+
+These presets are assembled from building blocks defined in
+`support/Environments/Presets.json`: `debug-flags`, `release-flags` and
+`release-debug-flags`. You can combine these build-type flags with your own
+machine-specific configuration that supplies the compilers and dependency paths.
+
+- **On a personal machine**, create a `CMakeUserPresets.json` file in the source
+  root (this file is git-ignored). Define a preset with your local compiler
+  settings and dependency paths (e.g. name it `local`), then add
+  `debug`/`release`/`release-debug` presets that combine `local` with the
+  build-type flags. CMake reads `CMakeUserPresets.json` automatically, so `cmake
+  --preset release-debug` will use your configuration. Here's an example
+  `CMakeUserPresets.json`:
+  ```json
+  {
+    "version": 7,
+    "configurePresets": [
+      {
+        "name": "local",
+        "inherits": "base",
+        "hidden": true,
+        "generator": "Ninja",
+        "cacheVariables": {
+          "CMAKE_C_COMPILER": "clang",
+          "CMAKE_CXX_COMPILER": "clang++",
+          "CMAKE_Fortran_COMPILER": "gfortran",
+          "MEMORY_ALLOCATOR": "SYSTEM"
+        }
+      },
+      {
+        "name": "debug",
+        "inherits": ["local", "debug-flags"]
+      },
+      {
+        "name": "release",
+        "inherits": ["local", "release-flags"]
+      },
+      {
+        "name": "release-debug",
+        "inherits": ["local", "release-debug-flags"]
+      }
+    ]
+  }
+  ```
+- **On a supercomputer**, we supply preset files on supported machines. To use
+  the correct preset file, set the `SPECTRE_MACHINE` environment variable
+  (supported machines are listed in support/Environments/). Then, `cmake
+  --preset release-debug` works just the same as on a personal machine (it pulls
+  the correct presets through `CMakePresets.json` in the repository root). Use
+  the environment shell scripts in support/Environments/ to load
+  modules and set `SPECTRE_MACHINE`.
+
 ## Commonly Used CMake flags {#common_cmake_flags}
 The following are common flags used to control building SpECTRE with CMake (in
 alphabetical order):

--- a/docs/Installation/InstallationOnClusters.md
+++ b/docs/Installation/InstallationOnClusters.md
@@ -101,7 +101,8 @@ you do not need to install any dependencies, so you can skip steps 5 and 6.
 
 ## Mbot at Cornell
 
-Follow steps 1-3 of the general instructions.
+Follow steps 1-2 of the general instructions (clone SpECTRE and set
+`SPECTRE_HOME`).
 
 The only modules you need to load on `mbot` are `gcc/11.4.0 spectre-deps`.
 This  will load everything you need, including LLVM/Clang. You
@@ -109,13 +110,10 @@ can source the environment file by running
 `. $SPECTRE_HOME/support/Environments/mbot.sh` and load the modules using
 `spectre_load_modules`. This offers two functions, `spectre_run_cmake_gcc`
 and `spectre_run_cmake_clang` for the different compilers.
-These both default to `Release` mode. If you are developing code, please use
-either `spectre_run_cmake_clang -D CMAKE_BUILD_TYPE=Debug` or
-`spectre_run_cmake_clang -D SPECTRE_DEBUG=ON` (you can also use gcc).
-The second command with `SPECTRE_DEBUG=ON` enables sanity checks and
-optimizations. This means it can be used in production-level runs to ensure
-there aren't any subtle bugs that might only arise after a decently
-long simulation.
+You can use these functions, or run `cmake --preset release-debug` yourself.
+More presets (clang builds, debug builds) are available in
+`support/Environments/MbotPresets.json` (see
+\ref cmake_presets "configuring with CMake presets").
 
 ## Sonic at ICTS-TIFR
 

--- a/support/Environments/MbotPresets.json
+++ b/support/Environments/MbotPresets.json
@@ -1,0 +1,64 @@
+{
+  "version": 7,
+  "include": ["Presets.json"],
+  "configurePresets": [
+    {
+      "name": "mbot",
+      "hidden": true,
+      "inherits": "base",
+      "generator": "Ninja",
+      "cacheVariables": {
+        "CHARM_ROOT": "$env{CHARM_ROOT}",
+        "MEMORY_ALLOCATOR": "JEMALLOC",
+        "BUILD_PYTHON_BINDINGS": "ON",
+        "ENABLE_PARAVIEW": "ON",
+        "USE_XSIMD": "ON"
+      }
+    },
+    {
+      "name": "mbot-gcc",
+      "hidden": true,
+      "inherits": "mbot",
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "gcc",
+        "CMAKE_CXX_COMPILER": "g++",
+        "CMAKE_Fortran_COMPILER": "gfortran",
+        "DEBUG_SYMBOLS": "OFF"
+      }
+    },
+    {
+      "name": "mbot-clang",
+      "hidden": true,
+      "inherits": "mbot",
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "clang",
+        "CMAKE_CXX_COMPILER": "clang++",
+        "CMAKE_Fortran_COMPILER": "gfortran"
+      }
+    },
+    {
+      "name": "debug",
+      "inherits": ["mbot-gcc", "debug-flags"]
+    },
+    {
+      "name": "release",
+      "inherits": ["mbot-gcc", "release-flags"]
+    },
+    {
+      "name": "release-debug",
+      "inherits": ["mbot-gcc", "release-debug-flags"]
+    },
+    {
+      "name": "debug-clang",
+      "inherits": ["mbot-clang", "debug-flags"]
+    },
+    {
+      "name": "release-clang",
+      "inherits": ["mbot-clang", "release-flags"]
+    },
+    {
+      "name": "release-debug-clang",
+      "inherits": ["mbot-clang", "release-debug-flags"]
+    }
+  ]
+}

--- a/support/Environments/Presets.json
+++ b/support/Environments/Presets.json
@@ -1,0 +1,35 @@
+{
+  "version": 7,
+  "configurePresets": [
+    {
+      "name": "base",
+      "hidden": true,
+      "binaryDir": "${sourceDir}/build-${presetName}",
+      "cacheVariables": {
+        "MACHINE": "$env{SPECTRE_MACHINE}"
+      }
+    },
+    {
+      "name": "debug-flags",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "release-flags",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": "release-debug-flags",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "SPECTRE_DEBUG": "ON"
+      }
+    }
+  ]
+}

--- a/support/Environments/mbot.sh
+++ b/support/Environments/mbot.sh
@@ -8,6 +8,7 @@ spectre_setup_modules() {
 }
 
 spectre_load_modules() {
+    export SPECTRE_MACHINE=Mbot
     # The order here is important
     module load gcc/11.4.0
     module load spectre-deps > /dev/null 2>&1
@@ -25,19 +26,7 @@ spectre_run_cmake_gcc() {
         return 1
     fi
     spectre_load_modules > /dev/null 2>&1
-    cmake -D CMAKE_C_COMPILER=gcc \
-          -D CMAKE_CXX_COMPILER=g++ \
-          -D CMAKE_Fortran_COMPILER=gfortran \
-          -D CHARM_ROOT=$CHARM_ROOT \
-          -D CMAKE_BUILD_TYPE=Release \
-          -D MEMORY_ALLOCATOR=JEMALLOC \
-          -D BUILD_PYTHON_BINDINGS=ON \
-          -D ENABLE_PARAVIEW=ON \
-          -D MACHINE=Mbot \
-          -D USE_XSIMD=yes \
-          -D DEBUG_SYMBOLS=OFF \
-          "$@" \
-          $SPECTRE_HOME
+    cmake -S $SPECTRE_HOME -B . --preset release-debug "$@"
 }
 
 spectre_run_cmake_clang() {
@@ -46,16 +35,5 @@ spectre_run_cmake_clang() {
         return 1
     fi
     spectre_load_modules > /dev/null 2>&1
-    cmake -D CMAKE_C_COMPILER=clang \
-          -D CMAKE_CXX_COMPILER=clang++ \
-          -D CMAKE_Fortran_COMPILER=gfortran \
-          -D CHARM_ROOT=$CHARM_ROOT \
-          -D CMAKE_BUILD_TYPE=Release \
-          -D MEMORY_ALLOCATOR=JEMALLOC \
-          -D BUILD_PYTHON_BINDINGS=ON \
-          -D ENABLE_PARAVIEW=ON \
-          -D MACHINE=Mbot \
-          -D USE_XSIMD=yes \
-          "$@" \
-          $SPECTRE_HOME
+    cmake -S $SPECTRE_HOME -B . --preset release-debug-clang "$@"
 }


### PR DESCRIPTION
## Proposed changes

This PR adds support for CMake presets, which are just a nice way of storing a set of CMake settings in a json file. It's largely optional, in that no existing functionality is changed in this PR. Added documentation describes how to add a CMakeUserPresets.json file to store user-specific CMake settings, and suggests to use the standard preset names `debug`, `release-debug`, and `release`.

Presets are also useful on clusters, in that we can store the CMake settings in a json file and just run `cmake --preset debug/release/release-debug` rather than a custom shell script (though `spectre_run_cmake` is still supported and just invokes `cmake --preset release-debug` internally). An example on Mbot is included in this PR. In the future we can expand the use of presets further, but that's optional.

Note that the use of CMake presets also makes it easier for AI agents to configure the build, as the agents can just discover the presets and run cmake (locally and on clusters). This reduces token usages significantly, as the agents don't have to go through trial-and-error until they get a working build.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
