### PR TITLE
Use no-avx512 only on not ARM64

### DIFF
--- a/cmake/SetupCxxFlags.cmake
+++ b/cmake/SetupCxxFlags.cmake
@@ -58,30 +58,37 @@ if(${DEBUG_SYMBOLS})
     APPEND PROPERTY INTERFACE_COMPILE_OPTIONS -g)
 endif(${DEBUG_SYMBOLS})
 
+set(_NO_AVX512 "")
+if((NOT APPLE OR NOT "${CMAKE_HOST_SYSTEM_PROCESSOR}" STREQUAL "arm64")
+    # sometimes ARM architectures use the name "aarch64"
+    AND NOT "${CMAKE_HOST_SYSTEM_PROCESSOR}" STREQUAL "aarch64"
+  )
+  # The -mno-avx512f flag is necessary to avoid a Blaze 3.8 bug. The flag
+  # should be re-enabled when we can insist on Blaze 3.9 which will include
+  # a fix that allows this vectorization flag again.
+  set(_NO_AVX512 "-mno-avx512f")
+endif()
+
 # Always compile only for the current architecture. This can be overridden
 # by passing `-D OVERRIDE_ARCH=THE_ARCHITECTURE` to CMake
 if(NOT "${OVERRIDE_ARCH}" STREQUAL "OFF")
-  set_property(TARGET SpectreFlags
+  if(NOT APPLE)
+    set_property(TARGET SpectreFlags
       APPEND PROPERTY
       INTERFACE_COMPILE_OPTIONS
-      # The -mno-avx512f flag is necessary to avoid a Blaze 3.8 bug. The flag
-      # should be re-enabled when we can insist on Blaze 3.9 which will include
-      # a fix that allows this vectorization flag again.
-      $<$<COMPILE_LANGUAGE:C>:-march=${OVERRIDE_ARCH} -mno-avx512f>
-      $<$<COMPILE_LANGUAGE:CXX>:-march=${OVERRIDE_ARCH} -mno-avx512f>
-      $<$<COMPILE_LANGUAGE:Fortran>:-march=${OVERRIDE_ARCH} -mno-avx512f>)
+      $<$<COMPILE_LANGUAGE:C>:-march=${OVERRIDE_ARCH} ${_NO_AVX512}>
+      $<$<COMPILE_LANGUAGE:CXX>:-march=${OVERRIDE_ARCH} ${_NO_AVX512}>
+      $<$<COMPILE_LANGUAGE:Fortran>:-march=${OVERRIDE_ARCH} ${_NO_AVX512}>)
+  endif()
 else()
   # Apple Silicon Macs do not support the -march flag or the -mno-avx512f flag
-  if((NOT APPLE OR NOT "${CMAKE_HOST_SYSTEM_PROCESSOR}" STREQUAL "arm64")
-    # sometimes ARM architectures use the name "aarch64"
-    AND NOT "${CMAKE_HOST_SYSTEM_PROCESSOR}" STREQUAL "aarch64"
-    )
+  if(NOT APPLE)
     set_property(TARGET SpectreFlags
         APPEND PROPERTY
         INTERFACE_COMPILE_OPTIONS
-        $<$<COMPILE_LANGUAGE:C>:-march=native -mno-avx512f>
-        $<$<COMPILE_LANGUAGE:CXX>:-march=native -mno-avx512f>
-        $<$<COMPILE_LANGUAGE:Fortran>:-march=native -mno-avx512f>)
+        $<$<COMPILE_LANGUAGE:C>:-march=native ${_NO_AVX512}>
+        $<$<COMPILE_LANGUAGE:CXX>:-march=native ${_NO_AVX512}>
+        $<$<COMPILE_LANGUAGE:Fortran>:-march=native ${_NO_AVX512}>)
   endif()
 endif()
 


### PR DESCRIPTION
## Proposed changes

We need this for deploying ARM64 CCE executables

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
