### PR TITLE
Add unopinionated AGENTS.md

### DIFF
--- a/.claude/rules/InputFiles.md
+++ b/.claude/rules/InputFiles.md
@@ -1,0 +1,15 @@
+---
+triggers:
+  - glob: "**/*.yaml"
+---
+
+# Running executables from input files
+- Input files specify runtime options for executables in YAML. The corresponding
+  executable is named near the top with `Executable: <executable_name>`. Build
+  that target, then run it with
+  `<build_directory>/bin/<executable_name> --input-file <input_file.yaml>`. Add
+  `+p <number_of_cores>` to run in parallel.
+- Run executables in a temporary run directory inside the build directory to
+  avoid stale output files.
+- Pipe output to `spectre.log` for easier debugging:
+  `<executable> --input-file <input_file.yaml> | tee spectre.log`.

--- a/.gitignore
+++ b/.gitignore
@@ -76,10 +76,7 @@ tags
 !Tags/
 
 # AI/LLM Agent/CLI tools
-AGENTS.md
-
+AGENTS.local.md
 .aider*
-
-CLAUDE.md
 .claude/settings.local.json
 CLAUDE.local.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,41 @@
+# Project structure
+- Source code is in `src/`, tests in `tests/`, documentation in `docs/`.
+- The main branch is `develop`.
+
+# Configure and build
+- Use the CMake build system. Place build directories in the repo named `build*`
+  (git-ignored).
+- Prefer CMake presets listed in CMakePresets.json and CMakeUserPresets.json.
+  Use `debug` for most work; use `release-debug` for performance-sensitive work
+  (optimized but with sanity checks). Build directories are named
+  `build-<preset_name>`. If presets don't exist, suggest creating
+  CMakeUserPresets.json following support/Environments/, or fall back to
+  `-D CMAKE_BUILD_TYPE=Debug`. Prefer clang over gcc if both are available. More
+  options in docs/Installation/BuildSystem.md.
+- In a git worktree, symlink the git-ignored CMakeUserPresets.json from the main
+  checkout and pass `-D USE_GIT_HOOKS=OFF` to CMake. Suggest adding a
+  `post-checkout` git hook in `.git/hooks` to create the symlink automatically.
+- Never build `all`. Build only the targets you need (find them in the closest
+  CMakeLists.txt).
+
+# Testing
+- Run tests with `ctest --output-on-failure`.
+- Run only tests affected by changes for fast feedback. To catch regressions,
+  build `unit-tests` and run `ctest -L unit -j <number_of_cores>` (set
+  number_of_cores from AGENTS.local.md, otherwise use 2).
+
+# Commit & PR guidelines
+- Use short, imperative subject lines and reference issue numbers when
+  available. PRs summarize motivation, user-visible effects, and testing
+  performed.
+
+# Running executables and scripts
+- Input files are YAML (see how to run executables in the InputFiles rule).
+- `<build_directory>/bin/spectre` is a self-documenting CLI: use `--help` to
+  list subcommands and options. Build the `cli` target to enable it.
+- Run Python with `<build_directory>/bin/python-spectre`, never plain `python`.
+  If import fails, build `all-pybindings`. The `spectre` package mirrors the C++
+  tree (`src/<Path>/Python/` -> `spectre.<Path>`).
+
+# Additional instructions
+- Always prefer personal overrides: @AGENTS.local.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/cmake/SetupFormaline.cmake
+++ b/cmake/SetupFormaline.cmake
@@ -16,8 +16,10 @@ set(SPECTRE_FORMALINE_LOCATIONS
   .dockerignore
   .github
   .gitignore
+  AGENTS.md
   citation.bib
   CITATION.cff
+  CLAUDE.md
   cmake
   CMakeLists.txt
   containers

--- a/tools/FileTestDefs.sh
+++ b/tools/FileTestDefs.sh
@@ -440,8 +440,10 @@ license() {
               '.svg' \
               '.patch' \
               '.xmf' \
+              'AGENTS.md' \
               'LICENSE' \
               'citation.bib' \
+              'CLAUDE.md' \
               'cmake/CodeCoverage.cmake$' \
               'cmake/CodeCoverageDetection.cmake$' \
               'cmake/FindCatch.cmake$' \


### PR DESCRIPTION
## Proposed changes

Adds AGENTS.md with facts from our docs so AI agents don't have to spend time and tokens to figure these things out by themselves.
User-specific overrides can be written in `AGENTS.local.md`.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
- If you already have an AGENTS.md, rename it to `AGENTS.local.md`.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
