### PR TITLE
Add free data for initial data solve for KerrSchild + wave pulse

### DIFF
--- a/src/Elliptic/Actions/InitializeAnalyticSolution.hpp
+++ b/src/Elliptic/Actions/InitializeAnalyticSolution.hpp
@@ -32,7 +32,6 @@ struct Inertial;
 /// \endcond
 
 namespace elliptic::Actions {
-
 /// @{
 /*!
  * \brief Place the analytic solution of the system fields in the DataBox.
@@ -45,7 +44,10 @@ namespace elliptic::Actions {
  * Uses:
  * - DataBox:
  *   - `AnalyticSolutionTag` or `BackgroundTag`
+ *   - `domain::Tags::Mesh<Dim>`
  *   - `Tags::Coordinates<Dim, Frame::Inertial>`
+ *   - `domain::Tags::InverseJacobian<Dim, Frame::ElementLogical,
+ *     Frame::Inertial>`
  *
  * DataBox:
  * - Adds:
@@ -79,16 +81,20 @@ struct InitializeOptionalAnalyticSolution
   using return_tags = tmpl::list<analytic_fields_tag>;
   using argument_tags =
       tmpl::list<domain::Tags::Mesh<Dim>,
-                 domain::Tags::Coordinates<Dim, Frame::Inertial>, BackgroundTag,
-                 Parallel::Tags::Metavariables>;
+                 domain::Tags::Coordinates<Dim, Frame::Inertial>,
+                 domain::Tags::InverseJacobian<Dim, Frame::ElementLogical,
+                                               Frame::Inertial>,
+                 BackgroundTag, Parallel::Tags::Metavariables>;
 
   template <typename Background, typename Metavariables, typename... AmrData>
-  static void apply(const gsl::not_null<typename analytic_fields_tag::type*>
-                        analytic_solution_fields,
-                    const Mesh<Dim>& mesh,
-                    const tnsr::I<DataVector, Dim> inertial_coords,
-                    const Background& background, const Metavariables& /*meta*/,
-                    const AmrData&... amr_data) {
+  static void apply(
+      const gsl::not_null<typename analytic_fields_tag::type*>
+          analytic_solution_fields,
+      const Mesh<Dim>& mesh, const tnsr::I<DataVector, Dim> inertial_coords,
+      const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
+                            Frame::Inertial>& inv_jacobian,
+      const Background& background, const Metavariables& /*meta*/,
+      const AmrData&... amr_data) {
     if constexpr (sizeof...(AmrData) == 1) {
       if constexpr (std::is_same_v<AmrData...,
                                    std::pair<Mesh<Dim>, Element<Dim>>>) {
@@ -107,9 +113,10 @@ struct InitializeOptionalAnalyticSolution
       *analytic_solution_fields = call_with_dynamic_type<
           Variables<AnalyticSolutionFields>,
           tmpl::at<factory_classes, AnalyticSolutionType>>(
-          analytic_solution, [&inertial_coords](const auto* const derived) {
-            return variables_from_tagged_tuple(
-                derived->variables(inertial_coords, AnalyticSolutionFields{}));
+          analytic_solution,
+          [&inertial_coords, &mesh, &inv_jacobian](const auto* const derived) {
+            return variables_from_tagged_tuple(derived->variables(
+                inertial_coords, mesh, inv_jacobian, AnalyticSolutionFields{}));
           });
     } else {
       *analytic_solution_fields = std::nullopt;

--- a/src/Elliptic/BoundaryConditions/AnalyticSolution.hpp
+++ b/src/Elliptic/BoundaryConditions/AnalyticSolution.hpp
@@ -8,6 +8,8 @@
 #include <ostream>
 #include <pup.h>
 #include <string>
+#include <type_traits>
+#include <utility>
 #include <vector>
 
 #include "DataStructures/DataBox/MetavariablesTag.hpp"
@@ -20,14 +22,32 @@
 #include "Elliptic/BoundaryConditions/Tags.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/NormalDotFlux.hpp"
 #include "Options/String.hpp"
-#include "PointwiseFunctions/InitialDataUtilities/AnalyticSolution.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/InitialGuess.hpp"
 #include "Utilities/CallWithDynamicType.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/Serialization/Serialize.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace elliptic::BoundaryConditions {
+namespace detail {
+
+template <typename Solution, size_t Dim, typename Tag, typename = std::void_t<>>
+struct has_boundary_variables : std::false_type {};
+
+template <typename Solution, size_t Dim, typename Tag>
+struct has_boundary_variables<
+    Solution, Dim, Tag,
+    std::void_t<decltype(std::declval<const Solution&>().variables(
+        std::declval<const tnsr::I<DataVector, Dim, Frame::Inertial>&>(),
+        tmpl::list<Tag>{}))>> : std::true_type {};
+
+template <typename Solution, size_t Dim, typename Tag>
+constexpr bool has_boundary_variables_v =
+    has_boundary_variables<Solution, Dim, Tag>::value;
+
+}  // namespace detail
 
 /// \cond
 template <typename System, size_t Dim = System::volume_dim,
@@ -54,9 +74,9 @@ class AnalyticSolution<System, Dim, tmpl::list<FieldTags...>,
 
  public:
   struct Solution {
-    using type = std::unique_ptr<elliptic::analytic_data::AnalyticSolution>;
+    using type = std::unique_ptr<elliptic::analytic_data::InitialGuess>;
     static constexpr Options::String help = {
-        "The analytic solution to impose on the boundary"};
+        "The analytic data to impose on the boundary"};
   };
 
   using options =
@@ -69,7 +89,9 @@ class AnalyticSolution<System, Dim, tmpl::list<FieldTags...>,
   AnalyticSolution(const AnalyticSolution& rhs) : Base(rhs) { *this = rhs; }
   AnalyticSolution& operator=(const AnalyticSolution& rhs) {
     if (rhs.solution_ != nullptr) {
-      solution_ = rhs.solution_->get_clone();
+      solution_ = serialize_and_deserialize<
+          std::unique_ptr<elliptic::analytic_data::InitialGuess>>(
+          rhs.solution_);
     } else {
       solution_ = nullptr;
     }
@@ -88,7 +110,7 @@ class AnalyticSolution<System, Dim, tmpl::list<FieldTags...>,
 
   /// Select which `elliptic::BoundaryConditionType` to apply for each field
   explicit AnalyticSolution(
-      std::unique_ptr<elliptic::analytic_data::AnalyticSolution> solution,
+      std::unique_ptr<elliptic::analytic_data::InitialGuess> solution,
       // This pack expansion repeats the type `elliptic::BoundaryConditionType`
       // for each system field
       const typename elliptic::OptionTags::BoundaryConditionType<
@@ -134,46 +156,59 @@ class AnalyticSolution<System, Dim, tmpl::list<FieldTags...>,
              const Metavariables& /*meta*/,
              const tnsr::I<DataVector, Dim>& face_inertial_coords,
              const tnsr::i<DataVector, Dim>& face_normal) const {
-    // Retrieve variables for both Dirichlet and Neumann conditions, then decide
-    // which to impose. We could also retrieve either the field for the flux for
-    // each field individually based on the selection, but that would incur the
-    // overhead of calling into the analytic solution multiple times and
-    // possibly computing temporary quantities multiple times. This performance
-    // consideration is probably irrelevant because the boundary conditions are
-    // only evaluated once at the beginning of the solve.
-    using analytic_tags = tmpl::list<FieldTags..., FluxTags...>;
     using factory_classes =
         typename Metavariables::factory_creation::factory_classes;
-    const auto solution_vars = call_with_dynamic_type<
-        tuples::tagged_tuple_from_typelist<analytic_tags>,
-        tmpl::at<factory_classes, elliptic::analytic_data::AnalyticSolution>>(
-        solution_.get(), [&face_inertial_coords](const auto* const derived) {
-          return derived->variables(face_inertial_coords, analytic_tags{});
+    call_with_dynamic_type<
+        void, tmpl::at<factory_classes, elliptic::analytic_data::InitialGuess>>(
+        solution_.get(), [this, &face_inertial_coords, &face_normal, &fields...,
+                          &n_dot_fluxes...](const auto* const derived) {
+          const auto impose_boundary_condition = [this, &face_inertial_coords,
+                                                  &face_normal, derived](
+                                                     auto field_tag_v,
+                                                     auto flux_tag_v,
+                                                     const auto field,
+                                                     const auto n_dot_flux) {
+            using field_tag = std::decay_t<decltype(field_tag_v)>;
+            using flux_tag = std::decay_t<decltype(flux_tag_v)>;
+            using derived_type = std::decay_t<decltype(*derived)>;
+            switch (get<elliptic::Tags::BoundaryConditionType<field_tag>>(
+                boundary_condition_types_)) {
+              case elliptic::BoundaryConditionType::Dirichlet: {
+                if constexpr (detail::has_boundary_variables_v<
+                                  derived_type, Dim, field_tag>) {
+                  const auto solution_vars = derived->variables(
+                      face_inertial_coords, tmpl::list<field_tag>{});
+                  *field = get<field_tag>(solution_vars);
+                } else {
+                  ERROR(
+                      "The analytic data does not provide the field required "
+                      "for this Dirichlet boundary condition.");
+                }
+                break;
+              }
+              case elliptic::BoundaryConditionType::Neumann: {
+                if constexpr (detail::has_boundary_variables_v<derived_type,
+                                                               Dim, flux_tag>) {
+                  const auto solution_vars = derived->variables(
+                      face_inertial_coords, tmpl::list<flux_tag>{});
+                  normal_dot_flux(n_dot_flux, face_normal,
+                                  get<flux_tag>(solution_vars));
+                } else {
+                  ERROR(
+                      "The analytic data does not provide the flux required "
+                      "for this Neumann boundary condition.");
+                }
+                break;
+              }
+              default:
+                ERROR("Unsupported boundary condition type: "
+                      << get<elliptic::Tags::BoundaryConditionType<field_tag>>(
+                             boundary_condition_types_));
+            }
+          };
+          EXPAND_PACK_LEFT_TO_RIGHT(impose_boundary_condition(
+              FieldTags{}, FluxTags{}, fields, n_dot_fluxes));
         });
-    const auto impose_boundary_condition = [this, &solution_vars, &face_normal](
-                                               auto field_tag_v,
-                                               auto flux_tag_v,
-                                               const auto field,
-                                               const auto n_dot_flux) {
-      using field_tag = decltype(field_tag_v);
-      using flux_tag = decltype(flux_tag_v);
-      switch (get<elliptic::Tags::BoundaryConditionType<field_tag>>(
-          boundary_condition_types_)) {
-        case elliptic::BoundaryConditionType::Dirichlet:
-          *field = get<field_tag>(solution_vars);
-          break;
-        case elliptic::BoundaryConditionType::Neumann:
-          normal_dot_flux(n_dot_flux, face_normal,
-                          get<flux_tag>(solution_vars));
-          break;
-        default:
-          ERROR("Unsupported boundary condition type: "
-                << get<elliptic::Tags::BoundaryConditionType<field_tag>>(
-                       boundary_condition_types_));
-      }
-    };
-    EXPAND_PACK_LEFT_TO_RIGHT(impose_boundary_condition(FieldTags{}, FluxTags{},
-                                                        fields, n_dot_fluxes));
   }
 
   using argument_tags_linearized = tmpl::list<>;
@@ -185,28 +220,27 @@ class AnalyticSolution<System, Dim, tmpl::list<FieldTags...>,
       const TensorMetafunctions::prepend_spatial_index<
           typename FieldTags::type, Dim, UpLo::Lo,
           Frame::Inertial>&... /*deriv_fields*/) const {
-    const auto impose_boundary_condition = [this](auto field_tag_v,
-                                                  const auto field,
-                                                  const auto n_dot_flux) {
-      using field_tag = decltype(field_tag_v);
-      switch (get<elliptic::Tags::BoundaryConditionType<field_tag>>(
-          boundary_condition_types_)) {
-        case elliptic::BoundaryConditionType::Dirichlet:
-          for (auto& field_component : *field) {
-            field_component = 0.;
+    const auto impose_boundary_condition =
+        [this](auto field_tag_v, const auto field, const auto n_dot_flux) {
+          using field_tag = decltype(field_tag_v);
+          switch (get<elliptic::Tags::BoundaryConditionType<field_tag>>(
+              boundary_condition_types_)) {
+            case elliptic::BoundaryConditionType::Dirichlet:
+              for (auto& field_component : *field) {
+                field_component = 0.;
+              }
+              break;
+            case elliptic::BoundaryConditionType::Neumann:
+              for (auto& n_dot_flux_component : *n_dot_flux) {
+                n_dot_flux_component = 0.;
+              }
+              break;
+            default:
+              ERROR("Unsupported boundary condition type: "
+                    << get<elliptic::Tags::BoundaryConditionType<field_tag>>(
+                           boundary_condition_types_));
           }
-          break;
-        case elliptic::BoundaryConditionType::Neumann:
-          for (auto& n_dot_flux_component : *n_dot_flux) {
-            n_dot_flux_component = 0.;
-          }
-          break;
-        default:
-          ERROR("Unsupported boundary condition type: "
-                << get<elliptic::Tags::BoundaryConditionType<field_tag>>(
-                       boundary_condition_types_));
-      }
-    };
+        };
     EXPAND_PACK_LEFT_TO_RIGHT(
         impose_boundary_condition(FieldTags{}, fields, n_dot_fluxes));
   }
@@ -215,7 +249,7 @@ class AnalyticSolution<System, Dim, tmpl::list<FieldTags...>,
   void pup(PUP::er& p) override;
 
  private:
-  std::unique_ptr<elliptic::analytic_data::AnalyticSolution> solution_{nullptr};
+  std::unique_ptr<elliptic::analytic_data::InitialGuess> solution_{nullptr};
   tuples::TaggedTuple<elliptic::Tags::BoundaryConditionType<FieldTags>...>
       boundary_condition_types_{};
 };

--- a/src/Elliptic/Executables/Xcts/SolveXcts.hpp
+++ b/src/Elliptic/Executables/Xcts/SolveXcts.hpp
@@ -43,6 +43,7 @@
 #include "ParallelAlgorithms/LinearSolver/Multigrid/ElementsAllocator.hpp"
 #include "ParallelAlgorithms/LinearSolver/Multigrid/Tags.hpp"
 #include "PointwiseFunctions/AnalyticData/Xcts/Binary.hpp"
+#include "PointwiseFunctions/AnalyticData/Xcts/KerrSchildTeukolsky.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Xcts/Factory.hpp"
 #include "PointwiseFunctions/Hydro/LowerSpatialFourVelocity.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"
@@ -123,6 +124,7 @@ struct Metavariables {
       : tt::ConformsTo<Options::protocols::FactoryCreation> {
     using analytic_solutions_and_data = tmpl::push_back<
         Xcts::Solutions::all_analytic_solutions,
+        Xcts::AnalyticData::KerrSchildTeukolsky,
         Xcts::AnalyticData::Binary<elliptic::analytic_data::AnalyticSolution,
                                    Xcts::Solutions::all_analytic_solutions>,
         elliptic::analytic_data::NumericData>;

--- a/src/Elliptic/Systems/Xcts/HydroQuantities.hpp
+++ b/src/Elliptic/Systems/Xcts/HydroQuantities.hpp
@@ -3,6 +3,9 @@
 
 #pragma once
 
+#include <type_traits>
+#include <utility>
+
 #include "DataStructures/DataBox/MetavariablesTag.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
@@ -18,6 +21,19 @@
 #include "Utilities/TMPL.hpp"
 
 namespace Xcts::Tags {
+namespace detail {
+
+template <typename Background, typename HydroTags, typename = std::void_t<>>
+struct has_hydro_variables : std::false_type {};
+
+template <typename Background, typename HydroTags>
+struct has_hydro_variables<
+    Background, HydroTags,
+    std::void_t<decltype(std::declval<const Background&>().variables(
+        std::declval<const tnsr::I<DataVector, 3, Frame::Inertial>&>(),
+        HydroTags{}))>> : std::true_type {};
+
+}  // namespace detail
 
 /*!
  * \brief MHD quantities retrieved from the background solution/data
@@ -46,8 +62,14 @@ struct HydroQuantitiesCompute : ::Tags::Variables<HydroTags>, db::ComputeTag {
                  elliptic::analytic_data::Background>;
     *result = call_with_dynamic_type<Variables<HydroTags>, background_classes>(
         &background, [&inertial_coords](const auto* const derived) {
-          return variables_from_tagged_tuple(
-              derived->variables(inertial_coords, HydroTags{}));
+          using derived_type = std::decay_t<decltype(*derived)>;
+          if constexpr (detail::has_hydro_variables<derived_type,
+                                                    HydroTags>::value) {
+            return variables_from_tagged_tuple(
+                derived->variables(inertial_coords, HydroTags{}));
+          } else {
+            return Variables<HydroTags>{inertial_coords.begin()->size(), 0.};
+          }
         });
   }
 };

--- a/src/PointwiseFunctions/AnalyticData/Xcts/Binary.hpp
+++ b/src/PointwiseFunctions/AnalyticData/Xcts/Binary.hpp
@@ -309,6 +309,9 @@ template <typename IsolatedObjectBase, typename IsolatedObjectClasses>
 class Binary : public elliptic::analytic_data::Background,
                public elliptic::analytic_data::InitialGuess {
  public:
+  template <typename DataType>
+  using tags = typename detail::BinaryVariablesCache<DataType>::tags_list;
+
   struct XCoords {
     static constexpr Options::String help =
         "The coordinates on the x-axis where the two objects are placed";
@@ -395,14 +398,18 @@ class Binary : public elliptic::analytic_data::Background,
   using PUP::able::register_constructor;
   WRAPPED_PUPable_decl_template(Binary);
 
-  template <typename DataType, typename... RequestedTags>
+  template <typename DataType, typename... RequestedTags,
+            Requires<tmpl2::flat_all_v<tmpl::list_contains_v<
+                tags<DataType>, RequestedTags>...>> = nullptr>
   tuples::TaggedTuple<RequestedTags...> variables(
       const tnsr::I<DataType, 3, Frame::Inertial>& x,
       tmpl::list<RequestedTags...> /*meta*/) const {
     return variables_impl<DataType>(x, std::nullopt, std::nullopt,
                                     tmpl::list<RequestedTags...>{});
   }
-  template <typename... RequestedTags>
+  template <typename... RequestedTags,
+            Requires<tmpl2::flat_all_v<tmpl::list_contains_v<
+                tags<DataVector>, RequestedTags>...>> = nullptr>
   tuples::TaggedTuple<RequestedTags...> variables(
       const tnsr::I<DataVector, 3, Frame::Inertial>& x, const Mesh<3>& mesh,
       const InverseJacobian<DataVector, 3, Frame::ElementLogical,
@@ -457,7 +464,9 @@ class Binary : public elliptic::analytic_data::Background,
   std::array<double, 3> linear_velocity_{};
   std::optional<std::array<double, 2>> falloff_widths_{};
 
-  template <typename DataType, typename... RequestedTags>
+  template <typename DataType, typename... RequestedTags,
+            Requires<tmpl2::flat_all_v<tmpl::list_contains_v<
+                tags<DataType>, RequestedTags>...>> = nullptr>
   tuples::TaggedTuple<RequestedTags...> variables_impl(
       const tnsr::I<DataType, 3, Frame::Inertial>& x,
       std::optional<std::reference_wrapper<const Mesh<3>>> mesh,

--- a/src/PointwiseFunctions/AnalyticData/Xcts/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticData/Xcts/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   Binary.cpp
+  KerrSchildTeukolsky.cpp
   )
 
 spectre_target_headers(
@@ -19,6 +20,7 @@ spectre_target_headers(
   Binary.hpp
   CommonVariables.hpp
   CommonVariables.tpp
+  KerrSchildTeukolsky.hpp
   )
 
 target_link_libraries(
@@ -27,10 +29,13 @@ target_link_libraries(
   DataStructures
   ErrorHandling
   GeneralRelativity
+  GeneralRelativitySolutions
   Hydro
+  InitialDataUtilities
   LinearOperators
   Options
   Parallel
+  Serialization
   Spectral
   Utilities
   PRIVATE

--- a/src/PointwiseFunctions/AnalyticData/Xcts/CommonVariables.tpp
+++ b/src/PointwiseFunctions/AnalyticData/Xcts/CommonVariables.tpp
@@ -25,7 +25,6 @@
 #include "PointwiseFunctions/GeneralRelativity/Ricci.hpp"
 #include "PointwiseFunctions/Xcts/LongitudinalOperator.hpp"
 #include "Utilities/ContainerHelpers.hpp"
-#include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/Gsl.hpp"
 
@@ -139,9 +138,10 @@ void CommonVariables<DataType, Cache>::operator()(
     ::Tags::deriv<
         Tags::ConformalChristoffelSecondKind<DataType, Dim, Frame::Inertial>,
         tmpl::size_t<Dim>, Frame::Inertial> /*meta*/) const {
-  ASSERT(mesh.has_value() and inv_jacobian.has_value(),
-         "Need a mesh and a Jacobian for numeric differentiation.");
   if constexpr (std::is_same_v<DataType, DataVector>) {
+    if (not(mesh.has_value() and inv_jacobian.has_value())) {
+      ERROR("Need a mesh and a Jacobian for numeric differentiation.");
+    }
     const auto& conformal_christoffel_second_kind = cache->get_var(
         *this,
         Tags::ConformalChristoffelSecondKind<DataType, Dim, Frame::Inertial>{});
@@ -200,9 +200,10 @@ void CommonVariables<DataType, Cache>::operator()(
     const gsl::not_null<Cache*> cache,
     ::Tags::deriv<gr::Tags::TraceExtrinsicCurvature<DataType>,
                   tmpl::size_t<Dim>, Frame::Inertial> /*meta*/) const {
-  ASSERT(mesh.has_value() and inv_jacobian.has_value(),
-         "Need a mesh and a Jacobian for numeric differentiation.");
   if constexpr (std::is_same_v<DataType, DataVector>) {
+    if (not(mesh.has_value() and inv_jacobian.has_value())) {
+      ERROR("Need a mesh and a Jacobian for numeric differentiation.");
+    }
     const auto& extrinsic_curvature_trace =
         cache->get_var(*this, gr::Tags::TraceExtrinsicCurvature<DataType>{});
     partial_derivative(deriv_extrinsic_curvature_trace,
@@ -246,9 +247,10 @@ void CommonVariables<DataType, Cache>::operator()(
     const gsl::not_null<Cache*> cache,
     ::Tags::div<Tags::LongitudinalShiftBackgroundMinusDtConformalMetric<
         DataType, Dim, Frame::Inertial>> /*meta*/) const {
-  ASSERT(mesh.has_value() and inv_jacobian.has_value(),
-         "Need a mesh and a Jacobian for numeric differentiation.");
   if constexpr (std::is_same_v<DataType, DataVector>) {
+    if (not(mesh.has_value() and inv_jacobian.has_value())) {
+      ERROR("Need a mesh and a Jacobian for numeric differentiation.");
+    }
     // Copy into a Variables to take the divergence because at this time the
     // `divergence` function only works with Variables. This won't be used for
     // anything performance-critical, but adding a `divergence` overload that

--- a/src/PointwiseFunctions/AnalyticData/Xcts/KerrSchildTeukolsky.cpp
+++ b/src/PointwiseFunctions/AnalyticData/Xcts/KerrSchildTeukolsky.cpp
@@ -1,0 +1,251 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/AnalyticData/Xcts/KerrSchildTeukolsky.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <type_traits>
+#include <utility>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "DataStructures/Tensor/EagerMath/Trace.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Elliptic/Systems/Xcts/Tags.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "PointwiseFunctions/AnalyticData/Xcts/CommonVariables.tpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace Xcts::AnalyticData::detail {
+
+template <typename DataType>
+void KerrSchildTeukolskyVariables<DataType>::operator()(
+    const gsl::not_null<tnsr::ii<DataType, Dim>*> conformal_metric,
+    const gsl::not_null<Cache*> /*cache*/,
+    Xcts::Tags::ConformalMetric<DataType, Dim, Frame::Inertial> /*meta*/)
+    const {
+  *conformal_metric =
+      get<gr::Tags::SpatialMetric<DataType, Dim>>(kerr_schild_vars.get());
+  const auto& teukolsky_spatial_metric =
+      get<gr::Tags::SpatialMetric<DataType, Dim, Frame::Inertial>>(
+          teukolsky_vars.get());
+  for (size_t i = 0; i < Dim; ++i) {
+    for (size_t j = 0; j <= i; ++j) {
+      conformal_metric->get(i, j) += teukolsky_spatial_metric.get(i, j);
+    }
+  }
+}
+
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsuggest-attribute=noreturn"
+#endif  // defined(__GNUC__) && !defined(__clang__)
+
+template <typename DataType>
+void KerrSchildTeukolskyVariables<DataType>::operator()(
+    const gsl::not_null<tnsr::ijj<DataType, Dim>*> deriv_conformal_metric,
+    const gsl::not_null<Cache*> cache,
+    ::Tags::deriv<Xcts::Tags::ConformalMetric<DataType, Dim, Frame::Inertial>,
+                  tmpl::size_t<Dim>, Frame::Inertial> /*meta*/) const {
+  if constexpr (std::is_same_v<DataType, DataVector>) {
+    if (not(this->mesh.has_value() and this->inv_jacobian.has_value())) {
+      ERROR("Need a mesh and a Jacobian for numeric differentiation.");
+    }
+    const auto& conformal_metric = cache->get_var(
+        *this, Xcts::Tags::ConformalMetric<DataType, Dim, Frame::Inertial>{});
+    partial_derivative(deriv_conformal_metric, conformal_metric,
+                       this->mesh->get(), this->inv_jacobian->get());
+  } else {
+    (void)deriv_conformal_metric;
+    (void)cache;
+    ERROR(
+        "The derivative of the perturbed conformal metric is computed "
+        "numerically and requires DataVector grid data.");
+  }
+}
+
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif  // defined(__GNUC__) && !defined(__clang__)
+
+template <typename DataType>
+void KerrSchildTeukolskyVariables<DataType>::operator()(
+    const gsl::not_null<Scalar<DataType>*> trace_extrinsic_curvature,
+    const gsl::not_null<Cache*> /*cache*/,
+    gr::Tags::TraceExtrinsicCurvature<DataType> /*meta*/) const {
+  const auto& extrinsic_curvature =
+      get<gr::Tags::ExtrinsicCurvature<DataType, Dim>>(kerr_schild_vars.get());
+  const auto& inv_spatial_metric =
+      get<gr::Tags::InverseSpatialMetric<DataType, Dim>>(
+          kerr_schild_vars.get());
+  trace(trace_extrinsic_curvature, extrinsic_curvature, inv_spatial_metric);
+}
+
+template <typename DataType>
+void KerrSchildTeukolskyVariables<DataType>::operator()(
+    const gsl::not_null<Scalar<DataType>*> dt_trace_extrinsic_curvature,
+    const gsl::not_null<Cache*> /*cache*/,
+    ::Tags::dt<gr::Tags::TraceExtrinsicCurvature<DataType>> /*meta*/) const {
+  get(*dt_trace_extrinsic_curvature) = 0.;
+}
+
+template <typename DataType>
+void KerrSchildTeukolskyVariables<DataType>::operator()(
+    const gsl::not_null<Scalar<DataType>*> conformal_factor_minus_one,
+    const gsl::not_null<Cache*> /*cache*/,
+    Xcts::Tags::ConformalFactorMinusOne<DataType> /*meta*/) const {
+  get(*conformal_factor_minus_one) = 0.;
+}
+
+template <typename DataType>
+void KerrSchildTeukolskyVariables<DataType>::operator()(
+    const gsl::not_null<Scalar<DataType>*>
+        lapse_times_conformal_factor_minus_one,
+    const gsl::not_null<Cache*> /*cache*/,
+    Xcts::Tags::LapseTimesConformalFactorMinusOne<DataType> /*meta*/) const {
+  *lapse_times_conformal_factor_minus_one =
+      get<gr::Tags::Lapse<DataType>>(kerr_schild_vars.get());
+  get(*lapse_times_conformal_factor_minus_one) -= 1.;
+}
+
+template <typename DataType>
+void KerrSchildTeukolskyVariables<DataType>::operator()(
+    const gsl::not_null<tnsr::I<DataType, Dim>*> shift_background,
+    const gsl::not_null<Cache*> /*cache*/,
+    Xcts::Tags::ShiftBackground<DataType, Dim, Frame::Inertial> /*meta*/)
+    const {
+  std::fill(shift_background->begin(), shift_background->end(), 0.);
+}
+
+template <typename DataType>
+void KerrSchildTeukolskyVariables<DataType>::operator()(
+    const gsl::not_null<tnsr::iJ<DataType, Dim>*> deriv_shift_background,
+    const gsl::not_null<Cache*> /*cache*/,
+    ::Tags::deriv<Xcts::Tags::ShiftBackground<DataType, Dim, Frame::Inertial>,
+                  tmpl::size_t<Dim>, Frame::Inertial> /*meta*/) const {
+  std::fill(deriv_shift_background->begin(), deriv_shift_background->end(), 0.);
+}
+
+template <typename DataType>
+void KerrSchildTeukolskyVariables<DataType>::operator()(
+    const gsl::not_null<tnsr::II<DataType, Dim, Frame::Inertial>*>
+        longitudinal_shift_background_minus_dt_conformal_metric,
+    const gsl::not_null<Cache*> cache,
+    Xcts::Tags::LongitudinalShiftBackgroundMinusDtConformalMetric<
+        DataType, Dim, Frame::Inertial> /*meta*/) const {
+  const auto& dt_teukolsky_metric =
+      get<::Tags::dt<gr::Tags::SpatialMetric<DataType, Dim, Frame::Inertial>>>(
+          teukolsky_vars.get());
+  const auto& conformal_metric = cache->get_var(
+      *this, Xcts::Tags::ConformalMetric<DataType, Dim, Frame::Inertial>{});
+  const auto& inv_conformal_metric = cache->get_var(
+      *this,
+      Xcts::Tags::InverseConformalMetric<DataType, Dim, Frame::Inertial>{});
+
+  const auto trace_dt_metric = trace(dt_teukolsky_metric, inv_conformal_metric);
+
+  tnsr::ii<DataType, Dim, Frame::Inertial> trace_free_dt_metric{
+      get_size(*x.get().begin())};
+  for (size_t i = 0; i < Dim; ++i) {
+    for (size_t j = 0; j <= i; ++j) {
+      trace_free_dt_metric.get(i, j) =
+          dt_teukolsky_metric.get(i, j) -
+          conformal_metric.get(i, j) * get(trace_dt_metric) / 3.;
+    }
+  }
+
+  for (size_t i = 0; i < Dim; ++i) {
+    for (size_t j = 0; j <= i; ++j) {
+      longitudinal_shift_background_minus_dt_conformal_metric->get(i, j) = 0.;
+      for (size_t k = 0; k < Dim; ++k) {
+        for (size_t l = 0; l < Dim; ++l) {
+          longitudinal_shift_background_minus_dt_conformal_metric->get(i, j) -=
+              inv_conformal_metric.get(i, k) * inv_conformal_metric.get(j, l) *
+              trace_free_dt_metric.get(k, l);
+        }
+      }
+    }
+  }
+}
+
+template <typename DataType>
+void KerrSchildTeukolskyVariables<DataType>::operator()(
+    const gsl::not_null<tnsr::I<DataType, Dim>*> shift_excess,
+    const gsl::not_null<Cache*> /*cache*/,
+    Xcts::Tags::ShiftExcess<DataType, Dim, Frame::Inertial> /*meta*/) const {
+  *shift_excess = get<gr::Tags::Shift<DataType, Dim>>(kerr_schild_vars.get());
+}
+
+template <typename DataType>
+void KerrSchildTeukolskyVariables<DataType>::operator()(
+    const gsl::not_null<Scalar<DataType>*> energy_density,
+    const gsl::not_null<Cache*> /*cache*/,
+    gr::Tags::Conformal<gr::Tags::EnergyDensity<DataType>, 0> /*meta*/) const {
+  get(*energy_density) = 0.;
+}
+
+template <typename DataType>
+void KerrSchildTeukolskyVariables<DataType>::operator()(
+    const gsl::not_null<Scalar<DataType>*> stress_trace,
+    const gsl::not_null<Cache*> /*cache*/,
+    gr::Tags::Conformal<gr::Tags::StressTrace<DataType>, 0> /*meta*/) const {
+  get(*stress_trace) = 0.;
+}
+
+template <typename DataType>
+void KerrSchildTeukolskyVariables<DataType>::operator()(
+    const gsl::not_null<tnsr::I<DataType, Dim>*> momentum_density,
+    const gsl::not_null<Cache*> /*cache*/,
+    gr::Tags::Conformal<gr::Tags::MomentumDensity<DataType, Dim>, 0> /*meta*/)
+    const {
+  std::fill(momentum_density->begin(), momentum_density->end(), 0.);
+}
+
+template class KerrSchildTeukolskyVariables<double>;
+template class KerrSchildTeukolskyVariables<DataVector>;
+
+}  // namespace Xcts::AnalyticData::detail
+
+namespace Xcts::AnalyticData {
+
+KerrSchildTeukolsky::KerrSchildTeukolsky(
+    gr::Solutions::KerrSchild kerr_schild,
+    const gr::Solutions::TeukolskyWave& teukolsky_wave)
+    : kerr_schild_(std::move(kerr_schild)),
+      teukolsky_wave_(teukolsky_wave.amplitude(), teukolsky_wave.mode(),
+                      teukolsky_wave.parity(), teukolsky_wave.direction(),
+                      teukolsky_wave.center(), teukolsky_wave.radius(),
+                      teukolsky_wave.width(), false) {}
+
+void KerrSchildTeukolsky::pup(PUP::er& p) {
+  elliptic::analytic_data::Background::pup(p);
+  elliptic::analytic_data::InitialGuess::pup(p);
+  p | kerr_schild_;
+  p | teukolsky_wave_;
+}
+
+bool operator==(const KerrSchildTeukolsky& lhs,
+                const KerrSchildTeukolsky& rhs) {
+  return lhs.kerr_schild_ == rhs.kerr_schild_ and
+         lhs.teukolsky_wave_ == rhs.teukolsky_wave_;
+}
+
+bool operator!=(const KerrSchildTeukolsky& lhs,
+                const KerrSchildTeukolsky& rhs) {
+  return not(lhs == rhs);
+}
+
+PUP::able::PUP_ID KerrSchildTeukolsky::my_PUP_ID = 0;  // NOLINT
+
+}  // namespace Xcts::AnalyticData
+
+template class Xcts::AnalyticData::CommonVariables<
+    double, typename Xcts::AnalyticData::detail::KerrSchildTeukolskyVariables<
+                double>::Cache>;
+template class Xcts::AnalyticData::CommonVariables<
+    DataVector, typename Xcts::AnalyticData::detail::
+                    KerrSchildTeukolskyVariables<DataVector>::Cache>;

--- a/src/PointwiseFunctions/AnalyticData/Xcts/KerrSchildTeukolsky.hpp
+++ b/src/PointwiseFunctions/AnalyticData/Xcts/KerrSchildTeukolsky.hpp
@@ -1,0 +1,280 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <pup.h>
+
+#include "DataStructures/CachedTempBuffer.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/TaggedTuple.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Elliptic/Systems/Xcts/Tags.hpp"
+#include "NumericalAlgorithms/LinearOperators/Divergence.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Options/String.hpp"
+#include "PointwiseFunctions/AnalyticData/Xcts/CommonVariables.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/TeukolskyWave.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags/Conformal.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/Background.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/InitialGuess.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Requires.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace Xcts::AnalyticData {
+namespace detail {
+
+template <typename DataType>
+using KerrSchildTeukolskyVariablesCache =
+    cached_temp_buffer_from_typelist<tmpl::append<
+        common_tags<DataType>,
+        tmpl::list<
+            gr::Tags::Conformal<gr::Tags::EnergyDensity<DataType>, 0>,
+            gr::Tags::Conformal<gr::Tags::StressTrace<DataType>, 0>,
+            gr::Tags::Conformal<gr::Tags::MomentumDensity<DataType, 3>, 0>,
+            Tags::ConformalFactorMinusOne<DataType>,
+            Tags::LapseTimesConformalFactorMinusOne<DataType>,
+            Tags::ShiftExcess<DataType, 3, Frame::Inertial>>>>;
+
+template <typename DataType>
+struct KerrSchildTeukolskyVariables
+    : CommonVariables<DataType, KerrSchildTeukolskyVariablesCache<DataType>> {
+  static constexpr size_t Dim = 3;
+  using Cache = KerrSchildTeukolskyVariablesCache<DataType>;
+  using Base = CommonVariables<DataType, Cache>;
+  using Base::operator();
+
+  using kerr_schild_tags =
+      tmpl::list<gr::Tags::SpatialMetric<DataType, Dim>,
+                 gr::Tags::InverseSpatialMetric<DataType, Dim>,
+                 gr::Tags::Lapse<DataType>, gr::Tags::Shift<DataType, Dim>,
+                 gr::Tags::ExtrinsicCurvature<DataType, Dim>>;
+
+  using teukolsky_tags = tmpl::list<
+      gr::Tags::SpatialMetric<DataType, Dim, Frame::Inertial>,
+      ::Tags::dt<gr::Tags::SpatialMetric<DataType, Dim, Frame::Inertial>>>;
+
+  KerrSchildTeukolskyVariables(
+      std::optional<std::reference_wrapper<const Mesh<Dim>>> local_mesh,
+      std::optional<std::reference_wrapper<const InverseJacobian<
+          DataType, Dim, Frame::ElementLogical, Frame::Inertial>>>
+          local_inv_jacobian,
+      const tnsr::I<DataType, Dim>& local_x,
+      const tuples::tagged_tuple_from_typelist<kerr_schild_tags>&
+          local_kerr_schild_vars,
+      const tuples::tagged_tuple_from_typelist<teukolsky_tags>&
+          local_teukolsky_vars)
+      : Base(std::move(local_mesh), std::move(local_inv_jacobian)),
+        x(local_x),
+        kerr_schild_vars(local_kerr_schild_vars),
+        teukolsky_vars(local_teukolsky_vars) {}
+
+  std::reference_wrapper<const tnsr::I<DataType, Dim>> x;
+  std::reference_wrapper<
+      const tuples::tagged_tuple_from_typelist<kerr_schild_tags>>
+      kerr_schild_vars;
+  std::reference_wrapper<
+      const tuples::tagged_tuple_from_typelist<teukolsky_tags>>
+      teukolsky_vars;
+
+  void operator()(
+      gsl::not_null<tnsr::ii<DataType, Dim>*> conformal_metric,
+      gsl::not_null<Cache*> cache,
+      Xcts::Tags::ConformalMetric<DataType, Dim, Frame::Inertial> /*meta*/)
+      const override;
+  void operator()(
+      gsl::not_null<tnsr::ijj<DataType, Dim>*> deriv_conformal_metric,
+      gsl::not_null<Cache*> cache,
+      ::Tags::deriv<Xcts::Tags::ConformalMetric<DataType, Dim, Frame::Inertial>,
+                    tmpl::size_t<Dim>, Frame::Inertial> /*meta*/)
+      const override;
+  void operator()(
+      gsl::not_null<Scalar<DataType>*> trace_extrinsic_curvature,
+      gsl::not_null<Cache*> cache,
+      gr::Tags::TraceExtrinsicCurvature<DataType> /*meta*/) const override;
+  void operator()(
+      gsl::not_null<Scalar<DataType>*> dt_trace_extrinsic_curvature,
+      gsl::not_null<Cache*> cache,
+      ::Tags::dt<gr::Tags::TraceExtrinsicCurvature<DataType>> /*meta*/)
+      const override;
+  void operator()(gsl::not_null<Scalar<DataType>*> conformal_factor_minus_one,
+                  gsl::not_null<Cache*> cache,
+                  Xcts::Tags::ConformalFactorMinusOne<DataType> /*meta*/) const;
+  void operator()(
+      gsl::not_null<Scalar<DataType>*> lapse_times_conformal_factor_minus_one,
+      gsl::not_null<Cache*> cache,
+      Xcts::Tags::LapseTimesConformalFactorMinusOne<DataType> /*meta*/) const;
+  void operator()(
+      gsl::not_null<tnsr::I<DataType, Dim>*> shift_background,
+      gsl::not_null<Cache*> cache,
+      Xcts::Tags::ShiftBackground<DataType, Dim, Frame::Inertial> /*meta*/)
+      const override;
+  void operator()(
+      gsl::not_null<tnsr::iJ<DataType, Dim>*> deriv_shift_background,
+      gsl::not_null<Cache*> cache,
+      ::Tags::deriv<Xcts::Tags::ShiftBackground<DataType, Dim, Frame::Inertial>,
+                    tmpl::size_t<Dim>, Frame::Inertial> /*meta*/)
+      const override;
+  void operator()(gsl::not_null<tnsr::II<DataType, Dim, Frame::Inertial>*>
+                      longitudinal_shift_background_minus_dt_conformal_metric,
+                  gsl::not_null<Cache*> cache,
+                  Xcts::Tags::LongitudinalShiftBackgroundMinusDtConformalMetric<
+                      DataType, Dim, Frame::Inertial> /*meta*/) const override;
+  void operator()(
+      gsl::not_null<tnsr::I<DataType, Dim>*> shift_excess,
+      gsl::not_null<Cache*> cache,
+      Xcts::Tags::ShiftExcess<DataType, Dim, Frame::Inertial> /*meta*/) const;
+  void operator()(
+      gsl::not_null<Scalar<DataType>*> energy_density,
+      gsl::not_null<Cache*> cache,
+      gr::Tags::Conformal<gr::Tags::EnergyDensity<DataType>, 0> /*meta*/) const;
+  void operator()(
+      gsl::not_null<Scalar<DataType>*> stress_trace,
+      gsl::not_null<Cache*> cache,
+      gr::Tags::Conformal<gr::Tags::StressTrace<DataType>, 0> /*meta*/) const;
+  void operator()(gsl::not_null<tnsr::I<DataType, Dim>*> momentum_density,
+                  gsl::not_null<Cache*> cache,
+                  gr::Tags::Conformal<gr::Tags::MomentumDensity<DataType, Dim>,
+                                      0> /*meta*/) const;
+};
+
+}  // namespace detail
+
+/*!
+ * \brief Kerr-Schild plus a Teukolsky perturbation in the conformal
+ * metric.
+ *
+ * This solution does not satisfy the constraint equations itself; it is
+ * intended for supplying the free data and Dirichlet boundary conditions
+ * needed to solve the XCTS equations for initial data containing a
+ * Kerr-Schild black hole plus a gravitational-wave pulse.
+ * In this solution, the Kerr-Schild solution supplies the lapse, shift, and
+ * trace of the extrinsic curvature, while the Teukolsky wave at \f$t=0\f$ is
+ * added only to the conformal spatial metric and its time derivative. The
+ * spatial derivative of the conformal spatial metric is computed using
+ * numerical partial derivatives.
+ */
+class KerrSchildTeukolsky : public elliptic::analytic_data::Background,
+                            public elliptic::analytic_data::InitialGuess {
+ public:
+  static constexpr size_t Dim = 3;
+
+  template <typename DataType>
+  using tags =
+      typename detail::KerrSchildTeukolskyVariablesCache<DataType>::tags_list;
+
+  struct KerrSchild {
+    using type = gr::Solutions::KerrSchild;
+    static constexpr Options::String help{
+        "Regular Cartesian Kerr-Schild black hole"};
+  };
+  struct TeukolskyWave {
+    using type = gr::Solutions::TeukolskyWave;
+    static constexpr Options::String help{
+        "Teukolsky perturbation added to the conformal metric"};
+  };
+
+  using options = tmpl::list<KerrSchild, TeukolskyWave>;
+  static constexpr Options::String help{
+      "Kerr-Schild black hole with a Teukolsky perturbation in the XCTS "
+      "conformal metric."};
+
+  KerrSchildTeukolsky() = default;
+  KerrSchildTeukolsky(const KerrSchildTeukolsky&) = default;
+  KerrSchildTeukolsky& operator=(const KerrSchildTeukolsky&) = default;
+  KerrSchildTeukolsky(KerrSchildTeukolsky&&) = default;
+  KerrSchildTeukolsky& operator=(KerrSchildTeukolsky&&) = default;
+  ~KerrSchildTeukolsky() override = default;
+
+  KerrSchildTeukolsky(gr::Solutions::KerrSchild kerr_schild,
+                      const gr::Solutions::TeukolskyWave& teukolsky_wave);
+
+  const gr::Solutions::KerrSchild& kerr_schild() const { return kerr_schild_; }
+  const gr::Solutions::TeukolskyWave& teukolsky_wave() const {
+    return teukolsky_wave_;
+  }
+
+  /// \cond
+  explicit KerrSchildTeukolsky(CkMigrateMessage* m)
+      : elliptic::analytic_data::Background(m),
+        elliptic::analytic_data::InitialGuess(m) {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(KerrSchildTeukolsky);
+  /// \endcond
+
+  template <typename DataType, typename... RequestedTags,
+            Requires<tmpl2::flat_all_v<tmpl::list_contains_v<
+                tags<DataType>, RequestedTags>...>> = nullptr>
+  tuples::TaggedTuple<RequestedTags...> variables(
+      const tnsr::I<DataType, Dim, Frame::Inertial>& x,
+      tmpl::list<RequestedTags...> /*meta*/) const {
+    return variables_impl<DataType>(x, std::nullopt, std::nullopt,
+                                    tmpl::list<RequestedTags...>{});
+  }
+
+  template <typename... RequestedTags,
+            Requires<tmpl2::flat_all_v<tmpl::list_contains_v<
+                tags<DataVector>, RequestedTags>...>> = nullptr>
+  tuples::TaggedTuple<RequestedTags...> variables(
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& x, const Mesh<Dim>& mesh,
+      const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
+                            Frame::Inertial>& inv_jacobian,
+      tmpl::list<RequestedTags...> /*meta*/) const {
+    return variables_impl<DataVector>(x, mesh, inv_jacobian,
+                                      tmpl::list<RequestedTags...>{});
+  }
+
+  void pup(PUP::er& p) override;
+
+ private:
+  template <typename DataType, typename... RequestedTags>
+  tuples::TaggedTuple<RequestedTags...> variables_impl(
+      const tnsr::I<DataType, Dim, Frame::Inertial>& x,
+      std::optional<std::reference_wrapper<const Mesh<Dim>>> mesh,
+      std::optional<std::reference_wrapper<const InverseJacobian<
+          DataType, Dim, Frame::ElementLogical, Frame::Inertial>>>
+          inv_jacobian,
+      tmpl::list<RequestedTags...> /*meta*/) const {
+    using VarsComputer = detail::KerrSchildTeukolskyVariables<DataType>;
+    const auto kerr_schild_vars = kerr_schild_.variables(
+        x, 0., typename VarsComputer::kerr_schild_tags{});
+    const auto teukolsky_vars = teukolsky_wave_.variables(
+        x, 0., typename VarsComputer::teukolsky_tags{});
+    const size_t num_points = get_size(*x.begin());
+    typename VarsComputer::Cache cache{num_points};
+    VarsComputer computer{mesh, inv_jacobian, x, kerr_schild_vars,
+                          teukolsky_vars};
+    const auto get_var = [&cache, &computer](auto tag_v) {
+      using tag = std::decay_t<decltype(tag_v)>;
+      return cache.get_var(computer, tag{});
+    };
+    return {get_var(RequestedTags{})...};
+  }
+
+  friend bool operator==(const KerrSchildTeukolsky& lhs,
+                         const KerrSchildTeukolsky& rhs);
+
+  gr::Solutions::KerrSchild kerr_schild_{};
+  gr::Solutions::TeukolskyWave teukolsky_wave_{};
+};
+
+bool operator==(const KerrSchildTeukolsky& lhs, const KerrSchildTeukolsky& rhs);
+bool operator!=(const KerrSchildTeukolsky& lhs, const KerrSchildTeukolsky& rhs);
+
+}  // namespace Xcts::AnalyticData

--- a/src/PointwiseFunctions/AnalyticSolutions/Elasticity/BentBeam.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Elasticity/BentBeam.hpp
@@ -8,10 +8,12 @@
 
 #include "DataStructures/CachedTempBuffer.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
 #include "DataStructures/TaggedTuple.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Elliptic/Systems/Elasticity/Tags.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Options/String.hpp"
 #include "PointwiseFunctions/Elasticity/ConstitutiveRelations/IsotropicHomogeneous.hpp"
 #include "PointwiseFunctions/InitialDataUtilities/AnalyticSolution.hpp"
@@ -187,6 +189,15 @@ class BentBeam : public elliptic::analytic_data::AnalyticSolution {
     const VarsComputer computer{x, length_, height_, bending_moment_,
                                 constitutive_relation_};
     return {cache.get_var(computer, RequestedTags{})...};
+  }
+
+  template <typename... RequestedTags>
+  tuples::TaggedTuple<RequestedTags...> variables(
+      const tnsr::I<DataVector, 2>& x, const Mesh<2>& /*mesh*/,
+      const InverseJacobian<DataVector, 2, Frame::ElementLogical,
+                            Frame::Inertial>& /*inv_jacobian*/,
+      tmpl::list<RequestedTags...> meta) const {
+    return variables(x, meta);
   }
 
   /// NOLINTNEXTLINE(google-runtime-references)

--- a/src/PointwiseFunctions/AnalyticSolutions/Elasticity/HalfSpaceMirror.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Elasticity/HalfSpaceMirror.hpp
@@ -9,9 +9,11 @@
 #include "DataStructures/CachedTempBuffer.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
 #include "DataStructures/TaggedTuple.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Elliptic/Systems/Elasticity/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Options/String.hpp"
 #include "PointwiseFunctions/Elasticity/ConstitutiveRelations/IsotropicHomogeneous.hpp"
 #include "PointwiseFunctions/InitialDataUtilities/AnalyticSolution.hpp"
@@ -222,6 +224,15 @@ class HalfSpaceMirror : public elliptic::analytic_data::AnalyticSolution {
                                 absolute_tolerance_,
                                 relative_tolerance_};
     return {cache.get_var(computer, RequestedTags{})...};
+  }
+
+  template <typename... RequestedTags>
+  tuples::TaggedTuple<RequestedTags...> variables(
+      const tnsr::I<DataVector, 3>& x, const Mesh<3>& /*mesh*/,
+      const InverseJacobian<DataVector, 3, Frame::ElementLogical,
+                            Frame::Inertial>& /*inv_jacobian*/,
+      tmpl::list<RequestedTags...> meta) const {
+    return variables(x, meta);
   }
 
   /// NOLINTNEXTLINE(google-runtime-references)

--- a/src/PointwiseFunctions/AnalyticSolutions/Elasticity/Zero.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Elasticity/Zero.hpp
@@ -7,10 +7,12 @@
 #include <pup.h>
 
 #include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
 #include "DataStructures/TaggedTuple.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Elliptic/Systems/Elasticity/Tags.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Options/String.hpp"
 #include "PointwiseFunctions/InitialDataUtilities/AnalyticSolution.hpp"
 #include "Utilities/MakeWithValue.hpp"
@@ -64,6 +66,15 @@ class Zero : public elliptic::analytic_data::AnalyticSolution {
                                                    supported_tags>>::value == 0,
                   "The requested tag is not supported");
     return {make_with_value<typename RequestedTags::type>(x, 0.)...};
+  }
+
+  template <typename... RequestedTags>
+  tuples::TaggedTuple<RequestedTags...> variables(
+      const tnsr::I<DataVector, Dim>& x, const Mesh<Dim>& /*mesh*/,
+      const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
+                            Frame::Inertial>& /*inv_jacobian*/,
+      tmpl::list<RequestedTags...> meta) const {
+    return variables(x, meta);
   }
 };
 

--- a/src/PointwiseFunctions/AnalyticSolutions/Poisson/Lorentzian.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Poisson/Lorentzian.hpp
@@ -14,6 +14,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Elliptic/Systems/Poisson/Tags.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Options/String.hpp"
 #include "PointwiseFunctions/InitialDataUtilities/AnalyticSolution.hpp"
 #include "Utilities/ContainerHelpers.hpp"
@@ -131,6 +132,15 @@ class Lorentzian : public elliptic::analytic_data::AnalyticSolution {
     typename VarsComputer::Cache cache{get_size(*x.begin())};
     const VarsComputer computer{x, constant_, complex_phase_};
     return {cache.get_var(computer, RequestedTags{})...};
+  }
+
+  template <typename... RequestedTags>
+  tuples::TaggedTuple<RequestedTags...> variables(
+      const tnsr::I<DataVector, Dim>& x, const Mesh<Dim>& /*mesh*/,
+      const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
+                            Frame::Inertial>& /*inv_jacobian*/,
+      tmpl::list<RequestedTags...> meta) const {
+    return variables(x, meta);
   }
 
   void pup(PUP::er& p) override {

--- a/src/PointwiseFunctions/AnalyticSolutions/Poisson/MathFunction.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Poisson/MathFunction.hpp
@@ -8,10 +8,12 @@
 
 #include "DataStructures/CachedTempBuffer.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
 #include "DataStructures/TaggedTuple.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Elliptic/Systems/Poisson/Tags.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Options/String.hpp"
 #include "PointwiseFunctions/InitialDataUtilities/AnalyticSolution.hpp"
 #include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
@@ -93,6 +95,15 @@ class MathFunction : public elliptic::analytic_data::AnalyticSolution {
     typename VarsComputer::Cache cache{get_size(*x.begin())};
     const VarsComputer computer{x, *math_function_};
     return {cache.get_var(computer, RequestedTags{})...};
+  }
+
+  template <typename... RequestedTags>
+  tuples::TaggedTuple<RequestedTags...> variables(
+      const tnsr::I<DataVector, Dim>& x, const Mesh<Dim>& /*mesh*/,
+      const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
+                            Frame::Inertial>& /*inv_jacobian*/,
+      tmpl::list<RequestedTags...> meta) const {
+    return variables(x, meta);
   }
 
   // NOLINTNEXTLINE(google-runtime-references)

--- a/src/PointwiseFunctions/AnalyticSolutions/Poisson/Moustache.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Poisson/Moustache.hpp
@@ -8,10 +8,12 @@
 
 #include "DataStructures/CachedTempBuffer.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
 #include "DataStructures/TaggedTuple.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Elliptic/Systems/Poisson/Tags.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Options/String.hpp"
 #include "PointwiseFunctions/InitialDataUtilities/AnalyticSolution.hpp"
 #include "Utilities/ContainerHelpers.hpp"
@@ -104,6 +106,15 @@ class Moustache : public elliptic::analytic_data::AnalyticSolution {
     typename VarsComputer::Cache cache{get_size(*x.begin())};
     const VarsComputer computer{x};
     return {cache.get_var(computer, RequestedTags{})...};
+  }
+
+  template <typename... RequestedTags>
+  tuples::TaggedTuple<RequestedTags...> variables(
+      const tnsr::I<DataVector, Dim>& x, const Mesh<Dim>& /*mesh*/,
+      const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
+                            Frame::Inertial>& /*inv_jacobian*/,
+      tmpl::list<RequestedTags...> meta) const {
+    return variables(x, meta);
   }
 };
 

--- a/src/PointwiseFunctions/AnalyticSolutions/Poisson/ProductOfSinusoids.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Poisson/ProductOfSinusoids.hpp
@@ -16,6 +16,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Elliptic/Systems/Poisson/Tags.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Options/String.hpp"
 #include "PointwiseFunctions/InitialDataUtilities/AnalyticSolution.hpp"
 #include "Utilities/ContainerHelpers.hpp"
@@ -121,6 +122,15 @@ class ProductOfSinusoids : public elliptic::analytic_data::AnalyticSolution {
     typename VarsComputer::Cache cache{get_size(*x.begin())};
     const VarsComputer computer{x, wave_numbers_, complex_phase_};
     return {cache.get_var(computer, RequestedTags{})...};
+  }
+
+  template <typename... RequestedTags>
+  tuples::TaggedTuple<RequestedTags...> variables(
+      const tnsr::I<DataVector, Dim>& x, const Mesh<Dim>& /*mesh*/,
+      const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
+                            Frame::Inertial>& /*inv_jacobian*/,
+      tmpl::list<RequestedTags...> meta) const {
+    return variables(x, meta);
   }
 
   // NOLINTNEXTLINE(google-runtime-references)

--- a/src/PointwiseFunctions/AnalyticSolutions/Poisson/Zero.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Poisson/Zero.hpp
@@ -12,6 +12,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Elliptic/Systems/Poisson/Tags.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Options/String.hpp"
 #include "PointwiseFunctions/InitialDataUtilities/AnalyticSolution.hpp"
 #include "Utilities/MakeWithValue.hpp"
@@ -61,6 +62,15 @@ class Zero : public elliptic::analytic_data::AnalyticSolution {
                                                    supported_tags>>::value == 0,
                   "The requested tag is not supported");
     return {make_with_value<typename RequestedTags::type>(x, 0.)...};
+  }
+
+  template <typename... RequestedTags>
+  tuples::TaggedTuple<RequestedTags...> variables(
+      const tnsr::I<DataVector, Dim>& x, const Mesh<Dim>& /*mesh*/,
+      const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
+                            Frame::Inertial>& /*inv_jacobian*/,
+      tmpl::list<RequestedTags...> meta) const {
+    return variables(x, meta);
   }
 };
 

--- a/src/PointwiseFunctions/AnalyticSolutions/Xcts/ConstantDensityStar.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/Xcts/ConstantDensityStar.hpp
@@ -8,10 +8,12 @@
 #include <pup.h>
 
 #include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
 #include "DataStructures/TaggedTuple.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Elliptic/Systems/Xcts/Tags.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Options/Context.hpp"
 #include "Options/String.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
@@ -178,6 +180,15 @@ class ConstantDensityStar : public elliptic::analytic_data::AnalyticSolution {
                   "The generic template will recurse infinitely if only one "
                   "tag is being retrieved.");
     return {tuples::get<Tags>(variables(x, tmpl::list<Tags>{}))...};
+  }
+
+  template <typename... Tags>
+  tuples::TaggedTuple<Tags...> variables(
+      const tnsr::I<DataVector, 3, Frame::Inertial>& x, const Mesh<3>& /*mesh*/,
+      const InverseJacobian<DataVector, 3, Frame::ElementLogical,
+                            Frame::Inertial>& /*inv_jacobian*/,
+      tmpl::list<Tags...> meta) const {
+    return variables(x, meta);
   }
 
   // NOLINTNEXTLINE(google-runtime-references)

--- a/tests/InputFiles/Xcts/KerrSchildTeukolsky.yaml
+++ b/tests/InputFiles/Xcts/KerrSchildTeukolsky.yaml
@@ -1,0 +1,163 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+Executable: SolveXcts
+Testing:
+  Check: parse;execute
+  Timeout: 120
+
+---
+
+Parallelization:
+  ElementDistribution: NumGridPoints
+
+ResourceInfo:
+  AvoidGlobalProc0: false
+  Singletons: Auto
+
+Background: &solution
+  KerrSchildTeukolsky:
+    KerrSchild:
+      Mass: &KerrMass 1.
+      Spin: &KerrSpin [0.1, -0.2, 0.3]
+      Center: &KerrCenter [0., 0., 0.]
+      Velocity: [0., 0., 0.]
+    TeukolskyWave:
+      Amplitude: 0.02
+      Mode: 2
+      Parity: odd
+      Direction: outgoing
+      Center: [0.1, -0.2, 0.3]
+      Radius: 20.
+      Width: 4.
+
+InitialGuess: *solution
+
+RandomizeInitialGuess: None
+
+DomainCreator:
+  Sphere:
+    InnerRadius: &InnerRadius 1.8
+    OuterRadius: &OuterRadius 36.
+    Interior:
+      ExciseWithBoundaryCondition:
+        AnalyticSolution:
+          Solution: *solution
+          ConformalFactorMinusOne: Dirichlet
+          LapseTimesConformalFactorMinusOne: Dirichlet
+          ShiftExcess: Dirichlet
+    InitialRefinement: 0
+    InitialGridPoints: 6
+    UseEquiangularMap: True
+    EquatorialCompression: None
+    WhichWedges: All
+    RadialPartitioning: [3., 6.]
+    RadialDistribution:
+      - Logarithmic
+      - Logarithmic
+      - Inverse
+    TimeDependentMaps:
+      Shape:
+        InitialTime: 0.
+        LMax: 18
+        CoefficientTruncationLimit: 0.
+        Mass: *KerrMass
+        Spin: *KerrSpin
+        Center: *KerrCenter
+        InnerRadius: *InnerRadius
+        OuterRadius: *OuterRadius
+    OuterBoundaryCondition:
+      AnalyticSolution:
+        Solution: *solution
+        ConformalFactorMinusOne: Dirichlet
+        LapseTimesConformalFactorMinusOne: Dirichlet
+        ShiftExcess: Dirichlet
+
+Amr:
+  Verbosity: Verbose
+  Criteria:
+    - IncreaseResolution
+  EnableInBlocks: All
+  Policies:
+    EnforceTwoToOneBalanceInNormalDirection: true
+    Isotropy: Anisotropic
+    Limits:
+      NumGridPoints: Auto
+      RefinementLevel: Auto
+      ErrorBeyondLimits: False
+    AllowCoarsening: True
+  MaxCoarseLevels: Auto
+  Iterations: 0
+
+PhaseChangeAndTriggers: []
+
+Discretization:
+  DiscontinuousGalerkin:
+    PenaltyParameter: 1.
+    Massive: True
+    Quadrature: GaussLobatto
+    Formulation: WeakInertial
+
+Observers:
+  VolumeFileName: "KerrSchildTeukolskyVolume"
+  ReductionFileName: "KerrSchildTeukolskyReductions"
+
+NonlinearSolver:
+  NewtonRaphson:
+    ConvergenceCriteria:
+      MaxIterations: 20
+      RelativeResidual: 0.
+      AbsoluteResidual: 1.e-6
+    SufficientDecrease: 1.e-4
+    MaxGlobalizationSteps: 40
+    DampingFactor: 1.
+    Verbosity: Quiet
+
+LinearSolver:
+  Gmres:
+    ConvergenceCriteria:
+      MaxIterations: 30
+      RelativeResidual: 1.e-4
+      AbsoluteResidual: 1.e-12
+    Verbosity: Quiet
+
+  Multigrid:
+    Iterations: 1
+    InitialCoarseLevels: Auto
+    PreSmoothing: True
+    UseBottomSolver: False
+    PostSmoothingAtBottom: False
+    Verbosity: Silent
+    OutputVolumeData: False
+
+  SchwarzSmoother:
+    Iterations: 3
+    MaxOverlap: 2
+    Verbosity: Silent
+    SubdomainSolver:
+      Gmres:
+        ConvergenceCriteria:
+          MaxIterations: 3
+          RelativeResidual: 1.e-4
+          AbsoluteResidual: 1.e-12
+        Verbosity: Silent
+        Restart: None
+        Preconditioner:
+          MinusLaplacian:
+            Solver:
+              ExplicitInverse:
+                WriteMatrixToFile: None
+            BoundaryConditions: Auto
+    SkipResets: True
+    ObservePerCoreReductions: False
+    OutputVolumeData: False
+
+RadiallyCompressedCoordinates: None
+
+EventsAndTriggersAtIterations: []
+
+BuildMatrix:
+  MatrixSubfileName: None
+  Verbosity: Verbose
+  EnableDirectSolve: True
+  SkipResets: False

--- a/tests/Unit/Elliptic/Actions/Test_InitializeAnalyticSolution.cpp
+++ b/tests/Unit/Elliptic/Actions/Test_InitializeAnalyticSolution.cpp
@@ -17,6 +17,9 @@
 #include "Elliptic/Actions/InitializeAnalyticSolution.hpp"
 #include "Elliptic/Tags.hpp"
 #include "Framework/ActionTesting.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
 #include "Options/Protocols/FactoryCreation.hpp"
 #include "Parallel/ParallelComponentHelpers.hpp"
 #include "Parallel/Phase.hpp"
@@ -59,13 +62,17 @@ struct AnalyticSolution : elliptic::analytic_data::AnalyticSolution {
   }
 
   static tuples::TaggedTuple<ScalarFieldTag> variables(
-      const tnsr::I<DataVector, 1>& x, tmpl::list<ScalarFieldTag> /*meta*/) {
+      const tnsr::I<DataVector, 1>& x, const Mesh<1>& /*mesh*/,
+      const InverseJacobian<DataVector, 1, Frame::ElementLogical,
+                            Frame::Inertial>& /*inv_jacobian*/,
+      tmpl::list<ScalarFieldTag> /*meta*/) {
     Scalar<DataVector> solution{2. * get<0>(x)};
     return {std::move(solution)};
   }
 };
 
 PUP::able::PUP_ID AnalyticSolution::my_PUP_ID = 0;  // NOLINT
+
 #pragma GCC diagnostic pop
 
 template <typename Metavariables>
@@ -78,7 +85,9 @@ struct ElementArray {
           Parallel::Phase::Initialization,
           tmpl::list<ActionTesting::InitializeDataBox<
               tmpl::list<domain::Tags::Mesh<1>,
-                         domain::Tags::Coordinates<1, Frame::Inertial>>>>>,
+                         domain::Tags::Coordinates<1, Frame::Inertial>,
+                         domain::Tags::InverseJacobian<1, Frame::ElementLogical,
+                                                       Frame::Inertial>>>>>,
 
       Parallel::PhaseActions<
           Parallel::Phase::Testing,
@@ -112,24 +121,28 @@ void test_initialize_analytic_solution(
 
   register_factory_classes_with_charm<metavariables>();
 
-  const auto initialize_analytic_solution =
-      [&inertial_coords](auto analytic_solution_or_data) {
-        ActionTesting::MockRuntimeSystem<metavariables> runner{
-            {std::move(analytic_solution_or_data)}};
-        const ElementId<1> element_id{0};
-        ActionTesting::emplace_component_and_initialize<element_array>(
-            &runner, element_id, {Mesh<1>{}, inertial_coords});
-        ActionTesting::set_phase(make_not_null(&runner),
-                                 Parallel::Phase::Testing);
-        for (size_t i = 0; i < 2; ++i) {
-          ActionTesting::next_action<element_array>(make_not_null(&runner),
-                                                    element_id);
-        }
-        return ActionTesting::get_databox_tag<
-            element_array,
-            ::Tags::AnalyticSolutions<tmpl::list<ScalarFieldTag>>>(
-            runner, element_id);
-      };
+  const auto initialize_analytic_solution = [&inertial_coords](
+                                                auto
+                                                    analytic_solution_or_data) {
+    ActionTesting::MockRuntimeSystem<metavariables> runner{
+        {std::move(analytic_solution_or_data)}};
+    const ElementId<1> element_id{0};
+    const Mesh<1> mesh{4, Spectral::Basis::Legendre,
+                       Spectral::Quadrature::GaussLobatto};
+    InverseJacobian<DataVector, 1, Frame::ElementLogical, Frame::Inertial>
+        inv_jacobian{static_cast<size_t>(4)};
+    get<0, 0>(inv_jacobian) = 3.;
+    ActionTesting::emplace_component_and_initialize<element_array>(
+        &runner, element_id, {mesh, inertial_coords, inv_jacobian});
+    ActionTesting::set_phase(make_not_null(&runner), Parallel::Phase::Testing);
+    for (size_t i = 0; i < 2; ++i) {
+      ActionTesting::next_action<element_array>(make_not_null(&runner),
+                                                element_id);
+    }
+    return ActionTesting::get_databox_tag<
+        element_array, ::Tags::AnalyticSolutions<tmpl::list<ScalarFieldTag>>>(
+        runner, element_id);
+  };
 
   {
     INFO("Analytic solution is available");

--- a/tests/Unit/Elliptic/BoundaryConditions/Test_AnalyticSolution.cpp
+++ b/tests/Unit/Elliptic/BoundaryConditions/Test_AnalyticSolution.cpp
@@ -33,6 +33,7 @@
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
 #include "Options/Protocols/FactoryCreation.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/InitialGuess.hpp"
 #include "Utilities/Literals.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
@@ -66,9 +67,9 @@ using test_tags = tmpl::list<ScalarFieldTag<1>, ScalarFieldTag<2>,
                              FluxTag<Dim, 1>, FluxTag<Dim, 2>>;
 
 template <size_t Dim>
-struct TestSolution : elliptic::analytic_data::AnalyticSolution {
+struct TestSolution : elliptic::analytic_data::InitialGuess {
   using options = tmpl::list<>;
-  static constexpr Options::String help{"A solution."};
+  static constexpr Options::String help{"Initial data."};
   TestSolution() = default;
   TestSolution(const TestSolution&) = default;
   TestSolution& operator=(const TestSolution&) = default;
@@ -76,22 +77,18 @@ struct TestSolution : elliptic::analytic_data::AnalyticSolution {
   TestSolution& operator=(TestSolution&&) = default;
   ~TestSolution() override = default;
   explicit TestSolution(CkMigrateMessage* m)
-      : elliptic::analytic_data::AnalyticSolution(m) {}
+      : elliptic::analytic_data::InitialGuess(m) {}
   using PUP::able::register_constructor;
   WRAPPED_PUPable_decl_template(TestSolution);  // NOLINT
 
-  std::unique_ptr<elliptic::analytic_data::AnalyticSolution> get_clone()
-      const override {
-    return std::make_unique<TestSolution>(*this);
-  }
-
-  tuples::tagged_tuple_from_typelist<test_tags<Dim>> variables(
-      const tnsr::I<DataVector, Dim>& x, test_tags<Dim> /*meta*/) const {
+  template <typename... RequestedTags>
+  tuples::TaggedTuple<RequestedTags...> variables(
+      const tnsr::I<DataVector, Dim>& x,
+      tmpl::list<RequestedTags...> /*meta*/) const {
     // Create arbitrary analytic solution data
     Variables<test_tags<Dim>> result{x.begin()->size()};
     std::iota(result.data(), result.data() + result.size(), 1.);
-    return {get<ScalarFieldTag<1>>(result), get<ScalarFieldTag<2>>(result),
-            get<FluxTag<Dim, 1>>(result), get<FluxTag<Dim, 2>>(result)};
+    return {get<RequestedTags>(result)...};
   }
 };
 
@@ -106,7 +103,7 @@ struct Metavariables {
         tmpl::pair<elliptic::BoundaryConditions::BoundaryCondition<Dim>,
                    tmpl::list<elliptic::BoundaryConditions::AnalyticSolution<
                        System<Dim>>>>,
-        tmpl::pair<elliptic::analytic_data::AnalyticSolution,
+        tmpl::pair<elliptic::analytic_data::InitialGuess,
                    tmpl::list<TestSolution<Dim>>>>;
   };
 };

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/SubdomainOperator/Test_SubdomainOperator.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/SubdomainOperator/Test_SubdomainOperator.cpp
@@ -83,6 +83,7 @@
 #include "PointwiseFunctions/Elasticity/ConstitutiveRelations/IsotropicHomogeneous.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "PointwiseFunctions/InitialDataUtilities/Background.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/InitialGuess.hpp"
 #include "Utilities/CartesianProduct.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeArray.hpp"
@@ -512,6 +513,7 @@ struct Metavariables {
             tmpl::list<elliptic::BoundaryConditions::AnalyticSolution<System>>>,
         tmpl::pair<elliptic::analytic_data::Background,
                    tmpl::list<RandomBackground<volume_dim>>>,
+        tmpl::pair<elliptic::analytic_data::InitialGuess, tmpl::list<>>,
         tmpl::pair<::amr::Criterion, tmpl::list<::amr::Criteria::Random<
                                          amr::Criteria::Type::p>>>>;
   };
@@ -636,8 +638,7 @@ void test_subdomain_operator(
         logging::Tags::Verbosity<::amr::OptionTags::AmrGroup>>{
         std::move(domain), domain_creator.functions_of_time(),
         std::move(boundary_conditions),
-        std::make_unique<RandomBackground<Dim>>(),
-        std::vector<size_t>{},
+        std::make_unique<RandomBackground<Dim>>(), std::vector<size_t>{},
         max_overlap.has_value() ? std::optional<size_t>(overlap) : std::nullopt,
         ::Verbosity::Verbose, penalty_parameter, use_massive_dg_operator,
         quadrature, ::dg::Formulation::StrongInertial, std::move(amr_criteria),

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_DgOperator.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_DgOperator.cpp
@@ -62,6 +62,7 @@
 #include "PointwiseFunctions/AnalyticSolutions/Poisson/Lorentzian.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Poisson/ProductOfSinusoids.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/InitialGuess.hpp"
 #include "Utilities/CartesianProduct.hpp"
 #include "Utilities/Literals.hpp"
 #include "Utilities/MakeArray.hpp"
@@ -190,6 +191,8 @@ struct Metavariables {
             tmpl::list<elliptic::BoundaryConditions::AnalyticSolution<System>>>,
         tmpl::pair<elliptic::analytic_data::AnalyticSolution,
                    tmpl::list<AnalyticSolution>>,
+        tmpl::pair<elliptic::analytic_data::InitialGuess,
+                   tmpl::list<AnalyticSolution>>,
         tmpl::pair<AnalyticSolution, tmpl::list<AnalyticSolution>>,
         tmpl::pair<::amr::Criterion, tmpl::list<::amr::Criteria::Random<
                                          amr::Criteria::Type::p>>>>;
@@ -278,8 +281,7 @@ struct ModifiedPoissonSystemLinearized
   struct modify_boundary_data {
     static constexpr double omega = 0.3;
     using argument_tags = tmpl::list<>;
-    using argument_tags_linearized =
-        tmpl::list<domain::Tags::Element<Dim>>;
+    using argument_tags_linearized = tmpl::list<domain::Tags::Element<Dim>>;
     static void apply(
         const gsl::not_null<Scalar<DataVector>*> /*field*/,
         const gsl::not_null<Scalar<DataVector>*> /*normal_dot_flux*/,
@@ -345,6 +347,15 @@ struct ModifiedPoissonSolution : Poisson::Solutions::ProductOfSinusoids<Dim> {
     }
     return vars;
   }
+
+  template <typename... RequestedTags>
+  tuples::TaggedTuple<RequestedTags...> variables(
+      const tnsr::I<DataVector, Dim>& x, const Mesh<Dim>& /*mesh*/,
+      const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
+                            Frame::Inertial>& /*inv_jacobian*/,
+      tmpl::list<RequestedTags...> meta) const {
+    return variables(x, meta);
+  }
 };
 
 template <size_t Dim>
@@ -374,14 +385,13 @@ struct ModifiedPoissonSolutionLinearized
     if (get<0>(x)[0] <= 0.5) {
       return vars;
     }
-    constexpr double omega = ModifiedPoissonSystemLinearized<
-        Dim>::modify_boundary_data::omega;
+    constexpr double omega =
+        ModifiedPoissonSystemLinearized<Dim>::modify_boundary_data::omega;
     const DataVector mult_factor = 1. - omega * (get<0>(x) - 0.5);
     using FieldTag = Poisson::Tags::Field<DataVector>;
     using DerivTag =
         ::Tags::deriv<FieldTag, tmpl::size_t<Dim>, Frame::Inertial>;
-    using FluxTag =
-        ::Tags::Flux<FieldTag, tmpl::size_t<Dim>, Frame::Inertial>;
+    using FluxTag = ::Tags::Flux<FieldTag, tmpl::size_t<Dim>, Frame::Inertial>;
     using SourceTag = ::Tags::FixedSource<FieldTag>;
     // Parent's field and d_x field are needed for the derivative and source
     // perturbations regardless of which tags were requested.
@@ -397,8 +407,7 @@ struct ModifiedPoissonSolutionLinearized
     if constexpr (tmpl::list_contains_v<tmpl::list<RequestedTags...>,
                                         DerivTag>) {
       auto& d = get<DerivTag>(vars);
-      d.get(0) =
-          -omega * get(parent_field) + mult_factor * parent_deriv.get(0);
+      d.get(0) = -omega * get(parent_field) + mult_factor * parent_deriv.get(0);
       for (size_t i = 1; i < Dim; ++i) {
         d.get(i) *= mult_factor;
       }
@@ -406,8 +415,7 @@ struct ModifiedPoissonSolutionLinearized
     if constexpr (tmpl::list_contains_v<tmpl::list<RequestedTags...>,
                                         FluxTag>) {
       auto& f = get<FluxTag>(vars);
-      f.get(0) =
-          -omega * get(parent_field) + mult_factor * parent_deriv.get(0);
+      f.get(0) = -omega * get(parent_field) + mult_factor * parent_deriv.get(0);
       for (size_t i = 1; i < Dim; ++i) {
         f.get(i) *= mult_factor;
       }
@@ -421,10 +429,26 @@ struct ModifiedPoissonSolutionLinearized
     }
     return vars;
   }
+
+  template <typename... RequestedTags>
+  tuples::TaggedTuple<RequestedTags...> variables(
+      const tnsr::I<DataVector, Dim>& x, const Mesh<Dim>& /*mesh*/,
+      const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
+                            Frame::Inertial>& /*inv_jacobian*/,
+      tmpl::list<RequestedTags...> meta) const {
+    return variables(x, meta);
+  }
 };
 
 template <size_t Dim>
-PUP::able::PUP_ID ModifiedPoissonSolutionLinearized<Dim>::my_PUP_ID = 0;  // NOLINT
+PUP::able::PUP_ID ModifiedPoissonSolutionLinearized<Dim>::my_PUP_ID =  // NOLINT
+    0;
+
+template <typename System, bool Linearized, typename AnalyticSolution>
+void register_dg_operator_factory_classes() {
+  register_factory_classes_with_charm<
+      Metavariables<System, Linearized, AnalyticSolution>>();
+}
 
 template <
     typename System, bool Linearized, typename AnalyticSolution,
@@ -463,7 +487,8 @@ void test_dg_operator(
   using PrimalFluxesVars = typename primal_fluxes_vars_tag::type;
   using OperatorAppliedToVars = typename operator_applied_to_vars_tag::type;
 
-  register_factory_classes_with_charm<Metavars>();
+  register_dg_operator_factory_classes<System, Linearized,
+                                       AnalyticSolution>();
 
   // Get a list of all elements in the domain
   auto domain = domain_creator.create_domain();
@@ -507,9 +532,8 @@ void test_dg_operator(
       ::Verbosity::Debug}};
 
   // DataBox shortcuts
-  const auto get_tag =
-      [&runner](auto tag_v,
-                const ElementId<Dim>& local_element_id) -> const auto& {
+  const auto get_tag = [&runner](
+      auto tag_v, const ElementId<Dim>& local_element_id) -> const auto& {
     using tag = std::decay_t<decltype(tag_v)>;
     return ActionTesting::get_databox_tag<element_array, tag>(runner,
                                                               local_element_id);
@@ -954,6 +978,8 @@ SPECTRE_TEST_CASE("Unit.Elliptic.DG.Operator", "[Unit][Elliptic]") {
         Poisson::FirstOrderSystem<2, Poisson::Geometry::FlatCartesian>;
     const Poisson::Solutions::ProductOfSinusoids<2> analytic_solution{
         {{M_PI, M_PI}}};
+    register_dg_operator_factory_classes<
+        system, true, Poisson::Solutions::ProductOfSinusoids<2>>();
     {
       INFO("Regression tests");
       const auto dirichlet_bc =
@@ -1082,6 +1108,8 @@ SPECTRE_TEST_CASE("Unit.Elliptic.DG.Operator", "[Unit][Elliptic]") {
         Poisson::FirstOrderSystem<3, Poisson::Geometry::FlatCartesian>;
     const Poisson::Solutions::ProductOfSinusoids<3> analytic_solution{
         {{M_PI, M_PI, M_PI}}};
+    register_dg_operator_factory_classes<
+        system, true, Poisson::Solutions::ProductOfSinusoids<3>>();
     {
       INFO("Regression tests");
       const auto dirichlet_bc =
@@ -1387,6 +1415,9 @@ SPECTRE_TEST_CASE("Unit.Elliptic.DG.Operator", "[Unit][Elliptic]") {
                                   ComplexDataVector>;
     const Poisson::Solutions::ProductOfSinusoids<2, ComplexDataVector>
         analytic_solution{{{M_PI, M_PI}}};
+    register_dg_operator_factory_classes<
+        system, true,
+        Poisson::Solutions::ProductOfSinusoids<2, ComplexDataVector>>();
     const auto dirichlet_bc =
         elliptic::BoundaryConditions::AnalyticSolution<system>{
             analytic_solution.get_clone(),
@@ -1602,6 +1633,8 @@ SPECTRE_TEST_CASE("Unit.Elliptic.DG.Operator", "[Unit][Elliptic]") {
     INFO("2D with modified boundary data");
     using system = ModifiedPoissonSystem<2>;
     const ModifiedPoissonSolution<2> analytic_solution{{{M_PI, M_PI}}};
+    register_dg_operator_factory_classes<system, true,
+                                         ModifiedPoissonSolution<2>>();
     const auto dirichlet_bc =
         elliptic::BoundaryConditions::AnalyticSolution<system>{
             analytic_solution.get_clone(),
@@ -1640,6 +1673,8 @@ SPECTRE_TEST_CASE("Unit.Elliptic.DG.Operator", "[Unit][Elliptic]") {
     using system = ModifiedPoissonSystemLinearized<2>;
     const ModifiedPoissonSolutionLinearized<2> analytic_solution{
         {{M_PI, M_PI}}};
+    register_dg_operator_factory_classes<
+        system, true, ModifiedPoissonSolutionLinearized<2>>();
     const auto dirichlet_bc =
         elliptic::BoundaryConditions::AnalyticSolution<system>{
             analytic_solution.get_clone(),

--- a/tests/Unit/Elliptic/Systems/Xcts/Test_HydroQuantities.cpp
+++ b/tests/Unit/Elliptic/Systems/Xcts/Test_HydroQuantities.cpp
@@ -14,6 +14,7 @@
 #include "Options/Protocols/FactoryCreation.hpp"
 #include "PointwiseFunctions/AnalyticData/Xcts/Binary.hpp"
 #include "PointwiseFunctions/AnalyticData/Xcts/CommonVariables.hpp"
+#include "PointwiseFunctions/AnalyticData/Xcts/KerrSchildTeukolsky.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Xcts/Factory.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Xcts/TovStar.hpp"
 #include "PointwiseFunctions/Hydro/EquationsOfState/PolytropicFluid.hpp"
@@ -21,6 +22,7 @@
 #include "PointwiseFunctions/Hydro/Tags.hpp"
 #include "PointwiseFunctions/InitialDataUtilities/AnalyticSolution.hpp"
 #include "PointwiseFunctions/InitialDataUtilities/Background.hpp"
+#include "Utilities/MakeWithValue.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -32,6 +34,7 @@ struct Metavariables {
       : tt::ConformsTo<Options::protocols::FactoryCreation> {
     using analytic_solutions_and_data = tmpl::push_back<
         Xcts::Solutions::all_analytic_solutions,
+        Xcts::AnalyticData::KerrSchildTeukolsky,
         Xcts::AnalyticData::Binary<elliptic::analytic_data::AnalyticSolution,
                                    Xcts::Solutions::all_analytic_solutions>>;
     using factory_classes =
@@ -77,6 +80,28 @@ SPECTRE_TEST_CASE("Unit.Elliptic.Systems.Xcts.HydroQuantities",
   const auto expected_u_i =
       make_with_value<tnsr::i<DataVector, 3>>(DataVector(2), 0.);
   CHECK_ITERABLE_APPROX(u_i, expected_u_i);
+
+  const auto no_hydro_box = db::create<
+      db::AddSimpleTags<
+          domain::Tags::Coordinates<3, Frame::Inertial>,
+          gr::Tags::SpatialMetric<DataVector, 3>,
+          elliptic::Tags::Background<elliptic::analytic_data::Background>,
+          Parallel::Tags::MetavariablesImpl<Metavariables>>,
+      db::AddComputeTags<Tags::HydroQuantitiesCompute<hydro_tags>,
+                         hydro::Tags::LowerSpatialFourVelocityCompute>>(
+      x, spatial_metric,
+      std::unique_ptr<elliptic::analytic_data::Background>(
+          std::make_unique<AnalyticData::KerrSchildTeukolsky>()),
+      Metavariables{});
+  tmpl::for_each<hydro_tags>([&no_hydro_box, &x](const auto tag_v) {
+    using tag = tmpl::type_from<std::decay_t<decltype(tag_v)>>;
+    CHECK_ITERABLE_APPROX(db::get<tag>(no_hydro_box),
+                          make_with_value<typename tag::type>(x, 0.));
+  });
+  const auto no_hydro_u_i = db::get<
+      hydro::Tags::LowerSpatialFourVelocity<DataVector, 3, Frame::Inertial>>(
+      no_hydro_box);
+  CHECK_ITERABLE_APPROX(no_hydro_u_i, expected_u_i);
 }
 
 }  // namespace Xcts

--- a/tests/Unit/PointwiseFunctions/AnalyticData/Xcts/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/Xcts/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_XctsAnalyticData")
 
 set(LIBRARY_SOURCES
   Test_Binary.cpp
+  Test_KerrSchildTeukolsky.cpp
   )
 
 add_test_library(${LIBRARY} "${LIBRARY_SOURCES}")
@@ -13,6 +14,7 @@ target_link_libraries(
   ${LIBRARY}
   PRIVATE
   DataStructures
+  GeneralRelativitySolutions
   Utilities
   Xcts
   XctsAnalyticData

--- a/tests/Unit/PointwiseFunctions/AnalyticData/Xcts/Test_KerrSchildTeukolsky.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/Xcts/Test_KerrSchildTeukolsky.cpp
@@ -1,0 +1,231 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <string>
+#include <utility>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/Trace.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "PointwiseFunctions/AnalyticData/Xcts/KerrSchildTeukolsky.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/TeukolskyWave.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Xcts/WrappedGr.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/InitialGuess.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace Xcts::AnalyticData {
+namespace {
+
+using zero_amplitude_tags = tmpl::list<
+    Tags::ConformalMetric<DataVector, 3, Frame::Inertial>,
+    Tags::ConformalFactorMinusOne<DataVector>,
+    Tags::LapseTimesConformalFactorMinusOne<DataVector>,
+    Tags::ShiftBackground<DataVector, 3, Frame::Inertial>,
+    Tags::ShiftExcess<DataVector, 3, Frame::Inertial>,
+    gr::Tags::TraceExtrinsicCurvature<DataVector>,
+    ::Tags::dt<gr::Tags::TraceExtrinsicCurvature<DataVector>>,
+    gr::Tags::Conformal<gr::Tags::EnergyDensity<DataVector>, 0>,
+    gr::Tags::Conformal<gr::Tags::StressTrace<DataVector>, 0>,
+    gr::Tags::Conformal<gr::Tags::MomentumDensity<DataVector, 3>, 0>>;
+
+tnsr::I<DataVector, 3, Frame::Inertial> test_coords() {
+  tnsr::I<DataVector, 3, Frame::Inertial> x{4_st};
+  get<0>(x) = DataVector{{3.1, 5.4, -4.2, 7.8}};
+  get<1>(x) = DataVector{{1.2, -2.3, 3.7, -4.1}};
+  get<2>(x) = DataVector{{4.5, 6.6, 5.3, -2.9}};
+  return x;
+}
+
+void test_factory_and_semantics() {
+  const std::string options =
+      "KerrSchildTeukolsky:\n"
+      "  KerrSchild:\n"
+      "    Mass: 1.0\n"
+      "    Spin: [0., 0., 0.999]\n"
+      "    Center: [0., 0., 0.]\n"
+      "    Velocity: [0., 0., 0.]\n"
+      "  TeukolskyWave:\n"
+      "    Amplitude: 0.02\n"
+      "    Mode: 2\n"
+      "    Parity: odd\n"
+      "    Direction: outgoing\n"
+      "    Center: [0.1, -0.2, 0.3]\n"
+      "    Radius: 20.\n"
+      "    Width: 4.\n";
+  const auto created =
+      TestHelpers::test_factory_creation<elliptic::analytic_data::InitialGuess,
+                                         KerrSchildTeukolsky>(options);
+  REQUIRE(dynamic_cast<const KerrSchildTeukolsky*>(created.get()) != nullptr);
+  const auto& solution = dynamic_cast<const KerrSchildTeukolsky&>(*created);
+
+  CHECK(solution.kerr_schild().mass() == 1.0);
+  CHECK(solution.kerr_schild().dimensionless_spin() ==
+        std::array<double, 3>{{0., 0., 0.999}});
+  CHECK(solution.teukolsky_wave().amplitude() == 0.02);
+  CHECK(solution.teukolsky_wave().mode() == 2);
+  CHECK(solution.teukolsky_wave().parity() == "odd");
+  CHECK(solution.teukolsky_wave().direction() == "outgoing");
+  CHECK(solution.teukolsky_wave().center() ==
+        std::array<double, 3>{{0.1, -0.2, 0.3}});
+  CHECK_FALSE(solution.teukolsky_wave().include_minkowski_background());
+
+  test_serialization(solution);
+  test_copy_semantics(solution);
+  auto move_solution = solution;
+  test_move_semantics(std::move(move_solution), solution);
+}
+
+void test_zero_amplitude_matches_wrapped_kerr_schild() {
+  const gr::Solutions::KerrSchild kerr_schild{
+      1.0, {{0., 0., 0.2}}, {{0., 0., 0.}}, {{0., 0., 0.}}};
+  const KerrSchildTeukolsky solution{
+      kerr_schild,
+      gr::Solutions::TeukolskyWave{
+          0., 0, "even", "ingoing", {{0., 0., 0.}}, 20., 4., false}};
+  const Xcts::Solutions::WrappedGr<gr::Solutions::KerrSchild> wrapped_kerr{
+      kerr_schild};
+  const auto x = test_coords();
+
+  const auto vars = solution.variables(x, zero_amplitude_tags{});
+  const auto expected = wrapped_kerr.variables(x, zero_amplitude_tags{});
+
+  tmpl::for_each<zero_amplitude_tags>([&vars, &expected](auto tag_v) {
+    using tag = tmpl::type_from<decltype(tag_v)>;
+    CHECK_ITERABLE_APPROX(get<tag>(vars), get<tag>(expected));
+  });
+}
+
+void test_nonzero_teukolsky_perturbation() {
+  const gr::Solutions::KerrSchild kerr_schild{
+      1.0, {{0., 0., 0.999}}, {{0., 0., 0.}}, {{0., 0., 0.}}};
+  const gr::Solutions::TeukolskyWave teukolsky_wave{
+      0.02, -1, "even", "ingoing", {{0., 0., 0.}}, 20., 4., false};
+  const KerrSchildTeukolsky solution{kerr_schild, teukolsky_wave};
+  const auto x = test_coords();
+
+  using tags =
+      tmpl::list<Tags::ConformalMetric<DataVector, 3, Frame::Inertial>,
+                 Tags::InverseConformalMetric<DataVector, 3, Frame::Inertial>,
+                 Tags::LongitudinalShiftBackgroundMinusDtConformalMetric<
+                     DataVector, 3, Frame::Inertial>,
+                 gr::Tags::TraceExtrinsicCurvature<DataVector>,
+                 ::Tags::dt<gr::Tags::TraceExtrinsicCurvature<DataVector>>>;
+  const auto vars = solution.variables(x, tags{});
+
+  const auto kerr_vars = kerr_schild.variables(
+      x, 0.,
+      tmpl::list<gr::Tags::SpatialMetric<DataVector, 3>,
+                 gr::Tags::InverseSpatialMetric<DataVector, 3>,
+                 gr::Tags::ExtrinsicCurvature<DataVector, 3>>{});
+  const auto teukolsky_vars = teukolsky_wave.variables(
+      x, 0.,
+      tmpl::list<gr::Tags::SpatialMetric<DataVector, 3, Frame::Inertial>,
+                 ::Tags::dt<gr::Tags::SpatialMetric<DataVector, 3,
+                                                    Frame::Inertial>>>{});
+
+  const auto& conformal_metric =
+      get<Tags::ConformalMetric<DataVector, 3, Frame::Inertial>>(vars);
+  const auto& teukolsky_metric =
+      get<gr::Tags::SpatialMetric<DataVector, 3, Frame::Inertial>>(
+          teukolsky_vars);
+  const auto& kerr_metric =
+      get<gr::Tags::SpatialMetric<DataVector, 3>>(kerr_vars);
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = 0; j <= i; ++j) {
+      CHECK_ITERABLE_APPROX(conformal_metric.get(i, j),
+                            kerr_metric.get(i, j) + teukolsky_metric.get(i, j));
+    }
+  }
+
+  Scalar<DataVector> expected_k_trace{get_size(get<0>(x))};
+  trace(make_not_null(&expected_k_trace),
+        get<gr::Tags::ExtrinsicCurvature<DataVector, 3>>(kerr_vars),
+        get<gr::Tags::InverseSpatialMetric<DataVector, 3>>(kerr_vars));
+  CHECK_ITERABLE_APPROX(
+      get(get<gr::Tags::TraceExtrinsicCurvature<DataVector>>(vars)),
+      get(expected_k_trace));
+  CHECK_ITERABLE_APPROX(
+      get(get<::Tags::dt<gr::Tags::TraceExtrinsicCurvature<DataVector>>>(vars)),
+      DataVector(get_size(get<0>(x)), 0.));
+
+  const auto& inv_conformal_metric =
+      get<Tags::InverseConformalMetric<DataVector, 3, Frame::Inertial>>(vars);
+  const auto& longitudinal_shift_background_minus_dt_conformal_metric =
+      get<Tags::LongitudinalShiftBackgroundMinusDtConformalMetric<
+          DataVector, 3, Frame::Inertial>>(vars);
+  Scalar<DataVector> trace_u{get_size(get<0>(x)), 0.};
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = 0; j < 3; ++j) {
+      get(trace_u) -=
+          conformal_metric.get(i, j) *
+          longitudinal_shift_background_minus_dt_conformal_metric.get(i, j);
+    }
+  }
+  CHECK_ITERABLE_APPROX(get(trace_u), DataVector(get_size(get<0>(x)), 0.));
+
+  const auto& dt_teukolsky_metric =
+      get<::Tags::dt<gr::Tags::SpatialMetric<DataVector, 3, Frame::Inertial>>>(
+          teukolsky_vars);
+  Scalar<DataVector> trace_dt_metric{get_size(get<0>(x)), 0.};
+  for (size_t k = 0; k < 3; ++k) {
+    for (size_t l = 0; l < 3; ++l) {
+      get(trace_dt_metric) +=
+          inv_conformal_metric.get(k, l) * dt_teukolsky_metric.get(k, l);
+    }
+  }
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = 0; j <= i; ++j) {
+      DataVector expected = DataVector(get_size(get<0>(x)), 0.);
+      for (size_t k = 0; k < 3; ++k) {
+        for (size_t l = 0; l < 3; ++l) {
+          expected -= inv_conformal_metric.get(i, k) *
+                      inv_conformal_metric.get(j, l) *
+                      (dt_teukolsky_metric.get(k, l) -
+                       conformal_metric.get(k, l) * get(trace_dt_metric) / 3.);
+        }
+      }
+      CHECK_ITERABLE_APPROX(
+          longitudinal_shift_background_minus_dt_conformal_metric.get(i, j),
+          expected);
+    }
+  }
+}
+
+void test_numeric_derivative_requires_mesh() {
+  const KerrSchildTeukolsky solution{
+      gr::Solutions::KerrSchild{
+          1.0, {{0., 0., 0.999}}, {{0., 0., 0.}}, {{0., 0., 0.}}},
+      gr::Solutions::TeukolskyWave{
+          0.02, -1, "even", "ingoing", {{0., 0., 0.}}, 20., 4., false}};
+  using deriv_conformal_metric_tag =
+      ::Tags::deriv<Tags::ConformalMetric<DataVector, 3, Frame::Inertial>,
+                    tmpl::size_t<3>, Frame::Inertial>;
+  CHECK_THROWS_WITH(
+      solution.variables(test_coords(),
+                         tmpl::list<deriv_conformal_metric_tag>{}),
+      Catch::Matchers::ContainsSubstring(
+          "Need a mesh and a Jacobian for numeric differentiation."));
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.PointwiseFunctions.AnalyticData.Xcts.KerrSchildTeukolsky",
+    "[PointwiseFunctions][Unit]") {
+  test_factory_and_semantics();
+  test_zero_amplitude_matches_wrapped_kerr_schild();
+  test_nonzero_teukolsky_perturbation();
+  test_numeric_derivative_requires_mesh();
+}
+
+}  // namespace Xcts::AnalyticData


### PR DESCRIPTION
## Proposed changes

Adds an elliptic analytic solution that provides free data for solving the XCTS equations for a single black hole plus a gravitational-wave pulse. The solution does not satisfy the constraint equations itself but is indended for providing free data and data for Dirichlet boundary conditions in the elliptic solve. Spatial derivatives are taken numerically, since spectre (and SpEC) TeukolskyWave solutions do not provide analytic values for spatial derivatives.

To make this solution possible, this PR also makes changes to analytic initial data: 
- Optionally, analytic solutions can be "mesh aware," meaning variable evaluation can make use of mesh and inverse jacobian (needed, e.g., for computing numerical partial derivatives)
- Optionally, analytic solutions can support returning only the tag requested. In the current implementation, the pattern is "return all tags, then get the one you want." The new pattern enables returning only the requested tags, but still supports the old behavior for other solutions. This allows the TeukolskyWave solution to not have to return tags that it does not need to support for its intended purpose, such as derivatives of lapse and shift. Otherwise, you would have to derive and code up all those terms that aren't used in the initial data solve.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [x] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
