### PR TITLE
NumericalAlgorithms: add SpinWeightedSphericalHarmonics python bindings

### DIFF
--- a/src/NumericalAlgorithms/SpinWeightedSphericalHarmonics/CMakeLists.txt
+++ b/src/NumericalAlgorithms/SpinWeightedSphericalHarmonics/CMakeLists.txt
@@ -44,3 +44,5 @@ target_link_libraries(
   PRIVATE
   Boost::boost
   )
+
+add_subdirectory(Python)

--- a/src/NumericalAlgorithms/SpinWeightedSphericalHarmonics/Python/Bindings.cpp
+++ b/src/NumericalAlgorithms/SpinWeightedSphericalHarmonics/Python/Bindings.cpp
@@ -1,0 +1,18 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include <pybind11/pybind11.h>
+
+#include "NumericalAlgorithms/SpinWeightedSphericalHarmonics/Python/SwshCoefficients.hpp"
+#include "NumericalAlgorithms/SpinWeightedSphericalHarmonics/Python/SwshDerivatives.hpp"
+#include "Utilities/ErrorHandling/SegfaultHandler.hpp"
+
+namespace py = pybind11;
+
+PYBIND11_MODULE(_Pybindings, m) {  // NOLINT
+  enable_segfault_handler();
+  py::module_::import("spectre.DataStructures");
+  py_bindings::bind_goldberg_to_nodal(m);
+  py_bindings::bind_nodal_to_goldberg(m);
+  py_bindings::bind_swsh_derivatives(m);
+}

--- a/src/NumericalAlgorithms/SpinWeightedSphericalHarmonics/Python/CMakeLists.txt
+++ b/src/NumericalAlgorithms/SpinWeightedSphericalHarmonics/Python/CMakeLists.txt
@@ -1,0 +1,37 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "PySpinWeightedSphericalHarmonics")
+
+spectre_python_add_module(
+  SpinWeightedSphericalHarmonics
+  LIBRARY_NAME ${LIBRARY}
+  SOURCES
+  Bindings.cpp
+  SwshCoefficients.cpp
+  SwshDerivatives.cpp
+  PYTHON_FILES
+  __init__.py
+)
+
+spectre_python_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  InterleavedHelpers.hpp
+  SwshCoefficients.hpp
+  SwshDerivatives.hpp
+  )
+
+spectre_python_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  DataStructures
+  SpinWeightedSphericalHarmonics
+  pybind11::module
+)
+
+spectre_python_add_dependencies(
+  ${LIBRARY}
+  PyDataStructures
+  )

--- a/src/NumericalAlgorithms/SpinWeightedSphericalHarmonics/Python/InterleavedHelpers.hpp
+++ b/src/NumericalAlgorithms/SpinWeightedSphericalHarmonics/Python/InterleavedHelpers.hpp
@@ -1,0 +1,42 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <complex>
+#include <cstddef>
+#include <stdexcept>
+#include <string>
+
+#include "DataStructures/DataVector.hpp"
+
+namespace py_bindings::detail {
+// The bindings pass spin-weighted complex data as real, interleaved
+// [re, im, re, im, ...] arrays so they can be constructed directly from numpy.
+
+template <typename ComplexVector>
+ComplexVector interleaved_to_complex(const DataVector& interleaved) {
+  if (interleaved.size() % 2 != 0) {
+    throw std::invalid_argument(
+        "Interleaved [re, im, ...] array must have an even number of "
+        "entries, not " +
+        std::to_string(interleaved.size()) + ".");
+  }
+  ComplexVector result{interleaved.size() / 2};
+  for (size_t i = 0; i < result.size(); ++i) {
+    result[i] =
+        std::complex<double>(interleaved[2 * i], interleaved[2 * i + 1]);
+  }
+  return result;
+}
+
+template <typename ComplexVector>
+DataVector complex_to_interleaved(const ComplexVector& complex_values) {
+  DataVector result{2 * complex_values.size()};
+  for (size_t i = 0; i < complex_values.size(); ++i) {
+    result[2 * i] = complex_values[i].real();
+    result[2 * i + 1] = complex_values[i].imag();
+  }
+  return result;
+}
+}  // namespace py_bindings::detail

