### PR TITLE
Have time_dependence::None::functions_of_time return empty map

### DIFF
--- a/src/Domain/Creators/CartoonCylinder.cpp
+++ b/src/Domain/Creators/CartoonCylinder.cpp
@@ -199,10 +199,6 @@ std::unordered_map<std::string,
 CartoonCylinder::functions_of_time(
     const std::unordered_map<std::string, double>& initial_expiration_times)
     const {
-  if (time_dependence_->is_none()) {
-    return {};
-  } else {
-    return time_dependence_->functions_of_time(initial_expiration_times);
-  }
+  return time_dependence_->functions_of_time(initial_expiration_times);
 }
 }  // namespace domain::creators

--- a/src/Domain/Creators/CartoonSphere1D.cpp
+++ b/src/Domain/Creators/CartoonSphere1D.cpp
@@ -300,10 +300,6 @@ std::unordered_map<std::string,
 CartoonSphere1D::functions_of_time(
     const std::unordered_map<std::string, double>& initial_expiration_times)
     const {
-  if (time_dependence_->is_none()) {
-    return {};
-  } else {
-    return time_dependence_->functions_of_time(initial_expiration_times);
-  }
+  return time_dependence_->functions_of_time(initial_expiration_times);
 }
 }  // namespace domain::creators

--- a/src/Domain/Creators/CartoonSphere2D.cpp
+++ b/src/Domain/Creators/CartoonSphere2D.cpp
@@ -502,10 +502,6 @@ std::unordered_map<std::string,
 CartoonSphere2D::functions_of_time(
     const std::unordered_map<std::string, double>& initial_expiration_times)
     const {
-  if (time_dependence_->is_none()) {
-    return {};
-  } else {
-    return time_dependence_->functions_of_time(initial_expiration_times);
-  }
+  return time_dependence_->functions_of_time(initial_expiration_times);
 }
 }  // namespace domain::creators

--- a/src/Domain/Creators/Rectilinear.cpp
+++ b/src/Domain/Creators/Rectilinear.cpp
@@ -238,11 +238,7 @@ std::unordered_map<std::string,
 Rectilinear<Dim>::functions_of_time(
     const std::unordered_map<std::string, double>& initial_expiration_times)
     const {
-  if (time_dependence_->is_none()) {
-    return {};
-  } else {
-    return time_dependence_->functions_of_time(initial_expiration_times);
-  }
+  return time_dependence_->functions_of_time(initial_expiration_times);
 }
 
 template class Rectilinear<1>;

--- a/src/Domain/Creators/RotatedBricks.cpp
+++ b/src/Domain/Creators/RotatedBricks.cpp
@@ -145,11 +145,7 @@ std::unordered_map<std::string,
 RotatedBricks::functions_of_time(
     const std::unordered_map<std::string, double>& initial_expiration_times)
     const {
-  if (time_dependence_->is_none()) {
-    return {};
-  } else {
-    return time_dependence_->functions_of_time(initial_expiration_times);
-  }
+  return time_dependence_->functions_of_time(initial_expiration_times);
 }
 
 std::vector<DirectionMap<

--- a/src/Domain/Creators/RotatedIntervals.cpp
+++ b/src/Domain/Creators/RotatedIntervals.cpp
@@ -169,10 +169,6 @@ std::unordered_map<std::string,
 RotatedIntervals::functions_of_time(
     const std::unordered_map<std::string, double>& initial_expiration_times)
     const {
-  if (time_dependence_->is_none()) {
-    return {};
-  } else {
-    return time_dependence_->functions_of_time(initial_expiration_times);
-  }
+  return time_dependence_->functions_of_time(initial_expiration_times);
 }
 }  // namespace domain::creators

--- a/src/Domain/Creators/RotatedRectangles.cpp
+++ b/src/Domain/Creators/RotatedRectangles.cpp
@@ -126,11 +126,7 @@ std::unordered_map<std::string,
 RotatedRectangles::functions_of_time(
     const std::unordered_map<std::string, double>& initial_expiration_times)
     const {
-  if (time_dependence_->is_none()) {
-    return {};
-  } else {
-    return time_dependence_->functions_of_time(initial_expiration_times);
-  }
+  return time_dependence_->functions_of_time(initial_expiration_times);
 }
 
 std::vector<DirectionMap<

