### PR TITLE
Add prefix tag for spatial covariant derivatives and the Lie derivative with respect to the normal vector

### DIFF
--- a/src/DataStructures/DataBox/Prefixes.hpp
+++ b/src/DataStructures/DataBox/Prefixes.hpp
@@ -177,6 +177,19 @@ struct second_covariant_deriv<Tag, Dim, Frame> : db::PrefixTag, db::SimpleTag {
 };
 /// \endcond
 
+/*!
+ * \ingroup DataBoxTagsGroup
+ * \brief Prefix indicating the Lie derivative with respect to the unit vector
+ * normal to the spatial hypersurfaces.
+ *
+ * \snippet Test_DataBoxPrefixes.cpp lie_normal_name
+ */
+template <typename Tag>
+struct lie_normal : db::PrefixTag, db::SimpleTag {
+  using type = typename Tag::type;
+  using tag = Tag;
+};
+
 /// \ingroup DataBoxTagsGroup
 /// \brief Prefix indicating a flux
 ///

--- a/src/DataStructures/DataBox/Prefixes.hpp
+++ b/src/DataStructures/DataBox/Prefixes.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <cstddef>
+#include <type_traits>
 
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/Tensor/IndexType.hpp"
@@ -102,6 +103,76 @@ struct spacetime_deriv<Tag, Dim, Frame> : db::PrefixTag, db::SimpleTag {
   using type =
       TensorMetafunctions::prepend_spacetime_index<typename Tag::type,
                                                    Dim::value, UpLo::Lo, Frame>;
+  using tag = Tag;
+};
+/// \endcond
+
+/*!
+ * \ingroup DataBoxTagsGroup
+ * \brief Prefix indicating the spatial covariant derivative of a tensor.
+ *
+ * Prefix indicating the first covariant derivative of a tensor with respect
+ * to the spatial metric.
+ *
+ * \tparam Tag The tag to wrap
+ * \tparam Dim The volume dim as a type (e.g. `tmpl::size_t<Dim>`)
+ * \tparam Frame The frame of the derivative index
+ *
+ * \snippet Test_DataBoxPrefixes.cpp covariant_deriv_name
+ */
+template <typename Tag, typename Dim, typename Frame>
+struct covariant_deriv;
+
+/// \cond
+template <typename Tag, typename Dim, typename Frame>
+  requires(tt::is_a_v<Tensor, typename Tag::type>)
+struct covariant_deriv<Tag, Dim, Frame> : db::PrefixTag, db::SimpleTag {
+  using type =
+      TensorMetafunctions::prepend_spatial_index<typename Tag::type, Dim::value,
+                                                 UpLo::Lo, Frame>;
+  using tag = Tag;
+};
+/// \endcond
+
+/*!
+ * \ingroup DataBoxTagsGroup
+ * \brief Prefix indicating the second spatial covariant derivative of a tensor.
+ *
+ * Prefix indicating the second covariant derivative of a tensor with respect
+ * to the spatial metric.
+ *
+ * \tparam Tag The tag to wrap
+ * \tparam Dim The volume dim as a type (e.g. `tmpl::size_t<Dim>`)
+ * \tparam Frame The frame of the derivative index
+ *
+ * \note If ``Tag::type`` is ``Scalar``, then ``second_covariant_derivative``
+ * will hold a symmetric tensor.
+ *
+ * \snippet Test_DataBoxPrefixes.cpp second_covariant_deriv_name
+ */
+template <typename Tag, typename Dim, typename Frame>
+struct second_covariant_deriv;
+
+/// \cond
+template <typename Tag, typename Dim, typename Frame>
+  requires(tt::is_a_v<Tensor, typename Tag::type> and
+           not std::is_same_v<Scalar<typename Tag::type::type>,
+                              typename Tag::type>)
+struct second_covariant_deriv<Tag, Dim, Frame> : db::PrefixTag, db::SimpleTag {
+  using type = TensorMetafunctions::prepend_spatial_index<
+      TensorMetafunctions::prepend_spatial_index<typename Tag::type, Dim::value,
+                                                 UpLo::Lo, Frame>,
+      Dim::value, UpLo::Lo, Frame>;
+  using tag = Tag;
+};
+/// \endcond
+
+/// \cond
+template <typename Tag, typename Dim, typename Frame>
+  requires(std::is_same_v<Scalar<typename Tag::type::type>, typename Tag::type>)
+struct second_covariant_deriv<Tag, Dim, Frame> : db::PrefixTag, db::SimpleTag {
+  using type = TensorMetafunctions::prepend_two_symmetric_spatial_indices<
+      typename Tag::type, Dim::value, UpLo::Lo, Frame>;
   using tag = Tag;
 };
 /// \endcond

--- a/tests/Unit/DataStructures/DataBox/Test_DataBoxPrefixes.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_DataBoxPrefixes.cpp
@@ -22,6 +22,10 @@ struct Tag : db::SimpleTag {
 struct TensorTag : db::SimpleTag {
   using type = tnsr::I<DataVector, 2>;
 };
+
+struct ScalarTag : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.Prefixes",
@@ -32,6 +36,20 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.Prefixes",
   using Dim = tmpl::size_t<2>;
   using Frame = Frame::Inertial;
   using VariablesTag = Tags::Variables<tmpl::list<TensorTag>>;
+  // [covariant_deriv_name]
+  TestHelpers::db::test_prefix_tag<
+      Tags::covariant_deriv<TensorTag, Dim, Frame>>(
+      "covariant_deriv(TensorTag)");
+  // [covariant_deriv_name]
+  // [second_covariant_deriv_name]
+  TestHelpers::db::test_prefix_tag<
+      Tags::second_covariant_deriv<ScalarTag, Dim, Frame>>(
+      "second_covariant_deriv(ScalarTag)");
+  TestHelpers::db::test_prefix_tag<
+      Tags::second_covariant_deriv<TensorTag, Dim, Frame>>(
+      "second_covariant_deriv(TensorTag)");
+  // [second_covariant_deriv_name]
+
   // [flux_name]
   TestHelpers::db::test_prefix_tag<Tags::Flux<TensorTag, Dim, Frame>>(
       "Flux(TensorTag)");

--- a/tests/Unit/DataStructures/DataBox/Test_DataBoxPrefixes.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_DataBoxPrefixes.cpp
@@ -50,6 +50,10 @@ SPECTRE_TEST_CASE("Unit.DataStructures.DataBox.Prefixes",
       "second_covariant_deriv(TensorTag)");
   // [second_covariant_deriv_name]
 
+  // [lie_normal_name]
+  TestHelpers::db::test_prefix_tag<Tags::lie_normal<Tag>>("lie_normal(Tag)");
+  // [lie_normal_name]
+
   // [flux_name]
   TestHelpers::db::test_prefix_tag<Tags::Flux<TensorTag, Dim, Frame>>(
       "Flux(TensorTag)");


### PR DESCRIPTION
## Proposed changes

Add prefix tags for terms like $D_i \mathcal{T}$ and $D_i D_j \mathcal{T}$, where $D_i$ denotes derivation with respect to the spatial metric and $\mathcal{T}$ is a generic tensor. This PR also adds the prefix tag for the Lie derivative with respect to the 4-velocity of the eulerian observer, $\mathcal{L}_n$.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