--- a/src/NumericalAlgorithms/SpinWeightedSphericalHarmonics/Python/SwshCoefficients.cpp
+++ b/src/NumericalAlgorithms/SpinWeightedSphericalHarmonics/Python/SwshCoefficients.cpp
@@ -1,0 +1,126 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/SpinWeightedSphericalHarmonics/Python/SwshCoefficients.hpp"
+
+#include <cstddef>
+#include <pybind11/pybind11.h>
+#include <stdexcept>
+#include <string>
+
+#include "DataStructures/ComplexDataVector.hpp"
+#include "DataStructures/ComplexModalVector.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/SpinWeighted.hpp"
+#include "NumericalAlgorithms/SpinWeightedSphericalHarmonics/ComplexDataView.hpp"
+#include "NumericalAlgorithms/SpinWeightedSphericalHarmonics/Python/InterleavedHelpers.hpp"
+#include "NumericalAlgorithms/SpinWeightedSphericalHarmonics/SwshCoefficients.hpp"
+#include "NumericalAlgorithms/SpinWeightedSphericalHarmonics/SwshCollocation.hpp"
+#include "NumericalAlgorithms/SpinWeightedSphericalHarmonics/SwshTransform.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+
+namespace py = pybind11;
+
+namespace py_bindings {
+namespace {
+// goldberg modes -> libsharp modes -> nodal collocation values. Operates on a
+// single angular slice (number_of_radial_points == 1).
+template <int Spin>
+DataVector goldberg_to_nodal_for_spin(const DataVector& goldberg_interleaved,
+                                      const size_t l_max) {
+  const size_t expected_size = 2 * square(l_max + 1);
+  if (goldberg_interleaved.size() != expected_size) {
+    throw std::invalid_argument(
+        "The interleaved goldberg modes have " +
+        std::to_string(goldberg_interleaved.size()) +
+        " entries, but l_max = " + std::to_string(l_max) +
+        " requires 2 * (l_max + 1)^2 = " + std::to_string(expected_size) +
+        " entries.");
+  }
+  const SpinWeighted<ComplexModalVector, Spin> goldberg_modes{
+      detail::interleaved_to_complex<ComplexModalVector>(goldberg_interleaved)};
+  const auto libsharp_modes =
+      Spectral::Swsh::goldberg_to_libsharp_modes(goldberg_modes, l_max);
+  const auto nodal_values =
+      Spectral::Swsh::inverse_swsh_transform(l_max, 1, libsharp_modes);
+  return detail::complex_to_interleaved(nodal_values.data());
+}
+
+// nodal collocation values -> libsharp modes -> goldberg modes.
+template <int Spin>
+DataVector nodal_to_goldberg_for_spin(const DataVector& nodal_interleaved,
+                                      const size_t l_max) {
+  const size_t expected_size =
+      2 * Spectral::Swsh::number_of_swsh_collocation_points(l_max);
+  if (nodal_interleaved.size() != expected_size) {
+    throw std::invalid_argument(
+        "The interleaved nodal values have " +
+        std::to_string(nodal_interleaved.size()) +
+        " entries, but l_max = " + std::to_string(l_max) +
+        " requires 2 * (l_max + 1) * (2 * l_max + 1) = " +
+        std::to_string(expected_size) + " entries.");
+  }
+  const SpinWeighted<ComplexDataVector, Spin> nodal_values{
+      detail::interleaved_to_complex<ComplexDataVector>(nodal_interleaved)};
+  const auto libsharp_modes =
+      Spectral::Swsh::swsh_transform(l_max, 1, nodal_values);
+  const auto goldberg_modes =
+      Spectral::Swsh::libsharp_to_goldberg_modes(libsharp_modes, l_max);
+  return detail::complex_to_interleaved(goldberg_modes.data());
+}
+}  // namespace
+
+void bind_goldberg_to_nodal(py::module& m) {  // NOLINT
+  m.def(
+      "goldberg_to_nodal",
+      [](const DataVector& goldberg_modes_interleaved, const size_t l_max,
+         const int spin) {
+        DataVector result{};
+        bool spin_handled = false;
+        const auto try_spin = [&]<int Spin>() {
+          if (spin == Spin) {
+            result = goldberg_to_nodal_for_spin<Spin>(
+                goldberg_modes_interleaved, l_max);
+            spin_handled = true;
+          }
+        };
+        (try_spin.template operator()<-2>(), try_spin.template operator()<-1>(),
+         try_spin.template operator()<0>(), try_spin.template operator()<1>(),
+         try_spin.template operator()<2>());
+        if (not spin_handled) {
+          throw std::invalid_argument(
+              "Spin weight " + std::to_string(spin) +
+              " is outside the supported range [-2, 2].");
+        }
+        return result;
+      },
+      py::arg("goldberg_modes_interleaved"), py::arg("l_max"), py::arg("spin"));
+}
+
+void bind_nodal_to_goldberg(py::module& m) {  // NOLINT
+  m.def(
+      "nodal_to_goldberg",
+      [](const DataVector& nodal_values_interleaved, const size_t l_max,
+         const int spin) {
+        DataVector result{};
+        bool spin_handled = false;
+        const auto try_spin = [&]<int Spin>() {
+          if (spin == Spin) {
+            result = nodal_to_goldberg_for_spin<Spin>(nodal_values_interleaved,
+                                                      l_max);
+            spin_handled = true;
+          }
+        };
+        (try_spin.template operator()<-2>(), try_spin.template operator()<-1>(),
+         try_spin.template operator()<0>(), try_spin.template operator()<1>(),
+         try_spin.template operator()<2>());
+        if (not spin_handled) {
+          throw std::invalid_argument(
+              "Spin weight " + std::to_string(spin) +
+              " is outside the supported range [-2, 2].");
+        }
+        return result;
+      },
+      py::arg("nodal_values_interleaved"), py::arg("l_max"), py::arg("spin"));
+}
+}  // namespace py_bindings

