### PR TITLE
Add runtime checks for TimeStepper properties

### DIFF
--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -308,7 +308,8 @@ struct EvolutionMetavars {
 
   using initialization_actions = tmpl::list<
       Initialization::Actions::InitializeItems<
-          Initialization::TimeStepping<EvolutionMetavars, TimeStepperBase>,
+          Initialization::TimeStepping<EvolutionMetavars, TimeStepperBase,
+                                       false>,
           evolution::dg::Initialization::Domain<EvolutionMetavars>,
           Initialization::TimeStepperHistory<EvolutionMetavars>>,
       Initialization::Actions::ConservativeSystem<system>,

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
@@ -293,7 +293,8 @@ struct EvolutionMetavars {
 
   using initialization_actions = tmpl::list<
       Initialization::Actions::InitializeItems<
-          Initialization::TimeStepping<EvolutionMetavars, TimeStepperBase>,
+          Initialization::TimeStepping<EvolutionMetavars, TimeStepperBase,
+                                       false>,
           evolution::dg::Initialization::Domain<EvolutionMetavars>,
           Initialization::TimeStepperHistory<EvolutionMetavars>>,
       Initialization::Actions::NonconservativeSystem<system>,

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
@@ -289,7 +289,8 @@ struct EvolutionMetavars {
 
   using initialization_actions = tmpl::list<
       Initialization::Actions::InitializeItems<
-          Initialization::TimeStepping<EvolutionMetavars, TimeStepperBase>,
+          Initialization::TimeStepping<EvolutionMetavars, TimeStepperBase,
+                                       false>,
           evolution::dg::Initialization::Domain<EvolutionMetavars>,
           Initialization::TimeStepperHistory<EvolutionMetavars>>,
       Initialization::Actions::NonconservativeSystem<system>,

--- a/src/Evolution/Executables/ForceFree/EvolveForceFree.hpp
+++ b/src/Evolution/Executables/ForceFree/EvolveForceFree.hpp
@@ -223,7 +223,8 @@ struct EvolutionMetavars {
 
   using initialization_actions = tmpl::list<
       Initialization::Actions::InitializeItems<
-          Initialization::TimeStepping<EvolutionMetavars, TimeStepperBase>,
+          Initialization::TimeStepping<EvolutionMetavars, TimeStepperBase,
+                                       false>,
           evolution::dg::Initialization::Domain<EvolutionMetavars>,
           Initialization::TimeStepperHistory<EvolutionMetavars>>,
       Initialization::Actions::AddSimpleTags<

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -619,7 +619,8 @@ struct EvolutionMetavars {
 
   using initialization_actions = tmpl::list<
       Initialization::Actions::InitializeItems<
-          Initialization::TimeStepping<EvolutionMetavars, TimeStepperBase>,
+          Initialization::TimeStepping<EvolutionMetavars, TimeStepperBase,
+                                       use_control_systems>,
           evolution::dg::Initialization::Domain<EvolutionMetavars,
                                                 use_control_systems>,
           ::amr::Initialization::Initialize<volume_dim, EvolutionMetavars>,

--- a/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
@@ -419,7 +419,8 @@ struct GeneralizedHarmonicTemplateBase {
   template <typename DerivedMetavars, bool UseControlSystems>
   using initialization_actions = tmpl::list<
       Initialization::Actions::InitializeItems<
-          Initialization::TimeStepping<DerivedMetavars, TimeStepperBase>,
+          Initialization::TimeStepping<DerivedMetavars, TimeStepperBase,
+                                       UseControlSystems>,
           evolution::dg::Initialization::Domain<DerivedMetavars,
                                                 UseControlSystems>,
           ::amr::Initialization::Initialize<volume_dim, DerivedMetavars>,

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -877,7 +877,8 @@ struct GhValenciaDivCleanTemplateBase<
 
   using initialization_actions = tmpl::list<
       Initialization::Actions::InitializeItems<
-          Initialization::TimeStepping<derived_metavars, TimeStepperBase>,
+          Initialization::TimeStepping<derived_metavars, TimeStepperBase,
+                                       use_control_systems>,
           evolution::dg::Initialization::Domain<derived_metavars,
                                                 use_control_systems>,
           Initialization::TimeStepperHistory<derived_metavars>>,

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -531,7 +531,8 @@ struct EvolutionMetavars<tmpl::list<InterpolationTargetTags...>,
 
   using initialization_actions = tmpl::flatten<tmpl::list<
       Initialization::Actions::InitializeItems<
-          Initialization::TimeStepping<EvolutionMetavars, TimeStepperBase>,
+          Initialization::TimeStepping<EvolutionMetavars, TimeStepperBase,
+                                       false>,
           evolution::dg::Initialization::Domain<EvolutionMetavars>,
           Initialization::TimeStepperHistory<EvolutionMetavars>>,
       Initialization::Actions::AddSimpleTags<

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -267,7 +267,8 @@ struct EvolutionMetavars {
 
   using initialization_actions = tmpl::flatten<tmpl::list<
       Initialization::Actions::InitializeItems<
-          Initialization::TimeStepping<EvolutionMetavars, TimeStepperBase>,
+          Initialization::TimeStepping<EvolutionMetavars, TimeStepperBase,
+                                       false>,
           evolution::dg::Initialization::Domain<EvolutionMetavars>,
           Initialization::TimeStepperHistory<EvolutionMetavars>>,
       Initialization::Actions::ConservativeSystem<system>,

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
@@ -233,7 +233,8 @@ struct EvolutionMetavars {
 
   using initialization_actions = tmpl::list<
       Initialization::Actions::InitializeItems<
-          Initialization::TimeStepping<EvolutionMetavars, TimeStepperBase>,
+          Initialization::TimeStepping<EvolutionMetavars, TimeStepperBase,
+                                       false>,
           evolution::dg::Initialization::Domain<EvolutionMetavars>,
           Initialization::TimeStepperHistory<EvolutionMetavars>>,
       Initialization::Actions::AddSimpleTags<

--- a/src/Evolution/Executables/RadiationTransport/MonteCarlo/EvolveMonteCarlo.hpp
+++ b/src/Evolution/Executables/RadiationTransport/MonteCarlo/EvolveMonteCarlo.hpp
@@ -195,7 +195,8 @@ struct EvolutionMetavars {
 
   using initialization_actions = tmpl::list<
       Initialization::Actions::InitializeItems<
-          Initialization::TimeStepping<EvolutionMetavars, TimeStepperBase>,
+          Initialization::TimeStepping<EvolutionMetavars, TimeStepperBase,
+                                       false>,
           evolution::dg::Initialization::Domain<EvolutionMetavars>>,
       Initialization::Actions::AddSimpleTags<
           evolution::dg::BackgroundGrVars<system, EvolutionMetavars>>,

--- a/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
+++ b/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
@@ -336,7 +336,8 @@ struct EvolutionMetavars {
 
   using initialization_actions = tmpl::list<
       Initialization::Actions::InitializeItems<
-          Initialization::TimeStepping<EvolutionMetavars, TimeStepperBase>,
+          Initialization::TimeStepping<EvolutionMetavars, TimeStepperBase,
+                                       false>,
           evolution::dg::Initialization::Domain<EvolutionMetavars>,
           Initialization::TimeStepperHistory<EvolutionMetavars>>,
       Initialization::Actions::ConservativeSystem<system>,

--- a/src/Evolution/Executables/ScalarTensor/ScalarTensorBase.hpp
+++ b/src/Evolution/Executables/ScalarTensor/ScalarTensorBase.hpp
@@ -466,7 +466,8 @@ struct ScalarTensorTemplateBase {
   template <bool UseControlSystems>
   using initialization_actions = tmpl::list<
       Initialization::Actions::InitializeItems<
-          Initialization::TimeStepping<derived_metavars, TimeStepperBase>,
+          Initialization::TimeStepping<derived_metavars, TimeStepperBase,
+                                       UseControlSystems>,
           evolution::dg::Initialization::Domain<derived_metavars,
                                                 UseControlSystems>,
           Initialization::TimeStepperHistory<derived_metavars>>,

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -267,7 +267,8 @@ struct EvolutionMetavars {
 
   using initialization_actions = tmpl::list<
       Initialization::Actions::InitializeItems<
-          Initialization::TimeStepping<EvolutionMetavars, TimeStepperBase>,
+          Initialization::TimeStepping<EvolutionMetavars, TimeStepperBase,
+                                       false>,
           evolution::dg::Initialization::Domain<EvolutionMetavars>,
           ::amr::Initialization::Initialize<volume_dim, EvolutionMetavars>,
           Initialization::TimeStepperHistory<EvolutionMetavars>>,

--- a/src/Evolution/Initialization/Evolution.hpp
+++ b/src/Evolution/Initialization/Evolution.hpp
@@ -113,12 +113,14 @@ void set_next_time_step_id(const gsl::not_null<TimeStepId*> next_time_step_id,
 /// Since the evolution has not started yet, initialize the state
 /// _before_ the initial time. So `Tags::TimeStepId` is undefined at this point,
 /// and `Tags::Next<Tags::TimeStepId>` is the initial time.
-template <typename Metavariables, typename TimeStepperBase>
+template <typename Metavariables, typename TimeStepperBase,
+          bool WithControlSystems>
 struct TimeStepping {
   /// Tags for constant items added to the GlobalCache.  These items are
   /// initialized from input file options.
-  using const_global_cache_tags =
-      tmpl::list<::Tags::ConcreteTimeStepper<TimeStepperBase>, ::Tags::LtsMode>;
+  using const_global_cache_tags = tmpl::list<
+      ::Tags::ConcreteTimeStepper<TimeStepperBase, WithControlSystems>,
+      ::Tags::LtsMode>;
 
   /// Tags for mutable items added to the GlobalCache.  These items are
   /// initialized from input file options.
@@ -128,7 +130,7 @@ struct TimeStepping {
   using argument_tags =
       tmpl::list<::Tags::Time, Tags::InitialTimeDelta,
                  Tags::InitialSlabSize<TimeStepperBase::local_time_stepping>,
-                 ::Tags::ConcreteTimeStepper<TimeStepperBase>>;
+                 ::Tags::TimeStepper<TimeStepperBase>>;
 
   /// Tags for simple DataBox items that are initialized from input file options
   using simple_tags_from_options =
@@ -154,7 +156,8 @@ struct TimeStepping {
 
   /// Tags for immutable DataBox items (compute items or reference items) added
   /// to the DataBox.
-  using compute_tags = time_stepper_ref_tags<TimeStepperBase>;
+  using compute_tags =
+      time_stepper_ref_tags<TimeStepperBase, WithControlSystems>;
 
   /// Given the items fetched from a DataBox by the argument_tags when using
   /// LTS, mutate the items in the DataBox corresponding to return_tags

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonChare.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonChare.hpp
@@ -76,7 +76,7 @@ struct WorldtubeSingleton {
 
   using initialization_actions = tmpl::list<
       ::Initialization::Actions::InitializeItems<
-          ::Initialization::TimeStepping<Metavariables, TimeStepperBase>,
+          ::Initialization::TimeStepping<Metavariables, TimeStepperBase, false>,
           Initialization::InitializeEvolvedVariables,
           Initialization::InitializeElementFacesGridCoordinates<Dim>>,
       ::Initialization::Actions::AddComputeTags<

--- a/src/Executables/ExportCoordinates/ExportCoordinates.hpp
+++ b/src/Executables/ExportCoordinates/ExportCoordinates.hpp
@@ -338,7 +338,7 @@ struct Metavariables {
               tmpl::list<
                   Initialization::Actions::InitializeItems<
                       Initialization::TimeStepping<Metavariables,
-                                                   TimeStepperBase>,
+                                                   TimeStepperBase, false>,
                       evolution::dg::Initialization::Domain<Metavariables>,
                       ::amr::Initialization::Initialize<volume_dim,
                                                         Metavariables>,

--- a/src/Parallel/InitializationTag.hpp
+++ b/src/Parallel/InitializationTag.hpp
@@ -9,10 +9,19 @@
 
 namespace Parallel {
 namespace initialization_tag_detail {
+// This check should be implementable without all these structs by
+// using SFINAE directly in the concept, but that causes clang 13 to
+// segfault.
 template <template <typename> typename>
-constexpr bool is_templated() {
-  return true;
-}
+struct templated_check;
+
+template <typename Tag, typename = std::void_t<>>
+struct has_templated_option_tags : std::false_type {};
+
+template <typename Tag>
+struct has_templated_option_tags<
+    Tag, std::void_t<templated_check<Tag::template option_tags>>>
+    : std::true_type {};
 }  // namespace initialization_tag_detail
 
 /*!
@@ -22,7 +31,7 @@ constexpr bool is_templated() {
 template <typename Tag>
 concept templated_initialization_tag =
     db::simple_tag<Tag> and Tag::pass_metavariables and
-    initialization_tag_detail::is_templated<Tag::template option_tags>();
+    initialization_tag_detail::has_templated_option_tags<Tag>::value;
 
 /*!
  * \ingroup ParallelGroup

--- a/src/Time/Tags/TimeStepper.cpp
+++ b/src/Time/Tags/TimeStepper.cpp
@@ -3,13 +3,113 @@
 
 #include "Time/Tags/TimeStepper.hpp"
 
+#include <initializer_list>
 #include <memory>
+#include <string>
+#include <typeinfo>
+#include <vector>
 
+#include "DataStructures/TaggedVariant.hpp"
+#include "Time/LtsMode.hpp"
+#include "Time/TimeSteppers/Factory.hpp"
+#include "Time/TimeSteppers/ImexTimeStepper.hpp"
 #include "Time/TimeSteppers/LtsError.hpp"
 #include "Time/TimeSteppers/LtsTimeStepper.hpp"
 #include "Time/TimeSteppers/TimeStepper.hpp"
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/PrettyType.hpp"
+#include "Utilities/TMPL.hpp"
 
 namespace Tags {
+namespace {
+// Get a list of the valid time steppers for given options.  This
+// assumes that none of the validity criteria depend on the options
+// passed to the time-stepper constructors.
+template <typename... F>
+std::vector<std::string> list_valid_time_steppers(const F&... checks) {
+  std::vector<std::string> valid_names{};
+  tmpl::for_each<TimeSteppers::time_steppers>(
+      [&]<typename Stepper>(tmpl::type_<Stepper> /*meta*/) {
+        if ((... and checks(Stepper{}))) {
+          valid_names.push_back(pretty_type::name<Stepper>());
+        }
+      });
+  return valid_names;
+}
+
+// Use structs instead of lambdas for these requirements to avoid an nvcc bug.
+struct ConservationRequirement {
+  ::LtsMode lts_mode;
+
+  bool operator()(const ::TimeStepper& local_time_stepper) const {
+    return lts_mode != ::LtsMode::Conservative or
+           dynamic_cast<const LtsTimeStepper*>(&local_time_stepper) != nullptr;
+  }
+};
+
+struct MonotonicityRequirement {
+  bool monotonic_lts;
+  ::LtsMode lts_mode;
+
+  bool operator()(const ::TimeStepper& local_time_stepper) const {
+    return not monotonic_lts or lts_mode == ::LtsMode::Off or
+           local_time_stepper.monotonic();
+  }
+};
+
+struct FactoryRequirement {
+  std::initializer_list<const std::type_info*> factory_types;
+
+  template <typename LocalStepper>
+  bool operator()(const LocalStepper& /*local_time_stepper*/) const {
+    return alg::found_if(factory_types, [](const std::type_info* const info) {
+      return *info == typeid(LocalStepper);
+    });
+  }
+};
+}  // namespace
+
+template <typename StepperType, bool MonotonicLts>
+void ConcreteTimeStepper<StepperType, MonotonicLts>::validate_time_stepper(
+    const StepperType& time_stepper, const ::LtsMode lts_mode,
+    std::initializer_list<const std::type_info*> factory_types) {
+  if (lts_mode == ::LtsMode::Off and
+      variants::holds_alternative<TimeSteppers::Tags::VariableOrder>(
+          time_stepper.order())) {
+    ERROR_NO_TRACE(
+        "Variable-order TimeSteppers are only supported in evolutions with "
+        "local time-stepping.");
+  }
+
+  const ConservationRequirement conservation_requirement{lts_mode};
+  const MonotonicityRequirement monotonicity_requirement{MonotonicLts,
+                                                         lts_mode};
+  // We don't have to check this one because the option parser
+  // enforces it, but we should try not to print invalid values in the
+  // suggestion lists in the errors.
+  const FactoryRequirement factory_requirement{factory_types};
+
+  if (not conservation_requirement(time_stepper)) {
+    ERROR_NO_TRACE(
+        "Chosen TimeStepper does not support conservative local "
+        "time-stepping.  Valid time steppers for your settings: "
+        << list_valid_time_steppers(conservation_requirement,
+                                    monotonicity_requirement,
+                                    factory_requirement));
+  }
+  if (not monotonicity_requirement(time_stepper)) {
+    ERROR_NO_TRACE(
+        "Local time-stepping with control systems requires a monotonic "
+        "TimeStepper to avoid deadlocks.  Valid time steppers for your "
+        "settings: "
+        << list_valid_time_steppers(conservation_requirement,
+                                    monotonicity_requirement,
+                                    factory_requirement));
+  }
+}
+
 const LtsTimeStepper& LtsOrError::get(const ::TimeStepper& stepper) {
   if (const auto* const lts_stepper =
           dynamic_cast<const LtsTimeStepper*>(&stepper)) {
@@ -19,4 +119,18 @@ const LtsTimeStepper& LtsOrError::get(const ::TimeStepper& stepper) {
     return lts_error;
   }
 }
+
+#define STEPPER_TYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+#define MONOTONIC_LTS(data) BOOST_PP_TUPLE_ELEM(1, data)
+
+#define INSTANTIATE(_, data) \
+  template struct ConcreteTimeStepper<STEPPER_TYPE(data), MONOTONIC_LTS(data)>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE,
+                        (::TimeStepper, LtsTimeStepper, ImexTimeStepper),
+                        (true, false))
+
+#undef INSTANTIATE
+#undef MONOTONIC_LTS
+#undef STEPPER_TYPE
 }  // namespace Tags

--- a/src/Time/Tags/TimeStepper.hpp
+++ b/src/Time/Tags/TimeStepper.hpp
@@ -3,45 +3,61 @@
 
 #pragma once
 
+#include <initializer_list>
 #include <memory>
 #include <type_traits>
+#include <typeinfo>
 
 #include "DataStructures/DataBox/Tag.hpp"
-#include "DataStructures/TaggedVariant.hpp"
+#include "Time/LtsMode.hpp"
 #include "Time/OptionTags/TimeStepper.hpp"
 #include "Time/TimeSteppers/LtsTimeStepper.hpp"
 #include "Time/TimeSteppers/TimeStepper.hpp"
-#include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/Serialization/Serialize.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace Tags {
 /// \ingroup DataBoxTagsGroup
 /// \ingroup TimeGroup
-/// The evolution TimeStepper.  The template parameter should be one
-/// of the time stepper base classes, such as `TimeStepper` or
-/// `LtsTimeStepper`.
+/// The evolution TimeStepper.
+///
+/// The \p StepperType template parameter should be one of the time
+/// stepper base classes, such as `TimeStepper` or `LtsTimeStepper`.
+///
+/// If the \p MonotonicLts parameter is true, the chosen stepper will
+/// be required to be monotonic when parsed from options in local
+/// time-stepping mode.  This is generally required for evolutions
+/// with control systems.
 ///
 /// For the contained object to be used, the reference tags listed in
 /// `time_stepper_ref_tags<StepperType>` will also need to be added to
 /// the DataBox.
-template <typename StepperType>
+template <typename StepperType, bool MonotonicLts = false>
 struct ConcreteTimeStepper : db::SimpleTag {
   using type = std::unique_ptr<StepperType>;
+  template <typename Metavars>
   using option_tags = tmpl::list<::OptionTags::TimeStepper<StepperType>>;
 
-  static constexpr bool pass_metavariables = false;
+  static constexpr bool pass_metavariables = true;
+  template <typename Metavars>
   static std::unique_ptr<StepperType> create_from_options(
       const std::unique_ptr<StepperType>& time_stepper) {
-    if (not std::is_same_v<StepperType, LtsTimeStepper> and
-        variants::holds_alternative<TimeSteppers::Tags::VariableOrder>(
-            time_stepper->order())) {
-      ERROR_NO_TRACE(
-          "Variable-order TimeSteppers are only supported in evolutions with "
-          "local time-stepping.");
-    }
+    const ::LtsMode lts_mode = Metavars::local_time_stepping
+                                   ? ::LtsMode::Conservative
+                                   : ::LtsMode::Off;
+    using factory_types =
+        tmpl::at<typename Metavars::factory_creation::factory_classes,
+                 StepperType>;
+    [&]<typename... Derived>(tmpl::list<Derived...> /*meta*/) {
+      validate_time_stepper(*time_stepper, lts_mode, {&typeid(Derived)...});
+    }(factory_types{});
     return serialize_and_deserialize<type>(time_stepper);
   }
+
+ private:
+  static void validate_time_stepper(
+      const StepperType& time_stepper, ::LtsMode lts_mode,
+      std::initializer_list<const std::type_info*> factory_types);
 };
 
 /// \ingroup DataBoxTagsGroup
@@ -65,10 +81,12 @@ struct TimeStepper : db::SimpleTag {
 /// provided interfaces, such as `Tags::TimeStepper<TimeStepper>` and
 /// `Tags::TimeStepper<LtsTimeStepper>`.  Usually added through the
 /// `time_stepper_ref_tags` alias.
-template <typename StepperInterface, typename StepperType>
+template <typename StepperInterface, typename StepperType,
+          typename MonotonicLts>
 struct TimeStepperRef : TimeStepper<StepperInterface>, db::ReferenceTag {
   using base = TimeStepper<StepperInterface>;
-  using argument_tags = tmpl::list<ConcreteTimeStepper<StepperType>>;
+  using argument_tags =
+      tmpl::list<ConcreteTimeStepper<StepperType, MonotonicLts::value>>;
   static const StepperInterface& get(const StepperType& stepper) {
     return stepper;
   }
@@ -86,11 +104,12 @@ struct LtsOrError : TimeStepper<LtsTimeStepper>, db::ReferenceTag {
 
 /// \ingroup TimeGroup
 /// List of immutable tags needed when adding a Tags::ConcreteTimeStepper.
-template <typename StepperType>
+template <typename StepperType, bool MonotonicLts = false>
 using time_stepper_ref_tags = tmpl::append<
     tmpl::transform<
         typename StepperType::provided_time_stepper_interfaces,
-        tmpl::bind<::Tags::TimeStepperRef, tmpl::_1, tmpl::pin<StepperType>>>,
+        tmpl::bind<::Tags::TimeStepperRef, tmpl::_1, tmpl::pin<StepperType>,
+                   std::bool_constant<MonotonicLts>>>,
     tmpl::conditional_t<
         tmpl::list_contains_v<
             typename StepperType::provided_time_stepper_interfaces,

--- a/tests/Unit/Evolution/Initialization/Test_Evolution.cpp
+++ b/tests/Unit/Evolution/Initialization/Test_Evolution.cpp
@@ -121,14 +121,15 @@ void test_gts() {
           Initialization::Tags::InitialSlabSize<false>,
           ::Tags::Next<::Tags::TimeStepId>, ::Tags::TimeStep,
           ::Tags::ChangeSlabSize::SlabSizeGoal>,
-      tmpl::list<Parallel::Tags::FromGlobalCache<
-          ::Tags::ConcreteTimeStepper<TimeStepper>,
-          TestMetavariables<TimeStepper>>>>(
+      tmpl::push_front<time_stepper_ref_tags<TimeStepper>,
+                       Parallel::Tags::FromGlobalCache<
+                           ::Tags::ConcreteTimeStepper<TimeStepper>,
+                           TestMetavariables<TimeStepper>>>>(
       &global_cache, initial_time, initial_dt, initial_slab_size, TimeStepId{},
       TimeDelta{}, std::numeric_limits<double>::signaling_NaN());
 
   db::mutate_apply<Initialization::TimeStepping<TestMetavariables<TimeStepper>,
-                                                TimeStepper>>(
+                                                TimeStepper, false>>(
       make_not_null(&box));
 
   CHECK(db::get<::Tags::Next<::Tags::TimeStepId>>(box) ==
@@ -166,14 +167,16 @@ void test_lts() {
           Initialization::Tags::InitialSlabSize<true>,
           ::Tags::Next<::Tags::TimeStepId>, ::Tags::TimeStep,
           ::Tags::ChangeSlabSize::SlabSizeGoal>,
-      tmpl::list<Parallel::Tags::FromGlobalCache<
-          ::Tags::ConcreteTimeStepper<LtsTimeStepper>,
-          TestMetavariables<LtsTimeStepper>>>>(
+      tmpl::push_front<time_stepper_ref_tags<LtsTimeStepper>,
+                       Parallel::Tags::FromGlobalCache<
+                           ::Tags::ConcreteTimeStepper<LtsTimeStepper>,
+                           TestMetavariables<LtsTimeStepper>>>>(
       &global_cache, initial_time, initial_dt, initial_slab_size, TimeStepId{},
       TimeDelta{}, std::numeric_limits<double>::signaling_NaN());
 
   db::mutate_apply<Initialization::TimeStepping<
-      TestMetavariables<LtsTimeStepper>, LtsTimeStepper>>(make_not_null(&box));
+      TestMetavariables<LtsTimeStepper>, LtsTimeStepper, false>>(
+      make_not_null(&box));
 
   CHECK(db::get<::Tags::Next<::Tags::TimeStepId>>(box) ==
         expected_next_time_step_id);

--- a/tests/Unit/Time/Tags/Test_TimeStepper.cpp
+++ b/tests/Unit/Time/Tags/Test_TimeStepper.cpp
@@ -6,15 +6,18 @@
 #include <optional>
 #include <string>
 #include <type_traits>
+#include <utility>
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
 #include "Time/Tags/TimeStepper.hpp"
-#include "Time/TimeSteppers/AdamsBashforth.hpp"
+#include "Time/TimeSteppers/AdamsMoultonPc.hpp"
 #include "Time/TimeSteppers/LtsError.hpp"
 #include "Time/TimeSteppers/LtsTimeStepper.hpp"
 #include "Time/TimeSteppers/Rk3HesthavenSsp.hpp"
 #include "Time/TimeSteppers/TimeStepper.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -34,15 +37,44 @@ class MoreSpecificFakeTimeStepper : public FakeTimeStepper {
 
 static_assert(std::is_same_v<
               time_stepper_ref_tags<FakeTimeStepper>,
-              tmpl::list<Tags::TimeStepperRef<FakeTimeStepper, FakeTimeStepper>,
+              tmpl::list<Tags::TimeStepperRef<FakeTimeStepper, FakeTimeStepper,
+                                              std::bool_constant<false>>,
+                         Tags::LtsOrError>>);
+static_assert(std::is_same_v<
+              time_stepper_ref_tags<FakeTimeStepper, true>,
+              tmpl::list<Tags::TimeStepperRef<FakeTimeStepper, FakeTimeStepper,
+                                              std::bool_constant<true>>,
                          Tags::LtsOrError>>);
 static_assert(
     std::is_same_v<time_stepper_ref_tags<MoreSpecificFakeTimeStepper>,
                    tmpl::list<Tags::TimeStepperRef<MoreSpecificFakeTimeStepper,
-                                                   MoreSpecificFakeTimeStepper>,
+                                                   MoreSpecificFakeTimeStepper,
+                                                   std::bool_constant<false>>,
                               Tags::TimeStepperRef<FakeTimeStepper,
-                                                   MoreSpecificFakeTimeStepper>,
+                                                   MoreSpecificFakeTimeStepper,
+                                                   std::bool_constant<false>>,
                               Tags::LtsOrError>>);
+
+template <bool LocalTimeStepping>
+struct Metavariables {
+  static constexpr bool local_time_stepping = LocalTimeStepping;
+
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes = tmpl::map<
+        tmpl::pair<TimeStepper, tmpl::list<TimeSteppers::AdamsMoultonPc<false>,
+                                           TimeSteppers::AdamsMoultonPc<true>,
+                                           TimeSteppers::Rk3HesthavenSsp>>>;
+  };
+};
+
+template <bool LocalTimeStepping, bool MonotonicLts, typename Stepper,
+          typename... Args>
+void try_create(Args&&... args) {
+  Tags::ConcreteTimeStepper<TimeStepper, MonotonicLts>::
+      template create_from_options<Metavariables<LocalTimeStepping>>(
+          std::make_unique<Stepper>(std::forward<Args>(args)...));
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Time.Tags.TimeStepper", "[Unit][Time]") {
@@ -50,24 +82,60 @@ SPECTRE_TEST_CASE("Unit.Time.Tags.TimeStepper", "[Unit][Time]") {
       "ConcreteTimeStepper");
   TestHelpers::db::test_simple_tag<Tags::TimeStepper<DummyType>>("TimeStepper");
   TestHelpers::db::test_reference_tag<
-      Tags::TimeStepperRef<DummyType, DummyType>>("TimeStepper");
+      Tags::TimeStepperRef<DummyType, DummyType, std::bool_constant<false>>>(
+      "TimeStepper");
   TestHelpers::db::test_reference_tag<Tags::LtsOrError>("TimeStepper");
 
-  register_classes_with_charm<TimeSteppers::AdamsBashforth>();
-  // Check that these are allowed...
-  Tags::ConcreteTimeStepper<TimeStepper>::create_from_options(
-      std::make_unique<TimeSteppers::AdamsBashforth>(3));
-  Tags::ConcreteTimeStepper<LtsTimeStepper>::create_from_options(
-      std::make_unique<TimeSteppers::AdamsBashforth>(3));
-  Tags::ConcreteTimeStepper<LtsTimeStepper>::create_from_options(
-      std::make_unique<TimeSteppers::AdamsBashforth>(std::nullopt));
-  // ...but this isn't.
+  register_factory_classes_with_charm<Metavariables<false>>();
+
+  // Check that everything is allowed in GTS except variable-order
+  try_create<false, false, TimeSteppers::Rk3HesthavenSsp>();
+  try_create<false, false, TimeSteppers::AdamsMoultonPc<false>>(3);
+  try_create<false, false, TimeSteppers::AdamsMoultonPc<true>>(3);
+  try_create<false, true, TimeSteppers::Rk3HesthavenSsp>();
+  try_create<false, true, TimeSteppers::AdamsMoultonPc<false>>(3);
+  try_create<false, true, TimeSteppers::AdamsMoultonPc<true>>(3);
   CHECK_THROWS_WITH(
-      Tags::ConcreteTimeStepper<TimeStepper>::create_from_options(
-          std::make_unique<TimeSteppers::AdamsBashforth>(std::nullopt)),
+      (try_create<false, false, TimeSteppers::AdamsMoultonPc<false>>(
+          std::nullopt)),
       Catch::Matchers::ContainsSubstring(
           "Variable-order TimeSteppers are only supported in evolutions with "
           "local time-stepping."));
+
+  // Check that LTS rejects non-LTS steppers
+  CHECK_THROWS_WITH(
+      (try_create<true, false, TimeSteppers::Rk3HesthavenSsp>()),
+      Catch::Matchers::ContainsSubstring(
+          "Chosen TimeStepper does not support conservative local "
+          "time-stepping.  Valid time steppers for your settings: "
+          "(AdamsMoultonPc,AdamsMoultonPcMonotonic)"));
+  CHECK_THROWS_WITH(
+      (try_create<true, true, TimeSteppers::Rk3HesthavenSsp>()),
+      Catch::Matchers::ContainsSubstring(
+          "Chosen TimeStepper does not support conservative local "
+          "time-stepping.  Valid time steppers for your settings: "
+          "(AdamsMoultonPcMonotonic)"));
+
+  // Check that LTS rejects non-monotonic steppers if that's required.
+  try_create<true, false, TimeSteppers::AdamsMoultonPc<false>>(3);
+  try_create<true, false, TimeSteppers::AdamsMoultonPc<true>>(3);
+  try_create<true, true, TimeSteppers::AdamsMoultonPc<true>>(3);
+  CHECK_THROWS_WITH(
+      (try_create<true, true, TimeSteppers::AdamsMoultonPc<false>>(3)),
+      Catch::Matchers::ContainsSubstring(
+          "Local time-stepping with control systems requires a monotonic "
+          "TimeStepper to avoid deadlocks.  Valid time steppers for your "
+          "settings: (AdamsMoultonPcMonotonic)"));
+  try_create<true, false, TimeSteppers::AdamsMoultonPc<false>>(std::nullopt);
+  try_create<true, false, TimeSteppers::AdamsMoultonPc<true>>(std::nullopt);
+  try_create<true, true, TimeSteppers::AdamsMoultonPc<true>>(std::nullopt);
+  CHECK_THROWS_WITH(
+      (try_create<true, true, TimeSteppers::AdamsMoultonPc<false>>(
+          std::nullopt)),
+      Catch::Matchers::ContainsSubstring(
+          "Local time-stepping with control systems requires a monotonic "
+          "TimeStepper to avoid deadlocks.  Valid time steppers for your "
+          "settings: (AdamsMoultonPcMonotonic)"));
 
   // Test LtsOrError
   {
@@ -75,7 +143,7 @@ SPECTRE_TEST_CASE("Unit.Time.Tags.TimeStepper", "[Unit][Time]") {
         db::create<db::AddSimpleTags<Tags::ConcreteTimeStepper<TimeStepper>>,
                    time_stepper_ref_tags<TimeStepper>>(
             static_cast<std::unique_ptr<TimeStepper>>(
-                std::make_unique<TimeSteppers::AdamsBashforth>(3)));
+                std::make_unique<TimeSteppers::AdamsMoultonPc<true>>(3)));
     const LtsTimeStepper& lts_stepper =
         db::get<Tags::TimeStepper<LtsTimeStepper>>(box);
     CHECK(dynamic_cast<const TimeSteppers::LtsError*>(&lts_stepper) == nullptr);


### PR DESCRIPTION
Currently everything checked here is redundant with the factory-creation class lists, but with runtime-LTS we won't be able to enforce that at compile-time anymore.

I will also note that while this uses some typeid expressions, they are only used for printing error messages, so if they somehow go wrong somewhere it isn't a big deal.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
