### PR TITLE
CCE: compute Dy<BondiH> for volume output

### DIFF
--- a/src/Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp
+++ b/src/Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp
@@ -190,6 +190,10 @@ struct CharacteristicEvolution {
       tmpl::transform<bondi_hypersurface_step_tags,
                       tmpl::bind<hypersurface_computation, tmpl::_1>>,
       Actions::FilterSwshVolumeQuantity<Tags::BondiH>,
+      // `Tags::Dy<Tags::BondiH>` is not an input to any hypersurface
+      // integration (unlike the other Bondi radial derivatives), so it is
+      // computed explicitly here, from the filtered `H`, for volume output.
+      ::Actions::MutateApply<PreSwshDerivatives<Tags::Dy<Tags::BondiH>>>,
       ::Actions::MutateApply<
           CalculateScriPlusValue<::Tags::dt<Tags::InertialRetardedTime>>>,
       Actions::CalculateScriInputs,
@@ -224,6 +228,10 @@ struct CharacteristicEvolution {
       tmpl::transform<bondi_hypersurface_step_tags,
                       tmpl::bind<hypersurface_computation, tmpl::_1>>,
       Actions::FilterSwshVolumeQuantity<Tags::BondiH>,
+      // `Tags::Dy<Tags::BondiH>` is not an input to any hypersurface
+      // integration (unlike the other Bondi radial derivatives), so it is
+      // computed explicitly here, from the filtered `H`, for volume output.
+      ::Actions::MutateApply<PreSwshDerivatives<Tags::Dy<Tags::BondiH>>>,
       tmpl::conditional_t<
           evolve_ccm, tmpl::list<>,
           tmpl::flatten<tmpl::list<

--- a/src/Evolution/Systems/Cce/Components/KleinGordonCharacteristicEvolution.hpp
+++ b/src/Evolution/Systems/Cce/Components/KleinGordonCharacteristicEvolution.hpp
@@ -113,6 +113,10 @@ struct KleinGordonCharacteristicEvolution
                       tmpl::bind<hypersurface_computation, tmpl::_1>>,
       klein_gordon_hypersurface_computation,
       Actions::FilterSwshVolumeQuantity<Tags::BondiH>,
+      // `Tags::Dy<Tags::BondiH>` is not an input to any hypersurface
+      // integration (unlike the other Bondi radial derivatives), so it is
+      // computed explicitly here, from the filtered `H`, for volume output.
+      ::Actions::MutateApply<PreSwshDerivatives<Tags::Dy<Tags::BondiH>>>,
       Actions::FilterSwshVolumeQuantity<Tags::KleinGordonPi>,
       ::Actions::MutateApply<
           CalculateScriPlusValue<::Tags::dt<Tags::InertialRetardedTime>>>,
@@ -165,6 +169,10 @@ struct KleinGordonCharacteristicEvolution
                       tmpl::bind<hypersurface_computation, tmpl::_1>>,
       klein_gordon_hypersurface_computation,
       Actions::FilterSwshVolumeQuantity<Tags::BondiH>,
+      // `Tags::Dy<Tags::BondiH>` is not an input to any hypersurface
+      // integration (unlike the other Bondi radial derivatives), so it is
+      // computed explicitly here, from the filtered `H`, for volume output.
+      ::Actions::MutateApply<PreSwshDerivatives<Tags::Dy<Tags::BondiH>>>,
       Actions::FilterSwshVolumeQuantity<Tags::KleinGordonPi>,
       compute_scri_quantities_and_observe,
       ::Actions::MutateApply<ChangeStepSize<


### PR DESCRIPTION
Tags::Dy< Tags::BondiH> is observed by the volume ObserveFields event and has storage allocated, but nothing populated it, so it was written to volume data as identically zero.

Unlike the first radial derivatives of the other Bondi variables (Dy< Beta>, Dy< Q>, Dy< U>, Dy< W>), which are computed during the hypersurface steps because they are inputs to a later integration step, H is the final hypersurface quantity and its radial derivative is not needed by any integration. Compute it explicitly via the generic PreSwshDerivatives< Dy< Tag>> spectral differentiation immediately after H is integrated and filtered, before the volume observation, so the observed value is the fresh, current-step derivative of the filtered H.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
