### PR TITLE
Handle -march=native on all supported platforms

### DIFF
--- a/cmake/AddCxxFlag.cmake
+++ b/cmake/AddCxxFlag.cmake
@@ -6,6 +6,11 @@
 # have to write it to a file.
 set(_CHECK_CXX_FLAGS_SOURCE "${CMAKE_BINARY_DIR}/CMakeFiles/CheckCxxFlags.cpp")
 write_file(${_CHECK_CXX_FLAGS_SOURCE} "")
+# Gfortran rejects compiling a file with a .cpp extension as Fortran when
+# -Werror is enabled, so use a separate empty Fortran source.
+set(_CHECK_FORTRAN_FLAGS_SOURCE
+  "${CMAKE_BINARY_DIR}/CMakeFiles/CheckFortranFlags.f")
+write_file(${_CHECK_FORTRAN_FLAGS_SOURCE} "")
 
 # Checks if a flag is supported by the compiler and creates the target
 # TARGET_NAME whose INTERFACE_COMPILE_OPTIONS are set to the FLAG_TO_CHECK

--- a/cmake/SetupCxxFlags.cmake
+++ b/cmake/SetupCxxFlags.cmake
@@ -69,6 +69,25 @@ if((NOT APPLE OR NOT "${CMAKE_HOST_SYSTEM_PROCESSOR}" STREQUAL "arm64")
   set(_NO_AVX512 "-mno-avx512f")
 endif()
 
+# Check whether -march=native is supported before adding it to SpectreFlags.
+# This avoids using the flag on compilers that reject it, such as clang on
+# arm64 Linux.
+function(_spectre_check_native_architecture_flag LANGUAGE XTYPE SOURCE_FILE
+         FLAG_VARIABLE)
+  set(${FLAG_VARIABLE} "" PARENT_SCOPE)
+  execute_process(
+    COMMAND
+    bash -c
+    "LC_ALL=POSIX ${CMAKE_${LANGUAGE}_COMPILER} -Werror \
+-march=native -x ${XTYPE} -c ${SOURCE_FILE} -o /dev/null"
+    RESULT_VARIABLE RESULT
+    ERROR_VARIABLE ERROR_FROM_COMPILATION
+    OUTPUT_QUIET)
+  if(${RESULT} EQUAL 0)
+    set(${FLAG_VARIABLE} "-march=native" PARENT_SCOPE)
+  endif()
+endfunction()
+
 # Always compile only for the current architecture. This can be overridden
 # by passing `-D OVERRIDE_ARCH=THE_ARCHITECTURE` to CMake
 if(NOT "${OVERRIDE_ARCH}" STREQUAL "OFF")
@@ -81,15 +100,22 @@ if(NOT "${OVERRIDE_ARCH}" STREQUAL "OFF")
       $<$<COMPILE_LANGUAGE:Fortran>:-march=${OVERRIDE_ARCH} ${_NO_AVX512}>)
   endif()
 else()
-  # Apple Silicon Macs do not support the -march flag or the -mno-avx512f flag
-  if(NOT APPLE)
-    set_property(TARGET SpectreFlags
-        APPEND PROPERTY
-        INTERFACE_COMPILE_OPTIONS
-        $<$<COMPILE_LANGUAGE:C>:-march=native ${_NO_AVX512}>
-        $<$<COMPILE_LANGUAGE:CXX>:-march=native ${_NO_AVX512}>
-        $<$<COMPILE_LANGUAGE:Fortran>:-march=native ${_NO_AVX512}>)
-  endif()
+  _spectre_check_native_architecture_flag(
+    C c ${_CHECK_CXX_FLAGS_SOURCE} _SPECTRE_C_NATIVE_ARCHITECTURE_FLAG)
+  _spectre_check_native_architecture_flag(
+    CXX c++ ${_CHECK_CXX_FLAGS_SOURCE} _SPECTRE_CXX_NATIVE_ARCHITECTURE_FLAG)
+  _spectre_check_native_architecture_flag(
+    Fortran f95 ${_CHECK_FORTRAN_FLAGS_SOURCE}
+    _SPECTRE_FORTRAN_NATIVE_ARCHITECTURE_FLAG)
+  set_property(TARGET SpectreFlags
+      APPEND PROPERTY
+      INTERFACE_COMPILE_OPTIONS
+      $<$<COMPILE_LANGUAGE:C>:${_SPECTRE_C_NATIVE_ARCHITECTURE_FLAG}>
+      $<$<COMPILE_LANGUAGE:C>:${_NO_AVX512}>
+      $<$<COMPILE_LANGUAGE:CXX>:${_SPECTRE_CXX_NATIVE_ARCHITECTURE_FLAG}>
+      $<$<COMPILE_LANGUAGE:CXX>:${_NO_AVX512}>
+      $<$<COMPILE_LANGUAGE:Fortran>:${_SPECTRE_FORTRAN_NATIVE_ARCHITECTURE_FLAG}>
+      $<$<COMPILE_LANGUAGE:Fortran>:${_NO_AVX512}>)
 endif()
 
 # We are getting multiple types of linker warnings on macOS:


### PR DESCRIPTION
## Proposed changes

Recent changes to the cmake files break clang builds on arm64 linux, as I found when building in an arm64 linux container on my Apple Silicon Mac. The problem is `-march=native` is not supported by the clang compiler, but is supported by the gcc compiler, in the arm64 container. So this PR checks if `-march=native` is supported and uses it if so, but does not use the flag if it is not supported by the current compiler. (This is all in the branch where the user has not overriden the arcitecture with the provided cmake options).

This is my first PR invoving cmake, so I would appreciate any comments that would help me better understand regarding these changes. I verified that this fixes my error and that I can build with clang and with gcc in my container.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [x] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
