### PR TITLE
Add subcell reconstruction for ZernikeB1

### DIFF
--- a/src/Evolution/DgSubcell/Matrices.cpp
+++ b/src/Evolution/DgSubcell/Matrices.cpp
@@ -29,6 +29,7 @@
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Numeric.hpp"
+#include "Utilities/RuntimeCache.hpp"
 #include "Utilities/StaticCache.hpp"
 
 namespace evolution::dg::subcell::fd {
@@ -421,6 +422,144 @@ const Matrix& reconstruction_matrix(const Mesh<Dim>& dg_mesh,
   };
 }
 
+const Matrix& reconstruction_matrix(const Mesh<1>& dg_mesh,
+                                    const size_t subcell_extents,
+                                    const Spectral::Parity parity) {
+  ASSERT(dg_mesh.basis(0) == Spectral::Basis::ZernikeB1 and
+             dg_mesh.quadrature(0) == Spectral::Quadrature::GaussRadauUpper,
+         "reconstruction_matrix with a Parity argument only supports "
+         "ZernikeB1 with GaussRadauUpper quadrature, but got "
+             << dg_mesh);
+  ASSERT(parity != Spectral::Parity::Uninitialized,
+         "Parity must be set when using ZernikeB1");
+  ASSERT(subcell_extents >= dg_mesh.extents(0),
+         "Subcell extents ("
+             << subcell_extents << ") must be >= DG extents ("
+             << dg_mesh.extents(0)
+             << ") for ZernikeB1 reconstruction to be well-posed (P^T P "
+                "would be singular)");
+
+  static const auto cache = make_runtime_cache<
+      CacheRange<
+          Spectral::minimum_number_of_points<
+              Spectral::Basis::ZernikeB1,
+              Spectral::Quadrature::GaussRadauUpper>,
+          Spectral::maximum_number_of_points<Spectral::Basis::ZernikeB1> + 1>,
+      CacheRange<Spectral::minimum_number_of_points<
+                     Spectral::Basis::FiniteDifference,
+                     Spectral::Quadrature::CellCentered>,
+                 Spectral::maximum_number_of_points<
+                     Spectral::Basis::FiniteDifference> +
+                     1>,
+      CacheEnumeration<Spectral::Parity, Spectral::Parity::Even,
+                       Spectral::Parity::Odd>>(
+      [](const size_t n_dg, const size_t n_fd,
+         const Spectral::Parity local_parity) {
+        const Matrix& proj_matrix = projection_matrix(
+            Mesh<1>{n_dg, Spectral::Basis::ZernikeB1,
+                    Spectral::Quadrature::GaussRadauUpper},
+            n_fd, Spectral::Quadrature::CellCentered, local_parity);
+
+        // Compute 2 P^T P (n_dg x n_dg)
+        Matrix two_pt_p(n_dg, n_dg, 0.0);
+        dgemm_<true>('T', 'N', n_dg, n_dg, n_fd, 2.0, proj_matrix.data(),
+                     proj_matrix.spacing(), proj_matrix.data(),
+                     proj_matrix.spacing(), 0.0, two_pt_p.data(),
+                     two_pt_p.spacing());
+
+        // RHS top block: 2 P^T (n_dg x n_fd)
+        Matrix rhs_top(n_dg, n_fd);
+        for (size_t k = 0; k < n_fd; ++k) {
+          for (size_t l = 0; l < n_dg; ++l) {
+            rhs_top(l, k) = 2.0 * proj_matrix(k, l);
+          }
+        }
+
+        // For odd parity, the conservation constraint
+        //
+        //   sum_i w_i^DG u(r_i^DG) = sum_j w_j^FD u(r_j^FD)
+        //
+        // is inconsistent because the DG quadrature points are the roots of
+        // Pi^{m=0}(2*n_dg, r) = Q^0_{2*n_dg} - Q^0_{2*n_dg-2}, which are
+        // optimised for integrating even-parity (m=0) functions Q^0_k. They
+        // are not accurate for odd-parity (m=1) integrands Q^1_k.
+        //
+        // For example, with n_dg=2 (points 0.447, 1.0; weights 0.833, 0.167)
+        // and u(r) = r (the lowest odd-parity basis function):
+        //
+        //   sum_i w_i^DG * r_i  =  0.0787   (DG quadrature, inaccurate for m=1)
+        //   sum_j w_j^FD * r_j  =  0.5000   (6th-order FD, = int_0^1 r dr)
+        //
+        // Imposing this as a constraint via a Lagrange multiplier forces R to
+        // satisfy a false equation, corrupting the reconstruction. The pure
+        // pseudoinverse R = (2 P^T P)^{-1} 2P^T does not impose a conservation
+        // constraint and still satisfies R P = I exactly by construction.
+        if (local_parity == Spectral::Parity::Odd) {
+          // Use the pure pseudoinverse R = (P^T P)^{-1} P^T, which satisfies
+          // R . P = (P^T P)^{-1} (P^T P) = I exactly without relying on any
+          // conservation constraint.
+          const Matrix inv_two_pt_p = inv(two_pt_p);
+          Matrix result(n_dg, n_fd);
+          dgemm_<true>('N', 'N', n_dg, n_fd, n_dg, 1.0, inv_two_pt_p.data(),
+                       inv_two_pt_p.spacing(), rhs_top.data(),
+                       rhs_top.spacing(), 0.0, result.data(), result.spacing());
+          return result;
+        }
+
+        // Even parity: the conservation constraint is self-consistent (see
+        // discussion above), so use Lagrange-constrained least-squares.
+        const size_t aug_size = n_dg + 1;
+        Matrix lhs(aug_size, aug_size, 0.0);
+        for (size_t l = 0; l < n_dg; ++l) {
+          for (size_t j = 0; j < n_dg; ++j) {
+            lhs(l, j) = two_pt_p(l, j);
+          }
+        }
+
+        // Lagrange multiplier row and column (conservation constraint)
+        const DataVector& dg_weights =
+            Spectral::quadrature_weights<Spectral::Basis::ZernikeB1,
+                                         Spectral::Quadrature::GaussRadauUpper>(
+                n_dg);
+        for (size_t i = 0; i < n_dg; ++i) {
+          lhs(i, n_dg) = -dg_weights[i];
+          lhs(n_dg, i) = dg_weights[i];
+        }
+
+        // Fill augmented RHS: rows 0..n_dg-1 hold 2 P^T, row n_dg holds the
+        // FD integration weights. The ZernikeB1 physical domain is [0,1], so
+        // the cell width is 1/n_fd (not 2/n_fd as for Legendre on [-1,1]).
+        Matrix rhs(aug_size, n_fd);
+        for (size_t k = 0; k < n_fd; ++k) {
+          for (size_t l = 0; l < n_dg; ++l) {
+            rhs(l, k) = rhs_top(l, k);
+          }
+        }
+        const double delta = 1.0 / static_cast<double>(n_fd);
+        for (size_t i = 0; i < n_fd; ++i) {
+          rhs(n_dg, i) =
+              delta * get_sixth_order_integration_coefficient(n_fd, i);
+        }
+
+        const Matrix inv_lhs = inv(lhs);
+        Matrix full_recons(aug_size, n_fd);
+        dgemm_<true>('N', 'N', inv_lhs.rows(), n_fd, inv_lhs.columns(), 1.0,
+                     inv_lhs.data(), inv_lhs.spacing(), rhs.data(),
+                     rhs.spacing(), 0.0, full_recons.data(),
+                     full_recons.spacing());
+        // Drop the Lagrange multiplier row
+        Matrix result(n_dg, n_fd);
+        for (size_t i = 0; i < n_dg; ++i) {
+          for (size_t j = 0; j < n_fd; ++j) {
+            result(i, j) = full_recons(i, j);
+          }
+        }
+        return result;
+      });
+
+  return cache(dg_mesh.extents(0), subcell_extents, parity);
+}
+
 const Matrix& projection_matrix(const Mesh<1>& dg_mesh,
                                 const size_t subcell_extents,
                                 const size_t ghost_zone_size, const Side side) {
@@ -432,42 +571,40 @@ const Matrix& projection_matrix(const Mesh<1>& dg_mesh,
   ASSERT(ghost_zone_size <= max_ghost_zone_size and ghost_zone_size >= 2,
          "ghost_zone_size must be in [2, " << max_ghost_zone_size
                                            << " ] but got " << ghost_zone_size);
-  static const auto cache =
-      make_static_cache<
-          CacheRange<
-              Spectral::minimum_number_of_points<
-                  Spectral::Basis::Legendre,
-                  Spectral::Quadrature::GaussLobatto>,
-              Spectral::maximum_number_of_points<Spectral::Basis::Legendre> +
-                  1>,
-          CacheRange<Spectral::minimum_number_of_points<
-                         Spectral::Basis::FiniteDifference,
-                         Spectral::Quadrature::CellCentered>,
-                     Spectral::maximum_number_of_points<
-                         Spectral::Basis::FiniteDifference> +
-                         1>,
-          CacheRange<2_st, max_ghost_zone_size + 1>,
-          CacheEnumeration<Spectral::Quadrature, Spectral::Quadrature::Gauss,
-                           Spectral::Quadrature::GaussLobatto>,
-          CacheEnumeration<Side, Side::Lower, Side::Upper>>(
-          [](const size_t local_num_dg_points, const size_t local_num_fd_points,
-             const size_t local_ghost_zone_size,
-             const Spectral::Quadrature dg_quadrature, const Side local_side) {
-            const DataVector& fd_points = Spectral::collocation_points<
-                Spectral::Basis::FiniteDifference,
-                Spectral::Quadrature::CellCentered>(local_num_fd_points);
-            DataVector target_points(local_ghost_zone_size);
-            for (size_t i = 0; i < local_ghost_zone_size; ++i) {
-              target_points[i] = fd_points[local_side == Side::Lower
-                                               ? i
-                                               : (local_num_fd_points -
-                                                  local_ghost_zone_size + i)];
-            }
-            return Spectral::interpolation_matrix(
-                Mesh<1>{local_num_dg_points, Spectral::Basis::Legendre,
-                        dg_quadrature},
-                target_points);
-          });
+  static const auto cache = make_static_cache<
+      CacheRange<
+          Spectral::minimum_number_of_points<
+              Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto>,
+          Spectral::maximum_number_of_points<Spectral::Basis::Legendre> + 1>,
+      CacheRange<Spectral::minimum_number_of_points<
+                     Spectral::Basis::FiniteDifference,
+                     Spectral::Quadrature::CellCentered>,
+                 Spectral::maximum_number_of_points<
+                     Spectral::Basis::FiniteDifference> +
+                     1>,
+      CacheRange<2_st, max_ghost_zone_size + 1>,
+      CacheEnumeration<Spectral::Quadrature, Spectral::Quadrature::Gauss,
+                       Spectral::Quadrature::GaussLobatto>,
+      CacheEnumeration<Side, Side::Lower, Side::Upper>>(
+      [](const size_t local_num_dg_points, const size_t local_num_fd_points,
+         const size_t local_ghost_zone_size,
+         const Spectral::Quadrature dg_quadrature, const Side local_side) {
+        const DataVector& fd_points =
+            Spectral::collocation_points<Spectral::Basis::FiniteDifference,
+                                         Spectral::Quadrature::CellCentered>(
+                local_num_fd_points);
+        DataVector target_points(local_ghost_zone_size);
+        for (size_t i = 0; i < local_ghost_zone_size; ++i) {
+          target_points[i] = fd_points[local_side == Side::Lower
+                                           ? i
+                                           : (local_num_fd_points -
+                                              local_ghost_zone_size + i)];
+        }
+        return Spectral::interpolation_matrix(
+            Mesh<1>{local_num_dg_points, Spectral::Basis::Legendre,
+                    dg_quadrature},
+            target_points);
+      });
   return cache(dg_mesh.extents(0), subcell_extents, ghost_zone_size,
                dg_mesh.quadrature(0), side);
 }

--- a/src/Evolution/DgSubcell/Matrices.hpp
+++ b/src/Evolution/DgSubcell/Matrices.hpp
@@ -87,6 +87,24 @@ const Matrix& reconstruction_matrix(const Mesh<Dim>& dg_mesh,
 
 /*!
  * \ingroup DgSubcellGroup
+ * \brief Computes the 1D reconstruction matrix for a ZernikeB1 DG mesh.
+ *
+ * Uses the same constrained least-squares formula as the Legendre overload,
+ * but with the parity-aware ZernikeB1 interpolation matrix and GaussRadauUpper
+ * quadrature weights, notably only for even parity. For odd parity, the
+ * collocation points are inconsistent with the constraint equation, so we opt
+ * to directly use the pseduo-inverse. Only `DimByDim` reconstruction is
+ * supported for ZernikeB1  meshes; this overload is called per-dimension for
+ * the radial direction.
+ *
+ * The `parity` parameter must be `Even` or `Odd` (not `Uninitialized`).
+ */
+const Matrix& reconstruction_matrix(const Mesh<1>& dg_mesh,
+                                    size_t subcell_extents,
+                                    Spectral::Parity parity);
+
+/*!
+ * \ingroup DgSubcellGroup
  * \brief Computes the projection matrix in 1 dimension going from a DG
  * mesh to a conservative finite difference subcell mesh for only the ghost
  * zones.

--- a/src/Evolution/DgSubcell/Reconstruction.cpp
+++ b/src/Evolution/DgSubcell/Reconstruction.cpp
@@ -11,10 +11,13 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Matrix.hpp"
 #include "Evolution/DgSubcell/Matrices.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Parity.hpp"
 #include "Utilities/Blas.hpp"
 #include "Utilities/ContainerHelpers.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeArray.hpp"
@@ -26,7 +29,17 @@ void reconstruct_impl(
     gsl::span<double> dg_u,
     const gsl::span<const double> subcell_u_times_projected_det_jac,
     const Mesh<Dim>& dg_mesh, const Index<Dim>& subcell_extents,
-    const ReconstructionMethod reconstruction_method) {
+    const ReconstructionMethod reconstruction_method,
+    const Spectral::Parity parity) {
+  if (dg_mesh.basis(0) == Spectral::Basis::ZernikeB1) {
+    ASSERT(parity != Spectral::Parity::Uninitialized,
+           "Parity must be set when using ZernikeB1");
+    if (reconstruction_method == ReconstructionMethod::AllDimsAtOnce) {
+      ERROR(
+          "AllDimsAtOnce reconstruction is not supported for ZernikeB1 "
+          "meshes; use DimByDim");
+    }
+  }
   const size_t number_of_components =
       dg_u.size() / dg_mesh.number_of_grid_points();
   if (reconstruction_method == ReconstructionMethod::AllDimsAtOnce) {
@@ -46,8 +59,13 @@ void reconstruct_impl(
     const Matrix empty{};
     auto recons_matrices = make_array<Dim>(std::cref(empty));
     for (size_t d = 0; d < Dim; d++) {
-      gsl::at(recons_matrices, d) = std::cref(reconstruction_matrix(
-          dg_mesh.slice_through(d), Index<1>{subcell_extents[d]}));
+      if (dg_mesh.basis(d) == Spectral::Basis::ZernikeB1) {
+        gsl::at(recons_matrices, d) = std::cref(reconstruction_matrix(
+            dg_mesh.slice_through(d), subcell_extents[d], parity));
+      } else {
+        gsl::at(recons_matrices, d) = std::cref(reconstruction_matrix(
+            dg_mesh.slice_through(d), Index<1>{subcell_extents[d]}));
+      }
     }
     DataVector result{dg_u.data(), dg_u.size()};
     const DataVector u{
@@ -63,7 +81,8 @@ template <size_t Dim>
 void reconstruct(const gsl::not_null<DataVector*> dg_u,
                  const DataVector& subcell_u_times_projected_det_jac,
                  const Mesh<Dim>& dg_mesh, const Index<Dim>& subcell_extents,
-                 const ReconstructionMethod reconstruction_method) {
+                 const ReconstructionMethod reconstruction_method,
+                 const Spectral::Parity parity) {
   ASSERT(subcell_u_times_projected_det_jac.size() == subcell_extents.product(),
          "Incorrect subcell size of u: "
              << subcell_u_times_projected_det_jac.size() << " but should be "
@@ -73,17 +92,18 @@ void reconstruct(const gsl::not_null<DataVector*> dg_u,
       gsl::span<double>{dg_u->data(), dg_u->size()},
       gsl::span<const double>{subcell_u_times_projected_det_jac.data(),
                               subcell_u_times_projected_det_jac.size()},
-      dg_mesh, subcell_extents, reconstruction_method);
+      dg_mesh, subcell_extents, reconstruction_method, parity);
 }
 
 template <size_t Dim>
 DataVector reconstruct(const DataVector& subcell_u_times_projected_det_jac,
                        const Mesh<Dim>& dg_mesh,
                        const Index<Dim>& subcell_extents,
-                       const ReconstructionMethod reconstruction_method) {
+                       const ReconstructionMethod reconstruction_method,
+                       const Spectral::Parity parity) {
   DataVector dg_u{dg_mesh.number_of_grid_points()};
   reconstruct(&dg_u, subcell_u_times_projected_det_jac, dg_mesh,
-              subcell_extents, reconstruction_method);
+              subcell_extents, reconstruction_method, parity);
   return dg_u;
 }
 
@@ -92,14 +112,14 @@ DataVector reconstruct(const DataVector& subcell_u_times_projected_det_jac,
 #define INSTANTIATION(r, data)                                                 \
   template DataVector reconstruct(const DataVector&, const Mesh<DIM(data)>&,   \
                                   const Index<DIM(data)>&,                     \
-                                  ReconstructionMethod);                       \
+                                  ReconstructionMethod, Spectral::Parity);     \
   template void reconstruct(gsl::not_null<DataVector*>, const DataVector&,     \
                             const Mesh<DIM(data)>&, const Index<DIM(data)>&,   \
-                            ReconstructionMethod);                             \
+                            ReconstructionMethod, Spectral::Parity);           \
   template void detail::reconstruct_impl(                                      \
       gsl::span<double> dg_u, const gsl::span<const double>,                   \
       const Mesh<DIM(data)>& dg_mesh, const Index<DIM(data)>& subcell_extents, \
-      ReconstructionMethod);
+      ReconstructionMethod, Spectral::Parity);
 
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 

--- a/src/Evolution/DgSubcell/Reconstruction.hpp
+++ b/src/Evolution/DgSubcell/Reconstruction.hpp
@@ -3,15 +3,21 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cstddef>
 
+#include "DataStructures/DataVector.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Evolution/DgSubcell/ReconstructionMethod.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/Parity.hpp"
+#include "NumericalAlgorithms/Spectral/ParityFromSymmetry.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/MemoryHelpers.hpp"
+#include "Utilities/TMPL.hpp"
 
 /// \cond
-class DataVector;
 template <size_t>
 class Index;
 template <size_t>
@@ -25,7 +31,128 @@ void reconstruct_impl(gsl::span<double> dg_u,
                       gsl::span<const double> subcell_u_times_projected_det_jac,
                       const Mesh<Dim>& dg_mesh,
                       const Index<Dim>& subcell_extents,
-                      ReconstructionMethod reconstruction_method);
+                      ReconstructionMethod reconstruction_method,
+                      Spectral::Parity parity);
+
+/*!
+ * \brief Reconstruct `subcell_u` onto the DG grid, sorting even- and
+ * odd-parity components into separate batches when a ZernikeB1 basis is
+ * present.
+ *
+ * For non-ZernikeB1 meshes this falls through to `reconstruct_impl` with
+ * `Parity::Uninitialized`. The `TagList` must be the full Variables tag list
+ * so that `Spectral::compute_parity_list` can determine per-component parity.
+ */
+template <typename TagList, size_t Dim>
+void reconstruct_impl_with_tag_list(
+    gsl::span<double> dg_u, gsl::span<const double> subcell_u,
+    const Mesh<Dim>& dg_mesh, const Index<Dim>& subcell_extents,
+    const ReconstructionMethod reconstruction_method) {
+  if (dg_mesh.basis(0) == Spectral::Basis::ZernikeB1) {
+    ASSERT(Variables<TagList>::number_of_independent_components *
+                   dg_mesh.number_of_grid_points() ==
+               dg_u.size(),
+           "Passed TagList does not have the same components, "
+               << Variables<TagList>::number_of_independent_components
+               << ", as dg_u holds, "
+               << dg_u.size() / dg_mesh.number_of_grid_points());
+    constexpr auto parity_info = Spectral::compute_parity_list<TagList>();
+    constexpr auto parity_list = std::get<0>(parity_info);
+    constexpr size_t num_even = std::get<1>(parity_info);
+    constexpr size_t num_odd = std::get<2>(parity_info);
+
+    const size_t num_dg_pts = dg_mesh.number_of_grid_points();
+    const size_t num_subcell_pts = subcell_extents.product();
+
+    // NOLINTNEXTLINE(modernize-avoid-c-arrays)
+    auto buffer = cpp20::make_unique_for_overwrite<double[]>(
+        (num_even + num_odd) * (num_subcell_pts + num_dg_pts));
+    DataVector even_subcell_input{&buffer[0], num_even * num_subcell_pts};
+    DataVector odd_subcell_input{&buffer[num_even * num_subcell_pts],
+                                 num_odd * num_subcell_pts};
+    DataVector even_dg_output{&buffer[(num_even + num_odd) * num_subcell_pts],
+                              num_even * num_dg_pts};
+    DataVector odd_dg_output{
+        &buffer[(num_even + num_odd) * num_subcell_pts + num_even * num_dg_pts],
+        num_odd * num_dg_pts};
+
+    // Sort subcell input into even/odd parity buffers
+    const double* p_in = subcell_u.data();
+    double* p_even_in = even_subcell_input.data();
+    double* p_odd_in = odd_subcell_input.data();
+    bool is_even = true;
+    for (const size_t seg_size : parity_list) {
+      if (seg_size == 0) {
+        if (is_even) {
+          is_even = false;
+          continue;
+        } else {
+          break;
+        }
+      }
+      if (is_even) {
+        std::copy(p_in, p_in + seg_size * num_subcell_pts,  // NOLINT
+                  p_even_in);
+        p_even_in += seg_size * num_subcell_pts;  // NOLINT
+      } else {
+        std::copy(p_in, p_in + seg_size * num_subcell_pts,  // NOLINT
+                  p_odd_in);
+        p_odd_in += seg_size * num_subcell_pts;  // NOLINT
+      }
+      p_in += seg_size * num_subcell_pts;  // NOLINT
+      is_even = not is_even;
+    }
+
+    // Reconstruct each parity batch with the appropriate reconstruction
+    // matrix
+    if constexpr (num_even > 0) {
+      reconstruct_impl(
+          gsl::span<double>{even_dg_output.data(), even_dg_output.size()},
+          gsl::span<const double>{even_subcell_input.data(),
+                                  even_subcell_input.size()},
+          dg_mesh, subcell_extents, reconstruction_method,
+          Spectral::Parity::Even);
+    }
+    if constexpr (num_odd > 0) {
+      reconstruct_impl(
+          gsl::span<double>{odd_dg_output.data(), odd_dg_output.size()},
+          gsl::span<const double>{odd_subcell_input.data(),
+                                  odd_subcell_input.size()},
+          dg_mesh, subcell_extents, reconstruction_method,
+          Spectral::Parity::Odd);
+    }
+
+    // Reassemble output in original component order
+    double* p_out = dg_u.data();
+    const double* p_even_out = even_dg_output.data();
+    const double* p_odd_out = odd_dg_output.data();
+    is_even = true;
+    for (const size_t seg_size : parity_list) {
+      if (seg_size == 0) {
+        if (is_even) {
+          is_even = false;
+          continue;
+        } else {
+          break;
+        }
+      }
+      if (is_even) {
+        // NOLINTNEXTLINE
+        std::copy(p_even_out, p_even_out + seg_size * num_dg_pts, p_out);
+        p_even_out += seg_size * num_dg_pts;  // NOLINT
+      } else {
+        // NOLINTNEXTLINE
+        std::copy(p_odd_out, p_odd_out + seg_size * num_dg_pts, p_out);
+        p_odd_out += seg_size * num_dg_pts;  // NOLINT
+      }
+      p_out += seg_size * num_dg_pts;  // NOLINT
+      is_even = not is_even;
+    }
+    return;
+  }
+  reconstruct_impl(dg_u, subcell_u, dg_mesh, subcell_extents,
+                   reconstruction_method, Spectral::Parity::Uninitialized);
+}
 }  // namespace detail
 
 /// @{
@@ -49,18 +176,26 @@ void reconstruct_impl(gsl::span<double> dg_u,
  * latter has the advantage that, in general, we are ideally projecting to the
  * subcells much more often than reconstructing from them (a statement that we
  * would rather use DG more than the subcells).
+ *
+ * When the DG mesh uses a ZernikeB1 basis the Variables overloads deduce
+ * per-component parity from the tag list automatically. The raw `DataVector`
+ * overloads accepting a `Spectral::Parity` are for single-component data where
+ * the caller already knows the parity. Only `DimByDim` reconstruction is
+ * supported for ZernikeB1 meshes.
  */
 template <size_t Dim>
-DataVector reconstruct(const DataVector& subcell_u_times_projected_det_jac,
-                       const Mesh<Dim>& dg_mesh,
-                       const Index<Dim>& subcell_extents,
-                       ReconstructionMethod reconstruction_method);
+DataVector reconstruct(
+    const DataVector& subcell_u_times_projected_det_jac,
+    const Mesh<Dim>& dg_mesh, const Index<Dim>& subcell_extents,
+    ReconstructionMethod reconstruction_method,
+    Spectral::Parity parity = Spectral::Parity::Uninitialized);
 
 template <size_t Dim>
 void reconstruct(gsl::not_null<DataVector*> dg_u,
                  const DataVector& subcell_u_times_projected_det_jac,
                  const Mesh<Dim>& dg_mesh, const Index<Dim>& subcell_extents,
-                 ReconstructionMethod reconstruction_method);
+                 ReconstructionMethod reconstruction_method,
+                 Spectral::Parity parity = Spectral::Parity::Uninitialized);
 
 template <typename SubcellTagList, typename DgTagList, size_t Dim>
 void reconstruct(const gsl::not_null<Variables<DgTagList>*> dg_u,
@@ -75,7 +210,7 @@ void reconstruct(const gsl::not_null<Variables<DgTagList>*> dg_u,
                dg_mesh.number_of_grid_points())) {
     dg_u->initialize(dg_mesh.number_of_grid_points(), 0.0);
   }
-  detail::reconstruct_impl(
+  detail::reconstruct_impl_with_tag_list<DgTagList>(
       gsl::span<double>{dg_u->data(), dg_u->size()},
       gsl::span<const double>{subcell_u.data(), subcell_u.size()}, dg_mesh,
       subcell_extents, reconstruction_method);

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/ResizeAndComputePrimitives.cpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/ResizeAndComputePrimitives.cpp
@@ -51,7 +51,8 @@ void ResizeAndComputePrims<OrderedListOfRecoverySchemes>::apply(
               &get(get<hydro::Tags::Pressure<DataVector>>(*prim_vars))),
           get(fd_pressure), dg_mesh, subcell_mesh.extents(),
           // Always do dim-by-dim reconstruction because it's fast
-          evolution::dg::subcell::fd ::ReconstructionMethod::DimByDim);
+          evolution::dg::subcell::fd::ReconstructionMethod::DimByDim,
+          Spectral::Parity::Even);
     }
 
     // Compute the spatial metric, inverse spatial metric, and sqrt{det{spatial

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/ResizeAndComputePrimitives.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/ResizeAndComputePrimitives.cpp
@@ -52,7 +52,8 @@ void ResizeAndComputePrims<OrderedListOfRecoverySchemes>::apply(
               &get(get<hydro::Tags::Pressure<DataVector>>(*prim_vars))),
           get(fd_pressure), dg_mesh, subcell_mesh.extents(),
           // Always do dim-by-dim reconstruction because it's fast
