### PR TITLE
CCE: add CauchySecondOrder initial-data scheme

### DIFF
--- a/src/Evolution/Systems/Cce/Initialize/CMakeLists.txt
+++ b/src/Evolution/Systems/Cce/Initialize/CMakeLists.txt
@@ -4,6 +4,7 @@
 spectre_target_sources(
   ${LIBRARY}
   PRIVATE
+  CauchySecondOrder.cpp
   ComputeSecondOrderRadialDerivativeJ.cpp
   ConformalFactor.cpp
   InitializeJ.cpp
@@ -16,6 +17,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  CauchySecondOrder.hpp
   ComputeSecondOrderRadialDerivativeJ.hpp
   ConformalFactor.hpp
   InitializeJ.hpp

--- a/src/Evolution/Systems/Cce/Initialize/CauchySecondOrder.cpp
+++ b/src/Evolution/Systems/Cce/Initialize/CauchySecondOrder.cpp
@@ -1,0 +1,244 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/Cce/Initialize/CauchySecondOrder.hpp"
+
+#include <cmath>
+#include <cstddef>
+#include <memory>
+#include <utility>
+
+#include "DataStructures/ComplexDataVector.hpp"
+#include "DataStructures/SpinWeighted.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/Cce/Initialize/ComputeSecondOrderRadialDerivativeJ.hpp"
+#include "Evolution/Systems/Cce/Initialize/InitializeJ.hpp"
+#include "Evolution/Systems/Cce/LinearOperators.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/CollocationPoints.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "NumericalAlgorithms/SpinWeightedSphericalHarmonics/SwshCollocation.hpp"
+#include "Parallel/NodeLock.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace Cce::InitializeJ {
+
+CauchySecondOrder::CauchySecondOrder(const double angular_coordinate_tolerance,
+                                     const size_t max_iterations,
+                                     const bool require_convergence,
+                                     const double max_scri_second_derivative)
+    : require_convergence_{require_convergence},
+      angular_coordinate_tolerance_{angular_coordinate_tolerance},
+      max_iterations_{max_iterations},
+      max_scri_second_derivative_{max_scri_second_derivative} {}
+
+std::unique_ptr<InitializeJ<false>> CauchySecondOrder::get_clone() const {
+  return std::make_unique<CauchySecondOrder>(*this);
+}
+
+void CauchySecondOrder::operator()(
+    const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 2>>*> j,
+    const gsl::not_null<tnsr::i<DataVector, 3>*> cartesian_cauchy_coordinates,
+    const gsl::not_null<
+        tnsr::i<DataVector, 2, ::Frame::Spherical<::Frame::Inertial>>*>
+        angular_cauchy_coordinates,
+    const Scalar<SpinWeighted<ComplexDataVector, 2>>& boundary_j,
+    const Scalar<SpinWeighted<ComplexDataVector, 1>>& boundary_u,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& boundary_w,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& boundary_beta,
+    const Scalar<SpinWeighted<ComplexDataVector, 1>>& boundary_q,
+    const Scalar<SpinWeighted<ComplexDataVector, 2>>& boundary_du_j,
+    const Scalar<SpinWeighted<ComplexDataVector, 2>>& boundary_dr_j,
+    const Scalar<SpinWeighted<ComplexDataVector, 2>>& boundary_du_dr_j,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& boundary_du_r,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& r, const size_t l_max,
+    const size_t number_of_radial_points,
+    const gsl::not_null<Parallel::NodeLock*> /*hdf5_lock*/) const {
+  const size_t number_of_angular_points =
+      Spectral::Swsh::number_of_swsh_collocation_points(l_max);
+
+  // Solve the H hypersurface equation at y = -1 for dy^2 J using the worldtube
+  // boundary data, then build the volume J as a polynomial in (1 - y) that
+  // matches J, dr_j, and dy^2 J at the worldtube.
+  Scalar<SpinWeighted<ComplexDataVector, 2>> boundary_dy2_j{
+      number_of_angular_points};
+  CauchySecondOrder_detail::compute_dy_dy_j(
+      make_not_null(&boundary_dy2_j), boundary_j, boundary_u, boundary_w,
+      boundary_beta, boundary_q, boundary_du_j, boundary_dr_j, boundary_du_dr_j,
+      boundary_du_r, r, l_max);
+
+  const DataVector one_minus_y_collocation =
+      1.0 - Spectral::collocation_points<Spectral::Basis::Legendre,
+                                         Spectral::Quadrature::GaussLobatto>(
+                number_of_radial_points);
+
+  for (size_t i = 0; i < number_of_radial_points; ++i) {
+    ComplexDataVector angular_view_j{
+        get(*j).data().data() + get(boundary_j).size() * i,  // NOLINT
+        get(boundary_j).size()};
+    // Store expressions so that the later equation for `j` is easier to read.
+    const auto constant_term = get(boundary_j).data() +
+                               get(r).data() * get(boundary_dr_j).data() +
+                               (4.0 / 3.0) * get(boundary_dy2_j).data();
+    const auto one_minus_y_coefficient =
+        -(0.5 * get(r).data() * get(boundary_dr_j).data() +
+          get(boundary_dy2_j).data());
+    const auto one_minus_y_cubed_coefficient =
+        (1.0 / 12.0) * get(boundary_dy2_j).data();
+
+    angular_view_j =
+        constant_term + one_minus_y_collocation[i] * one_minus_y_coefficient +
+        pow<3>(one_minus_y_collocation[i]) * one_minus_y_cubed_coefficient;
+  }
+
+  // Iteratively adjust the angular coordinates so that J vanishes at scri+
+  // (identical to the procedure in NoIncomingRadiation).
+  const SpinWeighted<ComplexDataVector, 2> j_at_scri_view;
+  make_const_view(make_not_null(&j_at_scri_view), get(*j),
+                  (number_of_radial_points - 1) * number_of_angular_points,
+                  number_of_angular_points);
+
+  Variables<
+      tmpl::list<::Tags::SpinWeighted<::Tags::TempScalar<0, ComplexDataVector>,
+                                      std::integral_constant<int, 2>>,
+                 ::Tags::SpinWeighted<::Tags::TempScalar<1, ComplexDataVector>,
+                                      std::integral_constant<int, 0>>,
+                 ::Tags::SpinWeighted<::Tags::TempScalar<2, ComplexDataVector>,
+                                      std::integral_constant<int, 0>>>>
+      iteration_buffers{number_of_angular_points};
+
+  auto& evolution_gauge_surface_j =
+      get(get<::Tags::SpinWeighted<::Tags::TempScalar<0, ComplexDataVector>,
+                                   std::integral_constant<int, 2>>>(
+          iteration_buffers));
+  auto& interpolated_k =
+      get(get<::Tags::SpinWeighted<::Tags::TempScalar<1, ComplexDataVector>,
+                                   std::integral_constant<int, 0>>>(
+          iteration_buffers));
+  auto& gauge_omega =
+      get<::Tags::SpinWeighted<::Tags::TempScalar<2, ComplexDataVector>,
+                               std::integral_constant<int, 0>>>(
+          iteration_buffers);
+
+  auto iteration_function =
+      [&interpolated_k, &gauge_omega, &evolution_gauge_surface_j,
+       &j_at_scri_view](
+          const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 2>>*>
+              gauge_c_step,
+          const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*>
+              gauge_d_step,
+          const Scalar<SpinWeighted<ComplexDataVector, 2>>& gauge_c,
+          const Scalar<SpinWeighted<ComplexDataVector, 0>>& gauge_d,
+          const Spectral::Swsh::SwshInterpolator& iteration_interpolator) {
+        iteration_interpolator.interpolate(
+            make_not_null(&evolution_gauge_surface_j), j_at_scri_view);
+        interpolated_k.data() =
+            sqrt(1.0 + evolution_gauge_surface_j.data() *
+                           conj(evolution_gauge_surface_j.data()));
+        get(gauge_omega).data() =
+            0.5 * sqrt(get(gauge_d).data() * conj(get(gauge_d).data()) -
+                       get(gauge_c).data() * conj(get(gauge_c).data()));
+        evolution_gauge_surface_j.data() =
+            0.25 *
+            (square(conj(get(gauge_d).data())) *
+                 evolution_gauge_surface_j.data() +
+             square(get(gauge_c).data()) *
+                 conj(evolution_gauge_surface_j.data()) +
+             2.0 * get(gauge_c).data() * conj(get(gauge_d).data()) *
+                 interpolated_k.data()) /
+            square(get(gauge_omega).data());
+
+        const double max_error = max(abs(evolution_gauge_surface_j.data()));
+        get(*gauge_c_step).data() =
+            -0.5 * evolution_gauge_surface_j.data() *
+            square(get(gauge_omega).data()) /
+            (get(gauge_d).data() * interpolated_k.data());
+        get(*gauge_d_step).data() = get(*gauge_c_step).data() *
+                                    conj(get(gauge_c).data()) /
+                                    conj(get(gauge_d).data());
+        return max_error;
+      };
+
+  auto finalize_function =
+      [&j, &gauge_omega, &l_max](
+          const Scalar<SpinWeighted<ComplexDataVector, 2>>& gauge_c,
+          const Scalar<SpinWeighted<ComplexDataVector, 0>>& gauge_d,
+          const tnsr::i<DataVector, 2, ::Frame::Spherical<::Frame::Inertial>>&
+              local_angular_cauchy_coordinates,
+          const Spectral::Swsh::SwshInterpolator& interpolator) {
+        get(gauge_omega).data() =
+            0.5 * sqrt(get(gauge_d).data() * conj(get(gauge_d).data()) -
+                       get(gauge_c).data() * conj(get(gauge_c).data()));
+        GaugeAdjustInitialJ::apply(j, gauge_c, gauge_d, gauge_omega,
+                                   local_angular_cauchy_coordinates,
+                                   interpolator, l_max);
+      };
+
+  // The angular solve can only eliminate J at scri+ through a well-behaved
+  // alteration of the spherical mesh, so it tolerates only a small asymptotic
+  // J. Guard against a large asymptotic initial J in Cauchy coordinates before
+  // attempting the solve, which would otherwise fail less informatively.
+  const double max_angular_solve_error = 1.0e-2;
+  const double max_asymptotic_j = max(abs(j_at_scri_view.data()));
+  if (max_asymptotic_j > max_angular_solve_error) {
+    ERROR(
+        "The asymptotic value of the initial J in Cauchy coordinates has "
+        "magnitude "
+        << max_asymptotic_j
+        << ", which is too large for the angular-coordinate solve to "
+           "eliminate. The worldtube data may be incorrect, or the worldtube "
+           "may be too close to the strong-field region. Consider using the "
+           "ConformalFactor initial-data generator instead.");
+  }
+
+  detail::iteratively_adapt_angular_coordinates(
+      cartesian_cauchy_coordinates, angular_cauchy_coordinates, l_max,
+      angular_coordinate_tolerance_, max_iterations_, max_angular_solve_error,
+      iteration_function, require_convergence_, finalize_function);
+
+  // Safeguard: the second-order construction forces the second radial
+  // derivative of J to vanish at scri+, and the angular gauge transform only
+  // adds a strain-suppressed contribution, so the final initial data must
+  // retain a tiny second derivative there. A large value signals a poorly
+  // matched solution that should not be evolved.
+  const Mesh<3> volume_mesh{
+      {{Spectral::Swsh::number_of_swsh_theta_collocation_points(l_max),
+        Spectral::Swsh::number_of_swsh_phi_collocation_points(l_max),
+        number_of_radial_points}},
+      Spectral::Basis::Legendre,
+      Spectral::Quadrature::GaussLobatto};
+  SpinWeighted<ComplexDataVector, 2> dy_j{number_of_angular_points *
+                                          number_of_radial_points};
+  SpinWeighted<ComplexDataVector, 2> dy_dy_j{number_of_angular_points *
+                                             number_of_radial_points};
+  // dimension 2 is the radial (y) direction; see PreSwshDerivatives.
+  logical_partial_directional_derivative_of_complex(
+      make_not_null(&dy_j.data()), get(*j).data(), volume_mesh, 2);
+  logical_partial_directional_derivative_of_complex(
+      make_not_null(&dy_dy_j.data()), dy_j.data(), volume_mesh, 2);
+  const SpinWeighted<ComplexDataVector, 2> scri_dy_dy_j;
+  make_const_view(make_not_null(&scri_dy_dy_j), dy_dy_j,
+                  (number_of_radial_points - 1) * number_of_angular_points,
+                  number_of_angular_points);
+  const double max_scri_dy_dy_j = max(abs(scri_dy_dy_j.data()));
+  if (max_scri_dy_dy_j > max_scri_second_derivative_) {
+    ERROR("The initial J has a second radial derivative at scri+ of magnitude "
+          << max_scri_dy_dy_j << ", which exceeds the threshold "
+          << max_scri_second_derivative_
+          << " set by the MaxScriSecondDerivative option. The matched solution "
+             "is not asymptotically well-behaved; check the worldtube boundary "
+             "data or raise the threshold.");
+  }
+}
+
+void CauchySecondOrder::pup(PUP::er& p) {
+  p | require_convergence_;
+  p | angular_coordinate_tolerance_;
+  p | max_iterations_;
+  p | max_scri_second_derivative_;
+}
+
+PUP::able::PUP_ID CauchySecondOrder::my_PUP_ID = 0;  // NOLINT
+}  // namespace Cce::InitializeJ

