### PR TITLE
Enable observing normalized GH constraint energy

### DIFF
--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -435,6 +435,7 @@ struct EvolutionMetavars {
               ::Tags::PointwiseL2NormCompute<
                   gh::Tags::FourIndexConstraint<DataVector, 3>>,
               gh::Tags::ConstraintEnergyCompute<3, ::Frame::Inertial>,
+              gh::Tags::NormalizedConstraintEnergyCompute<3, ::Frame::Inertial>,
               gh::Tags::ExtrinsicCurvatureCompute<3, ::Frame::Inertial>,
               ::Tags::DerivTensorCompute<
                   gr::Tags::ExtrinsicCurvature<DataVector, 3>,

--- a/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
@@ -246,6 +246,7 @@ struct ObserverTags {
               ::Tags::PointwiseL2NormCompute<
                   gh::Tags::FourIndexConstraint<DataVector, 3>>,
               gh::Tags::ConstraintEnergyCompute<3, Frame::Inertial>,
+              gh::Tags::NormalizedConstraintEnergyCompute<3, Frame::Inertial>,
               gh::Tags::ExtrinsicCurvatureCompute<3, Frame::Inertial>,
               ::Tags::DerivTensorCompute<
                   gr::Tags::ExtrinsicCurvature<DataVector, 3>,

--- a/src/Evolution/Systems/GeneralizedHarmonic/Constraints.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Constraints.cpp
@@ -1380,6 +1380,27 @@ void constraint_energy_normalization(
   get(*energy_norm) *= get(sqrt_spatial_metric_determinant);
 }
 
+template <typename DataType>
+Scalar<DataType> normalized_constraint_energy(
+    const Scalar<DataType>& constraint_energy,
+    const Scalar<DataType>& constraint_energy_normalization) {
+  auto normalized_energy =
+      make_with_value<Scalar<DataType>>(constraint_energy, 0.0);
+  normalized_constraint_energy<DataType>(make_not_null(&normalized_energy),
+                                         constraint_energy,
+                                         constraint_energy_normalization);
+  return normalized_energy;
+}
+
+template <typename DataType>
+void normalized_constraint_energy(
+    const gsl::not_null<Scalar<DataType>*> normalized_energy,
+    const Scalar<DataType>& constraint_energy,
+    const Scalar<DataType>& constraint_energy_normalization) {
+  get(*normalized_energy) =
+      get(constraint_energy) / (1.e-10 + get(constraint_energy_normalization));
+}
+
 }  // namespace gh
 
 // Explicit Instantiations
@@ -1600,6 +1621,21 @@ void constraint_energy_normalization(
           inverse_spatial_metric,                                             \
       const Scalar<DTYPE(data)>& sqrt_spatial_metric_determinant,             \
       double dimensional_constant);
+
+template Scalar<double> gh::normalized_constraint_energy(
+    const Scalar<double>& constraint_energy,
+    const Scalar<double>& constraint_energy_normalization);
+template Scalar<DataVector> gh::normalized_constraint_energy(
+    const Scalar<DataVector>& constraint_energy,
+    const Scalar<DataVector>& constraint_energy_normalization);
+template void gh::normalized_constraint_energy(
+    gsl::not_null<Scalar<double>*> normalized_energy,
+    const Scalar<double>& constraint_energy,
+    const Scalar<double>& constraint_energy_normalization);
+template void gh::normalized_constraint_energy(
+    gsl::not_null<Scalar<DataVector>*> normalized_energy,
+    const Scalar<DataVector>& constraint_energy,
+    const Scalar<DataVector>& constraint_energy_normalization);
 
 #define INSTANTIATE_ONLY_3D(_, data)                                       \
   template tnsr::iaa<DTYPE(data), DIM(data), FRAME(data)>                  \

--- a/src/Evolution/Systems/GeneralizedHarmonic/Constraints.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Constraints.hpp
@@ -561,7 +561,7 @@ void constraint_energy(
 
 /// @{
 /*!
- * \brief Computes the generalized-harmonic normalized constraint energy.
+ * \brief Computes the generalized-harmonic constraint energy normalization.
  *
  * \details Computes the generalized-harmonic normalized constraint energy
  * integrand [Eq. (70) of \cite Lindblom2005qh with \f$m^{ab}=\delta^{ab}\f$],
@@ -595,6 +595,29 @@ void constraint_energy_normalization(
     const tnsr::II<DataType, SpatialDim, Frame>& inverse_spatial_metric,
     const Scalar<DataType>& sqrt_spatial_metric_determinant,
     double dimensional_constant);
+/// @}
+
+/// @{
+/*!
+ * \brief Computes the generalized-harmonic normalized constraint energy.
+ *
+ * \details Computes `constraint_energy()` and then normalizes by dividing
+ * the unnormalized constraint energy. by `(eps +
+ * constraint_energy_normalization())`, where eps (following SpEC) has a value
+ * of 1.e-10, The `eps` term is present so that situations like Minkowski space,
+ * in which `constraint_energy_normalization()` vanishes, do not cause
+ * floating-point exceptions when computing the normalized constraint energy.
+ */
+template <typename DataType>
+Scalar<DataType> normalized_constraint_energy(
+    const Scalar<DataType>& constraint_energy,
+    const Scalar<DataType>& constraint_energy_normalization);
+
+template <typename DataType>
+void normalized_constraint_energy(
+    gsl::not_null<Scalar<DataType>*> normalized_energy,
+    const Scalar<DataType>& constraint_energy,
+    const Scalar<DataType>& constraint_energy_normalization);
 /// @}
 
 namespace Tags {
@@ -818,6 +841,50 @@ struct ConstraintEnergyCompute
   }
 
   using base = ConstraintEnergy<DataVector, SpatialDim, Frame>;
+};
+
+/*!
+ * \brief Compute item to get the normalized combined energy in all constraints
+ * for the generalized harmonic evolution system.
+ *
+ * \details See `normalized_constraint_energy()`. Can be retrieved using
+ * `gh::Tags::NormalizedConstraintEnergy`.
+ */
+template <size_t SpatialDim, typename Frame>
+struct NormalizedConstraintEnergyCompute
+    : NormalizedConstraintEnergy<DataVector, SpatialDim, Frame>,
+      db::ComputeTag {
+  using argument_tags = tmpl::list<
+      ConstraintEnergy<DataVector, SpatialDim, Frame>,
+      ::Tags::deriv<gr::Tags::SpacetimeMetric<DataVector, SpatialDim, Frame>,
+                    tmpl::size_t<SpatialDim>, Frame>,
+      ::Tags::deriv<Pi<DataVector, SpatialDim, Frame>, tmpl::size_t<SpatialDim>,
+                    Frame>,
+      ::Tags::deriv<Phi<DataVector, SpatialDim, Frame>,
+                    tmpl::size_t<SpatialDim>, Frame>,
+      gr::Tags::InverseSpatialMetric<DataVector, SpatialDim, Frame>,
+      gr::Tags::SqrtDetSpatialMetric<DataVector>>;
+
+  using return_type = Scalar<DataVector>;
+
+  static constexpr auto function(
+      const gsl::not_null<Scalar<DataVector>*> normalized_energy,
+      const Scalar<DataVector>& constraint_energy,
+      const tnsr::iaa<DataVector, SpatialDim, Frame>& d_spacetime_metric,
+      const tnsr::iaa<DataVector, SpatialDim, Frame>& d_pi,
+      const tnsr::ijaa<DataVector, SpatialDim, Frame>& d_phi,
+      const tnsr::II<DataVector, SpatialDim, Frame>& inverse_spatial_metric,
+      const Scalar<DataVector>& sqrt_spatial_metric_determinant) {
+    set_number_of_grid_points(normalized_energy, constraint_energy);
+    const auto normalization =
+        constraint_energy_normalization<DataVector, SpatialDim, Frame>(
+            d_spacetime_metric, d_pi, d_phi, inverse_spatial_metric,
+            sqrt_spatial_metric_determinant, 1.0);
+    normalized_constraint_energy<DataVector>(normalized_energy,
+                                             constraint_energy, normalization);
+  }
+
+  using base = NormalizedConstraintEnergy<DataVector, SpatialDim, Frame>;
 };
 }  // namespace Tags
 }  // namespace gh

