### PR TITLE
Add hp projections for spherical shells

### DIFF
--- a/src/Elliptic/DiscontinuousGalerkin/DgOperator.hpp
+++ b/src/Elliptic/DiscontinuousGalerkin/DgOperator.hpp
@@ -197,13 +197,11 @@ Variables<TagsList> mass_conservative_restriction(
   if constexpr (FaceDim == 0) {
     return mortar_vars;
   } else {
-    const auto projection_matrices =
-        Spectral::projection_matrix_child_to_parent(mortar_mesh, face_mesh,
-                                                    mortar_size, true);
     mortar_vars *= get(mortar_jacobian);
     ::dg::apply_mass_matrix(make_not_null(&mortar_vars), mortar_mesh);
-    auto face_vars =
-        apply_matrices(projection_matrices, mortar_vars, mortar_mesh.extents());
+    auto face_vars = Spectral::project(
+        mortar_vars, mortar_mesh, face_mesh, mortar_size,
+        make_array<FaceDim>(Spectral::SegmentSize::Full), true);
     face_vars /= get(face_jacobian);
     ::dg::apply_inverse_mass_matrix(make_not_null(&face_vars), face_mesh);
     return face_vars;

--- a/src/Evolution/DiscontinuousGalerkin/Initialization/Mortars.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/Initialization/Mortars.cpp
@@ -456,13 +456,10 @@ void ProjectMortars<Dim, LocalTimeStepping>::apply(
                     const gsl::not_null<::evolution::dg::MortarData<Dim>*>
                         data) {
                   const auto& old_mortar_mesh = data->mortar_mesh.value();
-                  const auto mortar_projection_matrices =
-                      Spectral::projection_matrices(
-                          old_mortar_mesh, new_mortar_mesh, old_mortar_size,
-                          new_mortar_size);
                   DataVector& vars = data->mortar_data.value();
-                  vars = apply_matrices(mortar_projection_matrices, vars,
-                                        old_mortar_mesh.extents());
+                  vars =
+                      Spectral::project(vars, old_mortar_mesh, new_mortar_mesh,
+                                        old_mortar_size, new_mortar_size);
                   data->mortar_mesh = new_mortar_mesh;
                   return true;
                 };
@@ -478,13 +475,9 @@ void ProjectMortars<Dim, LocalTimeStepping>::apply(
                         data) {
                   const auto& old_data = old_local_history.data(id);
                   const auto& old_mortar_mesh = old_data.mortar_mesh.value();
-                  const auto mortar_projection_matrices =
-                      Spectral::projection_matrices(
-                          old_mortar_mesh, new_mortar_mesh, old_mortar_size,
-                          new_mortar_size);
-                  data->mortar_data.value() += apply_matrices(
-                      mortar_projection_matrices, old_data.mortar_data.value(),
-                      old_mortar_mesh.extents());
+                  data->mortar_data.value() += Spectral::project(
+                      old_data.mortar_data.value(), old_mortar_mesh,
+                      new_mortar_mesh, old_mortar_size, new_mortar_size);
                   return true;
                 };
             local_history.for_each(project_local_mortar_data);

--- a/src/Evolution/DiscontinuousGalerkin/Initialization/Mortars.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Initialization/Mortars.hpp
@@ -11,7 +11,6 @@
 #include <utility>
 #include <vector>
 
-#include "DataStructures/ApplyMatrices.hpp"
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/DataBoxTag.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
@@ -300,14 +299,11 @@ struct ProjectMortars : tt::ConformsTo<amr::protocols::Projector> {
                   const TimeStepId& /* id */,
                   const gsl::not_null<::evolution::dg::MortarData<Dim>*> data) {
                 const auto& old_mortar_mesh = data->mortar_mesh.value();
-                const auto mortar_projection_matrices =
-                    Spectral::projection_matrices(
-                        old_mortar_mesh, new_mortar_mesh,
-                        make_array<Dim - 1>(Spectral::SegmentSize::Full),
-                        new_mortar_size);
                 DataVector& vars = data->mortar_data.value();
-                vars = apply_matrices(mortar_projection_matrices, vars,
-                                      old_mortar_mesh.extents());
+                vars = Spectral::project(
+                    vars, old_mortar_mesh, new_mortar_mesh,
+                    make_array<Dim - 1>(Spectral::SegmentSize::Full),
+                    new_mortar_size);
                 data->mortar_mesh = new_mortar_mesh;
                 return true;
               };
@@ -380,13 +376,10 @@ struct ProjectMortars : tt::ConformsTo<amr::protocols::Projector> {
                       const gsl::not_null<::evolution::dg::MortarData<Dim>*>
                           data) {
                     const auto& old_mortar_mesh = data->mortar_mesh.value();
-                    const auto mortar_projection_matrices =
-                        Spectral::projection_matrices(
-                            old_mortar_mesh, new_mortar_mesh, old_mortar_size,
-                            make_array<Dim - 1>(Spectral::SegmentSize::Full));
                     DataVector& vars = data->mortar_data.value();
-                    vars = apply_matrices(mortar_projection_matrices, vars,
-                                          old_mortar_mesh.extents());
+                    vars = Spectral::project(
+                        vars, old_mortar_mesh, new_mortar_mesh, old_mortar_size,
+                        make_array<Dim - 1>(Spectral::SegmentSize::Full));
                     data->mortar_mesh = new_mortar_mesh;
                     return true;
                   };
@@ -402,14 +395,10 @@ struct ProjectMortars : tt::ConformsTo<amr::protocols::Projector> {
                     const auto& old_data = old_remote_history.data(id);
                     const auto& old_mortar_mesh =
                         old_data.mortar_mesh.value();
-                    const auto mortar_projection_matrices =
-                        Spectral::projection_matrices(
-                            old_mortar_mesh, new_mortar_mesh, old_mortar_size,
-                            make_array<Dim - 1>(Spectral::SegmentSize::Full));
-                    data->mortar_data.value() +=
-                        apply_matrices(mortar_projection_matrices,
-                                       old_data.mortar_data.value(),
-                                       old_mortar_mesh.extents());
+                    data->mortar_data.value() += Spectral::project(
+                        old_data.mortar_data.value(), old_mortar_mesh,
+                        new_mortar_mesh, old_mortar_size,
+                        make_array<Dim - 1>(Spectral::SegmentSize::Full));
                     return true;
                   };
               remote_history.for_each(project_mortar_data);

--- a/src/Evolution/DiscontinuousGalerkin/MortarData.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/MortarData.cpp
@@ -12,7 +12,6 @@
 #include <utility>
 #include <vector>
 
-#include "DataStructures/ApplyMatrices.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
@@ -43,15 +42,13 @@ bool p_project_geometric_data(
     if (mortar_data->face_normal_magnitude.has_value()) {
       const auto& old_face_mesh = mortar_data->face_mesh.value();
       if (old_face_mesh != new_face_mesh) {
-        const auto face_projection_matrices =
-            Spectral::p_projection_matrices(old_face_mesh, new_face_mesh);
+        const auto full = make_array<Dim - 1>(Spectral::SegmentSize::Full);
         DataVector& n = get(mortar_data->face_normal_magnitude.value());
-        n = apply_matrices(face_projection_matrices, n,
-                           old_face_mesh.extents());
+        n = Spectral::project(n, old_face_mesh, new_face_mesh, full, full);
         if (mortar_data->face_det_jacobian.has_value()) {
           DataVector& det_j = get(mortar_data->face_det_jacobian.value());
-          det_j = apply_matrices(face_projection_matrices, det_j,
-                                 old_face_mesh.extents());
+          det_j = Spectral::project(det_j, old_face_mesh, new_face_mesh, full,
+                                    full);
         }
         mortar_data->face_mesh = new_face_mesh;
         changed = true;
@@ -61,11 +58,10 @@ bool p_project_geometric_data(
   if (mortar_data->volume_det_inv_jacobian.has_value()) {
     const auto& old_volume_mesh = mortar_data->volume_mesh.value();
     if (old_volume_mesh != new_volume_mesh) {
-      const auto volume_projection_matrices =
-          Spectral::p_projection_matrices(old_volume_mesh, new_volume_mesh);
+      const auto full = make_array<Dim>(Spectral::SegmentSize::Full);
       DataVector& det_inv_j = get(mortar_data->volume_det_inv_jacobian.value());
-      det_inv_j = apply_matrices(volume_projection_matrices, det_inv_j,
-                                 old_volume_mesh.extents());
+      det_inv_j = Spectral::project(det_inv_j, old_volume_mesh, new_volume_mesh,
+                                    full, full);
       mortar_data->volume_mesh = new_volume_mesh;
       changed = true;
     }
@@ -83,11 +79,10 @@ bool p_project_mortar_data(
     if (old_mortar_mesh == new_mortar_mesh) {
       return false;
     }
-    const auto mortar_projection_matrices =
-        Spectral::p_projection_matrices(old_mortar_mesh, new_mortar_mesh);
+    const auto full = make_array<Dim - 1>(Spectral::SegmentSize::Full);
     DataVector& vars = mortar_data->mortar_data.value();
-    vars = apply_matrices(mortar_projection_matrices, vars,
-                          old_mortar_mesh.extents());
+    vars =
+        Spectral::project(vars, old_mortar_mesh, new_mortar_mesh, full, full);
     mortar_data->mortar_mesh = new_mortar_mesh;
     return true;
   } else {

--- a/src/Evolution/Initialization/Evolution.hpp
+++ b/src/Evolution/Initialization/Evolution.hpp
@@ -11,7 +11,6 @@
 #include <unordered_map>
 #include <utility>
 
-#include "DataStructures/ApplyMatrices.hpp"
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/TaggedTuple.hpp"
@@ -396,13 +395,11 @@ struct ProjectTimeStepperHistory : tt::ConformsTo<amr::protocols::Projector> {
     if (old_mesh == new_mesh) {
       return;  // mesh was not refined, so no projection needed
     }
-    const auto projection_matrices =
-        Spectral::p_projection_matrices(old_mesh, new_mesh);
-    const auto& old_extents = old_mesh.extents();
-    history->map_entries(
-        [&projection_matrices, &old_extents](const auto entry) {
-          *entry = apply_matrices(projection_matrices, *entry, old_extents);
-        });
+    history->map_entries([&old_mesh, &new_mesh](const auto entry) {
+      *entry = Spectral::project(*entry, old_mesh, new_mesh,
+                                 make_array<dim>(Spectral::SegmentSize::Full),
+                                 make_array<dim>(Spectral::SegmentSize::Full));
+    });
     dt_vars->initialize(new_mesh.number_of_grid_points());
   }
 
@@ -454,13 +451,12 @@ struct ProjectTimeStepperHistory : tt::ConformsTo<amr::protocols::Projector> {
         const auto& parent_mesh = get<domain::Tags::Mesh<dim>>(parent_items);
         const auto child_sizes = domain::child_size(element_id.segment_ids(),
                                                     parent_id.segment_ids());
-        const auto projection_matrices =
-            Spectral::projection_matrix_parent_to_child(parent_mesh, new_mesh,
-                                                        child_sizes);
         transform(history, get<history_tag>(parent_items),
                   [&](const auto& source_entry) {
-                    return apply_matrices(projection_matrices, source_entry,
-                                          parent_mesh.extents());
+                    return Spectral::project(
+                        source_entry, parent_mesh, new_mesh,
+                        make_array<dim>(Spectral::SegmentSize::Full),
+                        child_sizes);
                   });
         break;
       }
@@ -521,22 +517,21 @@ struct ProjectTimeStepperHistory : tt::ConformsTo<amr::protocols::Projector> {
           const auto& child_mesh = get<domain::Tags::Mesh<dim>>(child_items);
           const auto child_sizes = domain::child_size(child_id.segment_ids(),
                                                       element_id.segment_ids());
-          const auto projection_matrices =
-              Spectral::projection_matrix_child_to_parent(child_mesh, new_mesh,
-                                                          child_sizes);
           if (first_child) {
             transform(history, get<history_tag>(child_items),
                       [&](const auto& source_entry) {
-                        return apply_matrices(projection_matrices, source_entry,
-                                              child_mesh.extents());
+                        return Spectral::project(
+                            source_entry, child_mesh, new_mesh, child_sizes,
+                            make_array<dim>(Spectral::SegmentSize::Full));
                       });
             first_child = false;
           } else {
             transform_mutate(
                 history, get<history_tag>(child_items),
                 [&](const auto dest_entry, const auto& source_entry) {
-                  *dest_entry += apply_matrices(
-                      projection_matrices, source_entry, child_mesh.extents());
+                  *dest_entry += Spectral::project(
+                      source_entry, child_mesh, new_mesh, child_sizes,
+                      make_array<dim>(Spectral::SegmentSize::Full));
                 });
           }
         }

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.hpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.hpp
@@ -11,7 +11,6 @@
 #include <type_traits>
 #include <utility>
 
-#include "DataStructures/ApplyMatrices.hpp"
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/Matrix.hpp"
@@ -85,11 +84,8 @@ void project_to_mortar(const gsl::not_null<Variables<Tags>*> result,
                        const Variables<Tags>& vars, const Mesh<Dim>& face_mesh,
                        const Mesh<Dim>& mortar_mesh,
                        const MortarSize<Dim>& mortar_size) {
-  const auto projection_matrices = Spectral::projection_matrix_parent_to_child(
-      face_mesh, mortar_mesh, mortar_size);
-  // We don't add an ASSERT about sizes here because there's already one in
-  // apply_matrices
-  apply_matrices(result, projection_matrices, vars, face_mesh.extents());
+  Spectral::project(result, vars, face_mesh, mortar_mesh,
+                    make_array<Dim>(Spectral::SegmentSize::Full), mortar_size);
 }
 
 template <typename Tags, size_t Dim>
@@ -116,11 +112,8 @@ void project_from_mortar(const gsl::not_null<Variables<Tags>*> result,
   ASSERT(Spectral::needs_projection(face_mesh, mortar_mesh, mortar_size),
          "project_from_mortar should not be called if the interface mesh and "
          "mortar mesh are identical. Please elide the copy instead.");
-  const auto projection_matrices = Spectral::projection_matrix_child_to_parent(
-      mortar_mesh, face_mesh, mortar_size);
-  // We don't add an ASSERT about sizes here because there's already one in
-  // apply_matrices
-  apply_matrices(result, projection_matrices, vars, mortar_mesh.extents());
+  Spectral::project(result, vars, mortar_mesh, face_mesh, mortar_size,
+                    make_array<Dim>(Spectral::SegmentSize::Full));
 }
 
 template <typename Tags, size_t Dim>

--- a/src/NumericalAlgorithms/Spectral/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Spectral/CMakeLists.txt
@@ -92,6 +92,7 @@ target_link_libraries(
   LAPACK::LAPACK
   RootFinding
   SPHEREPACK
+  SphericalHarmonics
   )
 
 add_subdirectory(BasisFunctions)

--- a/src/NumericalAlgorithms/Spectral/Projection.cpp
+++ b/src/NumericalAlgorithms/Spectral/Projection.cpp
@@ -532,14 +532,6 @@ std::array<std::reference_wrapper<const Matrix>, Dim> projection_matrices(
   return projection_matrices;
 }
 
-template <size_t Dim>
-std::array<std::reference_wrapper<const Matrix>, Dim> p_projection_matrices(
-    const Mesh<Dim>& source_mesh, const Mesh<Dim>& target_mesh) {
-  return projection_matrices(source_mesh, target_mesh,
-                             make_array<Dim>(SegmentSize::Full),
-                             make_array<Dim>(SegmentSize::Full));
-}
-
 void project_spherical_harmonics(const gsl::not_null<double*> result_data,
                                  const double* const source_data,
                                  const size_t num_components,
@@ -736,10 +728,7 @@ size_t MortarSizeHash<Dim>::operator()(
                       const Mesh<DIM(data)>& target_mesh,                     \
                       const std::array<SegmentSize, DIM(data)>& source_sizes, \
                       const std::array<SegmentSize, DIM(data)>& target_sizes, \
-                      bool operand_is_massive);                               \
-  template std::array<std::reference_wrapper<const Matrix>, DIM(data)>        \
-  p_projection_matrices(const Mesh<DIM(data)>& source_mesh,                   \
-                        const Mesh<DIM(data)>& target_mesh);
+                      bool operand_is_massive);
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (0, 1, 2, 3))
 #undef INSTANTIATE

--- a/src/NumericalAlgorithms/Spectral/Projection.cpp
+++ b/src/NumericalAlgorithms/Spectral/Projection.cpp
@@ -9,15 +9,22 @@
 #include <functional>
 #include <initializer_list>
 #include <ostream>
+#include <type_traits>
+#include <vector>
 
+#include "DataStructures/ApplyMatrices.hpp"
+#include "DataStructures/ComplexDataVector.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Matrix.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "NumericalAlgorithms/Spectral/CollocationPoints.hpp"
 #include "NumericalAlgorithms/Spectral/InterpolationMatrix.hpp"
 #include "NumericalAlgorithms/Spectral/MaximumNumberOfPoints.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/ModalToNodalMatrix.hpp"
 #include "NumericalAlgorithms/Spectral/NodalToModalMatrix.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Spherepack.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/SpherepackCache.hpp"
 #include "Utilities/Algorithm.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
@@ -485,7 +492,8 @@ template <size_t Dim>
 std::array<std::reference_wrapper<const Matrix>, Dim> projection_matrices(
     const Mesh<Dim>& source_mesh, const Mesh<Dim>& target_mesh,
     const std::array<SegmentSize, Dim>& source_sizes,
-    const std::array<SegmentSize, Dim>& target_sizes) {
+    const std::array<SegmentSize, Dim>& target_sizes,
+    const bool operand_is_massive) {
   static const Matrix identity{};
   auto projection_matrices = make_array<Dim>(std::cref(identity));
   const auto source_mesh_slices = source_mesh.slices();
@@ -499,17 +507,26 @@ std::array<std::reference_wrapper<const Matrix>, Dim> projection_matrices(
       if (source_mesh_slice == target_mesh_slice) {
         // No projection necessary, keep matrix the identity in this dimension
       } else {
+        // p-restriction and p-prolongation are the same (mode
+        // truncation/zero-padding)
         gsl::at(projection_matrices, d) = projection_matrix_child_to_parent(
-            source_mesh_slice, target_mesh_slice, SegmentSize::Full);
+            source_mesh_slice, target_mesh_slice, SegmentSize::Full,
+            operand_is_massive);
       }
     } else if (source_size == SegmentSize::Full) {
+      // h-prolongation
+      ASSERT(not operand_is_massive,
+             "Massive projection is a restriction (child to parent); cannot "
+             "prolong a massive quantity from parent to child.");
       gsl::at(projection_matrices, d) = projection_matrix_parent_to_child(
           source_mesh_slice, target_mesh_slice, target_size);
     } else {
+      // h-restriction
       ASSERT(target_size == SegmentSize::Full,
              "Cannot project from one half of segment to the other.");
       gsl::at(projection_matrices, d) = projection_matrix_child_to_parent(
-          source_mesh_slice, target_mesh_slice, source_size);
+          source_mesh_slice, target_mesh_slice, source_size,
+          operand_is_massive);
     }
   }
   return projection_matrices;
@@ -521,6 +538,156 @@ std::array<std::reference_wrapper<const Matrix>, Dim> p_projection_matrices(
   return projection_matrices(source_mesh, target_mesh,
                              make_array<Dim>(SegmentSize::Full),
                              make_array<Dim>(SegmentSize::Full));
+}
+
+void project_spherical_harmonics(const gsl::not_null<double*> result_data,
+                                 const double* const source_data,
+                                 const size_t num_components,
+                                 const size_t num_radial_points,
+                                 const size_t l_max_source,
+                                 const size_t l_max_target,
+                                 const bool operand_is_massive) {
+  const ylm::Spherepack& ylm_source = ylm::get_spherepack_cache(l_max_source);
+  const ylm::Spherepack& ylm_target = ylm::get_spherepack_cache(l_max_target);
+  const size_t source_points_per_component =
+      num_radial_points * ylm_source.physical_size();
+  const size_t target_points_per_component =
+      num_radial_points * ylm_target.physical_size();
+  DataVector source_coefficients(ylm_source.spectral_size() *
+                                 num_radial_points);
+  DataVector target_coefficients(ylm_target.spectral_size() *
+                                 num_radial_points);
+  // For massive restriction multiply by the angular quadrature weights:
+  // I^T = W_target * P_L2 * W_source^{-1}
+  const auto scale_by_angular_weights = [num_radial_points](
+                                            double* const data,
+                                            const std::vector<double>& weights,
+                                            const bool invert) {
+    for (size_t angular = 0; angular < weights.size(); ++angular) {
+      const double factor = invert ? 1.0 / weights[angular] : weights[angular];
+      for (size_t radial = 0; radial < num_radial_points; ++radial) {
+        data[angular * num_radial_points + radial] *= factor;
+      }
+    }
+  };
+  DataVector weighted_source(operand_is_massive ? source_points_per_component
+                                                : 0);
+  for (size_t component = 0; component < num_components; ++component) {
+    const double* source_component =
+        source_data + component * source_points_per_component;
+    if (operand_is_massive) {
+      std::copy(source_component,
+                source_component + source_points_per_component,
+                weighted_source.data());
+      scale_by_angular_weights(weighted_source.data(),
+                               ylm_source.integration_weights(), true);
+      source_component = weighted_source.data();
+    }
+    ylm_source.phys_to_spec_all_offsets(
+        make_not_null(source_coefficients.data()),
+        make_not_null(source_component), num_radial_points);
+    ylm::Spherepack::prolong_or_restrict(
+        make_not_null(&target_coefficients), source_coefficients, l_max_source,
+        l_max_source, l_max_target, l_max_target, num_radial_points);
+    double* const result_component =
+        result_data.get() + component * target_points_per_component;
+    ylm_target.spec_to_phys_all_offsets(
+        make_not_null(result_component),
+        make_not_null(target_coefficients.data()), num_radial_points);
+    if (operand_is_massive) {
+      scale_by_angular_weights(result_component,
+                               ylm_target.integration_weights(), false);
+    }
+  }
+}
+
+template <typename VectorType, size_t Dim>
+void project(const gsl::not_null<VectorType*> result, const VectorType& source,
+             const Mesh<Dim>& source_mesh, const Mesh<Dim>& target_mesh,
+             const std::array<SegmentSize, Dim>& source_sizes,
+             const std::array<SegmentSize, Dim>& target_sizes,
+             const bool operand_is_massive) {
+  ASSERT(result->data() != source.data(),
+         "The result must not alias the source, because the result is resized "
+         "to the target number of grid points.");
+  // The source may hold several components laid out component-major (e.g. a
+  // `Variables` or the multiple fields of DG boundary data), so infer the
+  // component count from its size.
+  ASSERT(source.size() % source_mesh.number_of_grid_points() == 0,
+         "The source size (" << source.size()
+                             << ") must be a multiple of the number of grid "
+                                "points in the source mesh ("
+                             << source_mesh.number_of_grid_points() << ").");
+  const size_t num_components =
+      source.size() / source_mesh.number_of_grid_points();
+  result->destructive_resize(num_components *
+                             target_mesh.number_of_grid_points());
+  // Handle spherical shells. This is only supported for real data because the
+  // Spherepack angular transforms operate on `double`.
+  if constexpr (std::is_same_v<VectorType, DataVector> and
+                (Dim == 2 or Dim == 3)) {
+    constexpr size_t theta_dim = Dim - 2;
+    if (source_mesh.basis(theta_dim) == Basis::SphericalHarmonic and
+        source_mesh.basis(theta_dim + 1) == Basis::SphericalHarmonic) {
+      ASSERT(target_mesh.basis(theta_dim) == Basis::SphericalHarmonic and
+                 target_mesh.basis(theta_dim + 1) == Basis::SphericalHarmonic,
+             "Both source and target meshes must be spherical-shell meshes.");
+      ASSERT(gsl::at(source_sizes, theta_dim) == SegmentSize::Full and
+                 gsl::at(source_sizes, theta_dim + 1) == SegmentSize::Full and
+                 gsl::at(target_sizes, theta_dim) == SegmentSize::Full and
+                 gsl::at(target_sizes, theta_dim + 1) == SegmentSize::Full,
+             "Spherical shells don't support angular h-refinement, so "
+             "the angular segment sizes must be Full.");
+      const size_t l_max_source = source_mesh.extents(theta_dim) - 1;
+      const size_t l_max_target = target_mesh.extents(theta_dim) - 1;
+      ASSERT(source_mesh.extents(theta_dim + 1) == 2 * l_max_source + 1 and
+                 target_mesh.extents(theta_dim + 1) == 2 * l_max_target + 1,
+             "Spherical-shell projection assumes m_max == l_max, i.e. "
+             "n_phi == 2 * l_max + 1.");
+      size_t num_radial_points = 1;
+      if constexpr (Dim == 3) {
+        // In 3D, project the radial dimension first
+        num_radial_points = target_mesh.extents(0);
+        const Matrix& radial_matrix = projection_matrices<1>(
+            source_mesh.slice_through(0), target_mesh.slice_through(0),
+            {{gsl::at(source_sizes, 0)}}, {{gsl::at(target_sizes, 0)}},
+            operand_is_massive)[0];
+        static const Matrix identity{};
+        if (radial_matrix != identity) {
+          const auto radial_matrices =
+              std::array{std::cref(radial_matrix), std::cref(identity),
+                         std::cref(identity)};
+          if (l_max_source == l_max_target) {
+            // Only radial projection needed, write directly into `result`
+            apply_matrices(result, radial_matrices, source,
+                           source_mesh.extents());
+          } else {
+            // First radial, then angular projection
+            const auto radially_projected =
+                apply_matrices(radial_matrices, source, source_mesh.extents());
+            project_spherical_harmonics(
+                make_not_null(result->data()), radially_projected.data(),
+                num_components, num_radial_points, l_max_source, l_max_target,
+                operand_is_massive);
+          }
+          return;
+        }
+      }
+      if (l_max_source == l_max_target) {
+        *result = source;
+      } else {
+        project_spherical_harmonics(
+            make_not_null(result->data()), source.data(), num_components,
+            num_radial_points, l_max_source, l_max_target, operand_is_massive);
+      }
+      return;
+    }
+  }
+  // Fall back to tensor-product projection for non-spherical meshes
+  apply_matrices(result,
+                 projection_matrices(source_mesh, target_mesh, source_sizes,
+                                     target_sizes, operand_is_massive),
+                 source, source_mesh.extents());
 }
 
 template <size_t DimMinusOne>
@@ -551,30 +718,44 @@ size_t MortarSizeHash<Dim>::operator()(
 }
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
-#define INSTANTIATE(r, data)                                                   \
-  template bool needs_projection(                                              \
-      const Mesh<DIM(data)>& mesh1, const Mesh<DIM(data)>& mesh2,              \
-      const std::array<SegmentSize, DIM(data)>& child_sizes);                  \
-  template std::array<std::reference_wrapper<const Matrix>, DIM(data)>         \
-  projection_matrix_child_to_parent(                                           \
-      const Mesh<DIM(data)>& child_mesh, const Mesh<DIM(data)>& parent_mesh,   \
-      const std::array<SegmentSize, DIM(data)>& child_sizes,                   \
-      bool operand_is_massive);                                                \
-  template std::array<std::reference_wrapper<const Matrix>, DIM(data)>         \
-  projection_matrix_parent_to_child(                                           \
-      const Mesh<DIM(data)>& parent_mesh, const Mesh<DIM(data)>& child_mesh,   \
-      const std::array<SegmentSize, DIM(data)>& child_sizes);                  \
-  template std::array<std::reference_wrapper<const Matrix>, DIM(data)>         \
-  projection_matrices(const Mesh<DIM(data)>& source_mesh,                      \
-                      const Mesh<DIM(data)>& target_mesh,                      \
-                      const std::array<SegmentSize, DIM(data)>& source_sizes,  \
-                      const std::array<SegmentSize, DIM(data)>& target_sizes); \
-  template std::array<std::reference_wrapper<const Matrix>, DIM(data)>         \
-  p_projection_matrices(const Mesh<DIM(data)>& source_mesh,                    \
+#define INSTANTIATE(r, data)                                                  \
+  template bool needs_projection(                                             \
+      const Mesh<DIM(data)>& mesh1, const Mesh<DIM(data)>& mesh2,             \
+      const std::array<SegmentSize, DIM(data)>& child_sizes);                 \
+  template std::array<std::reference_wrapper<const Matrix>, DIM(data)>        \
+  projection_matrix_child_to_parent(                                          \
+      const Mesh<DIM(data)>& child_mesh, const Mesh<DIM(data)>& parent_mesh,  \
+      const std::array<SegmentSize, DIM(data)>& child_sizes,                  \
+      bool operand_is_massive);                                               \
+  template std::array<std::reference_wrapper<const Matrix>, DIM(data)>        \
+  projection_matrix_parent_to_child(                                          \
+      const Mesh<DIM(data)>& parent_mesh, const Mesh<DIM(data)>& child_mesh,  \
+      const std::array<SegmentSize, DIM(data)>& child_sizes);                 \
+  template std::array<std::reference_wrapper<const Matrix>, DIM(data)>        \
+  projection_matrices(const Mesh<DIM(data)>& source_mesh,                     \
+                      const Mesh<DIM(data)>& target_mesh,                     \
+                      const std::array<SegmentSize, DIM(data)>& source_sizes, \
+                      const std::array<SegmentSize, DIM(data)>& target_sizes, \
+                      bool operand_is_massive);                               \
+  template std::array<std::reference_wrapper<const Matrix>, DIM(data)>        \
+  p_projection_matrices(const Mesh<DIM(data)>& source_mesh,                   \
                         const Mesh<DIM(data)>& target_mesh);
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (0, 1, 2, 3))
 #undef INSTANTIATE
+
+#define VECTOR(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define INSTANTIATE(r, data)                                                  \
+  template void project(                                                      \
+      gsl::not_null<VECTOR(data)*> result, const VECTOR(data) & source,       \
+      const Mesh<DIM(data)>& source_mesh, const Mesh<DIM(data)>& target_mesh, \
+      const std::array<SegmentSize, DIM(data)>& source_sizes,                 \
+      const std::array<SegmentSize, DIM(data)>& target_sizes,                 \
+      bool operand_is_massive);
+GENERATE_INSTANTIATIONS(INSTANTIATE, (0, 1, 2, 3),
+                        (DataVector, ComplexDataVector))
+#undef INSTANTIATE
+#undef VECTOR
 
 #define INSTANTIATE(r, data) template class MortarSizeHash<DIM(data)>;
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))

--- a/src/NumericalAlgorithms/Spectral/Projection.hpp
+++ b/src/NumericalAlgorithms/Spectral/Projection.hpp
@@ -112,12 +112,6 @@ std::array<std::reference_wrapper<const Matrix>, Dim> projection_matrices(
     const std::array<SegmentSize, Dim>& target_sizes,
     bool operand_is_massive = false);
 
-/// The projection matrices from a source mesh to a target mesh where the
-/// meshes cover the same physical volume
-template <size_t Dim>
-std::array<std::reference_wrapper<const Matrix>, Dim> p_projection_matrices(
-    const Mesh<Dim>& source_mesh, const Mesh<Dim>& target_mesh);
-
 /// Change the angular resolution (`l_max`, with `m_max == l_max`) of volume
 /// data on a spherical shell from `source_data` to `result_data`, for
 /// `num_components` components each laid out with the radial dimension varying

--- a/src/NumericalAlgorithms/Spectral/Projection.hpp
+++ b/src/NumericalAlgorithms/Spectral/Projection.hpp
@@ -6,16 +6,14 @@
 #include <array>
 #include <cstddef>
 #include <functional>
-#include <ostream>
 
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Matrix.hpp"
+#include "DataStructures/Variables.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/SegmentSize.hpp"
 #include "Utilities/ConstantExpressions.hpp"
-
-/// \cond
-class Matrix;
-template <size_t Dim>
-class Mesh;
-/// \endcond
+#include "Utilities/Gsl.hpp"
 
 namespace Spectral {
 /// Determine whether data needs to be projected between a child mesh and its
@@ -67,6 +65,16 @@ bool needs_projection(const Mesh<Dim>& mesh1, const Mesh<Dim>& mesh2,
  * T_{jk} = \frac{2 j + 1}{2} 2^j \sum_{n=0}^{j-k} \binom{j}{k+n}
  * \binom{(j + k + n - 1)/2}{j} \frac{(k + n)!^2}{(2 k + n + 1)! n!}
  * \f}
+ *
+ * \note This and the other matrix-returning projection functions in this file
+ * (projection_matrix_parent_to_child(), projection_matrices()) only support
+ * tensor-product bases (Legendre, Fourier, ZernikeB2). They cannot be used for
+ * spherical-shell meshes that use the `SphericalHarmonic` basis, because the
+ * angular projection couples the \f$\theta\f$ and \f$\phi\f$ directions and so
+ * cannot be expressed as the per-dimension matrices these functions return. Use
+ * Spectral::project() instead whenever spherical-shell meshes must be
+ * supported; it dispatches to these matrices for tensor-product meshes and to a
+ * Spherepack-based angular projection for spherical-shell meshes.
  */
 const Matrix& projection_matrix_child_to_parent(
     const Mesh<1>& child_mesh, const Mesh<1>& parent_mesh, SegmentSize size,
@@ -101,13 +109,97 @@ template <size_t Dim>
 std::array<std::reference_wrapper<const Matrix>, Dim> projection_matrices(
     const Mesh<Dim>& source_mesh, const Mesh<Dim>& target_mesh,
     const std::array<SegmentSize, Dim>& source_sizes,
-    const std::array<SegmentSize, Dim>& target_sizes);
+    const std::array<SegmentSize, Dim>& target_sizes,
+    bool operand_is_massive = false);
 
 /// The projection matrices from a source mesh to a target mesh where the
 /// meshes cover the same physical volume
 template <size_t Dim>
 std::array<std::reference_wrapper<const Matrix>, Dim> p_projection_matrices(
     const Mesh<Dim>& source_mesh, const Mesh<Dim>& target_mesh);
+
+/// Change the angular resolution (`l_max`, with `m_max == l_max`) of volume
+/// data on a spherical shell from `source_data` to `result_data`, for
+/// `num_components` components each laid out with the radial dimension varying
+/// fastest. Uses Spherepack prolong/restrict. \see Spectral::project() for the
+/// higher-level interface to call this.
+///
+/// For non-massive operands this is the L2 (Galerkin) projection,
+/// $P_\mathrm{L2}$. For massive operands (`operand_is_massive == true`) the
+/// restriction is the transpose of the prolongation (interpolation) operator,
+/// $I^T$, which is the L2 projection conjugated by the diagonal matrices $W$ of
+/// angular quadrature weights:
+/// $I^T = W_\mathrm{target} P_\mathrm{L2} W_\mathrm{source}^{-1}$.
+/// This means we divide by the source weights before projecting and multiply by
+/// the target weights afterwards. See projection_matrix_child_to_parent() for
+/// details on massive operands.
+void project_spherical_harmonics(gsl::not_null<double*> result_data,
+                                 const double* source_data,
+                                 size_t num_components,
+                                 size_t num_radial_points, size_t l_max_source,
+                                 size_t l_max_target, bool operand_is_massive);
+
+/// @{
+/*!
+ * \brief Project volume data from `source_mesh` to `target_mesh`, writing the
+ * (resized) result into `*result`.
+ *
+ * This is the unified entry point for projection regardless of basis. It
+ * handles both tensor-product meshes and spherical-shell meshes (Legendre
+ * radial dimension plus `SphericalHarmonic` angular dimensions with
+ * `m_max == l_max`):
+ * - For tensor-product meshes it delegates to the per-dimension projection
+ *   matrices above.
+ * - For spherical-shell meshes it projects the radial dimension with the 1D
+ *   projection matrix and changes the angular `l_max` with a Spherepack
+ *   prolong/restrict. The angular dimensions cannot be h-refined, so their
+ *   segment sizes must be `Full`.
+ *
+ * `source_sizes` and `target_sizes` carry h-refinement information (which
+ * portion of an element the source/target cover); pass `Full` in every
+ * dimension for pure p-refinement.
+ *
+ * \warning `*result` must not point to `source` (the result is resized to the
+ * target number of grid points).
+ */
+template <typename VectorType, size_t Dim>
+void project(gsl::not_null<VectorType*> result, const VectorType& source,
+             const Mesh<Dim>& source_mesh, const Mesh<Dim>& target_mesh,
+             const std::array<SegmentSize, Dim>& source_sizes,
+             const std::array<SegmentSize, Dim>& target_sizes,
+             bool operand_is_massive = false);
+
+template <size_t Dim, typename TagList>
+void project(const gsl::not_null<Variables<TagList>*> result,
+             const Variables<TagList>& source, const Mesh<Dim>& source_mesh,
+             const Mesh<Dim>& target_mesh,
+             const std::array<SegmentSize, Dim>& source_sizes,
+             const std::array<SegmentSize, Dim>& target_sizes,
+             const bool operand_is_massive = false) {
+  // Type-erase to the vector implementation with multiple components
+  using VectorType = typename Variables<TagList>::vector_type;
+  using ValueType = typename Variables<TagList>::value_type;
+  result->initialize(target_mesh.number_of_grid_points());
+  VectorType result_view(result->data(), result->size());
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+  const VectorType source_view(const_cast<ValueType*>(source.data()),
+                               source.size());
+  project(make_not_null(&result_view), source_view, source_mesh, target_mesh,
+          source_sizes, target_sizes, operand_is_massive);
+}
+
+template <size_t Dim, typename T>
+T project(const T& source, const Mesh<Dim>& source_mesh,
+          const Mesh<Dim>& target_mesh,
+          const std::array<SegmentSize, Dim>& source_sizes,
+          const std::array<SegmentSize, Dim>& target_sizes,
+          const bool operand_is_massive = false) {
+  T result{};
+  project(make_not_null(&result), source, source_mesh, target_mesh,
+          source_sizes, target_sizes, operand_is_massive);
+  return result;
+}
+/// @}
 
 /// @{
 /// \brief Performs a perfect hash of the mortars into $2^{d-1}$ slots on the

--- a/src/NumericalAlgorithms/SphericalHarmonics/Spherepack.cpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/Spherepack.cpp
@@ -891,30 +891,44 @@ void Spherepack::fill_scalar_work_arrays() {
   }
 }
 
-DataVector Spherepack::prolong_or_restrict(const DataVector& spectral_coefs,
-                                           const size_t l_max_coefs,
-                                           const size_t m_max_coefs,
-                                           const size_t l_max_target,
-                                           const size_t m_max_target) {
-  if (l_max_coefs == l_max_target and m_max_coefs == m_max_target) {
-    return spectral_coefs;
-  }
-
+void Spherepack::prolong_or_restrict(
+    const gsl::not_null<DataVector*> result, const DataVector& spectral_coefs,
+    const size_t l_max_coefs, const size_t m_max_coefs,
+    const size_t l_max_target, const size_t m_max_target, const size_t stride) {
   ASSERT(spectral_coefs.size() ==
-             Spherepack::spectral_size(l_max_coefs, m_max_coefs),
-         "Expecting " << Spherepack::spectral_size(l_max_coefs, m_max_coefs)
+             Spherepack::spectral_size(l_max_coefs, m_max_coefs) * stride,
+         "Expecting " << Spherepack::spectral_size(l_max_coefs, m_max_coefs) *
+                             stride
                       << ", got " << spectral_coefs.size());
-  const size_t spectral_size_target =
-      Spherepack::spectral_size(l_max_target, m_max_target);
-  DataVector result{spectral_size_target, 0.0};
+  if (l_max_coefs == l_max_target and m_max_coefs == m_max_target) {
+    *result = spectral_coefs;
+    return;
+  }
+  result->destructive_resize(
+      Spherepack::spectral_size(l_max_target, m_max_target) * stride);
+  *result = 0.0;
   SpherepackIterator src_it(l_max_coefs, m_max_coefs);
   SpherepackIterator dest_it(l_max_target, m_max_target);
   for (; dest_it; ++dest_it) {
     if (dest_it.l() <= src_it.l_max() and dest_it.m() <= src_it.m_max()) {
       src_it.set(dest_it.l(), dest_it.m(), dest_it.coefficient_array());
-      result[dest_it()] = spectral_coefs[src_it()];
+      for (size_t s = 0; s < stride; ++s) {
+        (*result)[dest_it() * stride + s] =
+            spectral_coefs[src_it() * stride + s];
+      }
     }
   }
+}
+
+DataVector Spherepack::prolong_or_restrict(const DataVector& spectral_coefs,
+                                           const size_t l_max_coefs,
+                                           const size_t m_max_coefs,
+                                           const size_t l_max_target,
+                                           const size_t m_max_target,
+                                           const size_t stride) {
+  DataVector result{};
+  prolong_or_restrict(make_not_null(&result), spectral_coefs, l_max_coefs,
+                      m_max_coefs, l_max_target, m_max_target, stride);
   return result;
 }
 

--- a/src/NumericalAlgorithms/SphericalHarmonics/Spherepack.hpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/Spherepack.hpp
@@ -497,10 +497,25 @@ class Spherepack {
   /// them to be compatible with a resolution given by `l_max_target` and
   /// `m_max_target`. This is done by truncation (restriction) or padding
   /// with zeros (prolongation).
+  ///
+  /// With `stride > 1`, `spectral_coefs` (and the result) hold `stride`
+  /// independent sets of coefficients interleaved with the given stride, i.e.
+  /// coefficient `c` of set `s` is at index `c * stride + s`. This is the
+  /// layout produced by `phys_to_spec_all_offsets`, so several sets (e.g.
+  /// radial points) can be prolonged or restricted in a single call.
   static DataVector prolong_or_restrict(const DataVector& spectral_coefs,
                                         size_t l_max_coefs, size_t m_max_coefs,
                                         size_t l_max_target,
-                                        size_t m_max_target);
+                                        size_t m_max_target, size_t stride = 1);
+
+  /// Same as the overload above, but writes into the pre-allocated `result`
+  /// buffer (resizing it only if necessary) to avoid allocating. Useful to
+  /// reuse a single buffer across repeated calls.
+  static void prolong_or_restrict(gsl::not_null<DataVector*> result,
+                                  const DataVector& spectral_coefs,
+                                  size_t l_max_coefs, size_t m_max_coefs,
+                                  size_t l_max_target, size_t m_max_target,
+                                  size_t stride = 1);
 
   /// Takes spectral coefficients compatible with `*this`, and either
   /// prolongs them or restricts them to be compatible with `target`.

--- a/src/ParallelAlgorithms/Amr/Projectors/Tensors.hpp
+++ b/src/ParallelAlgorithms/Amr/Projectors/Tensors.hpp
@@ -3,11 +3,12 @@
 
 #pragma once
 
+#include <array>
 #include <cstddef>
 #include <unordered_map>
 #include <utility>
 
-#include "DataStructures/ApplyMatrices.hpp"
+#include "DataStructures/DataVector.hpp"
 #include "DataStructures/TaggedTuple.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Domain/Structure/ChildSize.hpp"
@@ -16,8 +17,10 @@
 #include "Domain/Tags.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Projection.hpp"
+#include "NumericalAlgorithms/Spectral/SegmentSize.hpp"
 #include "ParallelAlgorithms/Amr/Protocols/Projector.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace amr::projectors {
@@ -47,13 +50,12 @@ struct ProjectTensors : tt::ConformsTo<amr::protocols::Projector> {
     if (old_mesh == new_mesh) {
       return;  // mesh was not refined, so no projection needed
     }
-    const auto projection_matrices =
-        Spectral::p_projection_matrices(old_mesh, new_mesh);
-    const auto& old_extents = old_mesh.extents();
-    const auto project_tensor = [&projection_matrices,
-                                 old_extents](auto& tensor) {
+    const auto project_tensor = [&old_mesh, &new_mesh](auto& tensor) {
       for (size_t i = 0; i < tensor.size(); ++i) {
-        tensor[i] = apply_matrices(projection_matrices, tensor[i], old_extents);
+        tensor[i] =
+            Spectral::project(tensor[i], old_mesh, new_mesh,
+                              make_array<Dim>(Spectral::SegmentSize::Full),
+                              make_array<Dim>(Spectral::SegmentSize::Full));
       }
     };
     EXPAND_PACK_LEFT_TO_RIGHT(project_tensor(*tensors));
@@ -68,13 +70,11 @@ struct ProjectTensors : tt::ConformsTo<amr::protocols::Projector> {
     const auto& parent_mesh = get<domain::Tags::Mesh<Dim>>(parent_items);
     const auto child_sizes =
         domain::child_size(element_id.segment_ids(), parent_id.segment_ids());
-    const auto projection_matrices =
-        Spectral::projection_matrix_parent_to_child(parent_mesh, new_mesh,
-                                                    child_sizes);
     const auto project_tensor = [&](auto& new_tensor, const auto& old_tensor) {
       for (size_t i = 0; i < new_tensor.size(); ++i) {
-        new_tensor[i] = apply_matrices(projection_matrices, old_tensor[i],
-                                       parent_mesh.extents());
+        Spectral::project(
+            make_not_null(&new_tensor[i]), old_tensor[i], parent_mesh, new_mesh,
+            make_array<Dim>(Spectral::SegmentSize::Full), child_sizes);
       }
       return 0;
     };
@@ -93,15 +93,13 @@ struct ProjectTensors : tt::ConformsTo<amr::protocols::Projector> {
       const auto& child_mesh = get<domain::Tags::Mesh<Dim>>(child_items);
       const auto child_sizes =
           domain::child_size(child_id.segment_ids(), element_id.segment_ids());
-      const auto projection_matrices =
-          Spectral::projection_matrix_child_to_parent(child_mesh, new_mesh,
-                                                      child_sizes);
       if (first_child) {
         const auto project_tensor = [&](auto& new_tensor,
                                         const auto& old_tensor) {
           for (size_t i = 0; i < new_tensor.size(); ++i) {
-            new_tensor[i] = apply_matrices(projection_matrices, old_tensor[i],
-                                           child_mesh.extents());
+            Spectral::project(make_not_null(&new_tensor[i]), old_tensor[i],
+                              child_mesh, new_mesh, child_sizes,
+                              make_array<Dim>(Spectral::SegmentSize::Full));
           }
           return 0;
         };
@@ -111,8 +109,9 @@ struct ProjectTensors : tt::ConformsTo<amr::protocols::Projector> {
         const auto project_tensor = [&](auto& new_tensor,
                                         const auto& old_tensor) {
           for (size_t i = 0; i < new_tensor.size(); ++i) {
-            new_tensor[i] += apply_matrices(projection_matrices, old_tensor[i],
-                                            child_mesh.extents());
+            new_tensor[i] += Spectral::project(
+                old_tensor[i], child_mesh, new_mesh, child_sizes,
+                make_array<Dim>(Spectral::SegmentSize::Full));
           }
           return 0;
         };

--- a/src/ParallelAlgorithms/Amr/Projectors/Variables.hpp
+++ b/src/ParallelAlgorithms/Amr/Projectors/Variables.hpp
@@ -3,11 +3,11 @@
 
 #pragma once
 
+#include <array>
 #include <cstddef>
 #include <unordered_map>
 #include <utility>
 
-#include "DataStructures/ApplyMatrices.hpp"
 #include "DataStructures/TaggedTuple.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Domain/Structure/ChildSize.hpp"
@@ -19,6 +19,7 @@
 #include "NumericalAlgorithms/Spectral/SegmentSize.hpp"
 #include "ParallelAlgorithms/Amr/Protocols/Projector.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace amr::projectors {
@@ -49,11 +50,10 @@ struct ProjectVariables : tt::ConformsTo<amr::protocols::Projector> {
     if (old_mesh == new_mesh) {
       return;  // mesh was not refined, so no projection needed
     }
-    const auto projection_matrices =
-        Spectral::p_projection_matrices(old_mesh, new_mesh);
-    const auto& old_extents = old_mesh.extents();
-    expand_pack(
-        (*vars = apply_matrices(projection_matrices, *vars, old_extents))...);
+    expand_pack((*vars = Spectral::project(
+                     *vars, old_mesh, new_mesh,
+                     make_array<Dim>(Spectral::SegmentSize::Full),
+                     make_array<Dim>(Spectral::SegmentSize::Full)))...);
   }
 
   // h-refinement
@@ -66,12 +66,11 @@ struct ProjectVariables : tt::ConformsTo<amr::protocols::Projector> {
     const auto& parent_mesh = get<domain::Tags::Mesh<Dim>>(parent_items);
     const auto child_sizes =
         domain::child_size(element_id.segment_ids(), parent_id.segment_ids());
-    const auto projection_matrices =
-        Spectral::projection_matrix_parent_to_child(parent_mesh, new_mesh,
-                                                    child_sizes);
-    expand_pack((*vars = apply_matrices(projection_matrices,
-                                        get<VariablesTags>(parent_items),
-                                        parent_mesh.extents()))...);
+    expand_pack((Spectral::project(vars, get<VariablesTags>(parent_items),
+                                   parent_mesh, new_mesh,
+                                   make_array<Dim>(Spectral::SegmentSize::Full),
+                                   child_sizes),
+                 0)...);
   }
 
   // h-coarsening
@@ -87,18 +86,18 @@ struct ProjectVariables : tt::ConformsTo<amr::protocols::Projector> {
       const auto& child_mesh = get<domain::Tags::Mesh<Dim>>(child_items);
       const auto child_sizes =
           domain::child_size(child_id.segment_ids(), element_id.segment_ids());
-      const auto projection_matrices =
-          Spectral::projection_matrix_child_to_parent(child_mesh, new_mesh,
-                                                      child_sizes);
       if (first_child) {
-        expand_pack((*vars = apply_matrices(projection_matrices,
-                                            get<VariablesTags>(child_items),
-                                            child_mesh.extents()))...);
+        expand_pack(
+            (Spectral::project(vars, get<VariablesTags>(child_items),
+                               child_mesh, new_mesh, child_sizes,
+                               make_array<Dim>(Spectral::SegmentSize::Full)),
+             0)...);
         first_child = false;
       } else {
-        expand_pack((*vars += apply_matrices(projection_matrices,
-                                             get<VariablesTags>(child_items),
-                                             child_mesh.extents()))...);
+        expand_pack((*vars += Spectral::project(
+                         get<VariablesTags>(child_items), child_mesh, new_mesh,
+                         child_sizes,
+                         make_array<Dim>(Spectral::SegmentSize::Full)))...);
       }
     }
   }

--- a/src/ParallelAlgorithms/Events/ObserveFields.hpp
+++ b/src/ParallelAlgorithms/Events/ObserveFields.hpp
@@ -15,7 +15,6 @@
 #include <utility>
 #include <vector>
 
-#include "DataStructures/ApplyMatrices.hpp"
 #include "DataStructures/DataBox/ObservationBox.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/DataBox/TagName.hpp"
@@ -292,12 +291,6 @@ class ObserveFields<VolumeDim, tmpl::list<Tensors...>,
     // If no interpolation_mesh is provided, the interpolation is essentially
     // ignored by the RegularGridInterpolant except for a single copy.
     const intrp::RegularGrid interpolant(mesh, target_mesh);
-    const std::optional<
-        std::array<std::reference_wrapper<const Matrix>, VolumeDim>>
-        projection_matrices =
-            do_projection ? std::make_optional(Spectral::p_projection_matrices(
-                                mesh, target_mesh))
-                          : std::nullopt;
 
     // Remove tensor types, only storing individual components.
     std::vector<TensorComponent> components;
@@ -324,17 +317,20 @@ class ObserveFields<VolumeDim, tmpl::list<Tensors...>,
         };
 
     const auto record_tensor_components_impl =
-        [&record_tensor_component_impl, &interpolant, &projection_matrices,
-         &mesh, do_projection](const auto& tensor,
-                               const FloatingPointType floating_point_type,
-                               const std::string& tag_name) {
+        [&record_tensor_component_impl, &interpolant, &mesh, &target_mesh,
+         do_projection](const auto& tensor,
+                        const FloatingPointType floating_point_type,
+                        const std::string& tag_name) {
           using TensorType = std::decay_t<decltype(tensor)>;
           using VectorType = typename TensorType::type;
           for (size_t i = 0; i < tensor.size(); ++i) {
             auto tensor_component =
-                do_projection ? apply_matrices(*projection_matrices, tensor[i],
-                                               mesh.extents())
-                              : interpolant.interpolate(tensor[i]);
+                do_projection
+                    ? Spectral::project(
+                          tensor[i], mesh, target_mesh,
+                          make_array<VolumeDim>(Spectral::SegmentSize::Full),
+                          make_array<VolumeDim>(Spectral::SegmentSize::Full))
+                    : interpolant.interpolate(tensor[i]);
             const std::string component_name =
                 tag_name + tensor.component_suffix(i);
             if constexpr (std::is_same_v<VectorType, ComplexDataVector>) {

--- a/src/ParallelAlgorithms/LinearSolver/Multigrid/Actions/RestrictFields.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Multigrid/Actions/RestrictFields.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <array>
 #include <cstddef>
 #include <map>
 #include <optional>
@@ -10,7 +11,6 @@
 #include <type_traits>
 #include <utility>
 
-#include "DataStructures/ApplyMatrices.hpp"
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/FixedHashMap.hpp"
@@ -23,6 +23,7 @@
 #include "IO/Observer/Tags.hpp"
 #include "NumericalAlgorithms/Convergence/Tags.hpp"
 #include "NumericalAlgorithms/Spectral/Projection.hpp"
+#include "NumericalAlgorithms/Spectral/SegmentSize.hpp"
 #include "Parallel/AlgorithmExecution.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/InboxInserters.hpp"
@@ -35,6 +36,7 @@
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/GetOutput.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
 #include "Utilities/PrettyType.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -129,17 +131,16 @@ struct SendFieldsToCoarserGrid<tmpl::list<FieldsTags...>, OptionsGroup,
     }
     tuples::TaggedTuple<ReceiveTags...> restricted_fields{};
     if (Spectral::needs_projection(mesh, *parent_mesh, child_size)) {
-      const auto restriction_operator =
-          Spectral::projection_matrix_child_to_parent(mesh, *parent_mesh,
-                                                      child_size, massive);
-      const auto restrict_fields = [&restricted_fields, &restriction_operator,
-                                    &mesh](const auto receive_tag_v,
-                                           const auto& fields) {
-        using receive_tag = std::decay_t<decltype(receive_tag_v)>;
-        get<receive_tag>(restricted_fields) = typename receive_tag::type(
-            apply_matrices(restriction_operator, fields, mesh.extents()));
-        return '0';
-      };
+      const auto restrict_fields =
+          [&restricted_fields, &mesh, &parent_mesh, &child_size, massive](
+              const auto receive_tag_v, const auto& fields) {
+            using receive_tag = std::decay_t<decltype(receive_tag_v)>;
+            get<receive_tag>(restricted_fields) =
+                typename receive_tag::type(Spectral::project(
+                    fields, mesh, *parent_mesh, child_size,
+                    make_array<Dim>(Spectral::SegmentSize::Full), massive));
+            return '0';
+          };
       expand_pack(restrict_fields(ReceiveTags{}, db::get<FieldsTags>(box))...);
     } else {
       expand_pack(

--- a/src/ParallelAlgorithms/LinearSolver/Multigrid/ElementActions.hpp
+++ b/src/ParallelAlgorithms/LinearSolver/Multigrid/ElementActions.hpp
@@ -9,7 +9,6 @@
 #include <unordered_map>
 #include <unordered_set>
 
-#include "DataStructures/ApplyMatrices.hpp"
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/FixedHashMap.hpp"
@@ -489,11 +488,9 @@ struct ReceiveCorrectionFromCoarserGrid {
     const auto prolongated_parent_correction =
         [&parent_correction, &parent_mesh, &mesh, &child_size]() {
           if (Spectral::needs_projection(*parent_mesh, mesh, child_size)) {
-            const auto prolongation_operator =
-                Spectral::projection_matrix_parent_to_child(*parent_mesh, mesh,
-                                                            child_size);
-            return apply_matrices(prolongation_operator, parent_correction,
-                                  parent_mesh->extents());
+            return Spectral::project(
+                parent_correction, *parent_mesh, mesh,
+                make_array<Dim>(Spectral::SegmentSize::Full), child_size);
           } else {
             return std::move(parent_correction);
           }

--- a/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_DgOperator.cpp
+++ b/tests/Unit/Elliptic/DiscontinuousGalerkin/Test_DgOperator.cpp
@@ -1363,9 +1363,9 @@ SPECTRE_TEST_CASE("Unit.Elliptic.DG.Operator", "[Unit][Elliptic]") {
           {{{{dirichlet_bc.get_clone(), dirichlet_bc.get_clone()}},
             {{dirichlet_bc.get_clone(), dirichlet_bc.get_clone()}}}}};
       Approx analytic_solution_aux_approx =
-          Approx::custom().epsilon(1.e-11).scale(M_PI);
+          Approx::custom().epsilon(1.e-10).scale(M_PI);
       Approx analytic_solution_operator_approx =
-          Approx::custom().epsilon(1.e-11).scale(M_PI * penalty_parameter *
+          Approx::custom().epsilon(1.e-10).scale(M_PI * penalty_parameter *
                                                  square(12));
       for (const auto& [massive, quadrature, dg_formulation] :
            cartesian_product(make_array(true, false),
@@ -1403,9 +1403,9 @@ SPECTRE_TEST_CASE("Unit.Elliptic.DG.Operator", "[Unit][Elliptic]") {
         {{{{dirichlet_bc.get_clone(), dirichlet_bc.get_clone()}},
           {{dirichlet_bc.get_clone(), dirichlet_bc.get_clone()}}}}};
     Approx analytic_solution_aux_approx =
-        Approx::custom().epsilon(1.e-11).scale(M_PI);
+        Approx::custom().epsilon(1.e-10).scale(M_PI);
     Approx analytic_solution_operator_approx =
-        Approx::custom().epsilon(1.e-11).scale(M_PI * penalty_parameter *
+        Approx::custom().epsilon(1.e-10).scale(M_PI * penalty_parameter *
                                                square(12));
     for (const auto& [massive, quadrature, dg_formulation] :
          cartesian_product(make_array(true, false),

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_Projection.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_Projection.cpp
@@ -530,8 +530,9 @@ void test_p_projection_matrices() {
   const auto quadrature = Spectral::Quadrature::GaussLobatto;
   {
     INFO("Identity");
-    const auto identity = Spectral::p_projection_matrices(
-        Mesh<Dim>{3, basis, quadrature}, Mesh<Dim>{3, basis, quadrature});
+    const auto identity = Spectral::projection_matrices(
+        Mesh<Dim>{3, basis, quadrature}, Mesh<Dim>{3, basis, quadrature},
+        make_array<Dim>(SegmentSize::Full), make_array<Dim>(SegmentSize::Full));
     for (size_t d = 0; d < Dim; ++d) {
       CHECK(gsl::at(identity, d).get() == Matrix{});
     }
@@ -540,9 +541,10 @@ void test_p_projection_matrices() {
     const size_t source_extents = 4;
     std::array<size_t, Dim> target_extents{};
     std::iota(target_extents.begin(), target_extents.end(), size_t{3});
-    const auto projection_matrix = Spectral::p_projection_matrices(
+    const auto projection_matrix = Spectral::projection_matrices(
         Mesh<Dim>{source_extents, basis, quadrature},
-        Mesh<Dim>{target_extents, basis, quadrature});
+        Mesh<Dim>{target_extents, basis, quadrature},
+        make_array<Dim>(SegmentSize::Full), make_array<Dim>(SegmentSize::Full));
     CHECK(&projection_matrix[0].get() ==
           &Spectral::projection_matrix_child_to_parent(
               {4, basis, quadrature}, {3, basis, quadrature},

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_Projection.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_Projection.cpp
@@ -5,9 +5,17 @@
 
 #include <cstddef>
 #include <initializer_list>
+#include <random>
+#include <vector>
 
+#include "DataStructures/ApplyMatrices.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Matrix.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
 #include "Helpers/NumericalAlgorithms/Spectral/FourierTestFunctions.hpp"
 #include "NumericalAlgorithms/DiscontinuousGalerkin/ApplyMassMatrix.hpp"
 #include "NumericalAlgorithms/LinearOperators/DefiniteIntegral.hpp"
@@ -20,10 +28,15 @@
 #include "NumericalAlgorithms/Spectral/Projection.hpp"
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
 #include "NumericalAlgorithms/Spectral/SegmentSize.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Spherepack.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/SpherepackCache.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/GetOutput.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/MakeArray.hpp"
+#include "Utilities/Math.hpp"
+#include "Utilities/TMPL.hpp"
 
 namespace Spectral {
 namespace {
@@ -542,6 +555,11 @@ void test_p_projection_matrices() {
             &Spectral::projection_matrix_child_to_parent(
                 {4, basis, quadrature}, {5, basis, quadrature},
                 Spectral::SegmentSize::Full));
+      // Interpolation is the same as mode-padding
+      CHECK(projection_matrix[2].get() ==
+            Spectral::projection_matrix_parent_to_child(
+                {4, basis, quadrature}, {5, basis, quadrature},
+                Spectral::SegmentSize::Full));
     }
   }
 }
@@ -820,6 +838,323 @@ void test_hash() {
   CHECK(Spectral::MortarSizeHash<3>{}(
             {Spectral::SegmentSize::Full, Spectral::SegmentSize::Full}) == 0);
 }
+
+// Tags used by the Variables overload test of Spectral::project.
+struct Scalar1 : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+struct Scalar2 : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+Mesh<3> shell_mesh(const size_t num_radial_points, const size_t l_max) {
+  return Mesh<3>{
+      {{num_radial_points, l_max + 1, 2 * l_max + 1}},
+      {{Spectral::Basis::Legendre, Spectral::Basis::SphericalHarmonic,
+        Spectral::Basis::SphericalHarmonic}},
+      {{Spectral::Quadrature::GaussLobatto, Spectral::Quadrature::Gauss,
+        Spectral::Quadrature::Equiangular}}};
+}
+
+Mesh<2> sphere_mesh(const size_t l_max) {
+  return Mesh<2>{
+      {{l_max + 1, 2 * l_max + 1}},
+      {{Spectral::Basis::SphericalHarmonic,
+        Spectral::Basis::SphericalHarmonic}},
+      {{Spectral::Quadrature::Gauss, Spectral::Quadrature::Equiangular}}};
+}
+
+// Build volume data on a spherical shell representing the separable function
+// radial_poly(r) * angular(theta, phi), where the angular part is defined by
+// `reference_modes` (the Spherepack spectral coefficients at `l_reference`,
+// with no content above that degree) and radial_poly is the polynomial with the
+// given `radial_coeffs` in the logical radial coordinate. As long as the mesh
+// resolves both factors (l_max >= l_reference and num_radial_points > degree),
+// this is the *same* function on every such mesh, so Spectral::project between
+// two of them must reproduce it exactly.
+DataVector shell_field(const Mesh<3>& mesh, const DataVector& reference_modes,
+                       const size_t l_reference,
+                       const std::vector<double>& radial_coeffs) {
+  const size_t l_max = mesh.extents(1) - 1;
+  const size_t num_radial_points = mesh.extents(0);
+  const ylm::Spherepack& ylm = ylm::get_spherepack_cache(l_max);
+  const DataVector modes = ylm::Spherepack::prolong_or_restrict(
+      reference_modes, l_reference, l_reference, l_max, l_max);
+  const DataVector angular = ylm.spec_to_phys(modes);
+  const DataVector radial = evaluate_polynomial(
+      radial_coeffs, Spectral::collocation_points(mesh.slice_through(0)));
+  DataVector field(num_radial_points * angular.size());
+  for (size_t a = 0; a < angular.size(); ++a) {
+    for (size_t r = 0; r < num_radial_points; ++r) {
+      field[r + num_radial_points * a] = radial[r] * angular[a];
+    }
+  }
+  return field;
+}
+
+// The angular factor of shell_field on its own, as a function on the 2D sphere
+// `mesh`. It contains no angular modes above degree `l_reference`, so it is the
+// same function on every mesh that resolves it (l_max >= l_reference) and
+// Spectral::project between two such meshes must reproduce it exactly.
+DataVector sphere_field(const Mesh<2>& mesh, const DataVector& reference_modes,
+                        const size_t l_reference) {
+  const size_t l_max = mesh.extents(0) - 1;
+  const ylm::Spherepack& ylm = ylm::get_spherepack_cache(l_max);
+  const DataVector modes = ylm::Spherepack::prolong_or_restrict(
+      reference_modes, l_reference, l_reference, l_max, l_max);
+  return ylm.spec_to_phys(modes);
+}
+
+// The cube (tensor-product) path of Spectral::project must reproduce exactly
+// the behavior of the matrix-returning API, so existing consumers are
+// unchanged.
+void test_project_cube() {
+  MAKE_GENERATOR(gen);
+  std::uniform_real_distribution<double> dist(-1.0, 1.0);
+  // p-refinement
+  {
+    const Mesh<2> source{{{3, 4}},
+                         Spectral::Basis::Legendre,
+                         Spectral::Quadrature::GaussLobatto};
+    const Mesh<2> target{{{5, 6}},
+                         Spectral::Basis::Legendre,
+                         Spectral::Quadrature::GaussLobatto};
+    DataVector data(source.number_of_grid_points());
+    fill_with_random_values(make_not_null(&data), make_not_null(&gen),
+                            make_not_null(&dist));
+    DataVector result{};
+    Spectral::project(make_not_null(&result), data, source, target,
+                      make_array<2>(Spectral::SegmentSize::Full),
+                      make_array<2>(Spectral::SegmentSize::Full));
+    const DataVector expected = apply_matrices(
+        Spectral::projection_matrices(
+            source, target, make_array<2>(Spectral::SegmentSize::Full),
+            make_array<2>(Spectral::SegmentSize::Full)),
+        data, source.extents());
+    CHECK_ITERABLE_APPROX(result, expected);
+  }
+  // h-refinement (parent -> child) in dimension 0
+  {
+    const Mesh<2> parent{{{4, 4}},
+                         Spectral::Basis::Legendre,
+                         Spectral::Quadrature::GaussLobatto};
+    const Mesh<2> child{{{4, 4}},
+                        Spectral::Basis::Legendre,
+                        Spectral::Quadrature::GaussLobatto};
+    const std::array child_sizes{Spectral::SegmentSize::UpperHalf,
+                                 Spectral::SegmentSize::Full};
+    DataVector data(parent.number_of_grid_points());
+    fill_with_random_values(make_not_null(&data), make_not_null(&gen),
+                            make_not_null(&dist));
+    DataVector result{};
+    Spectral::project(make_not_null(&result), data, parent, child,
+                      make_array<2>(Spectral::SegmentSize::Full), child_sizes);
+    const DataVector expected = apply_matrices(
+        Spectral::projection_matrix_parent_to_child(parent, child, child_sizes),
+        data, parent.extents());
+    CHECK_ITERABLE_APPROX(result, expected);
+  }
+  // massive restriction (child -> parent)
+  {
+    const Mesh<2> child{{{5, 5}},
+                        Spectral::Basis::Legendre,
+                        Spectral::Quadrature::GaussLobatto};
+    const Mesh<2> parent{{{3, 3}},
+                         Spectral::Basis::Legendre,
+                         Spectral::Quadrature::GaussLobatto};
+    const std::array child_sizes{Spectral::SegmentSize::LowerHalf,
+                                 Spectral::SegmentSize::Full};
+    DataVector data(child.number_of_grid_points());
+    fill_with_random_values(make_not_null(&data), make_not_null(&gen),
+                            make_not_null(&dist));
+    DataVector result{};
+    Spectral::project(make_not_null(&result), data, child, parent, child_sizes,
+                      make_array<2>(Spectral::SegmentSize::Full), true);
+    const DataVector expected =
+        apply_matrices(Spectral::projection_matrix_child_to_parent(
+                           child, parent, child_sizes, true),
+                       data, child.extents());
+    CHECK_ITERABLE_APPROX(result, expected);
+  }
+}
+
+void test_project_shell() {
+  MAKE_GENERATOR(gen);
+  std::uniform_real_distribution<double> dist(-1.0, 1.0);
+  const size_t l_reference = 4;
+  const ylm::Spherepack& ylm_reference = ylm::get_spherepack_cache(l_reference);
+  DataVector reference_phys(ylm_reference.physical_size());
+  fill_with_random_values(make_not_null(&reference_phys), make_not_null(&gen),
+                          make_not_null(&dist));
+  const DataVector reference_modes = ylm_reference.phys_to_spec(reference_phys);
+  std::vector<double> radial_coeffs(4);  // polynomial of degree 3
+  fill_with_random_values(make_not_null(&radial_coeffs), make_not_null(&gen),
+                          make_not_null(&dist));
+
+  const auto check_exact = [&reference_modes, &radial_coeffs](
+                               const Mesh<3>& source, const Mesh<3>& target) {
+    const DataVector source_field =
+        shell_field(source, reference_modes, l_reference, radial_coeffs);
+    const DataVector target_field =
+        shell_field(target, reference_modes, l_reference, radial_coeffs);
+    DataVector result{};
+    Spectral::project(make_not_null(&result), source_field, source, target,
+                      make_array<3>(Spectral::SegmentSize::Full),
+                      make_array<3>(Spectral::SegmentSize::Full));
+    CHECK_ITERABLE_APPROX(result, target_field);
+  };
+
+  const auto coarse = shell_mesh(5, 6);
+  const auto fine = shell_mesh(7, 10);
+  // identity
+  check_exact(coarse, coarse);
+  // combined radial + angular, both directions
+  check_exact(coarse, fine);
+  check_exact(fine, coarse);
+  // radial-only (angular l_max unchanged)
+  check_exact(shell_mesh(5, 6), shell_mesh(8, 6));
+  check_exact(shell_mesh(8, 6), shell_mesh(5, 6));
+  // angular-only (radial unchanged)
+  check_exact(shell_mesh(5, 6), shell_mesh(5, 9));
+  check_exact(shell_mesh(5, 9), shell_mesh(5, 6));
+
+  // prolong-then-restrict round trip returns the original coarse field
+  {
+    const DataVector coarse_field =
+        shell_field(coarse, reference_modes, l_reference, radial_coeffs);
+    DataVector fine_result{};
+    Spectral::project(make_not_null(&fine_result), coarse_field, coarse, fine,
+                      make_array<3>(Spectral::SegmentSize::Full),
+                      make_array<3>(Spectral::SegmentSize::Full));
+    DataVector round_trip{};
+    Spectral::project(make_not_null(&round_trip), fine_result, fine, coarse,
+                      make_array<3>(Spectral::SegmentSize::Full),
+                      make_array<3>(Spectral::SegmentSize::Full));
+    CHECK_ITERABLE_APPROX(round_trip, coarse_field);
+  }
+
+  // Variables overload is consistent with the DataVector overload
+  {
+    std::vector<double> other_radial_coeffs(4);
+    fill_with_random_values(make_not_null(&other_radial_coeffs),
+                            make_not_null(&gen), make_not_null(&dist));
+    using vars_tags = tmpl::list<Scalar1, Scalar2>;
+    Variables<vars_tags> source_vars(coarse.number_of_grid_points());
+    get(get<Scalar1>(source_vars)) =
+        shell_field(coarse, reference_modes, l_reference, radial_coeffs);
+    get(get<Scalar2>(source_vars)) =
+        shell_field(coarse, reference_modes, l_reference, other_radial_coeffs);
+    Variables<vars_tags> result_vars{};
+    Spectral::project(make_not_null(&result_vars), source_vars, coarse, fine,
+                      make_array<3>(Spectral::SegmentSize::Full),
+                      make_array<3>(Spectral::SegmentSize::Full));
+    DataVector expected1{};
+    DataVector expected2{};
+    Spectral::project(make_not_null(&expected1), get(get<Scalar1>(source_vars)),
+                      coarse, fine, make_array<3>(Spectral::SegmentSize::Full),
+                      make_array<3>(Spectral::SegmentSize::Full));
+    Spectral::project(make_not_null(&expected2), get(get<Scalar2>(source_vars)),
+                      coarse, fine, make_array<3>(Spectral::SegmentSize::Full),
+                      make_array<3>(Spectral::SegmentSize::Full));
+    CHECK_ITERABLE_APPROX(get(get<Scalar1>(result_vars)), expected1);
+    CHECK_ITERABLE_APPROX(get(get<Scalar2>(result_vars)), expected2);
+  }
+}
+
+// 2D spherical shell (sphere surface): angular-only projection, exercised
+// through both the DataVector and Variables overloads.
+void test_project_shell_2d() {
+  MAKE_GENERATOR(gen);
+  std::uniform_real_distribution<double> dist(-1.0, 1.0);
+  const size_t l_reference = 4;
+  const ylm::Spherepack& ylm_reference = ylm::get_spherepack_cache(l_reference);
+  DataVector reference_phys(ylm_reference.physical_size());
+  fill_with_random_values(make_not_null(&reference_phys), make_not_null(&gen),
+                          make_not_null(&dist));
+  const DataVector reference_modes = ylm_reference.phys_to_spec(reference_phys);
+
+  const auto coarse = sphere_mesh(6);
+  const auto fine = sphere_mesh(10);
+  const auto full = make_array<2>(Spectral::SegmentSize::Full);
+  const auto check_exact = [&reference_modes, &full](const Mesh<2>& source,
+                                                     const Mesh<2>& target) {
+    const DataVector source_field =
+        sphere_field(source, reference_modes, l_reference);
+    const DataVector target_field =
+        sphere_field(target, reference_modes, l_reference);
+    DataVector result{};
+    Spectral::project(make_not_null(&result), source_field, source, target,
+                      full, full);
+    CHECK_ITERABLE_APPROX(result, target_field);
+  };
+  check_exact(coarse, coarse);  // identity
+  check_exact(coarse, fine);
+  check_exact(fine, coarse);
+
+  // Variables overload is consistent with the DataVector overload
+  using vars_tags = tmpl::list<Scalar1, Scalar2>;
+  Variables<vars_tags> source_vars(coarse.number_of_grid_points());
+  get(get<Scalar1>(source_vars)) =
+      sphere_field(coarse, reference_modes, l_reference);
+  get(get<Scalar2>(source_vars)) =
+      2.0 * sphere_field(coarse, reference_modes, l_reference);
+  Variables<vars_tags> result_vars{};
+  Spectral::project(make_not_null(&result_vars), source_vars, coarse, fine,
+                    full, full);
+  CHECK_ITERABLE_APPROX(get(get<Scalar1>(result_vars)),
+                        sphere_field(fine, reference_modes, l_reference));
+  CHECK_ITERABLE_APPROX(get(get<Scalar2>(result_vars)),
+                        2.0 * sphere_field(fine, reference_modes, l_reference));
+}
+
+// The massive restriction must be the transpose of the (non-massive)
+// prolongation, just as for tensor-product meshes. Equivalently, for the
+// Euclidean inner products,
+//   <u_coarse, R_massive v_fine> == <I u_coarse, v_fine>,
+// where I is the prolongation coarse -> fine. This adjoint property is what
+// geometric multigrid relies on, so verify it across radial-only, angular-only,
+// and combined refinement of a spherical shell.
+void test_project_shell_massive() {
+  MAKE_GENERATOR(gen);
+  std::uniform_real_distribution<double> dist(-1.0, 1.0);
+  const auto full = make_array<3>(Spectral::SegmentSize::Full);
+  const auto custom_approx = Approx::custom().epsilon(1.0e-12).scale(1.0);
+  const auto check_adjoint = [&](const Mesh<3>& coarse, const Mesh<3>& fine) {
+    DataVector u_coarse(coarse.number_of_grid_points());
+    DataVector v_fine(fine.number_of_grid_points());
+    fill_with_random_values(make_not_null(&u_coarse), make_not_null(&gen),
+                            make_not_null(&dist));
+    fill_with_random_values(make_not_null(&v_fine), make_not_null(&gen),
+                            make_not_null(&dist));
+    DataVector prolonged{};
+    Spectral::project(make_not_null(&prolonged), u_coarse, coarse, fine, full,
+                      full);
+    DataVector restricted{};
+    Spectral::project(make_not_null(&restricted), v_fine, fine, coarse, full,
+                      full, true);
+    CHECK(sum(u_coarse * restricted) == custom_approx(sum(prolonged * v_fine)));
+  };
+  check_adjoint(shell_mesh(4, 4), shell_mesh(6, 7));  // radial and angular
+  check_adjoint(shell_mesh(4, 5), shell_mesh(6, 5));  // radial only
+  check_adjoint(shell_mesh(5, 4), shell_mesh(5, 7));  // angular only
+}
+
+#ifdef SPECTRE_DEBUG
+void test_project_shell_asserts() {
+  const auto coarse = shell_mesh(5, 6);
+  const auto fine = shell_mesh(7, 10);
+  DataVector data(coarse.number_of_grid_points(), 1.0);
+  DataVector result{};
+  // angular dimensions cannot be h-refined
+  CHECK_THROWS_WITH(
+      Spectral::project(make_not_null(&result), data, coarse, fine,
+                        std::array{Spectral::SegmentSize::Full,
+                                   Spectral::SegmentSize::UpperHalf,
+                                   Spectral::SegmentSize::Full},
+                        make_array<3>(Spectral::SegmentSize::Full)),
+      Catch::Matchers::ContainsSubstring("angular h-refinement"));
+}
+#endif  // SPECTRE_DEBUG
 }  // namespace
 
 // [[TimeOut, 10]]
@@ -851,8 +1186,13 @@ SPECTRE_TEST_CASE("Unit.Numerical.Spectral.Projection",
   test_projection_matrices<3>();
   test_fourier_p_projections();
   test_zernike_b2_fourier_equivalence();
+  test_project_cube();
+  test_project_shell();
+  test_project_shell_2d();
+  test_project_shell_massive();
 #ifdef SPECTRE_DEBUG
   test_fourier_and_zernikeb2_asserts();
+  test_project_shell_asserts();
 #endif  // SPECTRE_DEBUG
   test_hash();
 }

--- a/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Test_Spherepack.cpp
+++ b/tests/Unit/NumericalAlgorithms/SphericalHarmonics/Test_Spherepack.cpp
@@ -552,6 +552,48 @@ void test_prolong_restrict() {
   }
 }
 
+// The strided overload of prolong_or_restrict must reproduce the single-set
+// overload applied independently to each interleaved set.
+void test_prolong_restrict_strided() {
+  MAKE_GENERATOR(gen);
+  std::uniform_real_distribution<double> dist(-1.0, 1.0);
+  constexpr size_t stride = 3;
+  const auto check = [&gen, &dist](
+                         const size_t l_max_source, const size_t m_max_source,
+                         const size_t l_max_target, const size_t m_max_target) {
+    const size_t source_size =
+        Spherepack::spectral_size(l_max_source, m_max_source);
+    const size_t target_size =
+        Spherepack::spectral_size(l_max_target, m_max_target);
+    std::array<DataVector, stride> sets{};
+    DataVector interleaved(source_size * stride);
+    for (size_t s = 0; s < stride; ++s) {
+      gsl::at(sets, s) = DataVector(source_size);
+      for (size_t c = 0; c < source_size; ++c) {
+        const double value = dist(gen);
+        gsl::at(sets, s)[c] = value;
+        interleaved[c * stride + s] = value;
+      }
+    }
+    const DataVector strided_result =
+        Spherepack::prolong_or_restrict(interleaved, l_max_source, m_max_source,
+                                        l_max_target, m_max_target, stride);
+    REQUIRE(strided_result.size() == target_size * stride);
+    for (size_t s = 0; s < stride; ++s) {
+      const DataVector expected = Spherepack::prolong_or_restrict(
+          gsl::at(sets, s), l_max_source, m_max_source, l_max_target,
+          m_max_target);
+      for (size_t c = 0; c < target_size; ++c) {
+        CHECK(strided_result[c * stride + s] == approx(expected[c]));
+      }
+    }
+  };
+  check(10, 10, 7, 7);  // restriction
+  check(7, 7, 10, 10);  // prolongation
+  check(10, 8, 6, 2);   // restriction in both l and m
+  check(5, 5, 5, 5);    // equal resolution (no-op)
+}
+
 void test_loop_over_offset(
     const size_t l_max, const size_t m_max, const size_t physical_stride,
     const YlmTestFunctions::ScalarFunctionWithDerivs& func) {
@@ -1330,6 +1372,7 @@ SPECTRE_TEST_CASE("Unit.ApparentHorizonFinder.Spherepack",
   }
 
   test_prolong_restrict();
+  test_prolong_restrict_strided();
 
   Spherepack s(4, 4);
   auto s_copy(s);

--- a/tests/Unit/ParallelAlgorithms/Events/Test_ObserveFields.cpp
+++ b/tests/Unit/ParallelAlgorithms/Events/Test_ObserveFields.cpp
@@ -134,9 +134,12 @@ void test_observe(
   const std::optional<
       std::array<std::reference_wrapper<const Matrix>, volume_dim>>
       projection_matrices =
-          do_projection ? std::make_optional(Spectral::p_projection_matrices(
-                              mesh, target_mesh))
-                        : std::nullopt;
+          do_projection
+              ? std::make_optional(Spectral::projection_matrices(
+                    mesh, target_mesh,
+                    make_array<volume_dim>(Spectral::SegmentSize::Full),
+                    make_array<volume_dim>(Spectral::SegmentSize::Full)))
+              : std::nullopt;
   const double observation_time = 2.0;
   Variables<typename System::variables_tag::tags_list> vars(
       mesh.number_of_grid_points());

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Actions/Test_RestrictFields.cpp
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Actions/Test_RestrictFields.cpp
@@ -10,6 +10,7 @@
 #include <unordered_set>
 #include <utility>
 
+#include "DataStructures/ApplyMatrices.hpp"
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataVector.hpp"
@@ -19,12 +20,16 @@
 #include "DataStructures/Variables.hpp"
 #include "DataStructures/VariablesTag.hpp"
 #include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/SegmentId.hpp"
 #include "Domain/Tags.hpp"
 #include "Framework/ActionTesting.hpp"
 #include "IO/Logging/Tags.hpp"
 #include "IO/Logging/Verbosity.hpp"
 #include "NumericalAlgorithms/Convergence/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Projection.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
 #include "NumericalAlgorithms/Spectral/SegmentSize.hpp"
 #include "Parallel/Phase.hpp"
 #include "Parallel/PhaseDependentActionList.hpp"
@@ -84,13 +89,23 @@ struct Metavariables {
                           tmpl::list<>, tmpl::list<FieldsAreMassiveTag>>;
 };
 
-template <typename FieldsAreMassiveTag>
-void test_restrict_fields(const Mesh<1>& fine_mesh, const Mesh<1>& coarse_mesh,
+// Only dimension 0 is h-refined (for spherical shells this is the radial
+// dimension; the angular dimensions cannot be h-refined). The two fine children
+// are the lower and upper radial halves of the coarse element.
+template <size_t Dim>
+std::array<SegmentId, Dim> shell_segment_ids(const SegmentId& radial) {
+  auto segment_ids = make_array<Dim>(SegmentId{0, 0});
+  segment_ids[0] = radial;
+  return segment_ids;
+}
+
+template <typename FieldsAreMassiveTag, size_t Dim>
+void test_restrict_fields(const Mesh<Dim>& fine_mesh,
+                          const Mesh<Dim>& coarse_mesh,
                           const DataVector& fine_data_left,
                           const DataVector& fine_data_right,
                           const DataVector& expected_coarse_data,
                           const bool fields_are_massive = false) {
-  constexpr size_t Dim = 1;
   using metavariables = Metavariables<Dim, FieldsAreMassiveTag>;
   using element_array = typename metavariables::element_array;
 
@@ -128,9 +143,9 @@ void test_restrict_fields(const Mesh<1>& fine_mesh, const Mesh<1>& coarse_mesh,
             {parent_id, child_ids, mesh, parent_mesh, size_t{0},
              std::move(fields)});
       };
-  const ElementId<Dim> left_element_id{0, {{{1, 0}}}, 0};
-  const ElementId<Dim> right_element_id{0, {{{1, 1}}}, 0};
-  const ElementId<Dim> coarse_element_id{0, {{{0, 0}}}, 1};
+  const ElementId<Dim> left_element_id{0, shell_segment_ids<Dim>({1, 0}), 0};
+  const ElementId<Dim> right_element_id{0, shell_segment_ids<Dim>({1, 1}), 0};
+  const ElementId<Dim> coarse_element_id{0, shell_segment_ids<Dim>({0, 0}), 1};
   add_element(left_element_id, coarse_element_id, {}, fine_mesh, coarse_mesh,
               fine_data_left);
   add_element(right_element_id, coarse_element_id, {}, fine_mesh, coarse_mesh,
@@ -207,5 +222,44 @@ SPECTRE_TEST_CASE("Unit.ParallelMultigrid.Action.RestrictFields",
             fine_data_right, Index<1>{4});
     test_restrict_fields<MassiveTag>(fine_mesh, coarse_mesh, fine_data_left,
                                      fine_data_right, coarse_data, true);
+  }
+  // Spherical shells: multigrid coarsens the radial dimension via h-refinement
+  // (the angular dimensions cannot be h-refined) and may also lower the radial
+  // or angular resolution
+  {
+    const auto shell_mesh = [](const size_t num_radial_points,
+                               const size_t l_max) {
+      return Mesh<3>{
+          {{num_radial_points, l_max + 1, 2 * l_max + 1}},
+          {{Spectral::Basis::Legendre, Spectral::Basis::SphericalHarmonic,
+            Spectral::Basis::SphericalHarmonic}},
+          {{Spectral::Quadrature::GaussLobatto, Spectral::Quadrature::Gauss,
+            Spectral::Quadrature::Equiangular}}};
+    };
+    const Mesh<3> fine_shell = shell_mesh(4, 6);
+    const Mesh<3> coarse_shell = shell_mesh(3, 4);
+    DataVector fine_data_left_shell(fine_shell.number_of_grid_points());
+    DataVector fine_data_right_shell(fine_shell.number_of_grid_points());
+    for (size_t i = 0; i < fine_data_left_shell.size(); ++i) {
+      fine_data_left_shell[i] = 0.1 * static_cast<double>(i) - 1.0;
+      fine_data_right_shell[i] = 1.0 - 0.05 * static_cast<double>(i);
+    }
+    const auto project_child = [&fine_shell, &coarse_shell](
+                                   const DataVector& child_data,
+                                   const Spectral::SegmentSize radial_size) {
+      DataVector result{};
+      Spectral::project(make_not_null(&result), child_data, fine_shell,
+                        coarse_shell,
+                        std::array{radial_size, Spectral::SegmentSize::Full,
+                                   Spectral::SegmentSize::Full},
+                        make_array<3>(Spectral::SegmentSize::Full), true);
+      return result;
+    };
+    const DataVector coarse_data =
+        project_child(fine_data_left_shell, Spectral::SegmentSize::LowerHalf) +
+        project_child(fine_data_right_shell, Spectral::SegmentSize::UpperHalf);
+    test_restrict_fields<MassiveTag>(fine_shell, coarse_shell,
+                                     fine_data_left_shell,
+                                     fine_data_right_shell, coarse_data, true);
   }
 }


### PR DESCRIPTION
## Proposed changes

Add hp projection routines for spherical shells and upgrade the evolution/elliptic projections to use them. This means hp-nonconforming spherical shells should now be supported in mortars, AMR, and multigrid, though not yet enabled in simulations (AMR still needs criteria that actually refine spherical shells).

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
