### PR TITLE
CCE: raise second-order init-data test iteration cap to 1000

### DIFF
--- a/tests/Unit/Evolution/Systems/Cce/Test_InitializeCce.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_InitializeCce.cpp
@@ -294,10 +294,12 @@ void test_initialize_j_cauchy_second_order(
     const size_t l_max, const size_t number_of_radial_points) {
   auto node_lock = Parallel::NodeLock{};
   // The angular coordinates are adapted iteratively (as in NoIncomingRadiation
-  // and ConformalFactor), so we only request a tolerance the linearized solve
-  // can reliably reach for randomly generated data.
+  // and ConformalFactor). For randomly generated data the linearized solve
+  // occasionally needs more than a few hundred iterations to reach 1e-10, so we
+  // allow up to 1000 iterations (the option maximum) to reliably converge with
+  // `require_convergence = true`.
   const auto initializer =
-      InitializeJ::CauchySecondOrder{1.0e-10, 400, true, 1.0e-8};
+      InitializeJ::CauchySecondOrder{1.0e-10, 1000, true, 1.0e-8};
   db::mutate_apply<InitializeJ::CauchySecondOrder::return_tags,
                    InitializeJ::CauchySecondOrder::argument_tags>(
       initializer, box_to_initialize, make_not_null(&node_lock));
@@ -372,10 +374,13 @@ void test_cauchy_second_order_scri_derivative_error(
   // The second-order construction drives the second radial derivative of J at
   // scri+ to (near) zero, but a tiny numerical residual always remains. An
   // unachievably small `MaxScriSecondDerivative` therefore trips the safeguard.
+  // The scri-derivative guard only fires after the angular solve completes, so
+  // allow up to 1000 iterations (as in the successful case above) to reliably
+  // reach convergence rather than aborting on the convergence error first.
   auto node_lock = Parallel::NodeLock{};
   db::mutate_apply<InitializeJ::CauchySecondOrder::return_tags,
                    InitializeJ::CauchySecondOrder::argument_tags>(
-      InitializeJ::CauchySecondOrder{1.0e-10, 400, true, 1.0e-30},
+      InitializeJ::CauchySecondOrder{1.0e-10, 1000, true, 1.0e-30},
       box_to_initialize, make_not_null(&node_lock));
 }
 


### PR DESCRIPTION
The tests test_initialize_j_cauchy_second_order and test_cauchy_second_order_scri_derivative_error run the CauchySecondOrder angular solve with require_convergence=true at tolerance 1e-10, but cap the iteration count at 400. For a small fraction of random seeds the linearized solve needs more iterations to reach 1e-10 and aborts with the convergence error. That failed the normal test outright, and made the scri-derivative-guard test throw the convergence error instead of the expected "second radial derivative at scri+" error, so CHECK_THROWS_WITH failed (~2-3% of runs).

The solve converges slowly rather than stalling, so raise the iteration cap to 1000 (the MaxIterations option maximum) in both tests. This keeps require_convergence=true and removes the flake: 0 failures in 100 runs. 

The scri-derivative guard fires only after the solve completes, so the extra iterations simply let that test reach the guard. The asymptotic-J error test is left at 400: its guard fires before the angular solve, so the iteration count is irrelevant there.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