--- a/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
@@ -168,8 +168,9 @@ struct EvolvedFieldsFromCharacteristicFields : db::SimpleTag {
  * harmonic system, and their diagnostically useful combinations.
  * \details For details on how these are defined and computed, see
  * `GaugeConstraintCompute`, `FConstraintCompute`, `TwoIndexConstraintCompute`,
- * `ThreeIndexConstraintCompute`, `FourIndexConstraintCompute`, and
- * `ConstraintEnergyCompute` respectively
+ * `ThreeIndexConstraintCompute`, `FourIndexConstraintCompute`,
+ * `ConstraintEnergyCompute`, and `NormalizedConstraintEnergyCompute`
+ * respectively
  */
 template <typename DataType, size_t SpatialDim, typename Frame>
 struct GaugeConstraint : db::SimpleTag {
@@ -198,6 +199,11 @@ struct FourIndexConstraint : db::SimpleTag {
 /// \copydoc GaugeConstraint
 template <typename DataType, size_t SpatialDim, typename Frame>
 struct ConstraintEnergy : db::SimpleTag {
+  using type = Scalar<DataType>;
+};
+/// \copydoc GaugeConstraint
+template <typename DataType, size_t SpatialDim, typename Frame>
+struct NormalizedConstraintEnergy : db::SimpleTag {
   using type = Scalar<DataType>;
 };
 }  // namespace Tags

--- a/src/Evolution/Systems/GeneralizedHarmonic/TagsDeclarations.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/TagsDeclarations.hpp
@@ -72,6 +72,9 @@ struct FourIndexConstraint;
 template <typename DataType, size_t SpatialDim,
           typename Frame = Frame::Inertial>
 struct ConstraintEnergy;
+template <typename DataType, size_t SpatialDim,
+          typename Frame = Frame::Inertial>
+struct NormalizedConstraintEnergy;
 }  // namespace Tags
 
 /// \brief Input option tags for the generalized harmonic evolution system

--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -390,6 +390,9 @@ EventsAndTriggersAtSlabs:
           - Name: ConstraintEnergy
             NormType: L2Norm
             Components: Sum
+          - Name: NormalizedConstraintEnergy
+            NormType: L2Norm
+            Components: Sum
       - ErrorIfDataTooBig:
           Threshold: 10
           VariablesToCheck: [ConstraintEnergy]
@@ -422,6 +425,7 @@ EventsAndTriggersAtSlabs:
             - SpacetimeMetric
             # For diagnostics:
             - ConstraintEnergy
+            - NormalizedConstraintEnergy
             - PointwiseL2Norm(GaugeConstraint)
             - PointwiseL2Norm(ThreeIndexConstraint)
             # For visualization:

--- a/support/Pipelines/Bbh/Ringdown.yaml
+++ b/support/Pipelines/Bbh/Ringdown.yaml
@@ -253,6 +253,9 @@ EventsAndTriggersAtSlabs:
           - Name: ConstraintEnergy
             NormType: L2Norm
             Components: Sum
+          - Name: NormalizedConstraintEnergy
+            NormType: L2Norm
+            Components: Sum
       - ErrorIfDataTooBig:
           Threshold: 10
           VariablesToCheck: [ConstraintEnergy]
@@ -281,6 +284,7 @@ EventsAndTriggersAtSlabs:
             - SpacetimeMetric
             # For diagnostics:
             - ConstraintEnergy
+            - NormalizedConstraintEnergy
             - PointwiseL2Norm(GaugeConstraint)
             - PointwiseL2Norm(ThreeIndexConstraint)
             # For visualization:

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Constraints.py
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Constraints.py
@@ -1042,3 +1042,15 @@ def constraint_energy_normalization(
 
 
 # End test functions for normalized constraint energy
+
+# Begin test functions for normalized constraint energy
+
+
+def normalized_constraint_energy(
+    constraint_energy,
+    constraint_energy_normalization,
+):
+    return constraint_energy / (1.0e-10 + constraint_energy_normalization)
+
+
+# End test functions for normalized constraint energy

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Constraints.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Constraints.cpp
@@ -790,6 +790,27 @@ void test_constraint_energy_normalization_minkowski(
   CHECK(get(result) == 0.0);
 }
 
+// Test the return-by-value normalized constraint energy function using random
+// values
+template <typename DataType>
+void test_normalized_constraint_energy_random(const DataType& used_for_size) {
+  pypp::check_with_random_values<1>(
+      static_cast<Scalar<DataType> (*)(const Scalar<DataType>&,
+                                       const Scalar<DataType>&)>(
+          &gh::normalized_constraint_energy<DataType>),
+      "Constraints", "normalized_constraint_energy", {{{1.0, 2.0}}},
+      used_for_size);
+}
+
+void test_normalized_constraint_energy_zero_normalization() {
+  const Scalar<double> zero_double{0.0};
+  CHECK(get(gh::normalized_constraint_energy(zero_double, zero_double)) == 0.0);
+
+  const Scalar<DataVector> zero_datavector{DataVector(4, 0.0)};
+  CHECK(get(gh::normalized_constraint_energy(
+            zero_datavector, zero_datavector)) == DataVector(4, 0.0));
+}
+
 // Test compute items for various constraints via insertion and retrieval
 // in a databox
 template <typename Solution>
@@ -829,6 +850,9 @@ void test_constraint_compute_items(const Solution& solution,
   TestHelpers::db::test_compute_tag<
       gh::Tags::ConstraintEnergyCompute<3, Frame::Inertial>>(
       "ConstraintEnergy");
+  TestHelpers::db::test_compute_tag<
+      gh::Tags::NormalizedConstraintEnergyCompute<3, Frame::Inertial>>(
+      "NormalizedConstraintEnergy");
 
   // Check vs. time-independent analytic solution
   // Set up grid
@@ -998,6 +1022,7 @@ void test_constraint_compute_items(const Solution& solution,
                                                  Frame::Inertial>,
           gr::Tags::DetAndInverseSpatialMetricCompute<DataVector, 3,
                                                       Frame::Inertial>,
+          gr::Tags::SqrtDetSpatialMetricCompute<DataVector, 3, Frame::Inertial>,
           gr::Tags::InverseSpacetimeMetricCompute<DataVector, 3,
                                                   Frame::Inertial>,
           gr::Tags::SpatialChristoffelFirstKindCompute<DataVector, 3,
@@ -1015,7 +1040,8 @@ void test_constraint_compute_items(const Solution& solution,
           gh::Tags::TwoIndexConstraintCompute<3, Frame::Inertial>,
           gh::Tags::GaugeConstraintCompute<3, Frame::Inertial>,
           gh::Tags::FConstraintCompute<3, Frame::Inertial>,
-          gh::Tags::ConstraintEnergyCompute<3, Frame::Inertial>>>(
+          gh::Tags::ConstraintEnergyCompute<3, Frame::Inertial>,
+          gh::Tags::NormalizedConstraintEnergyCompute<3, Frame::Inertial>>>(
       std::move(functions_of_time),
       std::numeric_limits<double>::signaling_NaN(), x,
 
@@ -1080,6 +1106,12 @@ void test_constraint_compute_items(const Solution& solution,
       gauge_constraint, f_constraint, two_index_constraint,
       three_index_constraint, four_index_constraint, inverse_spatial_metric,
       det_spatial_metric);
+  const auto constraint_energy_normalization =
+      gh::constraint_energy_normalization(
+          deriv_spacetime_metric, deriv_pi, deriv_phi, inverse_spatial_metric,
+          db::get<gr::Tags::SqrtDetSpatialMetric<DataVector>>(box), 1.0);
+  const auto normalized_constraint_energy = gh::normalized_constraint_energy(
+      constraint_energy, constraint_energy_normalization);
 
   // Check that their compute items in databox furnish identical values
   CHECK(db::get<gh::Tags::ConstraintGamma0>(box) == gamma0);
@@ -1099,6 +1131,8 @@ void test_constraint_compute_items(const Solution& solution,
   CHECK(db::get<gh::Tags::FConstraint<DataVector, 3>>(box) == f_constraint);
   CHECK(db::get<gh::Tags::ConstraintEnergy<DataVector, 3>>(box) ==
         constraint_energy);
+  CHECK(db::get<gh::Tags::NormalizedConstraintEnergy<DataVector, 3>>(box) ==
+        normalized_constraint_energy);
 }
 
 void three_index_constraint() {
@@ -1347,6 +1381,14 @@ void constraint_energy_normalization() {
       std::numeric_limits<double>::signaling_NaN());
 }
 
+void normalized_constraint_energy() {
+  test_normalized_constraint_energy_random<DataVector>(
+      DataVector(4, std::numeric_limits<double>::signaling_NaN()));
+  test_normalized_constraint_energy_random<double>(
+      std::numeric_limits<double>::signaling_NaN());
+  test_normalized_constraint_energy_zero_normalization();
+}
+
 void test_compute_tags() {
   // Test the F constraint against Kerr Schild
   const double mass = 1.4;
@@ -1374,5 +1416,6 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.GeneralizedHarmonic.Constraints",
   f_constraint();
   constraint_energy();
   constraint_energy_normalization();
+  normalized_constraint_energy();
   test_compute_tags();
 }

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_Tags.cpp
@@ -68,6 +68,9 @@ void test_simple_tags() {
 
   TestHelpers::db::test_simple_tag<
       gh::Tags::ConstraintEnergy<DataVector, Dim, Frame>>("ConstraintEnergy");
+  TestHelpers::db::test_simple_tag<
+      gh::Tags::NormalizedConstraintEnergy<DataVector, Dim, Frame>>(
+      "NormalizedConstraintEnergy");
 }
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.GeneralizedHarmonic.Tags",


### PR DESCRIPTION
## Proposed changes

Enables outputting the noramalized generalized harmonic constraint energy. The code already has functions to compute the constraint energy and its normalization, but it never added the necessary code to enable the normalized constraint energy to be output during a simulation. Normalizing the constraint energy is important for interpreting how large or small a particular constraint value is, e.g.... it's better to use the normalized than unnormalized constraint energy for that purpose.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [x] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