--- a/src/NumericalAlgorithms/SpinWeightedSphericalHarmonics/Python/SwshCoefficients.hpp
+++ b/src/NumericalAlgorithms/SpinWeightedSphericalHarmonics/Python/SwshCoefficients.hpp
@@ -1,0 +1,13 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace py_bindings {
+// NOLINTNEXTLINE(google-runtime-references)
+void bind_goldberg_to_nodal(pybind11::module& m);
+// NOLINTNEXTLINE(google-runtime-references)
+void bind_nodal_to_goldberg(pybind11::module& m);
+}  // namespace py_bindings

--- a/src/NumericalAlgorithms/SpinWeightedSphericalHarmonics/Python/SwshDerivatives.cpp
+++ b/src/NumericalAlgorithms/SpinWeightedSphericalHarmonics/Python/SwshDerivatives.cpp
@@ -1,0 +1,93 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/SpinWeightedSphericalHarmonics/Python/SwshDerivatives.hpp"
+
+#include <cstddef>
+#include <pybind11/pybind11.h>
+#include <stdexcept>
+#include <string>
+
+#include "DataStructures/ComplexDataVector.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/SpinWeighted.hpp"
+#include "NumericalAlgorithms/SpinWeightedSphericalHarmonics/Python/InterleavedHelpers.hpp"
+#include "NumericalAlgorithms/SpinWeightedSphericalHarmonics/SwshCollocation.hpp"
+#include "NumericalAlgorithms/SpinWeightedSphericalHarmonics/SwshDerivatives.hpp"
+
+namespace py = pybind11;
+
+namespace py_bindings {
+namespace {
+// Apply a single spin-weighted angular derivative to nodal values supplied as a
+// real, interleaved [re, im, re, im, ...] array (matching the goldberg_to_nodal
+// and nodal_to_goldberg bindings), returning the result in the same layout.
+template <typename DerivativeKind, int Spin>
+DataVector apply_swsh_derivative(const DataVector& nodal_values_interleaved,
+                                 const size_t l_max,
+                                 const size_t number_of_radial_points) {
+  const size_t expected_size =
+      2 * Spectral::Swsh::number_of_swsh_collocation_points(l_max) *
+      number_of_radial_points;
+  if (nodal_values_interleaved.size() != expected_size) {
+    throw std::invalid_argument(
+        "The interleaved nodal values have " +
+        std::to_string(nodal_values_interleaved.size()) +
+        " entries, but l_max = " + std::to_string(l_max) + " with " +
+        std::to_string(number_of_radial_points) +
+        " radial point(s) requires 2 * (l_max + 1) * (2 * l_max + 1) * "
+        "number_of_radial_points = " +
+        std::to_string(expected_size) + " entries.");
+  }
+  const SpinWeighted<ComplexDataVector, Spin> input{
+      detail::interleaved_to_complex<ComplexDataVector>(
+          nodal_values_interleaved)};
+  const auto output = Spectral::Swsh::angular_derivative<
+      DerivativeKind, Spectral::Swsh::ComplexRepresentation::Interleaved, Spin>(
+      l_max, number_of_radial_points, input);
+  return detail::complex_to_interleaved(output.data());
+}
+
+// Bind one derivative operator over the spin weights for which it is
+// instantiated in the core library (see SwshDerivatives.cpp).
+template <typename DerivativeKind, int... Spins>
+void bind_derivative_kind(py::module& m, const std::string& name) {
+  m.def(
+      name.c_str(),
+      [](const DataVector& nodal_values, const size_t l_max,
+         const size_t number_of_radial_points, const int spin) {
+        DataVector result{};
+        bool spin_handled = false;
+        (
+            [&] {
+              if (spin == Spins) {
+                result = apply_swsh_derivative<DerivativeKind, Spins>(
+                    nodal_values, l_max, number_of_radial_points);
+                spin_handled = true;
+              }
+            }(),
+            ...);
+        if (not spin_handled) {
+          throw std::invalid_argument(
+              "The requested spin weight " + std::to_string(spin) +
+              " is not supported for this derivative operator.");
+        }
+        return result;
+      },
+      py::arg("nodal_values"), py::arg("l_max"),
+      py::arg("number_of_radial_points"), py::arg("spin"));
+}
+}  // namespace
+
+void bind_swsh_derivatives(py::module& m) {  // NOLINT
+  bind_derivative_kind<Spectral::Swsh::Tags::Eth, -2, -1, 0, 1, 2>(m, "eth");
+  bind_derivative_kind<Spectral::Swsh::Tags::Ethbar, -1, 0, 1, 2>(m, "ethbar");
+  bind_derivative_kind<Spectral::Swsh::Tags::EthEth, -2, -1, 0>(m, "eth_eth");
+  bind_derivative_kind<Spectral::Swsh::Tags::EthbarEthbar, 0, 1, 2>(
+      m, "ethbar_ethbar");
+  bind_derivative_kind<Spectral::Swsh::Tags::EthEthbar, -2, -1, 0, 1, 2>(
+      m, "eth_ethbar");
+  bind_derivative_kind<Spectral::Swsh::Tags::EthbarEth, -2, -1, 0, 1, 2>(
+      m, "ethbar_eth");
+}
+}  // namespace py_bindings

