### PR TITLE
Fix for Issue 7298

### DIFF
--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_Sources.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Test_Sources.cpp
@@ -1001,7 +1001,7 @@ void test_cartoon_dg_time_derivative() {
       dg_compute(cartoon_mesh, logical_coords_c, inertial_coords_c);
   const auto dg_3 = dg_compute(plain_mesh, logical_coords_3, inertial_coords_3);
 
-  const auto local_approx = Approx::custom().epsilon(1e-5).scale(1e-11);
+  const auto local_approx = Approx::custom().epsilon(1e-9).scale(1.0);
   constexpr size_t comp_dim = Spherical ? 1 : 2;
   CHECK_ITERABLE_CUSTOM_APPROX(dg_c.dt_tilde_d, dg_3.dt_tilde_d, local_approx);
   CHECK_ITERABLE_CUSTOM_APPROX(dg_c.dt_tilde_ye, dg_3.dt_tilde_ye,


### PR DESCRIPTION
## Proposed changes

Fix to issue #7298. The previous scale of 1e-11 was from previous versions of this test, and though I have no idea why this only occasionally fails, setting the scale to 1.0 should fix the problem of comparing numbers ~ O(1e-15).


<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