--- a/src/Evolution/Systems/Cce/Initialize/CauchySecondOrder.hpp
+++ b/src/Evolution/Systems/Cce/Initialize/CauchySecondOrder.hpp
@@ -1,0 +1,136 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <limits>
+#include <memory>
+#include <string>
+
+#include "DataStructures/SpinWeighted.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/Cce/Initialize/InitializeJ.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class ComplexDataVector;
+/// \endcond
+
+namespace Cce::InitializeJ {
+
+/*!
+ * \brief Initialize \f$J\f$ on the first hypersurface using a second-order
+ * matching at the worldtube.
+ *
+ * \details The volume \f$J\f$ is built from the worldtube values of
+ * \f$J\f$, \f$\partial_r J\f$, and \f$\partial_y^2 J\f$ computed from the
+ * H hypersurface equation. The remaining angular coordinates are determined
+ * iteratively to ensure asymptotic flatness. As a safeguard, the
+ * initialization aborts if the second radial derivative of \f$J\f$ at scri+
+ * of the final solution exceeds `MaxScriSecondDerivative`.
+ */
+struct CauchySecondOrder : InitializeJ<false> {
+  struct AngularCoordinateTolerance {
+    using type = double;
+    static std::string name() { return "AngularCoordTolerance"; }
+    static constexpr Options::String help = {
+        "Tolerance of initial angular coordinates for CCE"};
+    static type lower_bound() { return 1.0e-14; }
+    static type upper_bound() { return 1.0e-3; }
+    static type suggested_value() { return 1.0e-12; }
+  };
+
+  struct MaxIterations {
+    using type = size_t;
+    static constexpr Options::String help = {
+        "Number of linearized inversion iterations."};
+    static type lower_bound() { return 10; }
+    static type upper_bound() { return 1000; }
+    static type suggested_value() { return 300; }
+  };
+
+  struct RequireConvergence {
+    using type = bool;
+    static constexpr Options::String help = {
+        "If true, initialization will error if it hits MaxIterations"};
+    static type suggested_value() { return true; }
+  };
+
+  struct MaxScriSecondDerivative {
+    using type = double;
+    static constexpr Options::String help = {
+        "Abort initialization if the largest second radial derivative of J at "
+        "scri+ of the final initial data exceeds this threshold. The "
+        "second-order construction drives this derivative to (near) zero, so a "
+        "large value indicates a poorly matched solution. Set to a large value "
+        "to effectively disable the check."};
+    static type lower_bound() { return 1.0e-14; }
+    static type upper_bound() { return 1.0e2; }
+    static type suggested_value() { return 1.0e-8; }
+  };
+
+  using options = tmpl::list<AngularCoordinateTolerance, MaxIterations,
+                             RequireConvergence, MaxScriSecondDerivative>;
+  static constexpr Options::String help = {
+      "Second-order initial data generator for the Cauchy CCE evolution."};
+
+  WRAPPED_PUPable_decl_template(CauchySecondOrder);  // NOLINT
+  explicit CauchySecondOrder(CkMigrateMessage* /*unused*/) {}
+
+  CauchySecondOrder(double angular_coordinate_tolerance, size_t max_iterations,
+                    bool require_convergence,
+                    double max_scri_second_derivative);
+
+  CauchySecondOrder() = default;
+
+  std::unique_ptr<InitializeJ> get_clone() const override;
+
+  // Per-class tag lists. The flexible dispatch in `InitializeJ<false>` reads
+  // these via `call_with_dynamic_type` so this generator can request more
+  // worldtube boundary values than the simpler sibling classes do.
+  using return_tags = tmpl::list<Tags::BondiJ, Tags::CauchyCartesianCoords,
+                                 Tags::CauchyAngularCoords>;
+  using argument_tags = tmpl::list<
+      Tags::BoundaryValue<Tags::BondiJ>, Tags::BoundaryValue<Tags::BondiU>,
+      Tags::BoundaryValue<Tags::BondiW>, Tags::BoundaryValue<Tags::BondiBeta>,
+      Tags::BoundaryValue<Tags::BondiQ>,
+      Tags::BoundaryValue<Tags::Du<Tags::BondiJ>>,
+      Tags::BoundaryValue<Tags::Dr<Tags::BondiJ>>,
+      Tags::BoundaryValue<Tags::Du<Tags::Dr<Tags::BondiJ>>>,
+      Tags::BoundaryValue<Tags::Du<Tags::BondiR>>,
+      Tags::BoundaryValue<Tags::BondiR>, Tags::LMax,
+      Tags::NumberOfRadialPoints>;
+
+  void operator()(
+      gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 2>>*> j,
+      gsl::not_null<tnsr::i<DataVector, 3>*> cartesian_cauchy_coordinates,
+      gsl::not_null<
+          tnsr::i<DataVector, 2, ::Frame::Spherical<::Frame::Inertial>>*>
+          angular_cauchy_coordinates,
+      const Scalar<SpinWeighted<ComplexDataVector, 2>>& boundary_j,
+      const Scalar<SpinWeighted<ComplexDataVector, 1>>& boundary_u,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>& boundary_w,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>& boundary_beta,
+      const Scalar<SpinWeighted<ComplexDataVector, 1>>& boundary_q,
+      const Scalar<SpinWeighted<ComplexDataVector, 2>>& boundary_du_j,
+      const Scalar<SpinWeighted<ComplexDataVector, 2>>& boundary_dr_j,
+      const Scalar<SpinWeighted<ComplexDataVector, 2>>& boundary_du_dr_j,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>& boundary_du_r,
+      const Scalar<SpinWeighted<ComplexDataVector, 0>>& r, size_t l_max,
+      size_t number_of_radial_points,
+      gsl::not_null<Parallel::NodeLock*> hdf5_lock) const;
+
+  void pup(PUP::er& p) override;
+
+ private:
+  bool require_convergence_ = true;
+  double angular_coordinate_tolerance_ =
+      std::numeric_limits<double>::signaling_NaN();
+  size_t max_iterations_ = 0;
+  double max_scri_second_derivative_ =
+      std::numeric_limits<double>::signaling_NaN();
+};
+}  // namespace Cce::InitializeJ