--- a/src/NumericalAlgorithms/SpinWeightedSphericalHarmonics/Python/SwshDerivatives.hpp
+++ b/src/NumericalAlgorithms/SpinWeightedSphericalHarmonics/Python/SwshDerivatives.hpp
@@ -1,0 +1,11 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace py_bindings {
+// NOLINTNEXTLINE(google-runtime-references)
+void bind_swsh_derivatives(pybind11::module& m);
+}  // namespace py_bindings

--- a/src/NumericalAlgorithms/SpinWeightedSphericalHarmonics/Python/__init__.py
+++ b/src/NumericalAlgorithms/SpinWeightedSphericalHarmonics/Python/__init__.py
@@ -1,0 +1,4 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+from ._Pybindings import *

--- a/tests/Unit/NumericalAlgorithms/SpinWeightedSphericalHarmonics/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/SpinWeightedSphericalHarmonics/CMakeLists.txt
@@ -1,6 +1,8 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+add_subdirectory(Python)
+
 set(LIBRARY "Test_SpinWeightedSphericalHarmonics")
 
 set(LIBRARY_SOURCES

--- a/tests/Unit/NumericalAlgorithms/SpinWeightedSphericalHarmonics/Python/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/SpinWeightedSphericalHarmonics/Python/CMakeLists.txt
@@ -1,0 +1,8 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_add_python_bindings_test(
+  "Unit.NumericalAlgorithms.SpinWeightedSphericalHarmonics.Python.Swsh"
+  Test_Swsh.py
+  "Unit;NumericalAlgorithms;SpinWeightedSphericalHarmonics;Python"
+  PySpinWeightedSphericalHarmonics)

--- a/tests/Unit/NumericalAlgorithms/SpinWeightedSphericalHarmonics/Python/Test_Swsh.py
+++ b/tests/Unit/NumericalAlgorithms/SpinWeightedSphericalHarmonics/Python/Test_Swsh.py
@@ -1,0 +1,88 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+
+from spectre.SpinWeightedSphericalHarmonics import (
+    eth,
+    ethbar,
+    ethbar_eth,
+    goldberg_to_nodal,
+    nodal_to_goldberg,
+)
+
+
+def to_interleaved(complex_array):
+    """Pack a complex array into the real [re, im, re, im, ...] layout the
+    bindings consume."""
+    interleaved = np.zeros(2 * len(complex_array))
+    interleaved[0::2] = np.real(complex_array)
+    interleaved[1::2] = np.imag(complex_array)
+    return interleaved
+
+
+def from_interleaved(interleaved):
+    """Inverse of `to_interleaved`."""
+    return np.asarray(interleaved)[0::2] + 1j * np.asarray(interleaved)[1::2]
+
+
+class TestSwsh(unittest.TestCase):
+    def setUp(self):
+        self.l_max = 8
+        self.rng = np.random.default_rng(20260626)
+
+    def random_goldberg_modes(self):
+        # Goldberg coefficients are indexed by (l, m) as l**2 + l + m, for
+        # l = 0..l_max, so there are (l_max + 1)**2 complex modes.
+        num_modes = (self.l_max + 1) ** 2
+        return self.rng.uniform(-1.0, 1.0, num_modes) + 1j * self.rng.uniform(
+            -1.0, 1.0, num_modes
+        )
+
+    def test_goldberg_nodal_round_trip(self):
+        # nodal_to_goldberg is the inverse of goldberg_to_nodal, so a round trip
+        # of band-limited spin-0 modes recovers the original coefficients.
+        modes = self.random_goldberg_modes()
+        nodal = goldberg_to_nodal(to_interleaved(modes), self.l_max, 0)
+        recovered = from_interleaved(nodal_to_goldberg(nodal, self.l_max, 0))
+        npt.assert_allclose(recovered, modes, rtol=1e-12, atol=1e-12)
+
+    def test_ethbar_eth_matches_composition(self):
+        # The composite operator ethbar_eth must equal applying eth and then
+        # ethbar. This checks the individual eth and ethbar bindings against the
+        # composite, independent of any normalization convention.
+        modes = self.random_goldberg_modes()
+        nodal = goldberg_to_nodal(to_interleaved(modes), self.l_max, 0)
+        # eth raises spin 0 -> 1, ethbar lowers spin 1 -> 0
+        eth_nodal = eth(nodal, self.l_max, 1, 0)
+        composed = ethbar(eth_nodal, self.l_max, 1, 1)
+        direct = ethbar_eth(nodal, self.l_max, 1, 0)
+        npt.assert_allclose(
+            from_interleaved(composed),
+            from_interleaved(direct),
+            rtol=1e-11,
+            atol=1e-11,
+        )
+
+    def test_ethbar_eth_eigenvalue(self):
+        # ethbar_eth is the spin-0 angular Laplacian: it multiplies the (l, m)
+        # Goldberg coefficient by -l(l+1). Because it preserves spin weight, the
+        # eigenvalue is identical in the Goldberg and libsharp representations.
+        modes = self.random_goldberg_modes()
+        nodal = goldberg_to_nodal(to_interleaved(modes), self.l_max, 0)
+        result_modes = from_interleaved(
+            nodal_to_goldberg(
+                ethbar_eth(nodal, self.l_max, 1, 0), self.l_max, 0
+            )
+        )
+        mode_index = np.arange((self.l_max + 1) ** 2)
+        ell = np.floor(np.sqrt(mode_index)).astype(int)
+        expected = -ell * (ell + 1) * modes
+        npt.assert_allclose(result_modes, expected, rtol=1e-10, atol=1e-10)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Adds python bindings for the spin-weighted spherical harmonic transforms and angular derivatives:
  - goldberg_to_nodal / nodal_to_goldberg, converting between Goldberg mode coefficients and nodal collocation values (chaining the existing goldberg<->libsharp mode conversions with the libsharp swsh transforms).
  - eth, ethbar, eth_eth, ethbar_ethbar, eth_ethbar, ethbar_eth angular derivatives, each bound over the spin weights for which the core library instantiates them.

Spin-weighted complex data crosses the binding boundary as real, interleaved [re, im, ...] arrays so it constructs directly from numpy.

Test_Swsh.py checks a goldberg<->nodal round trip, that ethbar(eth(f)) matches the composite ethbar_eth operator, and that ethbar_eth reproduces the spin-0 angular-Laplacian eigenvalue -l(l+1).

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