--- a/src/Domain/Creators/TimeDependence/None.cpp
+++ b/src/Domain/Creators/TimeDependence/None.cpp
@@ -53,14 +53,12 @@ None<MeshDim>::block_maps_distorted_to_inertial(
 }
 
 template <size_t MeshDim>
-[[noreturn]] std::unordered_map<
-    std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+std::unordered_map<std::string,
+                   std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
 None<MeshDim>::functions_of_time(const std::unordered_map<std::string, double>&
                                  /*initial_expiration_times*/) const {
-  ERROR(
-      "The 'functions_of_time' function of the 'None' TimeDependence should "
-      "never be called because 'None' is only used as a place holder class to "
-      "mark that the mesh is time-independent.");
+  return std::unordered_map<
+      std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>{};
 }
 
 template <size_t Dim>

--- a/src/Domain/Creators/TimeDependence/None.hpp
+++ b/src/Domain/Creators/TimeDependence/None.hpp
@@ -29,10 +29,9 @@ struct Inertial;
 namespace domain::creators::time_dependence {
 /// \brief Make the mesh time independent so that it isn't moving.
 ///
-/// \warning Calling the `block_maps` and `functions_of_time` functions causes
-/// an error because the `None` class should be detected separately and
-/// optimizations applied so that the coordinates, Jacobians, etc. are not
-/// recomputed.
+/// \warning Calling the `block_maps` functions causes an error because the
+/// `None` class should be detected separately and optimizations applied so that
+/// the coordinates, Jacobians, etc. are not recomputed.
 template <size_t MeshDim>
 class None final : public TimeDependence<MeshDim> {
  public:
@@ -63,9 +62,8 @@ class None final : public TimeDependence<MeshDim> {
       const -> std::vector<std::unique_ptr<domain::CoordinateMapBase<
           Frame::Distorted, Frame::Inertial, MeshDim>>> override;
 
-  [[noreturn]] auto functions_of_time(
-      const std::unordered_map<std::string, double>& initial_expiration_times =
-          {}) const
+  auto functions_of_time(const std::unordered_map<std::string, double>&
+                             initial_expiration_times = {}) const
       -> std::unordered_map<
           std::string,
           std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>> override;

--- a/tests/Unit/Domain/Creators/TimeDependence/Test_None.cpp
+++ b/tests/Unit/Domain/Creators/TimeDependence/Test_None.cpp
@@ -5,6 +5,7 @@
 
 #include <cstddef>
 #include <memory>
+#include <unordered_map>
 
 #include "Domain/Creators/TimeDependence/None.hpp"
 #include "Domain/Creators/TimeDependence/TimeDependence.hpp"
@@ -24,6 +25,7 @@ void test() {
       std::make_unique<None<MeshDim>>();
   CHECK(time_dep != nullptr);
   CHECK(time_dep->is_none());
+  CHECK(time_dep->functions_of_time().empty());
 
   const std::unique_ptr<TimeDependence<MeshDim>> time_dep_clone =
       time_dep->get_clone();
@@ -49,9 +51,6 @@ void test() {
       (time_dep->block_maps_distorted_to_inertial(5)),
       Catch::Matchers::ContainsSubstring(
           "The 'block_maps_distorted_to_inertial' function of the"));
-  CHECK_THROWS_WITH((time_dep->functions_of_time()),
-                    Catch::Matchers::ContainsSubstring(
-                        "The 'functions_of_time' function of the 'None'"));
 }
 
 SPECTRE_TEST_CASE("Unit.Domain.Creators.TimeDependence.None",


### PR DESCRIPTION

## Proposed changes

Have time_dependence::None::functions_of_time return empty map

Previously it errored.  This makes it easier to use in generic tests.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