-          evolution::dg::subcell::fd ::ReconstructionMethod::DimByDim);
+          evolution::dg::subcell::fd::ReconstructionMethod::DimByDim,
+          Spectral::Parity::Even);
     }
 
     // We only need to compute the prims if we switched to the DG grid because

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnFdGrid.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnFdGrid.cpp
@@ -63,20 +63,23 @@ std::tuple<int, evolution::dg::subcell::RdmpTciData> TciOnFdGrid::apply(
   evolution::dg::subcell::fd::reconstruct(
       make_not_null(&get(dg_tilde_d)), get(subcell_tilde_d), dg_mesh,
       subcell_mesh.extents(),
-      evolution::dg::subcell::fd::ReconstructionMethod::DimByDim);
+      evolution::dg::subcell::fd::ReconstructionMethod::DimByDim,
+      Spectral::Parity::Even);
 
   Scalar<DataVector> dg_tilde_ye{};
   assign_data(make_not_null(&dg_tilde_ye), num_dg_pts);
   evolution::dg::subcell::fd::reconstruct(
       make_not_null(&get(dg_tilde_ye)), get(subcell_tilde_ye), dg_mesh,
       subcell_mesh.extents(),
-      evolution::dg::subcell::fd::ReconstructionMethod::DimByDim);
+      evolution::dg::subcell::fd::ReconstructionMethod::DimByDim,
+      Spectral::Parity::Even);
   Scalar<DataVector> dg_tilde_tau{};
   assign_data(make_not_null(&dg_tilde_tau), num_dg_pts);
   evolution::dg::subcell::fd::reconstruct(
       make_not_null(&get(dg_tilde_tau)), get(subcell_tilde_tau), dg_mesh,
       subcell_mesh.extents(),
-      evolution::dg::subcell::fd::ReconstructionMethod::DimByDim);
+      evolution::dg::subcell::fd::ReconstructionMethod::DimByDim,
+      Spectral::Parity::Even);
 
   if (min(get(dg_tilde_d)) <
           tci_options.minimum_rest_mass_density_times_lorentz_factor) {
@@ -104,7 +107,8 @@ std::tuple<int, evolution::dg::subcell::RdmpTciData> TciOnFdGrid::apply(
     evolution::dg::subcell::fd::reconstruct(
         make_not_null(&get(dg_pressure)), get(subcell_pressure), dg_mesh,
         subcell_mesh.extents(),
-        evolution::dg::subcell::fd::ReconstructionMethod::DimByDim);
+        evolution::dg::subcell::fd::ReconstructionMethod::DimByDim,
+        Spectral::Parity::Even);
 
     if (evolution::dg::subcell::persson_tci(
             dg_tilde_d, dg_mesh, persson_exponent,
@@ -128,7 +132,8 @@ std::tuple<int, evolution::dg::subcell::RdmpTciData> TciOnFdGrid::apply(
   evolution::dg::subcell::fd::reconstruct(
       make_not_null(&get(dg_mag_tilde_b)), get(subcell_mag_tilde_b), dg_mesh,
       subcell_mesh.extents(),
-      evolution::dg::subcell::fd::ReconstructionMethod::DimByDim);
+      evolution::dg::subcell::fd::ReconstructionMethod::DimByDim,
+      Spectral::Parity::Even);
   // Add the reconstructed DG solution to the check. This is done so that we
   // wouldn't violate RDMP if we switch back. However, we don't want to return
   // max/mins from a bad DG solution.

--- a/tests/Unit/Evolution/DgSubcell/Test_Matrices.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_Matrices.cpp
@@ -491,6 +491,92 @@ void test_zernike_b1_projection_matrix() {
   }
 }
 
+void test_zernike_b1_reconstruction_matrix() {
+  constexpr Spectral::Basis basis = Spectral::Basis::ZernikeB1;
+  constexpr Spectral::Quadrature quadrature =
+      Spectral::Quadrature::GaussRadauUpper;
+  const Approx custom_approx = Approx::custom().epsilon(1.0e-12).scale(1.);
+
+  for (size_t n_dg = 2_st; n_dg <= 6; ++n_dg) {
+    CAPTURE(n_dg);
+    const Mesh<1> dg_mesh{n_dg, basis, quadrature};
+    const DataVector xi_dg = get<0>(logical_coordinates(dg_mesh));
+    const size_t n_fd = 2 * n_dg - 1;
+
+    const Matrix& P_even =
+        projection_matrix(dg_mesh, n_fd, Spectral::Quadrature::CellCentered,
+                          Spectral::Parity::Even);
+    const Matrix& P_odd =
+        projection_matrix(dg_mesh, n_fd, Spectral::Quadrature::CellCentered,
+                          Spectral::Parity::Odd);
+    const Matrix& R_even = subcell::fd::reconstruction_matrix(
+        dg_mesh, n_fd, Spectral::Parity::Even);
+    const Matrix& R_odd = subcell::fd::reconstruction_matrix(
+        dg_mesh, n_fd, Spectral::Parity::Odd);
+
+    REQUIRE(R_even.rows() == n_dg);
+    REQUIRE(R_even.columns() == n_fd);
+    REQUIRE(R_odd.rows() == n_dg);
+    REQUIRE(R_odd.columns() == n_fd);
+
+    // We stay within degree 6 to remain within the 6th-order integration
+    // accuracy of the conservation constraint: even Q^0_{2k} has degree 2k,
+    // odd Q^1_{2k+1} has degree 2k+1.
+    for (size_t k = 0; k < std::min(n_dg, size_t{3}); ++k) {
+      CAPTURE(k);
+      // Even parity: Q^0_{2k} (degree 2k <= 4)
+      const DataVector f_even =
+          Spectral::compute_basis_function_value<basis>(2 * k, 0_st, xi_dg);
+      DataVector f_even_fd(n_fd, 0.0);
+      dgemv_('N', P_even.rows(), P_even.columns(), 1.0, P_even.data(),
+             P_even.spacing(), f_even.data(), 1, 0.0, f_even_fd.data(), 1);
+      DataVector f_even_reconstructed(n_dg, 0.0);
+      dgemv_('N', R_even.rows(), R_even.columns(), 1.0, R_even.data(),
+             R_even.spacing(), f_even_fd.data(), 1, 0.0,
+             f_even_reconstructed.data(), 1);
+      CHECK_ITERABLE_CUSTOM_APPROX(f_even_reconstructed, f_even, custom_approx);
+
+      // Odd parity: Q^1_{2k+1} (degree 2k+1 <= 5)
+      const DataVector f_odd =
+          Spectral::compute_basis_function_value<basis>(2 * k + 1, 1_st, xi_dg);
+      DataVector f_odd_fd(n_fd, 0.0);
+      dgemv_('N', P_odd.rows(), P_odd.columns(), 1.0, P_odd.data(),
+             P_odd.spacing(), f_odd.data(), 1, 0.0, f_odd_fd.data(), 1);
+      DataVector f_odd_reconstructed(n_dg, 0.0);
+      dgemv_('N', R_odd.rows(), R_odd.columns(), 1.0, R_odd.data(),
+             R_odd.spacing(), f_odd_fd.data(), 1, 0.0,
+             f_odd_reconstructed.data(), 1);
+      CHECK_ITERABLE_CUSTOM_APPROX(f_odd_reconstructed, f_odd, custom_approx);
+    }
+  }
+
+#ifdef SPECTRE_DEBUG
+  CHECK_THROWS_WITH(subcell::fd::reconstruction_matrix(
+                        Mesh<1>{3, Spectral::Basis::ZernikeB1,
+                                Spectral::Quadrature::GaussRadauUpper},
+                        5, Spectral::Parity::Uninitialized),
+                    Catch::Matchers::ContainsSubstring(
+                        "Parity must be set when using ZernikeB1"));
+  CHECK_THROWS_WITH(
+      subcell::fd::reconstruction_matrix(
+          Mesh<1>{3, Spectral::Basis::Legendre,
+                  Spectral::Quadrature::GaussLobatto},
+          5, Spectral::Parity::Even),
+      Catch::Matchers::ContainsSubstring("only supports ZernikeB1"));
+  // subcell_extents < n_dg makes P^T P singular.
+  CHECK_THROWS_WITH(subcell::fd::reconstruction_matrix(
+                        Mesh<1>{3, Spectral::Basis::ZernikeB1,
+                                Spectral::Quadrature::GaussRadauUpper},
+                        2, Spectral::Parity::Even),
+                    Catch::Matchers::ContainsSubstring("Subcell extents"));
+  CHECK_THROWS_WITH(subcell::fd::reconstruction_matrix(
+                        Mesh<1>{3, Spectral::Basis::ZernikeB1,
+                                Spectral::Quadrature::GaussRadauUpper},
+                        2, Spectral::Parity::Odd),
+                    Catch::Matchers::ContainsSubstring("Subcell extents"));
+#endif
+}
+
 SPECTRE_TEST_CASE("Unit.Evolution.Subcell.Fd.ProjectionMatrix",
                   "[Evolution][Unit]") {
   test_projection_matrix<10, 1, Spectral::Basis::Legendre,
@@ -550,6 +636,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Subcell.Fd.ReconstructionMatrix",
                         Spectral::Quadrature::GaussLobatto>(1.0e-11);
   reconstruction_matrix<4, 3, Spectral::Basis::Legendre,
                         Spectral::Quadrature::Gauss>(1.0e-11);
+  test_zernike_b1_reconstruction_matrix();
 }
 }  // namespace
 }  // namespace evolution::dg::subcell::fd

