### PR TITLE
CCE: add the first two Newman-Penrose Bianchi identity constraints

### DIFF
--- a/src/Evolution/Systems/Cce/NewmanPenrose.cpp
+++ b/src/Evolution/Systems/Cce/NewmanPenrose.cpp
@@ -370,6 +370,88 @@ void weyl_psi2_impl(
            + ( conj(np_alpha) - np_beta - conj(np_pi) ) * np_pi
            - np_sigma * np_lambda;
 }
+
+// Definition of the NP derivative terms in the Bianchi identities
+
+void newman_penrose_d_psi1_impl(
+    const gsl::not_null<SpinWeighted<ComplexDataVector, 1>*> np_d_psi_1,
+    const SpinWeighted<ComplexDataVector, 0>& bondi_r,
+    const SpinWeighted<ComplexDataVector, 1>& dy_psi_1,
+    const SpinWeighted<ComplexDataVector, 0>& one_minus_y) {
+  *np_d_psi_1 =
+      one_minus_y * one_minus_y / (2. * sqrt(2.) * bondi_r) * dy_psi_1;
+}
+
+void newman_penrose_deltabar_psi0_impl(
+    const gsl::not_null<SpinWeighted<ComplexDataVector, 1>*> np_deltabar_psi_0,
+    const SpinWeighted<ComplexDataVector, +2>& bondi_j,
+    const SpinWeighted<ComplexDataVector, 0>& bondi_k,
+    const SpinWeighted<ComplexDataVector, 0>& bondi_r,
+    const SpinWeighted<ComplexDataVector, 3>& eth_psi_0,
+    const SpinWeighted<ComplexDataVector, 1>& ethbar_psi_0,
+    const SpinWeighted<ComplexDataVector, 0>& one_minus_y) {
+  const auto sqrt_one_plus_k = sqrt(1. + bondi_k);
+  const auto prefactor = one_minus_y / (2. * sqrt(2.) * bondi_r);
+  *np_deltabar_psi_0 =
+      -prefactor *
+      ((1. / sqrt(2.)) * ethbar_psi_0 * sqrt_one_plus_k -
+       (1. / sqrt(2.)) * eth_psi_0 * conj(bondi_j) / sqrt_one_plus_k);
+}
+
+void bianchi_constraint_d_psi1_impl(
+    const gsl::not_null<SpinWeighted<ComplexDataVector, 1>*> constraint_d_psi1,
+    const SpinWeighted<ComplexDataVector, -1>& np_alpha,
+    const SpinWeighted<ComplexDataVector, 0>& np_epsilon,
+    const SpinWeighted<ComplexDataVector, 0>& np_rho,
+    const SpinWeighted<ComplexDataVector, -1>& np_pi,
+    const SpinWeighted<ComplexDataVector, 2>& psi_0,
+    const SpinWeighted<ComplexDataVector, 1>& psi_1,
+    const SpinWeighted<ComplexDataVector, 1>& np_d_psi_1,
+    const SpinWeighted<ComplexDataVector, 1>& np_deltabar_psi_0) {
+  *constraint_d_psi1 = np_d_psi_1 - np_deltabar_psi_0 +
+                       (4. * np_alpha - np_pi) * psi_0 -
+                       2. * (2. * np_rho + np_epsilon) * psi_1;
+}
+
+void newman_penrose_d_psi2_impl(
+    const gsl::not_null<SpinWeighted<ComplexDataVector, 0>*> np_d_psi_2,
+    const SpinWeighted<ComplexDataVector, 0>& bondi_r,
+    const SpinWeighted<ComplexDataVector, 0>& dy_psi_2,
+    const SpinWeighted<ComplexDataVector, 0>& one_minus_y) {
+  *np_d_psi_2 =
+      one_minus_y * one_minus_y / (2. * sqrt(2.) * bondi_r) * dy_psi_2;
+}
+
+void newman_penrose_deltabar_psi1_impl(
+    const gsl::not_null<SpinWeighted<ComplexDataVector, 0>*> np_deltabar_psi_1,
+    const SpinWeighted<ComplexDataVector, +2>& bondi_j,
+    const SpinWeighted<ComplexDataVector, 0>& bondi_k,
+    const SpinWeighted<ComplexDataVector, 0>& bondi_r,
+    const SpinWeighted<ComplexDataVector, 2>& eth_psi_1,
+    const SpinWeighted<ComplexDataVector, 0>& ethbar_psi_1,
+    const SpinWeighted<ComplexDataVector, 0>& one_minus_y) {
+  const auto sqrt_one_plus_k = sqrt(1. + bondi_k);
+  const auto prefactor = one_minus_y / (2. * sqrt(2.) * bondi_r);
+  *np_deltabar_psi_1 =
+      -prefactor *
+      ((1. / sqrt(2.)) * ethbar_psi_1 * sqrt_one_plus_k -
+       (1. / sqrt(2.)) * eth_psi_1 * conj(bondi_j) / sqrt_one_plus_k);
+}
+
+void bianchi_constraint_d_psi2_impl(
+    const gsl::not_null<SpinWeighted<ComplexDataVector, 0>*> constraint_d_psi2,
+    const SpinWeighted<ComplexDataVector, -1>& np_alpha,
+    const SpinWeighted<ComplexDataVector, -2>& np_lambda,
+    const SpinWeighted<ComplexDataVector, 0>& np_rho,
+    const SpinWeighted<ComplexDataVector, -1>& np_pi,
+    const SpinWeighted<ComplexDataVector, 2>& psi_0,
+    const SpinWeighted<ComplexDataVector, 1>& psi_1,
+    const SpinWeighted<ComplexDataVector, 0>& psi_2,
+    const SpinWeighted<ComplexDataVector, 0>& np_d_psi_2,
+    const SpinWeighted<ComplexDataVector, 0>& np_deltabar_psi_1) {
+  *constraint_d_psi2 = np_d_psi_2 + np_lambda * psi_0 - np_deltabar_psi_1 -
+                       2. * (np_pi - np_alpha) * psi_1 - 3. * np_rho * psi_2;
+}
 }  // namespace
 
 
