### PR TITLE
CCE: allow specifying InitializeJ from input file for analytic runs

### DIFF
--- a/src/Evolution/Systems/Cce/OptionTags.hpp
+++ b/src/Evolution/Systems/Cce/OptionTags.hpp
@@ -196,6 +196,28 @@ struct InitializeJ {
       "The initialization for the first hypersurface for J"};
   using group = Cce;
 };
+
+/// Option for choosing the first-hypersurface initialization of J in an
+/// analytic-solution CCE run.
+///
+/// \details Set to `FromAnalyticSolution` to use the J initialization provided
+/// by the analytic solution itself (via
+/// `Cce::Solutions::WorldtubeData::get_initialize_j`). Otherwise, any
+/// option-creatable `Cce::InitializeJ::InitializeJ<false>` may be specified to
+/// override the solution-provided initialization, exactly as in a standard CCE
+/// run.
+struct AnalyticInitializeJ {
+  static std::string name() { return "InitializeJ"; }
+  struct FromAnalyticSolution {};
+  using type =
+      Options::Auto<std::unique_ptr<::Cce::InitializeJ::InitializeJ<false>>,
+                    FromAnalyticSolution>;
+  static constexpr Options::String help{
+      "The initialization for the first hypersurface for J. Set to "
+      "'FromAnalyticSolution' to use the initialization provided by the "
+      "analytic solution."};
+  using group = Cce;
+};
 }  // namespace OptionTags
 
 /// \brief Initialization tags for CCE
@@ -558,17 +580,25 @@ struct InitializeJ : db::SimpleTag {
   }
 };
 
-// Tags that generates an `Cce::InitializeJ::InitializeJ` derived class from an
-// analytic solution.
+// Tag that generates an `Cce::InitializeJ::InitializeJ` derived class for an
+// analytic-solution run. By default the initialization is provided by the
+// analytic solution itself, but it may be overridden from the input file via
+// `OptionTags::AnalyticInitializeJ`.
 struct AnalyticInitializeJ : InitializeJ<false> {
   using base = InitializeJ<false>;
   using option_tags =
-      tmpl::list<OptionTags::AnalyticSolution, OptionTags::StartTime>;
+      tmpl::list<OptionTags::AnalyticInitializeJ, OptionTags::AnalyticSolution,
+                 OptionTags::StartTime>;
   static constexpr bool pass_metavariables = false;
   static std::unique_ptr<::Cce::InitializeJ::InitializeJ<false>>
   create_from_options(
+      const std::optional<std::unique_ptr<
+          ::Cce::InitializeJ::InitializeJ<false>>>& initialize_j,
       const std::unique_ptr<Cce::Solutions::WorldtubeData>& worldtube_data,
       const std::optional<double> start_time) {
+    if (initialize_j.has_value()) {
+      return initialize_j.value()->get_clone();
+    }
     return worldtube_data->get_initialize_j(*start_time);
   }
 };

--- a/tests/InputFiles/Cce/AnalyticTestBouncingBlackHole.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestBouncingBlackHole.yaml
@@ -69,6 +69,11 @@ Cce:
   EndTime: 0.8
   ExtractionRadius: 30.0
 
+  # The first-hypersurface initialization for J may be specified here just as
+  # in a standard CCE run, or set to 'FromAnalyticSolution' to use the
+  # initialization provided by the analytic solution.
+  InitializeJ: FromAnalyticSolution
+
   AnalyticSolution:
     BouncingBlackHole:
       Period: 40.0

--- a/tests/InputFiles/Cce/AnalyticTestGaugeWave.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestGaugeWave.yaml
@@ -69,6 +69,12 @@ Cce:
   EndTime: 4.0
   ExtractionRadius: 40.0
 
+  # The first-hypersurface initialization for J may be specified here just as
+  # in a standard CCE run, or set to 'FromAnalyticSolution' to use the
+  # initialization provided by the analytic solution.
+  InitializeJ:
+    InverseCubic:
+
   AnalyticSolution:
     GaugeWave:
       ExtractionRadius: 40.0

--- a/tests/InputFiles/Cce/AnalyticTestLinearizedBondiSachs.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestLinearizedBondiSachs.yaml
@@ -69,6 +69,11 @@ Cce:
   EndTime: 5.0
   ExtractionRadius: 40.0
 
+  # The first-hypersurface initialization for J may be specified here just as
+  # in a standard CCE run, or set to 'FromAnalyticSolution' to use the
+  # initialization provided by the analytic solution.
+  InitializeJ: FromAnalyticSolution
+
   AnalyticSolution:
     LinearizedBondiSachs:
       ExtractionRadius: 40.0