--- a/tests/Unit/Evolution/DgSubcell/Test_Reconstruction.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_Reconstruction.cpp
@@ -28,6 +28,7 @@
 #include "Evolution/DgSubcell/ReconstructionMethod.hpp"
 #include "Helpers/Evolution/DgSubcell/ProjectionTestHelpers.hpp"
 #include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/BasisFunctionValue.hpp"
 #include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/MinimumNumberOfPoints.hpp"
@@ -228,6 +229,107 @@ void test_reconstruct_fd(const std::vector<double>& eps,
   }
 }
 
+void test_zernike_b1_reconstruct() {
+  constexpr Spectral::Basis zernike_basis = Spectral::Basis::ZernikeB1;
+  constexpr Spectral::Quadrature zernike_quad =
+      Spectral::Quadrature::GaussRadauUpper;
+  const Approx custom_approx = Approx::custom().epsilon(1.0e-12).scale(1.);
+
+  for (size_t n_r = std::max(
+           size_t{2},
+           Spectral::minimum_number_of_points<zernike_basis, zernike_quad>);
+       n_r <= 5; ++n_r) {
+    CAPTURE(n_r);
+    const Mesh<3> dg_mesh{
+        {{n_r, 1, 1}},
+        {zernike_basis, Spectral::Basis::Cartoon, Spectral::Basis::Cartoon},
+        {zernike_quad, Spectral::Quadrature::SphericalSymmetry,
+         Spectral::Quadrature::SphericalSymmetry}};
+    const Index<3> subcell_extents{2 * n_r - 1, 1, 1};
+    const Mesh<1> dg_mesh_1d{n_r, zernike_basis, zernike_quad};
+    const auto xi_dg = get<0>(logical_coordinates(dg_mesh_1d));
+
+    // Test explicit-parity DataVector overloads: R(P(f)) = f for ZernikeB1
+    // basis functions of both parities.
+    for (size_t k = 0; k < std::min(n_r, size_t{3}); ++k) {
+      CAPTURE(k);
+      const DataVector f_even =
+          Spectral::compute_basis_function_value<zernike_basis>(2 * k, 0_st,
+                                                                xi_dg);
+      const DataVector f_even_subcell = evolution::dg::subcell::fd::project(
+          f_even, dg_mesh, subcell_extents, Spectral::Parity::Even);
+      const DataVector f_even_reconstructed =
+          evolution::dg::subcell::fd::reconstruct(
+              f_even_subcell, dg_mesh, subcell_extents,
+              evolution::dg::subcell::fd::ReconstructionMethod::DimByDim,
+              Spectral::Parity::Even);
+      CHECK_ITERABLE_CUSTOM_APPROX(f_even_reconstructed, f_even, custom_approx);
+
+      const DataVector f_odd =
+          Spectral::compute_basis_function_value<zernike_basis>(2 * k + 1, 1_st,
+                                                                xi_dg);
+      const DataVector f_odd_subcell = evolution::dg::subcell::fd::project(
+          f_odd, dg_mesh, subcell_extents, Spectral::Parity::Odd);
+      const DataVector f_odd_reconstructed =
+          evolution::dg::subcell::fd::reconstruct(
+              f_odd_subcell, dg_mesh, subcell_extents,
+              evolution::dg::subcell::fd::ReconstructionMethod::DimByDim,
+              Spectral::Parity::Odd);
+      CHECK_ITERABLE_CUSTOM_APPROX(f_odd_reconstructed, f_odd, custom_approx);
+    }
+
+    // Test the Variables overload, which deduces parity from the tag list.
+    using TagList = tmpl::list<Tags::Scalar, Tags::Vector<3>>;
+    Variables<TagList> dg_vars(dg_mesh.number_of_grid_points());
+    get(get<Tags::Scalar>(dg_vars)) =
+        Spectral::compute_basis_function_value<zernike_basis>(0, 0_st, xi_dg);
+    get<Tags::Vector<3>>(dg_vars).get(0) =
+        Spectral::compute_basis_function_value<zernike_basis>(1, 1_st, xi_dg);
+    for (size_t d = 1; d < 3; ++d) {
+      get<Tags::Vector<3>>(dg_vars).get(d) =
+          Spectral::compute_basis_function_value<zernike_basis>(0, 0_st, xi_dg);
+    }
+
+    const Variables<TagList> subcell_vars =
+        evolution::dg::subcell::fd::project(dg_vars, dg_mesh, subcell_extents);
+    const Variables<TagList> reconstructed_vars =
+        evolution::dg::subcell::fd::reconstruct(
+            subcell_vars, dg_mesh, subcell_extents,
+            evolution::dg::subcell::fd::ReconstructionMethod::DimByDim);
+
+    CHECK_ITERABLE_CUSTOM_APPROX(get(get<Tags::Scalar>(reconstructed_vars)),
+                                 get(get<Tags::Scalar>(dg_vars)),
+                                 custom_approx);
+    CHECK_ITERABLE_CUSTOM_APPROX(get<Tags::Vector<3>>(reconstructed_vars),
+                                 get<Tags::Vector<3>>(dg_vars), custom_approx);
+  }
+
+  // AllDimsAtOnce is not supported for ZernikeB1 (ERROR, not just ASSERT).
+  const Mesh<3> dg_mesh_err{
+      {{3, 1, 1}},
+      {zernike_basis, Spectral::Basis::Cartoon, Spectral::Basis::Cartoon},
+      {zernike_quad, Spectral::Quadrature::SphericalSymmetry,
+       Spectral::Quadrature::SphericalSymmetry}};
+  const Index<3> subcell_extents_err{5, 1, 1};
+  const DataVector f_err(5, 1.0);
+  CHECK_THROWS_WITH(
+      evolution::dg::subcell::fd::reconstruct(
+          f_err, dg_mesh_err, subcell_extents_err,
+          evolution::dg::subcell::fd::ReconstructionMethod::AllDimsAtOnce,
+          Spectral::Parity::Even),
+      Catch::Matchers::ContainsSubstring("AllDimsAtOnce"));
+
+#ifdef SPECTRE_DEBUG
+  // Uninitialized parity asserts for ZernikeB1.
+  CHECK_THROWS_WITH(
+      evolution::dg::subcell::fd::reconstruct(
+          f_err, dg_mesh_err, subcell_extents_err,
+          evolution::dg::subcell::fd::ReconstructionMethod::DimByDim,
+          Spectral::Parity::Uninitialized),
+      Catch::Matchers::ContainsSubstring("Parity must be set"));
+#endif
+}
+
 // [[TimeOut, 20]]
 SPECTRE_TEST_CASE("Unit.Evolution.Subcell.Fd.Reconstruction",
                   "[Evolution][Unit]") {
@@ -257,5 +359,6 @@ SPECTRE_TEST_CASE("Unit.Evolution.Subcell.Fd.Reconstruction",
                         Spectral::Quadrature::Gauss>(
         {1.0e-14, 1.0e-14, 1.0e-6, 3.0e-7, 3.0e-8}, reconstruction_method);
   }
+  test_zernike_b1_reconstruct();
 }
 }  // namespace


### PR DESCRIPTION
## Proposed changes

Analogous to #7241, update subcell reconstruction to account for ZernikeB1's requirement of parity to properly interpolate

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