--- a/src/Evolution/Systems/Cce/Initialize/ComputeSecondOrderRadialDerivativeJ.cpp
+++ b/src/Evolution/Systems/Cce/Initialize/ComputeSecondOrderRadialDerivativeJ.cpp
@@ -67,8 +67,8 @@ Scalar<SpinWeighted<ComplexDataVector, 2>> evaluate_worldtube_h_residual(
     const Scalar<SpinWeighted<ComplexDataVector, 0>>& beta_scalar,
     const Scalar<SpinWeighted<ComplexDataVector, 1>>& q_scalar,
     const Scalar<SpinWeighted<ComplexDataVector, 2>>& dy_j_scalar,
-    const Scalar<SpinWeighted<ComplexDataVector, 2>>& h_numerical_scalar,
-    const Scalar<SpinWeighted<ComplexDataVector, 2>>& dy_h_numerical_scalar,
+    const Scalar<SpinWeighted<ComplexDataVector, 2>>& h_scalar,
+    const Scalar<SpinWeighted<ComplexDataVector, 2>>& dy_h_scalar,
     const Scalar<SpinWeighted<ComplexDataVector, 0>>& du_r_scalar,
     const Scalar<SpinWeighted<ComplexDataVector, 0>>& r_scalar,
     const size_t l_max) {
@@ -107,7 +107,7 @@ Scalar<SpinWeighted<ComplexDataVector, 2>> evaluate_worldtube_h_residual(
   auto& du_r_divided_by_r = get<Temp<6, 0>>(buffer);
   get(du_r_divided_by_r) = du_r / r;
 
-  // `dy_j`, `h_numerical` and `dy_h_numerical` are supplied directly in the
+  // `dy_j`, `h` and `dy_h` are supplied directly in the
   // numerical (constant y) coordinate; the conversion from the physical
   // worldtube data is performed by the caller (`compute_dy_dy_j`).
   const auto& dy_j = get(dy_j_scalar);
@@ -382,10 +382,9 @@ Scalar<SpinWeighted<ComplexDataVector, 2>> evaluate_worldtube_h_residual(
   Scalar<SpinWeighted<ComplexDataVector, 2>> residual{n};
   get(residual).data() =
       get(pole_h).data() + 2.0 * get(regular_h).data() -
-      (2.0 * get(dy_h_numerical_scalar).data() +
-       get(linear_factor).data() * get(h_numerical_scalar).data() +
-       get(linear_factor_conjugate).data() *
-           conj(get(h_numerical_scalar).data()));
+      (2.0 * get(dy_h_scalar).data() +
+       get(linear_factor).data() * get(h_scalar).data() +
+       get(linear_factor_conjugate).data() * conj(get(h_scalar).data()));
   return residual;
 }
 
@@ -396,7 +395,7 @@ void compute_dy_dy_j(
     const Scalar<SpinWeighted<ComplexDataVector, 0>>& w_scalar,
     const Scalar<SpinWeighted<ComplexDataVector, 0>>& beta_scalar,
     const Scalar<SpinWeighted<ComplexDataVector, 1>>& q_scalar,
-    const Scalar<SpinWeighted<ComplexDataVector, 2>>& h_scalar,
+    const Scalar<SpinWeighted<ComplexDataVector, 2>>& du_j_scalar,
     const Scalar<SpinWeighted<ComplexDataVector, 2>>& dr_j_scalar,
     const Scalar<SpinWeighted<ComplexDataVector, 2>>& du_dr_j_scalar,
     const Scalar<SpinWeighted<ComplexDataVector, 0>>& du_r_scalar,
@@ -407,24 +406,24 @@ void compute_dy_dy_j(
   // coordinate that `evaluate_worldtube_h_residual` works in, using the
   // worldtube Jacobian dy_j = (R / 2) Dr<J>:
   //   dy_j           = (R / 2) Dr<J>,
-  //   h_numerical    = H + Du<R> Dr<J>            (= Du<J> at constant y),
-  //   dy_h_numerical = (1 / 2) (Du<R> Dr<J> + R Du<Dr<J>>)
-  //                                               (= Dy of h_numerical).
+  //   h    = Du<J> + Du<R> Dr<J>            (= Du<J> at constant y),
+  //   dy_h = (1 / 2) (Du<R> Dr<J> + R Du<Dr<J>>)
+  //                                               (= Dy of h).
   Scalar<SpinWeighted<ComplexDataVector, 2>> dy_j_scalar{n};
   get(dy_j_scalar).data() =
       0.5 * get(r_scalar).data() * get(dr_j_scalar).data();
-  Scalar<SpinWeighted<ComplexDataVector, 2>> h_numerical_scalar{n};
-  get(h_numerical_scalar).data() =
-      get(h_scalar).data() + get(du_r_scalar).data() * get(dr_j_scalar).data();
-  Scalar<SpinWeighted<ComplexDataVector, 2>> dy_h_numerical_scalar{n};
-  get(dy_h_numerical_scalar).data() =
+  Scalar<SpinWeighted<ComplexDataVector, 2>> h_scalar{n};
+  get(h_scalar).data() = get(du_j_scalar).data() +
+                         get(du_r_scalar).data() * get(dr_j_scalar).data();
+  Scalar<SpinWeighted<ComplexDataVector, 2>> dy_h_scalar{n};
+  get(dy_h_scalar).data() =
       0.5 * (get(du_r_scalar).data() * get(dr_j_scalar).data() +
              get(r_scalar).data() * get(du_dr_j_scalar).data());
   const auto residual = [&](const ComplexDataVector& dy_dy_j_value) {
-    return get(evaluate_worldtube_h_residual(
-                   dy_dy_j_value, j_scalar, u_scalar, w_scalar, beta_scalar,
-                   q_scalar, dy_j_scalar, h_numerical_scalar,
-                   dy_h_numerical_scalar, du_r_scalar, r_scalar, l_max))
+    return get(evaluate_worldtube_h_residual(dy_dy_j_value, j_scalar, u_scalar,
+                                             w_scalar, beta_scalar, q_scalar,
+                                             dy_j_scalar, h_scalar, dy_h_scalar,
+                                             du_r_scalar, r_scalar, l_max))
         .data();
   };
 

--- a/src/Evolution/Systems/Cce/Initialize/ComputeSecondOrderRadialDerivativeJ.hpp
+++ b/src/Evolution/Systems/Cce/Initialize/ComputeSecondOrderRadialDerivativeJ.hpp
@@ -84,7 +84,7 @@ void compute_dy_dy_j(
     const Scalar<SpinWeighted<ComplexDataVector, 0>>& w,
     const Scalar<SpinWeighted<ComplexDataVector, 0>>& beta,
     const Scalar<SpinWeighted<ComplexDataVector, 1>>& q,
-    const Scalar<SpinWeighted<ComplexDataVector, 2>>& h,
+    const Scalar<SpinWeighted<ComplexDataVector, 2>>& du_j,
     const Scalar<SpinWeighted<ComplexDataVector, 2>>& dr_j,
     const Scalar<SpinWeighted<ComplexDataVector, 2>>& du_dr_j,
     const Scalar<SpinWeighted<ComplexDataVector, 0>>& du_r,
@@ -104,8 +104,8 @@ void compute_dy_dy_j(
  * evaluated with the supplied trial value `dy_dy_j_value` for
  * \f$\partial_y^2 J\f$ (with \f$\partial_y^2 \bar J\f$ taken to be its complex
  * conjugate). All worldtube inputs are supplied in the numerical (constant
- * \f$y\f$) coordinate: `dy_j` \f$= \partial_y J\f$, `h_numerical`
- * \f$= \breve{H} = (\partial_u J)_y\f$, and `dy_h_numerical`
+ * \f$y\f$) coordinate: `dy_j` \f$= \partial_y J\f$, `h`
+ * \f$= \breve{H} = (\partial_u J)_y\f$, and `dy_h`
  * \f$= \partial_y \breve{H}\f$; no physical radial-derivative quantity is
  * passed. Every angular derivative is converted from the numerical to the
  * physical coordinate with `Cce::ApplySwshJacobianInplace`, and every
@@ -123,8 +123,8 @@ Scalar<SpinWeighted<ComplexDataVector, 2>> evaluate_worldtube_h_residual(
     const Scalar<SpinWeighted<ComplexDataVector, 0>>& beta,
     const Scalar<SpinWeighted<ComplexDataVector, 1>>& q,
     const Scalar<SpinWeighted<ComplexDataVector, 2>>& dy_j,
-    const Scalar<SpinWeighted<ComplexDataVector, 2>>& h_numerical,
-    const Scalar<SpinWeighted<ComplexDataVector, 2>>& dy_h_numerical,
+    const Scalar<SpinWeighted<ComplexDataVector, 2>>& h,
+    const Scalar<SpinWeighted<ComplexDataVector, 2>>& dy_h,
     const Scalar<SpinWeighted<ComplexDataVector, 0>>& du_r,
     const Scalar<SpinWeighted<ComplexDataVector, 0>>& r, size_t l_max);
 

--- a/src/Evolution/Systems/Cce/Initialize/InitializeJ.hpp
+++ b/src/Evolution/Systems/Cce/Initialize/InitializeJ.hpp
@@ -322,6 +322,7 @@ struct InverseCubic;
 template <bool evolve_ccm>
 struct InitializeJ;
 struct ConformalFactor;
+struct CauchySecondOrder;
 /// \endcond
 
 /*!
@@ -400,8 +401,8 @@ template <>
 struct InitializeJ<false> : public PUP::able {
   // Default boundary/mutate/argument tags used by the simple derived classes
   // (ConformalFactor, InverseCubic<false>, NoIncomingRadiation, ZeroNonSmooth).
-  // A derived class may shadow these with its own list, in which case the
-  // per-class list is used during dispatch.
+  // A derived class can shadow these with its own list (see CauchySecondOrder),
+  // in which case the per-class list is used during dispatch.
   using boundary_tags = tmpl::list<Tags::BoundaryValue<Tags::BondiJ>,
                                    Tags::BoundaryValue<Tags::Dr<Tags::BondiJ>>,
                                    Tags::BoundaryValue<Tags::BondiR>,
@@ -415,7 +416,7 @@ struct InitializeJ<false> : public PUP::able {
 
   using creatable_classes =
       tmpl::list<ConformalFactor, InverseCubic<false>, NoIncomingRadiation,
-                 ZeroNonSmooth,
+                 ZeroNonSmooth, CauchySecondOrder,
                  ::Cce::Solutions::LinearizedBondiSachs_detail::InitializeJ::
                      LinearizedBondiSachs>;
 
@@ -443,6 +444,7 @@ struct InitializeJ<false> : public PUP::able {
 }  // namespace Cce
 
 #include "Evolution/Systems/Cce/AnalyticSolutions/LinearizedBondiSachsInitializeJ.hpp"
+#include "Evolution/Systems/Cce/Initialize/CauchySecondOrder.hpp"
 #include "Evolution/Systems/Cce/Initialize/ConformalFactor.hpp"
 #include "Evolution/Systems/Cce/Initialize/InverseCubic.hpp"
 #include "Evolution/Systems/Cce/Initialize/NoIncomingRadiation.hpp"

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeFirstHypersurface.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeFirstHypersurface.cpp
@@ -41,11 +41,15 @@
 namespace Cce {
 
 namespace {
-using swsh_boundary_tags_to_generate =
-    tmpl::list<Tags::BoundaryValue<Tags::BondiJ>,
-               Tags::BoundaryValue<Tags::Dr<Tags::BondiJ>>,
-               Tags::BoundaryValue<Tags::BondiBeta>,
-               Tags::BoundaryValue<Tags::BondiR>>;
+using swsh_boundary_tags_to_generate = tmpl::list<
+    Tags::BoundaryValue<Tags::BondiJ>,
+    Tags::BoundaryValue<Tags::Dr<Tags::BondiJ>>,
+    Tags::BoundaryValue<Tags::BondiBeta>, Tags::BoundaryValue<Tags::BondiR>,
+    Tags::BoundaryValue<Tags::BondiU>, Tags::BoundaryValue<Tags::BondiW>,
+    Tags::BoundaryValue<Tags::BondiQ>,
+    Tags::BoundaryValue<Tags::Du<Tags::BondiJ>>,
+    Tags::BoundaryValue<Tags::Du<Tags::Dr<Tags::BondiJ>>>,
+    Tags::BoundaryValue<Tags::Du<Tags::BondiR>>>;
 
 using real_cauchy_boundary_tags_to_compute =
     tmpl::list<Tags::CauchyCartesianCoords, Tags::CauchyAngularCoords,
@@ -167,24 +171,23 @@ void test_InitializeFirstHypersurface() {
       number_of_radial_points};
   TimeStepId time_step_id{true, 0, Time{Slab{1.0, 2.0}, {0, 1}}};
 
-  tmpl::for_each<swsh_boundary_tags_to_generate>([&swsh_variables, &gen,
-                                                  &coefficient_distribution,
-                                                  &l_max](auto tag_v) {
-    using tag = typename decltype(tag_v)::type;
-    SpinWeighted<ComplexModalVector, tag::type::type::spin> generated_modes{
-        Spectral::Swsh::size_of_libsharp_coefficient_vector(l_max)};
-    Spectral::Swsh::TestHelpers::generate_swsh_modes<tag::type::type::spin>(
-        make_not_null(&generated_modes.data()), make_not_null(&gen),
-        make_not_null(&coefficient_distribution), 1, l_max);
-    Spectral::Swsh::inverse_swsh_transform(
-        l_max, 1, make_not_null(&get(get<tag>(swsh_variables))),
-        generated_modes);
-    // aggressive filter to make the uniformly generated random modes
-    // somewhat reasonable
-    Spectral::Swsh::filter_swsh_volume_quantity(
-        make_not_null(&get(get<tag>(swsh_variables))), l_max, l_max / 2, 32.0,
-        8);
-  });
+  tmpl::for_each<swsh_boundary_tags_to_generate>(
+      [&swsh_variables, &gen, &coefficient_distribution, &l_max](auto tag_v) {
+        using tag = typename decltype(tag_v)::type;
+        SpinWeighted<ComplexModalVector, tag::type::type::spin> generated_modes{
+            Spectral::Swsh::size_of_libsharp_coefficient_vector(l_max)};
+        Spectral::Swsh::TestHelpers::generate_swsh_modes<tag::type::type::spin>(
+            make_not_null(&generated_modes.data()), make_not_null(&gen),
+            make_not_null(&coefficient_distribution), 1, l_max);
+        Spectral::Swsh::inverse_swsh_transform(
+            l_max, 1, make_not_null(&get(get<tag>(swsh_variables))),
+            generated_modes);
+        // aggressive filter to make the uniformly generated random modes
+        // somewhat reasonable
+        Spectral::Swsh::filter_swsh_volume_quantity(
+            make_not_null(&get(get<tag>(swsh_variables))), l_max, l_max / 2,
+            32.0, 8);
+      });
 
   ActionTesting::emplace_component_and_initialize<
       mock_observer_writer<metavariables<EvolveCcm>>>(&runner, 0,

--- a/tests/Unit/Evolution/Systems/Cce/Test_ComputeSecondOrderRadialDerivativeJ.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_ComputeSecondOrderRadialDerivativeJ.cpp
@@ -65,7 +65,7 @@ void test_h_equation_is_satisfied(const size_t l_max) {
   const auto q = random_boundary_scalar<1>(
       make_not_null(&generator), make_not_null(&coefficient_distribution),
       l_max);
-  const auto h = random_boundary_scalar<2>(
+  const auto du_j = random_boundary_scalar<2>(
       make_not_null(&generator), make_not_null(&coefficient_distribution),
       l_max);
   const auto dr_j = random_boundary_scalar<2>(
@@ -98,33 +98,31 @@ void test_h_equation_is_satisfied(const size_t l_max) {
   // here to drive `evaluate_worldtube_h_residual`, which works purely in the
   // numerical coordinate:
   //   dy_j           = (R / 2) Dr<J>,
-  //   h_numerical    = H + Du<R> Dr<J>,
-  //   dy_h_numerical = (1 / 2) (Du<R> Dr<J> + R Du<Dr<J>>).
+  //   h    = Du<J> + Du<R> Dr<J>,
+  //   dy_h = (1 / 2) (Du<R> Dr<J> + R Du<Dr<J>>).
   Scalar<SpinWeighted<ComplexDataVector, 2>> dy_j{number_of_points};
   get(dy_j).data() = 0.5 * get(r).data() * get(dr_j).data();
-  Scalar<SpinWeighted<ComplexDataVector, 2>> h_numerical{number_of_points};
-  get(h_numerical).data() = get(h).data() + get(du_r).data() * get(dr_j).data();
-  Scalar<SpinWeighted<ComplexDataVector, 2>> dy_h_numerical{number_of_points};
-  get(dy_h_numerical).data() = 0.5 * (get(du_r).data() * get(dr_j).data() +
-                                      get(r).data() * get(du_dr_j).data());
+  Scalar<SpinWeighted<ComplexDataVector, 2>> h{number_of_points};
+  get(h).data() = get(du_j).data() + get(du_r).data() * get(dr_j).data();
+  Scalar<SpinWeighted<ComplexDataVector, 2>> dy_h{number_of_points};
+  get(dy_h).data() = 0.5 * (get(du_r).data() * get(dr_j).data() +
+                            get(r).data() * get(du_dr_j).data());
 
   Scalar<SpinWeighted<ComplexDataVector, 2>> dy_dy_j{number_of_points};
-  compute_dy_dy_j(make_not_null(&dy_dy_j), j, u, w, beta, q, h, dr_j, du_dr_j,
-                  du_r, r, l_max);
+  compute_dy_dy_j(make_not_null(&dy_dy_j), j, u, w, beta, q, du_j, dr_j,
+                  du_dr_j, du_r, r, l_max);
 
   // The natural scale of the H equation is the size of its source term, the
   // residual evaluated with dy^2 J set to zero.
   const auto residual_without_dy_dy_j = evaluate_worldtube_h_residual(
-      zero_dy_dy_j, j, u, w, beta, q, dy_j, h_numerical, dy_h_numerical, du_r,
-      r, l_max);
+      zero_dy_dy_j, j, u, w, beta, q, dy_j, h, dy_h, du_r, r, l_max);
   double scale = 0.0;
   for (const auto entry : get(residual_without_dy_dy_j).data()) {
     scale = std::max(scale, std::abs(entry));
   }
 
   const auto residual_at_solution = evaluate_worldtube_h_residual(
-      get(dy_dy_j).data(), j, u, w, beta, q, dy_j, h_numerical, dy_h_numerical,
-      du_r, r, l_max);
+      get(dy_dy_j).data(), j, u, w, beta, q, dy_j, h, dy_h, du_r, r, l_max);
   const Approx h_equation_approx =
       Approx::custom().epsilon(1.0e-10).scale(scale);
   CHECK_ITERABLE_CUSTOM_APPROX(get(residual_at_solution).data(), zero_dy_dy_j,
@@ -140,9 +138,8 @@ void test_h_equation_is_satisfied(const size_t l_max) {
       make_not_null(&generator), make_not_null(&coefficient_distribution),
       l_max);
   const auto evaluate = [&](const ComplexDataVector& trial) {
-    return get(evaluate_worldtube_h_residual(trial, j, u, w, beta, q, dy_j,
-                                             h_numerical, dy_h_numerical, du_r,
-                                             r, l_max))
+    return get(evaluate_worldtube_h_residual(trial, j, u, w, beta, q, dy_j, h,
+                                             dy_h, du_r, r, l_max))
         .data();
   };
   const ComplexDataVector residual_of_sum =

--- a/tests/Unit/Evolution/Systems/Cce/Test_InitializeCce.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_InitializeCce.cpp
@@ -11,6 +11,7 @@
 #include "DataStructures/Variables.hpp"
 #include "DataStructures/VariablesTag.hpp"
 #include "Evolution/Systems/Cce/GaugeTransformBoundaryData.hpp"
+#include "Evolution/Systems/Cce/Initialize/CauchySecondOrder.hpp"
 #include "Evolution/Systems/Cce/Initialize/ConformalFactor.hpp"
 #include "Evolution/Systems/Cce/Initialize/InitializeJ.hpp"
 #include "Evolution/Systems/Cce/Initialize/InverseCubic.hpp"
@@ -87,6 +88,25 @@ void check_boundary_and_asymptotic_j(
   CHECK_ITERABLE_CUSTOM_APPROX(scri_slice_j, scri_plus_zeroes, cce_approx);
   CHECK_ITERABLE_CUSTOM_APPROX(scri_slice_dy_dy_j.data(), scri_plus_zeroes,
                                cce_approx);
+}
+
+// Fill a worldtube boundary value with filtered random spin-weighted data of
+// the requested spin weight. Used to populate the additional boundary
+// quantities consumed by the `CauchySecondOrder` generator.
+template <int Spin, typename Generator, typename Distribution>
+void assign_random_swsh_boundary_value(
+    const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, Spin>>*> field,
+    const gsl::not_null<Generator*> generator,
+    const gsl::not_null<Distribution*> distribution, const size_t l_max) {
+  SpinWeighted<ComplexModalVector, Spin> generated_modes{
+      Spectral::Swsh::size_of_libsharp_coefficient_vector(l_max)};
+  Spectral::Swsh::TestHelpers::generate_swsh_modes<Spin>(
+      make_not_null(&generated_modes.data()), generator, distribution, 1,
+      l_max);
+  get(*field) =
+      Spectral::Swsh::inverse_swsh_transform(l_max, 1, generated_modes);
+  Spectral::Swsh::filter_swsh_boundary_quantity(make_not_null(&get(*field)),
+                                                l_max, l_max / 2);
 }
 
 template <typename DbTags>
@@ -266,6 +286,115 @@ void test_initialize_j_no_radiation(
     CHECK(cce_approx(real(val)) == 0.0);
     CHECK(cce_approx(imag(val)) == 0.0);
   }
+}
+
+template <typename DbTags>
+void test_initialize_j_cauchy_second_order(
+    const gsl::not_null<db::DataBox<DbTags>*> box_to_initialize,
+    const size_t l_max, const size_t number_of_radial_points) {
+  auto node_lock = Parallel::NodeLock{};
+  // The angular coordinates are adapted iteratively (as in NoIncomingRadiation
+  // and ConformalFactor), so we only request a tolerance the linearized solve
+  // can reliably reach for randomly generated data.
+  const auto initializer =
+      InitializeJ::CauchySecondOrder{1.0e-10, 400, true, 1.0e-8};
+  db::mutate_apply<InitializeJ::CauchySecondOrder::return_tags,
+                   InitializeJ::CauchySecondOrder::argument_tags>(
+      initializer, box_to_initialize, make_not_null(&node_lock));
+
+  // note we want to copy here to compare against the next version of the
+  // computation
+  // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
+  const auto initialized_j = db::get<Tags::BondiJ>(*box_to_initialize);
+  const auto serialized_and_deserialized_initializer =
+      serialize_and_deserialize(initializer);
+  db::mutate_apply<InitializeJ::CauchySecondOrder::return_tags,
+                   InitializeJ::CauchySecondOrder::argument_tags>(
+      serialized_and_deserialized_initializer, box_to_initialize,
+      make_not_null(&node_lock));
+  CHECK_ITERABLE_APPROX(get(initialized_j).data(),
+                        get(db::get<Tags::BondiJ>(*box_to_initialize)).data());
+
+  // generate the gauge quantities so the boundary data can be compared in the
+  // evolution gauge.
+  db::mutate_apply<GaugeUpdateAngularFromCartesian<
+      Tags::CauchyAngularCoords, Tags::CauchyCartesianCoords>>(
+      box_to_initialize);
+  db::mutate_apply<GaugeUpdateJacobianFromCoordinates<
+      Tags::PartiallyFlatGaugeC, Tags::PartiallyFlatGaugeD,
+      Tags::CauchyAngularCoords, Tags::CauchyCartesianCoords>>(
+      box_to_initialize);
+  db::mutate_apply<GaugeUpdateInterpolator<Tags::CauchyAngularCoords>>(
+      box_to_initialize);
+  db::mutate_apply<
+      GaugeUpdateOmega<Tags::PartiallyFlatGaugeC, Tags::PartiallyFlatGaugeD,
+                       Tags::PartiallyFlatGaugeOmega>>(box_to_initialize);
+  db::mutate_apply<GaugeAdjustedBoundaryValue<Tags::BondiJ>>(box_to_initialize);
+
+  // The polynomial construction matches J and its first radial derivative at
+  // the worldtube, so the volume J on the boundary should equal the
+  // gauge-transformed boundary value of J.
+  const size_t number_of_angular_points =
+      Spectral::Swsh::number_of_swsh_collocation_points(l_max);
+  const auto& boundary_gauge_j =
+      db::get<Tags::EvolutionGaugeBoundaryValue<Tags::BondiJ>>(
+          *box_to_initialize);
+  for (size_t i = 0; i < number_of_angular_points; ++i) {
+    CHECK(approx(real(get(initialized_j).data()[i])) ==
+          real(get(boundary_gauge_j).data()[i]));
+    CHECK(approx(imag(get(initialized_j).data()[i])) ==
+          imag(get(boundary_gauge_j).data()[i]));
+  }
+
+  // The cubic-in-(1 - y) construction forces the second radial derivative of J
+  // to vanish at scri+ in the numerical gauge; the angular gauge transform only
+  // adds a term proportional to the (strain-sized) coordinate distortion, so
+  // the final initial data must still have a tiny second derivative there.
+  db::mutate_apply<PreSwshDerivatives<Tags::Dy<Tags::BondiJ>>>(
+      box_to_initialize);
+  db::mutate_apply<PreSwshDerivatives<Tags::Dy<Tags::Dy<Tags::BondiJ>>>>(
+      box_to_initialize);
+  const SpinWeighted<ComplexDataVector, 2> scri_slice_dy_dy_j;
+  make_const_view(
+      make_not_null(&scri_slice_dy_dy_j),
+      get(db::get<Tags::Dy<Tags::Dy<Tags::BondiJ>>>(*box_to_initialize)),
+      number_of_angular_points * (number_of_radial_points - 1),
+      number_of_angular_points);
+  const ComplexDataVector scri_plus_zeroes{number_of_angular_points, 0.0};
+  const Approx scri_approx = Approx::custom().epsilon(1.0e-10).scale(1.0);
+  CHECK_ITERABLE_CUSTOM_APPROX(scri_slice_dy_dy_j.data(), scri_plus_zeroes,
+                               scri_approx);
+}
+
+template <typename DbTags>
+void test_cauchy_second_order_scri_derivative_error(
+    const gsl::not_null<db::DataBox<DbTags>*> box_to_initialize) {
+  // The second-order construction drives the second radial derivative of J at
+  // scri+ to (near) zero, but a tiny numerical residual always remains. An
+  // unachievably small `MaxScriSecondDerivative` therefore trips the safeguard.
+  auto node_lock = Parallel::NodeLock{};
+  db::mutate_apply<InitializeJ::CauchySecondOrder::return_tags,
+                   InitializeJ::CauchySecondOrder::argument_tags>(
+      InitializeJ::CauchySecondOrder{1.0e-10, 400, true, 1.0e-30},
+      box_to_initialize, make_not_null(&node_lock));
+}
+
+template <typename DbTags>
+void test_cauchy_second_order_asymptotic_j_error(
+    const gsl::not_null<db::DataBox<DbTags>*> box_to_initialize) {
+  // Inflate the worldtube J without the compensating radial derivative so the
+  // asymptotic value of the constructed Cauchy-coordinate J is far too large
+  // for the angular solve to eliminate, tripping the pre-solve guard. This
+  // corrupts the boundary data, so it must run after the other checks.
+  db::mutate<Tags::BoundaryValue<Tags::BondiJ>>(
+      [](const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 2>>*>
+             boundary_j) { get(*boundary_j).data() += 1.0; },
+      box_to_initialize);
+  auto node_lock = Parallel::NodeLock{};
+  db::mutate_apply<InitializeJ::CauchySecondOrder::return_tags,
+                   InitializeJ::CauchySecondOrder::argument_tags>(
+      InitializeJ::CauchySecondOrder{1.0e-10, 400, true, 1.0e-8},
+      box_to_initialize, make_not_null(&node_lock));
 }
 
 template <typename DbTags>
@@ -497,7 +626,12 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.InitializeJ", "[Unit][Cce]") {
       Tags::EvolutionGaugeBoundaryValue<Tags::BondiJ>,
       Tags::EvolutionGaugeBoundaryValue<Tags::Dr<Tags::BondiJ>>,
       Tags::EvolutionGaugeBoundaryValue<Tags::BondiR>,
-      Tags::EvolutionGaugeBoundaryValue<Tags::BondiBeta>>>;
+      Tags::EvolutionGaugeBoundaryValue<Tags::BondiBeta>,
+      Tags::BoundaryValue<Tags::BondiU>, Tags::BoundaryValue<Tags::BondiW>,
+      Tags::BoundaryValue<Tags::BondiQ>,
+      Tags::BoundaryValue<Tags::Du<Tags::BondiJ>>,
+      Tags::BoundaryValue<Tags::Du<Tags::Dr<Tags::BondiJ>>>,
+      Tags::BoundaryValue<Tags::Du<Tags::BondiR>>>>;
   using pre_swsh_derivatives_variables_tag = ::Tags::Variables<tmpl::list<
       Tags::BondiJ, Tags::Dy<Tags::BondiJ>, Tags::Dy<Tags::Dy<Tags::BondiJ>>,
       Tags::BondiK, Tags::BondiR, Tags::Integrand<Tags::BondiBeta>,
@@ -568,6 +702,52 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.InitializeJ", "[Unit][Cce]") {
         get(*boundary_dr_j) = -get(*boundary_j) / get(*boundary_r);
       },
       make_not_null(&box_to_initialize));
+  // The CauchySecondOrder generator additionally consumes the worldtube values
+  // of U, W, Q, Du(J), Du(Dr(J)), and Du(R) to evaluate the H hypersurface
+  // equation for dy^2 J. These enter through factors of the (large) worldtube
+  // radius R, so to keep the resulting dy^2 J at the same (strain) scale as J -
+  // and thus small enough for the angular coordinate solve to converge - they
+  // are drawn from a correspondingly smaller distribution.
+  UniformCustomDistribution<double> second_order_dist(1.0e-10, 1.0e-9);
+  db::mutate<Tags::BoundaryValue<Tags::BondiU>,
+             Tags::BoundaryValue<Tags::BondiW>,
+             Tags::BoundaryValue<Tags::BondiQ>,
+             Tags::BoundaryValue<Tags::Du<Tags::BondiJ>>,
+             Tags::BoundaryValue<Tags::Du<Tags::Dr<Tags::BondiJ>>>,
+             Tags::BoundaryValue<Tags::Du<Tags::BondiR>>>(
+      [&generator, &second_order_dist, &l_max](
+          const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 1>>*>
+              boundary_u,
+          const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*>
+              boundary_w,
+          const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 1>>*>
+              boundary_q,
+          const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 2>>*>
+              boundary_du_j,
+          const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 2>>*>
+              boundary_du_dr_j,
+          const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*>
+              boundary_du_r) {
+        assign_random_swsh_boundary_value<1>(
+            boundary_u, make_not_null(&generator),
+            make_not_null(&second_order_dist), l_max);
+        assign_random_swsh_boundary_value<0>(
+            boundary_w, make_not_null(&generator),
+            make_not_null(&second_order_dist), l_max);
+        assign_random_swsh_boundary_value<1>(
+            boundary_q, make_not_null(&generator),
+            make_not_null(&second_order_dist), l_max);
+        assign_random_swsh_boundary_value<2>(
+            boundary_du_j, make_not_null(&generator),
+            make_not_null(&second_order_dist), l_max);
+        assign_random_swsh_boundary_value<2>(
+            boundary_du_dr_j, make_not_null(&generator),
+            make_not_null(&second_order_dist), l_max);
+        assign_random_swsh_boundary_value<0>(
+            boundary_du_r, make_not_null(&generator),
+            make_not_null(&second_order_dist), l_max);
+      },
+      make_not_null(&box_to_initialize));
   {
     INFO("Check inverse cubic initial data generator");
     test_initialize_j_inverse_cubic(make_not_null(&box_to_initialize), l_max,
@@ -610,5 +790,22 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.InitializeJ", "[Unit][Cce]") {
             SpinWeight1CoordPerturbation,
         l_max, number_of_radial_points);
   }
+  {
+    INFO("Check second-order initial data generator");
+    test_initialize_j_cauchy_second_order(make_not_null(&box_to_initialize),
+                                          l_max, number_of_radial_points);
+  }
+  CHECK_THROWS_WITH(
+      test_cauchy_second_order_scri_derivative_error(
+          make_not_null(&box_to_initialize)),
+      Catch::Matchers::ContainsSubstring(
+          "The initial J has a second radial derivative at scri+ of "
+          "magnitude"));
+  CHECK_THROWS_WITH(
+      test_cauchy_second_order_asymptotic_j_error(
+          make_not_null(&box_to_initialize)),
+      Catch::Matchers::ContainsSubstring(
+          "The asymptotic value of the initial J in Cauchy coordinates has "
+          "magnitude"));
 }
 }  // namespace Cce

--- a/tests/Unit/Evolution/Systems/Cce/Test_OptionTags.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_OptionTags.cpp
@@ -166,6 +166,12 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.OptionTags", "[Unit][Cce]") {
       "InverseCubic");
   TestHelpers::test_option_tag<Cce::OptionTags::InitializeJ<false>>(
       "InverseCubic");
+  TestHelpers::test_option_tag<Cce::OptionTags::InitializeJ<false>>(
+      "CauchySecondOrder:\n"
+      "  AngularCoordTolerance: 1e-10\n"
+      "  MaxIterations: 300\n"
+      "  RequireConvergence: false\n"
+      "  MaxScriSecondDerivative: 1e-6");
   TestHelpers::test_option_tag<Cce::OptionTags::AnalyticSolution>(
       "BouncingBlackHole:\n"
       "  Period: 40.0\n"

--- a/tests/Unit/Helpers/Evolution/Systems/Cce/AnalyticSolutions/AnalyticDataHelpers.cpp
+++ b/tests/Unit/Helpers/Evolution/Systems/Cce/AnalyticSolutions/AnalyticDataHelpers.cpp
@@ -49,7 +49,7 @@ extract_bondi_scalars_from_cartesian_metric(
   get<0, 0>(inverse_spherical_metric) +=
       -2.0 * get<0, 1>(inverse_spherical_metric) +
       get<1, 1>(inverse_spherical_metric);
-  for(size_t i = 0; i < 3; ++i) {
+  for (size_t i = 0; i < 3; ++i) {
     inverse_spherical_metric.get(0, i) -= inverse_spherical_metric.get(1, i);
   }
   Scalar<SpinWeighted<ComplexDataVector, 0>> bondi_beta{
@@ -139,7 +139,7 @@ extract_dt_bondi_scalars_from_cartesian_metric(
   get<0, 0>(dt_inverse_spherical_metric) +=
       -2.0 * get<0, 1>(dt_inverse_spherical_metric) +
       get<1, 1>(dt_inverse_spherical_metric);
-  for(size_t i = 0; i < 3; ++i) {
+  for (size_t i = 0; i < 3; ++i) {
     inverse_spherical_metric.get(0, i) -= inverse_spherical_metric.get(1, i);
     dt_inverse_spherical_metric.get(0, i) -=
         dt_inverse_spherical_metric.get(1, i);
@@ -350,7 +350,13 @@ void test_initialize_j(const size_t l_max, const size_t number_of_radial_points,
             Tags::CauchyAngularCoords, Tags::BoundaryValue<Tags::BondiJ>,
             Tags::BoundaryValue<Tags::Dr<Tags::BondiJ>>,
             Tags::BoundaryValue<Tags::BondiR>,
-            Tags::BoundaryValue<Tags::BondiBeta>, Tags::LMax,
+            Tags::BoundaryValue<Tags::BondiBeta>,
+            Tags::BoundaryValue<Tags::BondiU>,
+            Tags::BoundaryValue<Tags::BondiW>,
+            Tags::BoundaryValue<Tags::BondiQ>,
+            Tags::BoundaryValue<Tags::Du<Tags::BondiJ>>,
+            Tags::BoundaryValue<Tags::Du<Tags::Dr<Tags::BondiJ>>>,
+            Tags::BoundaryValue<Tags::Du<Tags::BondiR>>, Tags::LMax,
             Tags::NumberOfRadialPoints>>(
             Scalar<SpinWeighted<ComplexDataVector, 2>>{
                 number_of_angular_points * number_of_radial_points},
@@ -362,6 +368,15 @@ void test_initialize_j(const size_t l_max, const size_t number_of_radial_points,
                 boundary_variables),
             get<Tags::BoundaryValue<Tags::BondiR>>(boundary_variables),
             get<Tags::BoundaryValue<Tags::BondiBeta>>(boundary_variables),
+            get<Tags::BoundaryValue<Tags::BondiU>>(boundary_variables),
+            get<Tags::BoundaryValue<Tags::BondiW>>(boundary_variables),
+            get<Tags::BoundaryValue<Tags::BondiQ>>(boundary_variables),
+            get<Tags::BoundaryValue<Tags::Du<Tags::BondiJ>>>(
+                boundary_variables),
+            get<Tags::BoundaryValue<Tags::Du<Tags::Dr<Tags::BondiJ>>>>(
+                boundary_variables),
+            get<Tags::BoundaryValue<Tags::Du<Tags::BondiR>>>(
+                boundary_variables),
             l_max, number_of_radial_points);
         (*generator)(make_not_null(&box), make_not_null(&node_lock));
         *j = db::get<Tags::BondiJ>(box);


### PR DESCRIPTION
Introduces a new `InitializeJ<false>`-derived scheme that builds the initial hypersurface $J$ by solving the H-hypersurface equation at the worldtube for $\partial_y^2 J$ and fitting a polynomial of the form $A + B(1 - y) + C(1 - y)^3$ that matches $J$, $\partial_r J$, and $\partial_y^2 J$ at $y = -1$. The initial angular-coordinate transformation is then found by driving the value of $J$ at scri+ (the constant coefficient $A$) below `AngularCoordTolerance` (default `1e-12`), and the volume $J$ on the initial null slice is finally transformed into these new angular coordinates.

The scheme is implemented in `CauchySecondOrder.{hpp,cpp}` and registered in `InitializeJ<false>::creatable_classes` so it can be selected from the `InitializeJ:` option. It declares its own `argument_tags` and is picked up by the `call_with_dynamic_type` dispatch. The H-equation evaluation is delegated to the second-order radial-derivative-of-$J$ helper (`compute_dy_dy_j`). `CauchySecondOrder` consumes the primitive worldtube boundary value `BoundaryValue<Du<Dr<BondiJ>>>` — obtained by numerically time-differentiating the primitive variable `Dr<J>` — along with the other worldtube boundary values it needs.

After the angular solve, the scheme computes $\partial_y^2 J$ of the gauge-transformed volume $J$ and errors if its scri+ magnitude exceeds the `MaxScriSecondDerivative` option (settable from the input file; defaults to `1e-8`). This is to make sure the initial J in the new coordinates complies the partially flat evolution gauge requirements.

`Test_InitializeCce.cpp` exercises the generator: it populates the additional worldtube boundary values the scheme consumes (`U`, `W`, `Q`, `Du(J)`, `Du(Dr(J))`, `Du(R)`) and checks the serialization round-trip, the worldtube boundary-$J$ match in the evolution gauge, and that the second radial derivative of $J$ at scri+ vanishes. These boundary values enter $\partial_y^2 J$ through factors of the (large) worldtube radius $R$, so they are drawn from a correspondingly smaller distribution than $J$ to keep $\partial_y^2 J$ at strain scale and let the iterative angular solve converge. The new option is also parse-tested in `Test_OptionTags`.