--- a/tests/InputFiles/Cce/AnalyticTestRobinsonTrautman.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestRobinsonTrautman.yaml
@@ -69,6 +69,11 @@ Cce:
   EndTime: 0.5
   ExtractionRadius: 40.0
 
+  # The first-hypersurface initialization for J may be specified here just as
+  # in a standard CCE run, or set to 'FromAnalyticSolution' to use the
+  # initialization provided by the analytic solution.
+  InitializeJ: FromAnalyticSolution
+
   AnalyticSolution:
     RobinsonTrautman:
       InitialModes:

--- a/tests/InputFiles/Cce/AnalyticTestRotatingSchwarzschild.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestRotatingSchwarzschild.yaml
@@ -69,6 +69,11 @@ Cce:
   EndTime: 2.4
   ExtractionRadius: 20.0
 
+  # The first-hypersurface initialization for J may be specified here just as
+  # in a standard CCE run, or set to 'FromAnalyticSolution' to use the
+  # initialization provided by the analytic solution.
+  InitializeJ: FromAnalyticSolution
+
   AnalyticSolution:
     RotatingSchwarzschild:
       ExtractionRadius: 20.0

--- a/tests/InputFiles/Cce/AnalyticTestTeukolskyWave.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestTeukolskyWave.yaml
@@ -69,6 +69,11 @@ Cce:
   EndTime: -1.0
   ExtractionRadius: 40.0
 
+  # The first-hypersurface initialization for J may be specified here just as
+  # in a standard CCE run, or set to 'FromAnalyticSolution' to use the
+  # initialization provided by the analytic solution.
+  InitializeJ: FromAnalyticSolution
+
   AnalyticSolution:
     TeukolskyWave:
       ExtractionRadius: 40.0

--- a/tests/InputFiles/Cce/AnalyticTestVolumeNewmanPenroseSpinCoefficients.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestVolumeNewmanPenroseSpinCoefficients.yaml
@@ -131,6 +131,11 @@ Cce:
   EndTime: 0.8
   ExtractionRadius: 30.0
 
+  # The first-hypersurface initialization for J may be specified here just as
+  # in a standard CCE run, or set to 'FromAnalyticSolution' to use the
+  # initialization provided by the analytic solution.
+  InitializeJ: FromAnalyticSolution
+
   AnalyticSolution:
     BouncingBlackHole:
       Period: 40.0

--- a/tests/InputFiles/Cce/AnalyticTestVolumeWeylScalars.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestVolumeWeylScalars.yaml
@@ -86,6 +86,11 @@ Cce:
   EndTime: 0.8
   ExtractionRadius: 30.0
 
+  # The first-hypersurface initialization for J may be specified here just as
+  # in a standard CCE run, or set to 'FromAnalyticSolution' to use the
+  # initialization provided by the analytic solution.
+  InitializeJ: FromAnalyticSolution
+
   AnalyticSolution:
     BouncingBlackHole:
       Period: 40.0

--- a/tests/Unit/Evolution/Systems/Cce/Test_OptionTags.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_OptionTags.cpp
@@ -172,6 +172,13 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.OptionTags", "[Unit][Cce]") {
       "  MaxIterations: 300\n"
       "  RequireConvergence: false\n"
       "  MaxScriSecondDerivative: 1e-6");
+  CHECK_FALSE(
+      TestHelpers::test_option_tag<Cce::OptionTags::AnalyticInitializeJ>(
+          "FromAnalyticSolution")
+          .has_value());
+  CHECK(TestHelpers::test_option_tag<Cce::OptionTags::AnalyticInitializeJ>(
+            "InverseCubic")
+            .has_value());
   TestHelpers::test_option_tag<Cce::OptionTags::AnalyticSolution>(
       "BouncingBlackHole:\n"
       "  Period: 40.0\n"


### PR DESCRIPTION
Previously the first-hypersurface initialization of J in an analytic-solution CCE run (AnalyticTestCharacteristicExtract) was fixed to whatever the analytic solution provided via
WorldtubeData::get_initialize_j, with no way to override it from the input file. Standard (H5) CCE runs read InitializeJ from the input file.

Add an OptionTags::AnalyticInitializeJ option (yaml key "InitializeJ") of type Options::Auto<unique_ptr<InitializeJ<false>>, FromAnalyticSolution>. Tags::AnalyticInitializeJ now uses the input-file-specified initialization when one is given, and falls back to the solution-provided initialization when set to FromAnalyticSolution.

Update the analytic CCE input files to set the now-required option and add unit-test coverage for the new option tag. The GaugeWave input file exercises the explicit-override path (InverseCubic), which is bit-identical to FromAnalyticSolution for that solution.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