@@ -533,6 +615,87 @@ void newman_penrose_lambda(
       get(eth_j), get(ethbar_j), get(bondi_k), get(bondi_h),
       get(bondi_r), get(bondi_u), get(eth_u), get(ethbar_u),
       get(bondi_w), get(exp_2_beta), get(one_minus_y));
+}
+
+void newman_penrose_d_psi1(
+    const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 1>>*> np_d_psi_1,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& bondi_r,
+    const Scalar<SpinWeighted<ComplexDataVector, 1>>& dy_psi_1,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& one_minus_y) {
+  newman_penrose_d_psi1_impl(make_not_null(&get(*np_d_psi_1)), get(bondi_r),
+                             get(dy_psi_1), get(one_minus_y));
+}
+
+void newman_penrose_deltabar_psi0(
+    const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 1>>*>
+        np_deltabar_psi_0,
+    const Scalar<SpinWeighted<ComplexDataVector, +2>>& bondi_j,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& bondi_k,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& bondi_r,
+    const Scalar<SpinWeighted<ComplexDataVector, 3>>& eth_psi_0,
+    const Scalar<SpinWeighted<ComplexDataVector, 1>>& ethbar_psi_0,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& one_minus_y) {
+  newman_penrose_deltabar_psi0_impl(
+      make_not_null(&get(*np_deltabar_psi_0)), get(bondi_j), get(bondi_k),
+      get(bondi_r), get(eth_psi_0), get(ethbar_psi_0), get(one_minus_y));
+}
+
+void bianchi_constraint_d_psi1(
+    const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 1>>*>
+        constraint_d_psi1,
+    const Scalar<SpinWeighted<ComplexDataVector, -1>>& np_alpha,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& np_epsilon,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& np_rho,
+    const Scalar<SpinWeighted<ComplexDataVector, -1>>& np_pi,
+    const Scalar<SpinWeighted<ComplexDataVector, 2>>& psi_0,
+    const Scalar<SpinWeighted<ComplexDataVector, 1>>& psi_1,
+    const Scalar<SpinWeighted<ComplexDataVector, 1>>& np_d_psi_1,
+    const Scalar<SpinWeighted<ComplexDataVector, 1>>& np_deltabar_psi_0) {
+  bianchi_constraint_d_psi1_impl(make_not_null(&get(*constraint_d_psi1)),
+                                 get(np_alpha), get(np_epsilon), get(np_rho),
+                                 get(np_pi), get(psi_0), get(psi_1),
+                                 get(np_d_psi_1), get(np_deltabar_psi_0));
+}
+
+void newman_penrose_d_psi2(
+    const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*> np_d_psi_2,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& bondi_r,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& dy_psi_2,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& one_minus_y) {
+  newman_penrose_d_psi2_impl(make_not_null(&get(*np_d_psi_2)), get(bondi_r),
+                             get(dy_psi_2), get(one_minus_y));
+}
+
+void newman_penrose_deltabar_psi1(
+    const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*>
+        np_deltabar_psi_1,
+    const Scalar<SpinWeighted<ComplexDataVector, +2>>& bondi_j,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& bondi_k,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& bondi_r,
+    const Scalar<SpinWeighted<ComplexDataVector, 2>>& eth_psi_1,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& ethbar_psi_1,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& one_minus_y) {
+  newman_penrose_deltabar_psi1_impl(
+      make_not_null(&get(*np_deltabar_psi_1)), get(bondi_j), get(bondi_k),
+      get(bondi_r), get(eth_psi_1), get(ethbar_psi_1), get(one_minus_y));
+}
+
+void bianchi_constraint_d_psi2(
+    const gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*>
+        constraint_d_psi2,
+    const Scalar<SpinWeighted<ComplexDataVector, -1>>& np_alpha,
+    const Scalar<SpinWeighted<ComplexDataVector, -2>>& np_lambda,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& np_rho,
+    const Scalar<SpinWeighted<ComplexDataVector, -1>>& np_pi,
+    const Scalar<SpinWeighted<ComplexDataVector, 2>>& psi_0,
+    const Scalar<SpinWeighted<ComplexDataVector, 1>>& psi_1,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& psi_2,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& np_d_psi_2,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& np_deltabar_psi_1) {
+  bianchi_constraint_d_psi2_impl(make_not_null(&get(*constraint_d_psi2)),
+                                 get(np_alpha), get(np_lambda), get(np_rho),
+                                 get(np_pi), get(psi_0), get(psi_1), get(psi_2),
+                                 get(np_d_psi_2), get(np_deltabar_psi_1));
 }
 
 void VolumeWeyl<Tags::Psi0>::apply(

--- a/src/Evolution/Systems/Cce/NewmanPenrose.hpp
+++ b/src/Evolution/Systems/Cce/NewmanPenrose.hpp
@@ -398,6 +398,89 @@ void newman_penrose_lambda(
     const Scalar<SpinWeighted<ComplexDataVector, 0>>& exp_2_beta,
     const Scalar<SpinWeighted<ComplexDataVector, 0>>& one_minus_y);
 
+/*!
+ * \brief Compute the NP $D\Psi_1$ derivative term of the first Bianchi
+ * identity.
+ */
+void newman_penrose_d_psi1(
+    gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 1>>*> np_d_psi_1,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& bondi_r,
+    const Scalar<SpinWeighted<ComplexDataVector, 1>>& dy_psi_1,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& one_minus_y);
+
+/*!
+ * \brief Compute the NP derivative $\bar{\delta}\Psi_0$ of the first Bianchi
+ * identity.
+ */
+void newman_penrose_deltabar_psi0(
+    gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 1>>*>
+        np_deltabar_psi_0,
+    const Scalar<SpinWeighted<ComplexDataVector, +2>>& bondi_j,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& bondi_k,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& bondi_r,
+    const Scalar<SpinWeighted<ComplexDataVector, 3>>& eth_psi_0,
+    const Scalar<SpinWeighted<ComplexDataVector, 1>>& ethbar_psi_0,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& one_minus_y);
+
+/*!
+ * \brief Compute the first NP Bianchi identity violation
+ * \f$D\Psi_1 - \bar{\delta}\Psi_0 + (4\alpha - \pi)\Psi_0
+ * - 2(2\rho + \epsilon)\Psi_1\f$ (spin weight 1).
+ */
+void bianchi_constraint_d_psi1(
+    gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 1>>*>
+        constraint_d_psi1,
+    const Scalar<SpinWeighted<ComplexDataVector, -1>>& np_alpha,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& np_epsilon,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& np_rho,
+    const Scalar<SpinWeighted<ComplexDataVector, -1>>& np_pi,
+    const Scalar<SpinWeighted<ComplexDataVector, 2>>& psi_0,
+    const Scalar<SpinWeighted<ComplexDataVector, 1>>& psi_1,
+    const Scalar<SpinWeighted<ComplexDataVector, 1>>& np_d_psi_1,
+    const Scalar<SpinWeighted<ComplexDataVector, 1>>& np_deltabar_psi_0);
+
+/*!
+ * \brief Compute the NP $D\Psi_2$ derivative term of the second Bianchi
+ * identity.
+ */
+void newman_penrose_d_psi2(
+    gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*> np_d_psi_2,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& bondi_r,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& dy_psi_2,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& one_minus_y);
+
+/*!
+ * \brief Compute the NP derivative $\bar{\delta}\Psi_1$ of the second Bianchi
+ * identity.
+ */
+void newman_penrose_deltabar_psi1(
+    gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*>
+        np_deltabar_psi_1,
+    const Scalar<SpinWeighted<ComplexDataVector, +2>>& bondi_j,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& bondi_k,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& bondi_r,
+    const Scalar<SpinWeighted<ComplexDataVector, 2>>& eth_psi_1,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& ethbar_psi_1,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& one_minus_y);
+
+/*!
+ * \brief Compute the second NP Bianchi identity violation
+ * \f$D\Psi_2 + \lambda\Psi_0 - \bar{\delta}\Psi_1 - 2(\pi - \alpha)\Psi_1
+ * - 3\rho\Psi_2\f$ (spin weight 0).
+ */
+void bianchi_constraint_d_psi2(
+    gsl::not_null<Scalar<SpinWeighted<ComplexDataVector, 0>>*>
+        constraint_d_psi2,
+    const Scalar<SpinWeighted<ComplexDataVector, -1>>& np_alpha,
+    const Scalar<SpinWeighted<ComplexDataVector, -2>>& np_lambda,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& np_rho,
+    const Scalar<SpinWeighted<ComplexDataVector, -1>>& np_pi,
+    const Scalar<SpinWeighted<ComplexDataVector, 2>>& psi_0,
+    const Scalar<SpinWeighted<ComplexDataVector, 1>>& psi_1,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& psi_2,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& np_d_psi_2,
+    const Scalar<SpinWeighted<ComplexDataVector, 0>>& np_deltabar_psi_1);
+
 namespace Tags {
 /*!
  * \brief Compute tag for $\alpha^{SW}$ in the volume.

--- a/tests/Unit/Evolution/Systems/Cce/NewmanPenrose.py
+++ b/tests/Unit/Evolution/Systems/Cce/NewmanPenrose.py
@@ -362,3 +362,79 @@ def psi2(
         + (np.conj(np_alpha) - np_beta - np.conj(np_pi)) * np_pi
         - np_sigma * np_lambda
     )
+
+
+def newman_penrose_d_psi1(bondi_r, dy_psi_1, one_minus_y):
+    return dy_psi_1 * one_minus_y**2 / (2 * np.sqrt(2) * bondi_r)
+
+
+def newman_penrose_deltabar_psi0(
+    bondi_j, bondi_k, bondi_r, eth_psi_0, ethbar_psi_0, one_minus_y
+):
+    sqrt_one_plus_k = np.sqrt(1.0 + bondi_k)
+
+    return (
+        -one_minus_y
+        * (
+            sqrt_one_plus_k * ethbar_psi_0 / np.sqrt(2)
+            - np.conj(bondi_j) * eth_psi_0 / (np.sqrt(2) * sqrt_one_plus_k)
+        )
+        / (2 * np.sqrt(2) * bondi_r)
+    )
+
+
+def bianchi_constraint_d_psi1(
+    np_alpha,
+    np_epsilon,
+    np_rho,
+    np_pi,
+    psi_0,
+    psi_1,
+    np_d_psi_1,
+    np_deltabar_psi_0,
+):
+    return (
+        np_d_psi_1
+        - np_deltabar_psi_0
+        + (4 * np_alpha - np_pi) * psi_0
+        - 2 * (2 * np_rho + np_epsilon) * psi_1
+    )
+
+
+def newman_penrose_d_psi2(bondi_r, dy_psi_2, one_minus_y):
+    return dy_psi_2 * one_minus_y**2 / (2 * np.sqrt(2) * bondi_r)
+
+
+def newman_penrose_deltabar_psi1(
+    bondi_j, bondi_k, bondi_r, eth_psi_1, ethbar_psi_1, one_minus_y
+):
+    sqrt_one_plus_k = np.sqrt(1.0 + bondi_k)
+
+    return (
+        -one_minus_y
+        * (
+            sqrt_one_plus_k * ethbar_psi_1 / np.sqrt(2)
+            - np.conj(bondi_j) * eth_psi_1 / (np.sqrt(2) * sqrt_one_plus_k)
+        )
+        / (2 * np.sqrt(2) * bondi_r)
+    )
+
+
+def bianchi_constraint_d_psi2(
+    np_alpha,
+    np_lambda,
+    np_rho,
+    np_pi,
+    psi_0,
+    psi_1,
+    psi_2,
+    np_d_psi_2,
+    np_deltabar_psi_1,
+):
+    return (
+        np_d_psi_2
+        + np_lambda * psi_0
+        - np_deltabar_psi_1
+        - 2 * (np_pi - np_alpha) * psi_1
+        - 3 * np_rho * psi_2
+    )

--- a/tests/Unit/Evolution/Systems/Cce/Test_NewmanPenrose.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_NewmanPenrose.cpp
@@ -79,6 +79,32 @@ void pypp_test_volume_weyl() {
                                     "NewmanPenrose", {"psi2"}, {{{1.0, 5.0}}},
                                     DataVector{num_pts});
 }
+
+void pypp_test_volume_np_bianchi() {
+  const pypp::SetupLocalPythonEnvironment local_python_env{
+      "Evolution/Systems/Cce/"};
+
+  const size_t num_pts = 5;
+
+  pypp::check_with_random_values<1>(&newman_penrose_d_psi1, "NewmanPenrose",
+                                    {"newman_penrose_d_psi1"}, {{{1.0, 5.0}}},
+                                    DataVector{num_pts});
+  pypp::check_with_random_values<1>(
+      &newman_penrose_deltabar_psi0, "NewmanPenrose",
+      {"newman_penrose_deltabar_psi0"}, {{{1.0, 5.0}}}, DataVector{num_pts});
+  pypp::check_with_random_values<1>(&bianchi_constraint_d_psi1, "NewmanPenrose",
+                                    {"bianchi_constraint_d_psi1"},
+                                    {{{1.0, 5.0}}}, DataVector{num_pts});
+  pypp::check_with_random_values<1>(&newman_penrose_d_psi2, "NewmanPenrose",
+                                    {"newman_penrose_d_psi2"}, {{{1.0, 5.0}}},
+                                    DataVector{num_pts});
+  pypp::check_with_random_values<1>(
+      &newman_penrose_deltabar_psi1, "NewmanPenrose",
+      {"newman_penrose_deltabar_psi1"}, {{{1.0, 5.0}}}, DataVector{num_pts});
+  pypp::check_with_random_values<1>(&bianchi_constraint_d_psi2, "NewmanPenrose",
+                                    {"bianchi_constraint_d_psi2"},
+                                    {{{1.0, 5.0}}}, DataVector{num_pts});
+}
 }  // namespace
 
 namespace {
@@ -177,6 +203,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.NewmanPenrose", "[Unit][Cce]") {
   pypp_test_volume_np_spin_coefficients();
 
   pypp_test_volume_weyl();
+
+  pypp_test_volume_np_bianchi();
 
   MAKE_GENERATOR(gen);
   compute_psi0_of_bh_on_wt(make_not_null(&gen));


### PR DESCRIPTION
Adds the Newman-Penrose Bianchi identity violations
  D Psi1 - deltabar Psi0 + (4 alpha - pi) Psi0 - 2 (2 rho + epsilon) Psi1
  D Psi2 + lambda Psi0 - deltabar Psi1 - 2 (pi - alpha) Psi1 - 3 rho Psi2
to NewmanPenrose, along with the D Psi1, deltabar Psi0, D Psi2, and deltabar Psi1 derivative terms they need. The NP spin coefficients and the Weyl scalars Psi0/Psi1/Psi2 they build on are already present.

Test_NewmanPenrose.cpp verifies each new function against a numpy implementation in NewmanPenrose.py with pypp::check_with_random_values.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
