### PR TITLE
Importer: unify with exporter library to speed up interpolation

### DIFF
--- a/src/Evolution/Systems/CurvedScalarWave/Actions/SetInitialData.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Actions/SetInitialData.cpp
@@ -14,13 +14,8 @@
 namespace CurvedScalarWave {
 
 NumericInitialData::NumericInitialData(
-    std::string file_glob, std::string subfile_name,
-    std::variant<double, importers::ObservationSelector> observation_value,
-    std::optional<double> observation_value_epsilon, bool enable_interpolation,
-    ScalarVars selected_variables)
-    : importer_options_(
-          std::move(file_glob), std::move(subfile_name), observation_value,
-          observation_value_epsilon.value_or(1.0e-12), enable_interpolation),
+    importers::ImporterOptions importer_options, ScalarVars selected_variables)
+    : importer_options_(std::move(importer_options)),
       selected_variables_(std::move(selected_variables)) {}
 
 NumericInitialData::NumericInitialData(CkMigrateMessage* msg)

--- a/src/Evolution/Systems/CurvedScalarWave/Actions/SetInitialData.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Actions/SetInitialData.hpp
@@ -77,8 +77,7 @@ class NumericInitialData : public evolution::initial_data::InitialData {
         "Set of initial data variables for the CurvedScalarWave system.";
   };
 
-  using options =
-      tmpl::push_back<importers::ImporterOptions::tags_list, Variables>;
+  using options = tmpl::list<importers::OptionTags::VolumeData, Variables>;
 
   static constexpr Options::String help =
       "Numeric initial data loaded from volume data files";
@@ -101,11 +100,8 @@ class NumericInitialData : public evolution::initial_data::InitialData {
     return std::make_unique<NumericInitialData>(*this);
   }
 
-  NumericInitialData(
-      std::string file_glob, std::string subfile_name,
-      std::variant<double, importers::ObservationSelector> observation_value,
-      std::optional<double> observation_value_epsilon,
-      bool enable_interpolation, ScalarVars selected_variables);
+  NumericInitialData(importers::ImporterOptions importer_options,
+                     ScalarVars selected_variables);
 
   const importers::ImporterOptions& importer_options() const;
 

--- a/src/Evolution/Systems/GeneralizedHarmonic/Actions/SetInitialData.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Actions/SetInitialData.cpp
@@ -55,14 +55,9 @@ void initial_gh_variables_from_adm(
 }
 
 NumericInitialData::NumericInitialData(
-    std::string file_glob, std::string subfile_name,
-    std::variant<double, importers::ObservationSelector> observation_value,
-    std::optional<double> observation_value_epsilon,
-    const bool enable_interpolation,
+    importers::ImporterOptions importer_options,
     std::variant<AdmVars, GhVars> selected_variables)
-    : importer_options_(
-          std::move(file_glob), std::move(subfile_name), observation_value,
-          observation_value_epsilon.value_or(1.0e-12), enable_interpolation),
+    : importer_options_(std::move(importer_options)),
       selected_variables_(std::move(selected_variables)) {}
 
 NumericInitialData::NumericInitialData(CkMigrateMessage* msg)

--- a/src/Evolution/Systems/GeneralizedHarmonic/Actions/SetInitialData.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Actions/SetInitialData.hpp
@@ -133,8 +133,7 @@ class NumericInitialData : public evolution::initial_data::InitialData {
         "system variables are computed.";
   };
 
-  using options =
-      tmpl::push_back<importers::ImporterOptions::tags_list, Variables>;
+  using options = tmpl::list<importers::OptionTags::VolumeData, Variables>;
 
   static constexpr Options::String help =
       "Numeric initial data loaded from volume data files";
@@ -157,12 +156,8 @@ class NumericInitialData : public evolution::initial_data::InitialData {
     return std::make_unique<NumericInitialData>(*this);
   }
 
-  NumericInitialData(
-      std::string file_glob, std::string subfile_name,
-      std::variant<double, importers::ObservationSelector> observation_value,
-      std::optional<double> observation_value_epsilon,
-      bool enable_interpolation,
-      std::variant<AdmVars, GhVars> selected_variables);
+  NumericInitialData(importers::ImporterOptions importer_options,
+                     std::variant<AdmVars, GhVars> selected_variables);
 
   const importers::ImporterOptions& importer_options() const {
     return importer_options_;

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Actions/SetInitialData.cpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Actions/SetInitialData.cpp
@@ -12,20 +12,13 @@
 namespace grmhd::GhValenciaDivClean {
 
 NumericInitialData::NumericInitialData(
-    std::string file_glob, std::string subfile_name,
-    std::variant<double, importers::ObservationSelector> observation_value,
-    std::optional<double> observation_value_epsilon,
-    const bool enable_interpolation,
+    importers::ImporterOptions importer_options,
     typename GhNumericId::Variables::type gh_selected_variables,
     typename HydroNumericId::Variables::type hydro_selected_variables,
     const double density_cutoff)
-    : gh_numeric_id_(file_glob, subfile_name, observation_value,
-                     observation_value_epsilon.value_or(1.0e-12),
-                     enable_interpolation, std::move(gh_selected_variables)),
-      hydro_numeric_id_(
-          std::move(file_glob), std::move(subfile_name), observation_value,
-          observation_value_epsilon.value_or(1.0e-12), enable_interpolation,
-          std::move(hydro_selected_variables), density_cutoff) {}
+    : gh_numeric_id_(importer_options, std::move(gh_selected_variables)),
+      hydro_numeric_id_(std::move(importer_options),
+                        std::move(hydro_selected_variables), density_cutoff) {}
 
 NumericInitialData::NumericInitialData(CkMigrateMessage* msg)
     : InitialData(msg) {}

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Actions/SetInitialData.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Actions/SetInitialData.hpp
@@ -73,9 +73,8 @@ class NumericInitialData : public evolution::initial_data::InitialData,
   struct GhVariables : GhNumericId::Variables {};
   struct HydroVariables : HydroNumericId::Variables {};
 
-  using options =
-      tmpl::push_back<importers::ImporterOptions::tags_list, GhVariables,
-                      HydroVariables, HydroNumericId::DensityCutoff>;
+  using options = tmpl::list<importers::OptionTags::VolumeData, GhVariables,
+                             HydroVariables, HydroNumericId::DensityCutoff>;
 
   static constexpr Options::String help =
       "Numeric initial data loaded from volume data files";
@@ -99,10 +98,7 @@ class NumericInitialData : public evolution::initial_data::InitialData,
   }
 
   NumericInitialData(
-      std::string file_glob, std::string subfile_name,
-      std::variant<double, importers::ObservationSelector> observation_value,
-      std::optional<double> observation_value_epsilon,
-      bool enable_interpolation,
+      importers::ImporterOptions importer_options,
       typename GhNumericId::Variables::type gh_selected_variables,
       typename HydroNumericId::Variables::type hydro_selected_variables,
       double density_cutoff);

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Actions/NumericInitialData.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Actions/NumericInitialData.cpp
@@ -14,14 +14,9 @@
 namespace grmhd::ValenciaDivClean {
 
 NumericInitialData::NumericInitialData(
-    std::string file_glob, std::string subfile_name,
-    std::variant<double, importers::ObservationSelector> observation_value,
-    std::optional<double> observation_value_epsilon,
-    const bool enable_interpolation, PrimitiveVars selected_variables,
-    const double density_cutoff)
-    : importer_options_(
-          std::move(file_glob), std::move(subfile_name), observation_value,
-          observation_value_epsilon.value_or(1.0e-12), enable_interpolation),
+    importers::ImporterOptions importer_options,
+    PrimitiveVars selected_variables, const double density_cutoff)
+    : importer_options_(std::move(importer_options)),
       selected_variables_(std::move(selected_variables)),
       density_cutoff_(density_cutoff) {}
 

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Actions/NumericInitialData.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Actions/NumericInitialData.hpp
@@ -108,8 +108,8 @@ class NumericInitialData : public evolution::initial_data::InitialData {
     static constexpr double lower_bound() { return 0.; }
   };
 
-  using options = tmpl::push_back<importers::ImporterOptions::tags_list,
-                                  Variables, DensityCutoff>;
+  using options =
+      tmpl::list<importers::OptionTags::VolumeData, Variables, DensityCutoff>;
 
   static constexpr Options::String help =
       "Numeric initial data loaded from volume data files";
@@ -132,12 +132,8 @@ class NumericInitialData : public evolution::initial_data::InitialData {
     return std::make_unique<NumericInitialData>(*this);
   }
 
-  NumericInitialData(
-      std::string file_glob, std::string subfile_name,
-      std::variant<double, importers::ObservationSelector> observation_value,
-      std::optional<double> observation_value_epsilon,
-      bool enable_interpolation, PrimitiveVars selected_variables,
-      double density_cutoff);
+  NumericInitialData(importers::ImporterOptions importer_options,
+                     PrimitiveVars selected_variables, double density_cutoff);
 
   const importers::ImporterOptions& importer_options() const {
     return importer_options_;

--- a/src/Evolution/Systems/ScalarTensor/Actions/SetInitialData.cpp
+++ b/src/Evolution/Systems/ScalarTensor/Actions/SetInitialData.cpp
@@ -25,18 +25,12 @@
 namespace ScalarTensor {
 
 NumericInitialData::NumericInitialData(
-    std::string file_glob, std::string subfile_name,
-    std::variant<double, importers::ObservationSelector> observation_value,
-    std::optional<double> observation_value_epsilon, bool enable_interpolation,
+    importers::ImporterOptions importer_options,
     typename GhNumericId::Variables::type gh_selected_variables,
     typename ScalarNumericId::Variables::type hydro_selected_variables)
-    : gh_numeric_id_(file_glob, subfile_name, observation_value,
-                     observation_value_epsilon.value_or(1.0e-12),
-                     enable_interpolation, std::move(gh_selected_variables)),
-      scalar_numeric_id_(
-          std::move(file_glob), std::move(subfile_name), observation_value,
-          observation_value_epsilon.value_or(1.0e-12), enable_interpolation,
-          std::move(hydro_selected_variables)) {}
+    : gh_numeric_id_(importer_options, std::move(gh_selected_variables)),
+      scalar_numeric_id_(std::move(importer_options),
+                         std::move(hydro_selected_variables)) {}
 
 NumericInitialData::NumericInitialData(CkMigrateMessage* msg)
     : InitialData(msg) {}

--- a/src/Evolution/Systems/ScalarTensor/Actions/SetInitialData.hpp
+++ b/src/Evolution/Systems/ScalarTensor/Actions/SetInitialData.hpp
@@ -59,8 +59,8 @@ class NumericInitialData : public evolution::initial_data::InitialData,
   struct GhVariables : GhNumericId::Variables {};
   struct ScalarVariables : ScalarNumericId::Variables {};
 
-  using options = tmpl::push_back<importers::ImporterOptions::tags_list,
-                                  GhVariables, ScalarVariables>;
+  using options = tmpl::list<importers::OptionTags::VolumeData, GhVariables,
+                             ScalarVariables>;
 
   static constexpr Options::String help =
       "Numeric initial data for the Scalar Tensor system loaded from volume "
@@ -85,10 +85,7 @@ class NumericInitialData : public evolution::initial_data::InitialData,
   }
 
   NumericInitialData(
-      std::string file_glob, std::string subfile_name,
-      std::variant<double, importers::ObservationSelector> observation_value,
-      std::optional<double> observation_value_epsilon,
-      bool enable_interpolation,
+      importers::ImporterOptions importer_options,
       typename GhNumericId::Variables::type gh_selected_variables,
       typename ScalarNumericId::Variables::type hydro_selected_variables);
 

--- a/src/IO/Exporter/Exporter.hpp
+++ b/src/IO/Exporter/Exporter.hpp
@@ -10,6 +10,7 @@
 
 #include <array>
 #include <cstddef>
+#include <limits>
 #include <optional>
 #include <string>
 #include <variant>
@@ -34,7 +35,19 @@ struct ObservationStep {
   int value;
 };
 
-using ObservationVariant = std::variant<ObservationId, ObservationStep, double>;
+/// Identifies an observation by its value (e.g. the time), selecting the
+/// observation whose value is closest to `value` within `epsilon`. This is the
+/// same selection as a bare `double`, but with a configurable tolerance.
+struct ObservationValue {
+  ObservationValue() = default;
+  explicit ObservationValue(double local_value, double local_epsilon = 1e-12)
+      : value(local_value), epsilon(local_epsilon) {}
+  double value = std::numeric_limits<double>::signaling_NaN();
+  double epsilon = 1e-12;
+};
+
+using ObservationVariant =
+    std::variant<ObservationId, ObservationStep, double, ObservationValue>;
 
 /*!
  * \brief Interpolate data in volume files to target points

--- a/src/IO/Exporter/PointwiseInterpolator.cpp
+++ b/src/IO/Exporter/PointwiseInterpolator.cpp
@@ -452,6 +452,10 @@ auto block_logical_coordinates(
           "frame at the moment.");
     }
   }
+  // Indices of target points that could not be located in the domain. Collected
+  // here (rather than erroring inside the OpenMP region, which is undefined
+  // behavior) and reported after the parallel region if requested.
+  std::vector<size_t> missing_point_indices{};
 #pragma omp parallel num_threads(resolved_num_threads)
   {
     // Set up thread-local variables
@@ -459,6 +463,7 @@ auto block_logical_coordinates(
     std::vector<BlockLogicalCoords<Dim>> extra_block_logical_coords{};
     std::vector<ExtrapolationInfo<num_extrapolation_anchors>>
         extra_extrapolation_info{};
+    std::vector<size_t> extra_missing_point_indices{};
     // Keep track of a priority order for blocks to accelerate the search.
     // This helps when the target points are ordered so that they are likely to
     // be in the same block as the previous point.
@@ -477,12 +482,11 @@ auto block_logical_coordinates(
       }
       if (not extrapolate_into_excisions) {
         // The point wasn't found in any block and we're not extrapolating.
-        // Check if we should throw an error or just skip this point.
+        // Record it for a later error if requested, then skip it.
         if (error_on_missing_points) {
-          ERROR("Point is not in any block:\n" << target_point);
-        } else {
-          continue;
+          extra_missing_point_indices.push_back(s);
         }
+        continue;
       }
       // The point wasn't found in any block. Check if it's in an excision and
       // set up extrapolation if requested.
@@ -500,7 +504,7 @@ auto block_logical_coordinates(
           }
         }
         if (not found_in_excision and error_on_missing_points) {
-          ERROR("Point is not in any block or excision:\n" << target_point);
+          extra_missing_point_indices.push_back(s);
         }
       }
     }  // omp for target points
@@ -519,8 +523,27 @@ auto block_logical_coordinates(
       extrapolation_info.insert(extrapolation_info.end(),
                                 extra_extrapolation_info.begin(),
                                 extra_extrapolation_info.end());
+      missing_point_indices.insert(missing_point_indices.end(),
+                                   extra_missing_point_indices.begin(),
+                                   extra_missing_point_indices.end());
     }  // omp critical
   }  // omp parallel
+  // Report points that could not be located in the domain (only reached when
+  // `error_on_missing_points` is set). Done here, outside the OpenMP region.
+  if (not missing_point_indices.empty()) {
+    std::string missing_points{};
+    for (const size_t s : missing_point_indices) {
+      tnsr::I<double, Dim, Frame> target_point{};
+      for (size_t d = 0; d < Dim; ++d) {
+        target_point.get(d) = get_element(target_points.get(d), s);
+      }
+      missing_points += get_output(target_point) + "\n";
+    }
+    ERROR(
+        "The following " << missing_point_indices.size()
+                         << " target point(s) are outside the source domain:\n"
+                         << missing_points);
+  }
   return std::make_tuple(std::move(block_logical_coords),
                          std::move(extrapolation_info));
 }

--- a/src/IO/Exporter/PointwiseInterpolator.cpp
+++ b/src/IO/Exporter/PointwiseInterpolator.cpp
@@ -42,9 +42,9 @@ size_t resolve_num_threads(const std::optional<size_t> num_threads) {
 #ifdef _OPENMP
   return num_threads.value_or(omp_get_max_threads());
 #else
-  if (num_threads.has_value()) {
+  if (num_threads.has_value() and num_threads.value() > 1) {
     ERROR_NO_TRACE(
-        "OpenMP is not available, so num_threads cannot be specified.");
+        "OpenMP is not available, so num_threads > 1 cannot be requested.");
   }
   return 1;
 #endif  // _OPENMP

--- a/src/IO/Exporter/Python/Bindings.cpp
+++ b/src/IO/Exporter/Python/Bindings.cpp
@@ -104,6 +104,11 @@ PYBIND11_MODULE(_Pybindings, m) {  // NOLINT
   py::class_<spectre::Exporter::ObservationStep>(m, "ObservationStep")
       .def(py::init<int>())
       .def_readonly("value", &spectre::Exporter::ObservationStep::value);
+  py::class_<spectre::Exporter::ObservationValue>(m, "ObservationValue")
+      .def(py::init<double, double>(), py::arg("value"),
+           py::arg("epsilon") = 1e-12)
+      .def_readonly("value", &spectre::Exporter::ObservationValue::value)
+      .def_readonly("epsilon", &spectre::Exporter::ObservationValue::epsilon);
   bind_interpolate_to_points_impl<1, Frame::Grid>(m);
   bind_interpolate_to_points_impl<2, Frame::Grid>(m);
   bind_interpolate_to_points_impl<3, Frame::Grid>(m);

--- a/src/IO/Exporter/SelectObservation.cpp
+++ b/src/IO/Exporter/SelectObservation.cpp
@@ -30,7 +30,13 @@ size_t SelectObservation::operator()(
 }
 
 size_t SelectObservation::operator()(const double observation_value) const {
-  return volfile.find_observation_id(observation_value, obs_value_eps);
+  return (*this)(ObservationValue{observation_value});
+}
+
+size_t SelectObservation::operator()(
+    const ObservationValue observation_value) const {
+  return volfile.find_observation_id(observation_value.value,
+                                     observation_value.epsilon);
 }
 
 }  // namespace spectre::Exporter

--- a/src/IO/Exporter/SelectObservation.hpp
+++ b/src/IO/Exporter/SelectObservation.hpp
@@ -17,9 +17,9 @@ struct SelectObservation {
   size_t operator()(ObservationId observation_id) const;
   size_t operator()(ObservationStep observation_step) const;
   size_t operator()(double observation_value) const;
+  size_t operator()(ObservationValue observation_value) const;
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
   const h5::VolumeData& volfile;
-  double obs_value_eps = 1e-12;
 };
 
 }  // namespace spectre::Exporter

--- a/src/IO/Importers/Actions/ReadVolumeData.hpp
+++ b/src/IO/Importers/Actions/ReadVolumeData.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cstddef>
 #include <optional>
 #include <string>
@@ -17,18 +18,18 @@
 #include "DataStructures/TaggedTuple.hpp"
 #include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "Domain/BlockLogicalCoordinates.hpp"
 #include "Domain/Domain.hpp"
-#include "Domain/ElementLogicalCoordinates.hpp"
 #include "Domain/ElementMap.hpp"
 #include "Domain/Structure/ElementId.hpp"
+#include "IO/Exporter/Exporter.hpp"
+#include "IO/Exporter/PointwiseInterpolator.hpp"
+#include "IO/Exporter/SelectObservation.hpp"
 #include "IO/H5/AccessType.hpp"
 #include "IO/H5/File.hpp"
 #include "IO/H5/TensorData.hpp"
 #include "IO/H5/VolumeData.hpp"
 #include "IO/Importers/ObservationSelector.hpp"
 #include "IO/Importers/Tags.hpp"
-#include "NumericalAlgorithms/Interpolation/IrregularInterpolant.hpp"
 #include "NumericalAlgorithms/Interpolation/RegularGridInterpolant.hpp"
 #include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
 #include "Parallel/AlgorithmExecution.hpp"
@@ -79,6 +80,35 @@ struct Selected : db::SimpleTag {
 }  // namespace Tags
 
 namespace detail {
+
+// Translate the importer's observation selection into the Exporter's
+// `ObservationVariant`
+inline spectre::Exporter::ObservationVariant observation_variant(
+    const std::variant<double, ObservationSelector>& observation_value,
+    const std::optional<double>& observation_value_epsilon) {
+  return std::visit(
+      Overloader{[&observation_value_epsilon](const double local_obs_value)
+                     -> spectre::Exporter::ObservationVariant {
+                   if (observation_value_epsilon.has_value()) {
+                     return spectre::Exporter::ObservationValue{
+                         local_obs_value, observation_value_epsilon.value()};
+                   }
+                   return local_obs_value;
+                 },
+                 [](const ObservationSelector local_obs_selector)
+                     -> spectre::Exporter::ObservationVariant {
+                   switch (local_obs_selector) {
+                     case ObservationSelector::First:
+                       return spectre::Exporter::ObservationStep{0};
+                     case ObservationSelector::Last:
+                       return spectre::Exporter::ObservationStep{-1};
+                     default:
+                       ERROR("Unknown importers::ObservationSelector: "
+                             << local_obs_selector);
+                   }
+                 }},
+      observation_value);
+}
 
 // Read the single `tensor_name` from the `volume_file`, taking care of suffixes
 // like "_x" etc for its components.
@@ -195,52 +225,6 @@ void verify_inertial_coordinates(
 }
 
 // Interpolate only the `selected_fields` in `source_element_data` to the
-// arbitrary `target_logical_coords` (used when elements are not the same)
-template <typename FieldTagsList, size_t Dim>
-void interpolate_selected_fields(
-    const gsl::not_null<tuples::tagged_tuple_from_typelist<FieldTagsList>*>
-        target_element_data,
-    const tuples::tagged_tuple_from_typelist<FieldTagsList>&
-        source_element_data,
-    const Mesh<Dim>& source_mesh,
-    const tnsr::I<DataVector, Dim, Frame::ElementLogical>&
-        target_logical_coords,
-    const std::vector<size_t>& offsets,
-    const tuples::tagged_tuple_from_typelist<
-        db::wrap_tags_in<Tags::Selected, FieldTagsList>>& selected_fields) {
-  const intrp::Irregular<Dim> interpolator{source_mesh, target_logical_coords};
-  const size_t target_num_points = target_logical_coords.begin()->size();
-  ASSERT(target_num_points == offsets.size(),
-         "The number of target points ("
-             << target_num_points << ") must match the number of offsets ("
-             << offsets.size() << ").");
-  DataVector target_tensor_component_buffer{target_num_points};
-  tmpl::for_each<FieldTagsList>([&source_element_data, &target_element_data,
-                                 &interpolator, &target_tensor_component_buffer,
-                                 &selected_fields, &offsets](auto field_tag_v) {
-    using field_tag = tmpl::type_from<decltype(field_tag_v)>;
-    const auto& selection = get<Tags::Selected<field_tag>>(selected_fields);
-    if (not selection.has_value()) {
-      return;
-    }
-    const auto& source_tensor_data = get<field_tag>(source_element_data);
-    auto& target_tensor_data = get<field_tag>(*target_element_data);
-    // Iterate independent components of the tensor
-    for (size_t i = 0; i < source_tensor_data.size(); ++i) {
-      const DataVector& source_tensor_component = source_tensor_data[i];
-      DataVector& target_tensor_component = target_tensor_data[i];
-      // Interpolate
-      interpolator.interpolate(make_not_null(&target_tensor_component_buffer),
-                               source_tensor_component);
-      // Fill target element data at corresponding offsets
-      for (size_t j = 0; j < target_tensor_component_buffer.size(); ++j) {
-        target_tensor_component[offsets[j]] = target_tensor_component_buffer[j];
-      }
-    }
-  });
-}
-
-// Interpolate only the `selected_fields` in `source_element_data` to the
 // `target_mesh` (used when elements differ only by p-refinement)
 template <typename FieldTagsList, size_t Dim>
 void interpolate_selected_fields(
@@ -271,6 +255,42 @@ void interpolate_selected_fields(
                                source_tensor_component);
     }
   });
+}
+
+// Scatter the slice `[start, start + num_points)` of the flat,
+// component-indexed `interpolated_data` (as produced by
+// `spectre::Exporter::interpolate_to_points`) into a tagged tuple of tensors
+// for a single target element. The components are laid out in `FieldTagsList`
+// order, skipping unselected fields, matching the order of the
+// `tensor_components` passed to the interpolation.
+template <typename FieldTagsList>
+tuples::tagged_tuple_from_typelist<FieldTagsList> scatter_element_data(
+    const std::vector<DataVector>& interpolated_data, const size_t start,
+    const size_t num_points,
+    const tuples::tagged_tuple_from_typelist<
+        db::wrap_tags_in<Tags::Selected, FieldTagsList>>& selected_fields) {
+  tuples::tagged_tuple_from_typelist<FieldTagsList> element_data{};
+  size_t component_index = 0;
+  tmpl::for_each<FieldTagsList>([&element_data, &interpolated_data, &start,
+                                 &num_points, &selected_fields,
+                                 &component_index](auto field_tag_v) {
+    using field_tag = tmpl::type_from<decltype(field_tag_v)>;
+    if (not get<Tags::Selected<field_tag>>(selected_fields).has_value()) {
+      return;
+    }
+    auto& element_tensor_data = get<field_tag>(element_data);
+    for (size_t i = 0; i < element_tensor_data.size(); ++i) {
+      DataVector component{num_points};
+      const DataVector& interpolated_component =
+          interpolated_data[component_index];
+      for (size_t j = 0; j < num_points; ++j) {
+        component[j] = interpolated_component[start + j];
+      }
+      element_tensor_data[i] = std::move(component);
+      ++component_index;
+    }
+  });
+  return element_data;
 }
 
 }  // namespace detail
@@ -374,23 +394,11 @@ struct ReadVolumeData {
  * elements. The `volume_data_id` passed to this action is used as key.
  *
  * \par Memory consumption
- * This action runs once on every node. It reads all volume data files on the
- * node, but doesn't keep them all in memory at once. The following items
- * contribute primarily to memory consumption and can be reconsidered if we run
- * into memory issues:
- *
- * - `all_tensor_data`: All requested tensor components in the volume data file
- *   at the specified observation ID. Only data from one volume data file is
- *   held in memory at any time. Only data from files that overlap with target
- *   elements on this node are read in.
- * - `target_element_data_buffer`: Holds incomplete interpolated data for each
- *   (target) element that resides on this node. In the worst case, when all
- *   target elements need data from the last source element in the last volume
- *   data file, the memory consumption of this buffer can grow to hold all
- *   requested tensor components on all elements that reside on this node.
- *   However, elements are erased from this buffer once their interpolated data
- *   is complete (and sent to the target element), so the memory consumption
- *   should remain much lower in practice.
+ * This action runs once on every node. Volume data files are loaded one at a
+ * time, so memory consumption does _not_ grow with the the number of source
+ * files. All coordinates of elements on this node and their interpolated data
+ * is held in memory at once, so memory consumption scales with the number of
+ * elements on this node.
  *
  * \see Dev guide on \ref dev_guide_importing
  */
@@ -455,16 +463,6 @@ struct ReadAllVolumeDataAndDistribute {
       return;
     }
 
-    // Temporary buffer for data on target elements. These variables get filled
-    // with interpolated data while we're reading in volume files. Once data on
-    // an element is complete, the data is sent to that element and removed from
-    // this list.
-    std::unordered_map<ElementId<Dim>,
-                       tuples::tagged_tuple_from_typelist<FieldTagsList>>
-        target_element_data_buffer{};
-    std::unordered_map<ElementId<Dim>, std::vector<size_t>>
-        all_indices_of_filled_interp_points{};
-
     // Resolve the file glob
     const std::string& file_glob = get<OptionTags::FileGlob>(options);
     const std::vector<std::string> file_paths = file_system::glob(file_glob);
@@ -472,7 +470,106 @@ struct ReadAllVolumeDataAndDistribute {
       ERROR_NO_TRACE("The file glob '" << file_glob << "' matches no files.");
     }
 
-    // Open every file in turn
+    // Select observation to read from each file
+    const spectre::Exporter::ObservationVariant observation =
+        detail::observation_variant(
+            get<OptionTags::ObservationValue>(options),
+            get<OptionTags::ObservationValueEpsilon>(options));
+
+    // When interpolation between the source and target grids is needed, reuse
+    // spectre::Exporter::interpolate_to_points to interpolate to all target
+    // points on this node at once, then scatter the results to the elements.
+    if (not elements_are_identical) {
+      // Gather all target points on this node into a single contiguous tensor,
+      // recording the range [start, start + num_points) of each target element.
+      std::vector<ElementId<Dim>> target_ids{};
+      std::vector<size_t> target_starts{};
+      std::vector<size_t> target_num_points{};
+      std::vector<const tnsr::I<DataVector, Dim, Frame::Inertial>*>
+          target_coords{};
+      target_ids.reserve(target_element_ids.size());
+      target_starts.reserve(target_element_ids.size());
+      target_num_points.reserve(target_element_ids.size());
+      target_coords.reserve(target_element_ids.size());
+      size_t total_num_points = 0;
+      for (const auto& target_element_id : target_element_ids) {
+        const auto& target_points =
+            get<Tags::RegisteredElements<Dim>>(box)
+                .at(Parallel::make_array_component_id<ReceiveComponent>(
+                    target_element_id))
+                .first;
+        target_ids.push_back(target_element_id);
+        target_coords.push_back(&target_points);
+        target_starts.push_back(total_num_points);
+        target_num_points.push_back(target_points.begin()->size());
+        total_num_points += target_num_points.back();
+      }
+      tnsr::I<DataVector, Dim, Frame::Inertial> all_target_points{
+          total_num_points};
+      for (size_t e = 0; e < target_ids.size(); ++e) {
+        for (size_t d = 0; d < Dim; ++d) {
+          for (size_t i = 0; i < target_num_points[e]; ++i) {
+            all_target_points.get(d)[target_starts[e] + i] =
+                target_coords[e]->get(d)[i];
+          }
+        }
+      }
+
+      // Flat list of dataset component names for the selected fields, in
+      // `FieldTagsList` order. The layout matches
+      // `detail::scatter_element_data`.
+      std::vector<std::string> tensor_components{};
+      tmpl::for_each<FieldTagsList>([&tensor_components,
+                                     &selected_fields](auto field_tag_v) {
+        using field_tag = tmpl::type_from<decltype(field_tag_v)>;
+        const auto& selection = get<Tags::Selected<field_tag>>(selected_fields);
+        if (not selection.has_value()) {
+          return;
+        }
+        using TensorType = typename field_tag::type;
+        for (size_t i = 0; i < TensorType::size(); ++i) {
+          tensor_components.push_back(selection.value() +
+                                      TensorType::component_suffix(i));
+        }
+      });
+
+      // Interpolate all target points at once. Error if any target point lies
+      // outside the source domain. This implementation opens each file in turn
+      // (so it doesn't hold all files in memory at once), and it is efficient
+      // about mapping points through the blocks of the source domain.
+      std::vector<DataVector> interpolated_data{};
+      spectre::Exporter::interpolate_to_points(
+          make_not_null(&interpolated_data), file_paths,
+          "/" + get<OptionTags::Subgroup>(options), observation,
+          tensor_components, all_target_points,
+          /*extrapolate_into_excisions=*/false,
+          /*error_on_missing_points=*/true,
+          /*num_threads=*/1);
+      // The target points are no longer needed; free them before distributing
+      // the (potentially large) interpolated data to the target elements.
+      all_target_points = tnsr::I<DataVector, Dim, Frame::Inertial>{};
+
+      // Distribute the interpolated data to the target elements.
+      for (size_t e = 0; e < target_ids.size(); ++e) {
+        auto target_element_data = detail::scatter_element_data<FieldTagsList>(
+            interpolated_data, target_starts[e], target_num_points[e],
+            selected_fields);
+        if constexpr (Parallel::is_dg_element_collection_v<ReceiveComponent>) {
+          ERROR("Can't yet do numerical initial data with nodegroups");
+        } else {
+          Parallel::receive_data<Tags::VolumeData<FieldTagsList>>(
+              Parallel::get_parallel_component<ReceiveComponent>(
+                  cache)[target_ids[e]],
+              volume_data_id, std::move(target_element_data));
+        }
+      }
+      return;
+    }  // not elements_are_identical
+
+    // Now handle identical elements:
+    // The source and target elements are the same (matching domains and
+    // h-refinement), so data is transferred one-to-one, interpolating only
+    // between different meshes (p-refinement).
     std::optional<size_t> prev_observation_id{};
     double observation_value = std::numeric_limits<double>::signaling_NaN();
     std::optional<Domain<Dim>> source_domain{};
@@ -486,27 +583,7 @@ struct ReadAllVolumeDataAndDistribute {
 
       // Select observation ID
       const size_t observation_id = std::visit(
-          Overloader{
-              [&volume_file, &options](const double local_obs_value) {
-                const auto& observation_value_epsilon =
-                    get<OptionTags::ObservationValueEpsilon>(options);
-                return volume_file.find_observation_id(
-                    local_obs_value, observation_value_epsilon);
-              },
-              [&volume_file](const ObservationSelector local_obs_selector) {
-                const std::vector<size_t> all_observation_ids =
-                    volume_file.list_observation_ids();
-                switch (local_obs_selector) {
-                  case ObservationSelector::First:
-                    return all_observation_ids.front();
-                  case ObservationSelector::Last:
-                    return all_observation_ids.back();
-                  default:
-                    ERROR("Unknown importers::ObservationSelector: "
-                          << local_obs_selector);
-                }
-              }},
-          get<OptionTags::ObservationValue>(options));
+          spectre::Exporter::SelectObservation{volume_file}, observation);
       if (prev_observation_id.has_value() and
           prev_observation_id.value() != observation_id) {
         ERROR("Inconsistent selection of observation ID in file "
@@ -517,9 +594,8 @@ struct ReadAllVolumeDataAndDistribute {
       observation_value = volume_file.get_observation_value(observation_id);
 
       // Memory buffer for the tensor data stored in this file. The data is
-      // loaded lazily when it is needed. We may find that we can skip loading
-      // some files because none of their data is needed to fill the elements on
-      // this node.
+      // loaded lazily when it is needed, so we can skip loading files that
+      // contain none of the elements on this node.
       std::optional<tuples::tagged_tuple_from_typelist<FieldTagsList>>
           all_tensor_data{};
 
@@ -530,14 +606,6 @@ struct ReadAllVolumeDataAndDistribute {
       const auto source_bases = volume_file.get_bases(observation_id);
       const auto source_quadratures =
           volume_file.get_quadratures(observation_id);
-      std::vector<ElementId<Dim>> source_element_ids{};
-      if (not elements_are_identical) {
-        // Need to parse all source grid names to element IDs
-        source_element_ids.reserve(source_grid_names.size());
-        for (const auto& grid_name : source_grid_names) {
-          source_element_ids.push_back(ElementId<Dim>(grid_name));
-        }
-      }
       // Reconstruct domain from volume data file
       const std::optional<std::vector<char>> serialized_domain =
           volume_file.get_domain();
@@ -560,16 +628,10 @@ struct ReadAllVolumeDataAndDistribute {
           source_domain = deserialize<Domain<Dim>>(serialized_domain->data());
         }
       } else {
-        if (elements_are_identical) {
-          Parallel::printf(
-              "WARNING: No serialized domain found in file. "
-              "Verification that elements in the source and target domain "
-              "match will be skipped.\n");
-        } else {
-          ERROR_NO_TRACE("No serialized domain found in file '"
-                         << file_name << volume_file.subfile_path()
-                         << "'. The domain is needed for interpolation.");
-        }
+        Parallel::printf(
+            "WARNING: No serialized domain found in file. "
+            "Verification that elements in the source and target domain "
+            "match will be skipped.\n");
       }
       // Reconstruct functions of time from volume data file
       if (source_domain_functions_of_time.empty() and
@@ -582,18 +644,17 @@ struct ReadAllVolumeDataAndDistribute {
         if (not serialized_functions_of_time.has_value()) {
           ERROR_NO_TRACE("No domain functions of time found in file '"
                          << file_name << volume_file.subfile_path()
-                         << "'. The functions of time are needed for "
-                            "interpolating with time-dependent maps.");
+                         << "'. The functions of time are needed to verify the "
+                            "inertial coordinates with time-dependent maps.");
         }
         source_domain_functions_of_time =
             deserialize<domain::FunctionsOfTimeMap>(
                 serialized_functions_of_time->data());
       }
 
-      // Distribute the tensor data to the registered (target) elements. We
-      // erase target elements when they are complete. This allows us to
-      // search only for incomplete elements in subsequent volume files, and
-      // to stop early when all registered elements are complete.
+      // Transfer the data to the target elements contained in this file. We
+      // erase target elements when they are complete, so subsequent files only
+      // search for the remaining elements and we can stop early.
       std::unordered_set<ElementId<Dim>> completed_target_elements{};
       for (const auto& target_element_id : target_element_ids) {
         const auto& [target_points, target_mesh] =
@@ -601,148 +662,54 @@ struct ReadAllVolumeDataAndDistribute {
                 Parallel::make_array_component_id<ReceiveComponent>(
                     target_element_id));
         const auto target_grid_name = get_output(target_element_id);
-
-        // Proceed with the registered element only if it overlaps with the
-        // volume file. It's possible that the volume file only contains data
-        // for a subset of elements, e.g., when each node of a simulation
-        // wrote volume data for its elements to a separate file.
-        std::vector<ElementId<Dim>> overlapping_source_element_ids{};
-        std::unordered_map<ElementId<Dim>, ElementLogicalCoordHolder<Dim>>
-            source_element_logical_coords{};
-        if (not elements_are_identical) {
-          // Transform the target points to block logical coords in the source
-          // domain
-          const auto source_block_logical_coords = block_logical_coordinates(
-              *source_domain, target_points, observation_value,
-              source_domain_functions_of_time);
-          // Find the target points in the subset of source elements contained
-          // in this volume file
-          source_element_logical_coords = element_logical_coordinates(
-              source_element_ids, source_block_logical_coords);
-          overlapping_source_element_ids.reserve(
-              source_element_logical_coords.size());
-          for (const auto& source_element_id_and_coords :
-               source_element_logical_coords) {
-            overlapping_source_element_ids.push_back(
-                source_element_id_and_coords.first);
-          }
-        } else {
-          // When elements match we process only volume files that contain the
-          // exact element
-          if (std::find(source_grid_names.begin(), source_grid_names.end(),
-                        target_grid_name) == source_grid_names.end()) {
-            continue;
-          }
-          overlapping_source_element_ids.push_back(target_element_id);
+        // Process this element only if it's in the file
+        if (std::find(source_grid_names.begin(), source_grid_names.end(),
+                      target_grid_name) == source_grid_names.end()) {
+          continue;
         }
 
-        // Lazily load the tensor data from the file if needed
-        if (not overlapping_source_element_ids.empty() and
-            not all_tensor_data.has_value()) {
+        // Lazily load the tensor data from the file
+        if (not all_tensor_data.has_value()) {
           all_tensor_data = detail::read_tensor_data<FieldTagsList>(
               volume_file, observation_id, selected_fields);
         }
 
-        // Iterate over the source elements in this volume file that overlap
-        // with the target element
-        for (const auto& source_element_id : overlapping_source_element_ids) {
-          const auto source_grid_name = get_output(source_element_id);
-          const auto source_mesh = h5::mesh_for_grid<Dim>(
-              source_grid_name, source_grid_names, source_extents, source_bases,
-              source_quadratures);
-          // Find the data offset that corresponds to this element
-          const auto element_data_offset_and_length =
-              h5::offset_and_length_for_grid(source_grid_name,
-                                             source_grid_names, source_extents);
-          // Extract this element's data from the read-in dataset
-          auto source_element_data =
-              detail::extract_element_data<FieldTagsList>(
-                  element_data_offset_and_length, *all_tensor_data,
-                  selected_fields);
+        const auto source_mesh = h5::mesh_for_grid<Dim>(
+            target_grid_name, source_grid_names, source_extents, source_bases,
+            source_quadratures);
+        const auto element_data_offset_and_length =
+            h5::offset_and_length_for_grid(target_grid_name, source_grid_names,
+                                           source_extents);
+        auto source_element_data = detail::extract_element_data<FieldTagsList>(
+            element_data_offset_and_length, *all_tensor_data, selected_fields);
 
-          if (not elements_are_identical) {
-            const size_t target_num_points = target_points.begin()->size();
+        // Verify that the source and target elements really are the same
+        if (source_domain.has_value()) {
+          detail::verify_inertial_coordinates(*source_domain, observation_value,
+                                              source_domain_functions_of_time,
+                                              target_element_id, target_mesh,
+                                              target_points);
+        }
 
-            // Get and resize target buffer
-            auto& target_element_data =
-                target_element_data_buffer[target_element_id];
-            tmpl::for_each<FieldTagsList>([&target_element_data,
-                                           &target_num_points,
-                                           &selected_fields](auto field_tag_v) {
-              using field_tag = tmpl::type_from<decltype(field_tag_v)>;
-              if (get<Tags::Selected<field_tag>>(selected_fields).has_value()) {
-                for (auto& component : get<field_tag>(target_element_data)) {
-                  component.destructive_resize(target_num_points);
-                }
-              }
-            });
-            auto& indices_of_filled_interp_points =
-                all_indices_of_filled_interp_points[target_element_id];
-
-            // Interpolate!
-            const auto& source_logical_coords_of_target_points =
-                source_element_logical_coords.at(source_element_id);
-            detail::interpolate_selected_fields<FieldTagsList>(
-                make_not_null(&target_element_data), source_element_data,
-                source_mesh,
-                source_logical_coords_of_target_points.element_logical_coords,
-                source_logical_coords_of_target_points.offsets,
-                selected_fields);
-            indices_of_filled_interp_points.insert(
-                indices_of_filled_interp_points.end(),
-                source_logical_coords_of_target_points.offsets.begin(),
-                source_logical_coords_of_target_points.offsets.end());
-
-            if (indices_of_filled_interp_points.size() == target_num_points) {
-              // Pass the (interpolated) data to the element. Now it can
-              // proceed in parallel with transforming the data, taking
-              // derivatives on the grid, etc.
-              if constexpr (Parallel::is_dg_element_collection_v<
-                                ReceiveComponent>) {
-                ERROR("Can't yet do numerical initial data with nodegroups");
-              } else {
-                Parallel::receive_data<Tags::VolumeData<FieldTagsList>>(
-                    Parallel::get_parallel_component<ReceiveComponent>(
-                        cache)[target_element_id],
-                    volume_data_id, std::move(target_element_data));
-              }
-              completed_target_elements.insert(target_element_id);
-              target_element_data_buffer.erase(target_element_id);
-              all_indices_of_filled_interp_points.erase(target_element_id);
-            }
-          } else {
-            // Source and target element are the same (matching domains and
-            // same h-refinement), so no interpolation across elements is
-            // needed. We still may have to interpolate between different
-            // meshes (p-refinement). First, verify this assumption:
-            if (source_domain.has_value()) {
-              detail::verify_inertial_coordinates(
-                  *source_domain, observation_value,
-                  source_domain_functions_of_time, target_element_id,
-                  target_mesh, target_points);
-            }
-            tuples::tagged_tuple_from_typelist<FieldTagsList>
-                target_element_data{};
-            if (source_mesh == target_mesh) {
-              target_element_data = std::move(source_element_data);
-            } else {
-              detail::interpolate_selected_fields<FieldTagsList>(
-                  make_not_null(&target_element_data), source_element_data,
-                  source_mesh, target_mesh, selected_fields);
-            }
-            // Pass data directly to the target element
-            if constexpr (Parallel::is_dg_element_collection_v<
-                              ReceiveComponent>) {
-              ERROR("Can't yet do numerical initial data with nodegroups");
-            } else {
-              Parallel::receive_data<Tags::VolumeData<FieldTagsList>>(
-                  Parallel::get_parallel_component<ReceiveComponent>(
-                      cache)[target_element_id],
-                  volume_data_id, std::move(target_element_data));
-            }
-            completed_target_elements.insert(target_element_id);
-          }
-        }  // loop over overlapping source elements
+        // Transfer the data one-to-one, interpolating only if the meshes differ
+        // by p-refinement
+        tuples::tagged_tuple_from_typelist<FieldTagsList> target_element_data{};
+        if (source_mesh == target_mesh) {
+          target_element_data = std::move(source_element_data);
+        } else {
+          detail::interpolate_selected_fields<FieldTagsList>(
+              make_not_null(&target_element_data), source_element_data,
+              source_mesh, target_mesh, selected_fields);
+        }
+        if constexpr (Parallel::is_dg_element_collection_v<ReceiveComponent>) {
+          ERROR("Can't yet do numerical initial data with nodegroups");
+        } else {
+          Parallel::receive_data<Tags::VolumeData<FieldTagsList>>(
+              Parallel::get_parallel_component<ReceiveComponent>(
+                  cache)[target_element_id],
+              volume_data_id, std::move(target_element_data));
+        }
+        completed_target_elements.insert(target_element_id);
       }  // loop over registered elements
       for (const auto& completed_element_id : completed_target_elements) {
         target_element_ids.erase(completed_element_id);
@@ -753,41 +720,17 @@ struct ReadAllVolumeDataAndDistribute {
       }
     }  // loop over volume files
 
-    // Have we completed all target elements? If we haven't, the target domain
-    // probably extends outside the source domain. In that case we report the
-    // coordinates that couldn't be filled.
+    // Have we completed all target elements? If we haven't, the source and
+    // target domains probably don't match.
     if (not target_element_ids.empty()) {
-      std::unordered_map<ElementId<Dim>, std::vector<std::array<double, Dim>>>
-          missing_coords{};
-      size_t num_missing_points = 0;
-      for (const auto& target_element_id : target_element_ids) {
-        const auto& target_inertial_coords =
-            get<Tags::RegisteredElements<Dim>>(box)
-                .at(Parallel::make_array_component_id<ReceiveComponent>(
-                    target_element_id))
-                .first;
-        const size_t target_num_points = target_inertial_coords.begin()->size();
-        const auto& indices_of_filled_interp_points =
-            all_indices_of_filled_interp_points[target_element_id];
-        for (size_t i = 0; i < target_num_points; ++i) {
-          if (alg::find(indices_of_filled_interp_points, i) ==
-              indices_of_filled_interp_points.end()) {
-            missing_coords[target_element_id].push_back(
-                [&target_inertial_coords, &i]() {
-                  std::array<double, Dim> x{};
-                  for (size_t d = 0; d < Dim; ++d) {
-                    x[d] = target_inertial_coords[d][i];
-                  }
-                  return x;
-                }());
-            ++num_missing_points;
-          }
-        }
-      }
-      ERROR_NO_TRACE("The following " << num_missing_points << " point(s) in "
-                                      << missing_coords.size()
-                                      << " element(s) could not be filled:\n"
-                                      << missing_coords);
+      ERROR_NO_TRACE("The following "
+                     << target_element_ids.size()
+                     << " element(s) were not found in the source volume "
+                        "data files:\n"
+                     << target_element_ids
+                     << "\nMake sure the source and target domains match "
+                        "when 'ElementsAreIdentical' is enabled, or set "
+                        "it to 'False' to interpolate between the grids.");
     }
   }
 

--- a/src/IO/Importers/Actions/ReadVolumeData.hpp
+++ b/src/IO/Importers/Actions/ReadVolumeData.hpp
@@ -542,9 +542,9 @@ struct ReadAllVolumeDataAndDistribute {
           make_not_null(&interpolated_data), file_paths,
           "/" + get<OptionTags::Subgroup>(options), observation,
           tensor_components, all_target_points,
-          /*extrapolate_into_excisions=*/false,
+          get<OptionTags::ExtrapolateIntoExcisions>(options),
           /*error_on_missing_points=*/true,
-          /*num_threads=*/1);
+          get<OptionTags::NumThreads>(options));
       // The target points are no longer needed; free them before distributing
       // the (potentially large) interpolated data to the target elements.
       all_target_points = tnsr::I<DataVector, Dim, Frame::Inertial>{};

--- a/src/IO/Importers/CMakeLists.txt
+++ b/src/IO/Importers/CMakeLists.txt
@@ -31,6 +31,7 @@ target_link_libraries(
   DataStructures
   Domain
   DomainStructure
+  Exporter
   Initialization
   Interpolation
   Parallel

--- a/src/IO/Importers/Tags.hpp
+++ b/src/IO/Importers/Tags.hpp
@@ -85,6 +85,32 @@ struct ElementsAreIdentical {
       "'InertialCoordinates(_x,_y,_z)' must exist in the files. They are used "
       "to verify that the target points indeed match the source data.";
 };
+
+/*!
+ * \brief Extrapolate data into excised regions of the source domain.
+ */
+struct ExtrapolateIntoExcisions {
+  using type = bool;
+  static constexpr Options::String help =
+      "Fill target points that fall inside excised regions of the source "
+      "domain by extrapolating the source data into the excision (see "
+      "'spectre::Exporter::interpolate_to_points').";
+};
+
+/*!
+ * \brief Number of threads to use to accelerate the import with OpenMP, or
+ * 'Auto' to use all available threads.
+ */
+struct NumThreads {
+  using type = Options::Auto<size_t>;
+  static constexpr Options::String help =
+      "Number of threads to use to read and interpolate the volume data with "
+      "OpenMP, or 'Auto' to use all available threads. Keep this at 1 (serial) "
+      "unless you know the node is otherwise idle during the import (e.g. when "
+      "loading initial data), because the importer shares the node with the "
+      "Charm++ worker threads and additional threads can oversubscribe them. "
+      "Has no effect if the code was built without OpenMP support.";
+};
 }  // namespace OptionTags
 
 /// Options that specify the volume data to load. See the option tags for
@@ -93,7 +119,8 @@ struct ImporterOptions
     : tuples::TaggedTuple<
           OptionTags::FileGlob, OptionTags::Subgroup,
           OptionTags::ObservationValue, OptionTags::ObservationValueEpsilon,
-          OptionTags::ElementsAreIdentical> {
+          OptionTags::ElementsAreIdentical,
+          OptionTags::ExtrapolateIntoExcisions, OptionTags::NumThreads> {
   using options = tags_list;
   static constexpr Options::String help = "The volume data to load.";
   using TaggedTuple::TaggedTuple;

--- a/src/IO/Importers/Tags.hpp
+++ b/src/IO/Importers/Tags.hpp
@@ -90,14 +90,23 @@ struct ElementsAreIdentical {
 /// Options that specify the volume data to load. See the option tags for
 /// details.
 struct ImporterOptions
-    : tuples::TaggedTuple<OptionTags::FileGlob, OptionTags::Subgroup,
-                          OptionTags::ObservationValue,
-                          OptionTags::ObservationValueEpsilon,
-                          OptionTags::ElementsAreIdentical> {
+    : tuples::TaggedTuple<
+          OptionTags::FileGlob, OptionTags::Subgroup,
+          OptionTags::ObservationValue, OptionTags::ObservationValueEpsilon,
+          OptionTags::ElementsAreIdentical> {
   using options = tags_list;
   static constexpr Options::String help = "The volume data to load.";
   using TaggedTuple::TaggedTuple;
 };
+
+namespace OptionTags {
+/// Bundles all \ref importers::ImporterOptions for use in factory-creatable
+/// classes
+struct VolumeData {
+  using type = ImporterOptions;
+  static constexpr Options::String help = ImporterOptions::help;
+};
+}  // namespace OptionTags
 
 /// The \ref DataBoxGroup tags associated with the data importer
 namespace Tags {

--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -55,6 +55,8 @@ InitialData:
       ObservationValue: {{ InitialTime }}
       ObservationValueEpsilon: Auto
       ElementsAreIdentical: True
+      ExtrapolateIntoExcisions: False
+      NumThreads: 1
     Variables:
       SpacetimeMetric: SpacetimeMetric
       Pi: Pi
@@ -63,6 +65,8 @@ InitialData:
       ObservationValue: Last
       ObservationValueEpsilon: Auto
       ElementsAreIdentical: False
+      ExtrapolateIntoExcisions: False
+      NumThreads: 1
     Variables:
       Lapse: Lapse
       # Load a shift that is not corotating. See `docs/Examples/BbhInitialData`

--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -48,20 +48,21 @@ InitialData:
     DataDirectory: "{{ SpecDataDirectory }}"
 {% else %}
   NumericInitialData:
-    FileGlob: "{{ IdFileGlob }}"
-    Subgroup: "{{ IdSubfile }}"
+    VolumeData:
+      FileGlob: "{{ IdFileGlob }}"
+      Subgroup: "{{ IdSubfile }}"
   {% if IdFromEvolution %}
-    ObservationValue: {{ InitialTime }}
-    ObservationValueEpsilon: Auto
-    ElementsAreIdentical: True
+      ObservationValue: {{ InitialTime }}
+      ObservationValueEpsilon: Auto
+      ElementsAreIdentical: True
     Variables:
       SpacetimeMetric: SpacetimeMetric
       Pi: Pi
       Phi: Phi
   {% else %}
-    ObservationValue: Last
-    ObservationValueEpsilon: Auto
-    ElementsAreIdentical: False
+      ObservationValue: Last
+      ObservationValueEpsilon: Auto
+      ElementsAreIdentical: False
     Variables:
       Lapse: Lapse
       # Load a shift that is not corotating. See `docs/Examples/BbhInitialData`

--- a/support/Pipelines/Bbh/Ringdown.yaml
+++ b/support/Pipelines/Bbh/Ringdown.yaml
@@ -16,11 +16,12 @@ Parallelization:
 
 InitialData:
   NumericInitialData:
-    FileGlob: "{{ IdFileGlob }}"
-    Subgroup: "{{ IdFileGlobSubgroup }}"
-    ObservationValue: &InitialTime {{ MatchTime }}
-    ObservationValueEpsilon: Auto
-    ElementsAreIdentical: False
+    VolumeData:
+      FileGlob: "{{ IdFileGlob }}"
+      Subgroup: "{{ IdFileGlobSubgroup }}"
+      ObservationValue: &InitialTime {{ MatchTime }}
+      ObservationValueEpsilon: Auto
+      ElementsAreIdentical: False
     Variables:
       SpacetimeMetric: SpacetimeMetric
       Pi: Pi

--- a/support/Pipelines/Bbh/Ringdown.yaml
+++ b/support/Pipelines/Bbh/Ringdown.yaml
@@ -22,6 +22,8 @@ InitialData:
       ObservationValue: &InitialTime {{ MatchTime }}
       ObservationValueEpsilon: Auto
       ElementsAreIdentical: False
+      ExtrapolateIntoExcisions: False
+      NumThreads: 1
     Variables:
       SpacetimeMetric: SpacetimeMetric
       Pi: Pi

--- a/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
@@ -486,6 +486,8 @@ InitialData:
       ObservationValue: Last
       ObservationValueEpsilon: Auto
       ElementsAreIdentical: False
+      ExtrapolateIntoExcisions: False
+      NumThreads: 1
     Variables:
       Lapse: Lapse
       # Load a shift that is not corotating. See `docs/Examples/BbhInitialData`

--- a/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
@@ -480,11 +480,12 @@ ControlSystems:
 #   on this exact grid.
 InitialData:
   NumericInitialData:
-    FileGlob: "/path/to/initial_data.h5"
-    Subgroup: "VolumeData"
-    ObservationValue: Last
-    ObservationValueEpsilon: Auto
-    ElementsAreIdentical: False
+    VolumeData:
+      FileGlob: "/path/to/initial_data.h5"
+      Subgroup: "VolumeData"
+      ObservationValue: Last
+      ObservationValueEpsilon: Auto
+      ElementsAreIdentical: False
     Variables:
       Lapse: Lapse
       # Load a shift that is not corotating. See `docs/Examples/BbhInitialData`

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
@@ -562,6 +562,8 @@ InitialData:
       ObservationValue: Last
       ObservationValueEpsilon: Auto
       ElementsAreIdentical: False
+      ExtrapolateIntoExcisions: False
+      NumThreads: 1
     GhVariables:
       Lapse: Lapse
       Shift: ShiftExcess

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
@@ -556,11 +556,12 @@ InitialData:
   #   AtmosphereDensity: *AtmosphereDensity
   #   ElectronFraction: 0.15
   NumericInitialData:
-    FileGlob: BnsVolume*.h5
-    Subgroup: VolumeData
-    ObservationValue: Last
-    ObservationValueEpsilon: Auto
-    ElementsAreIdentical: False
+    VolumeData:
+      FileGlob: BnsVolume*.h5
+      Subgroup: VolumeData
+      ObservationValue: Last
+      ObservationValueEpsilon: Auto
+      ElementsAreIdentical: False
     GhVariables:
       Lapse: Lapse
       Shift: ShiftExcess

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Actions/Test_SetInitialData.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Actions/Test_SetInitialData.cpp
@@ -288,18 +288,17 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.CurvedScalarWave.SetInitialData",
                   "[Unit][Evolution]") {
   register_factory_classes_with_charm<Metavariables>();
   test_set_initial_data(
-      NumericInitialData{"TestInitialData.h5",
-                         "VolumeData",
-                         0.,
-                         {1.0e-9},
-                         false,
-                         {"CustomPsi", "CustomPi", "CustomPhi"}},
+      NumericInitialData{
+          importers::ImporterOptions{"TestInitialData.h5", "VolumeData", 0.,
+                                     Options::Auto<double>{1.0e-9}, false},
+          NumericInitialData::ScalarVars{"CustomPsi", "CustomPi", "CustomPhi"}},
       "NumericInitialData:\n"
-      "  FileGlob: TestInitialData.h5\n"
-      "  Subgroup: VolumeData\n"
-      "  ObservationValue: 0.\n"
-      "  ObservationValueEpsilon: 1e-9\n"
-      "  ElementsAreIdentical: False\n"
+      "  VolumeData:\n"
+      "    FileGlob: TestInitialData.h5\n"
+      "    Subgroup: VolumeData\n"
+      "    ObservationValue: 0.\n"
+      "    ObservationValueEpsilon: 1e-9\n"
+      "    ElementsAreIdentical: False\n"
       "  Variables:\n"
       "    Psi: CustomPsi\n"
       "    Pi: CustomPi\n"

--- a/tests/Unit/Evolution/Systems/CurvedScalarWave/Actions/Test_SetInitialData.cpp
+++ b/tests/Unit/Evolution/Systems/CurvedScalarWave/Actions/Test_SetInitialData.cpp
@@ -290,7 +290,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.CurvedScalarWave.SetInitialData",
   test_set_initial_data(
       NumericInitialData{
           importers::ImporterOptions{"TestInitialData.h5", "VolumeData", 0.,
-                                     Options::Auto<double>{1.0e-9}, false},
+                                     Options::Auto<double>{1.0e-9}, false,
+                                     false, Options::Auto<size_t>{1}},
           NumericInitialData::ScalarVars{"CustomPsi", "CustomPi", "CustomPhi"}},
       "NumericInitialData:\n"
       "  VolumeData:\n"
@@ -299,6 +300,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.CurvedScalarWave.SetInitialData",
       "    ObservationValue: 0.\n"
       "    ObservationValueEpsilon: 1e-9\n"
       "    ElementsAreIdentical: False\n"
+      "    ExtrapolateIntoExcisions: False\n"
+      "    NumThreads: 1\n"
       "  Variables:\n"
       "    Psi: CustomPsi\n"
       "    Pi: CustomPi\n"

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Actions/Test_SetInitialData.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Actions/Test_SetInitialData.cpp
@@ -303,19 +303,18 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Gh.NumericInitialData",
                   "[Unit][Evolution]") {
   register_factory_classes_with_charm<Metavariables>();
   test_set_initial_data(
-      NumericInitialData{"TestInitialData.h5",
-                         "VolumeData",
-                         0.,
-                         {1.0e-9},
-                         false,
-                         NumericInitialData::GhVars{"CustomSpacetimeMetric",
-                                                    "CustomPi", "CustomPhi"}},
+      NumericInitialData{
+          importers::ImporterOptions{"TestInitialData.h5", "VolumeData", 0.,
+                                     Options::Auto<double>{1.0e-9}, false},
+          NumericInitialData::GhVars{"CustomSpacetimeMetric", "CustomPi",
+                                     "CustomPhi"}},
       "NumericInitialData:\n"
-      "  FileGlob: TestInitialData.h5\n"
-      "  Subgroup: VolumeData\n"
-      "  ObservationValue: 0.\n"
-      "  ObservationValueEpsilon: 1e-9\n"
-      "  ElementsAreIdentical: False\n"
+      "  VolumeData:\n"
+      "    FileGlob: TestInitialData.h5\n"
+      "    Subgroup: VolumeData\n"
+      "    ObservationValue: 0.\n"
+      "    ObservationValueEpsilon: 1e-9\n"
+      "    ElementsAreIdentical: False\n"
       "  Variables:\n"
       "    SpacetimeMetric: CustomSpacetimeMetric\n"
       "    Pi: CustomPi\n"
@@ -323,16 +322,18 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Gh.NumericInitialData",
       true);
   test_set_initial_data(
       NumericInitialData{
-          "TestInitialData.h5", "VolumeData", 0., std::nullopt, false,
+          importers::ImporterOptions{"TestInitialData.h5", "VolumeData", 0.,
+                                     Options::Auto<double>{}, false},
           NumericInitialData::AdmVars{"CustomSpatialMetric", "CustomLapse",
                                       "CustomShift",
                                       "CustomExtrinsicCurvature"}},
       "NumericInitialData:\n"
-      "  FileGlob: TestInitialData.h5\n"
-      "  Subgroup: VolumeData\n"
-      "  ObservationValue: 0.\n"
-      "  ObservationValueEpsilon: Auto\n"
-      "  ElementsAreIdentical: False\n"
+      "  VolumeData:\n"
+      "    FileGlob: TestInitialData.h5\n"
+      "    Subgroup: VolumeData\n"
+      "    ObservationValue: 0.\n"
+      "    ObservationValueEpsilon: Auto\n"
+      "    ElementsAreIdentical: False\n"
       "  Variables:\n"
       "    SpatialMetric: CustomSpatialMetric\n"
       "    Lapse: CustomLapse\n"

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Actions/Test_SetInitialData.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Actions/Test_SetInitialData.cpp
@@ -305,7 +305,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Gh.NumericInitialData",
   test_set_initial_data(
       NumericInitialData{
           importers::ImporterOptions{"TestInitialData.h5", "VolumeData", 0.,
-                                     Options::Auto<double>{1.0e-9}, false},
+                                     Options::Auto<double>{1.0e-9}, false,
+                                     false, Options::Auto<size_t>{1}},
           NumericInitialData::GhVars{"CustomSpacetimeMetric", "CustomPi",
                                      "CustomPhi"}},
       "NumericInitialData:\n"
@@ -315,6 +316,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Gh.NumericInitialData",
       "    ObservationValue: 0.\n"
       "    ObservationValueEpsilon: 1e-9\n"
       "    ElementsAreIdentical: False\n"
+      "    ExtrapolateIntoExcisions: False\n"
+      "    NumThreads: 1\n"
       "  Variables:\n"
       "    SpacetimeMetric: CustomSpacetimeMetric\n"
       "    Pi: CustomPi\n"
@@ -323,7 +326,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Gh.NumericInitialData",
   test_set_initial_data(
       NumericInitialData{
           importers::ImporterOptions{"TestInitialData.h5", "VolumeData", 0.,
-                                     Options::Auto<double>{}, false},
+                                     Options::Auto<double>{}, false, false,
+                                     Options::Auto<size_t>{1}},
           NumericInitialData::AdmVars{"CustomSpatialMetric", "CustomLapse",
                                       "CustomShift",
                                       "CustomExtrinsicCurvature"}},
@@ -334,6 +338,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Gh.NumericInitialData",
       "    ObservationValue: 0.\n"
       "    ObservationValueEpsilon: Auto\n"
       "    ElementsAreIdentical: False\n"
+      "    ExtrapolateIntoExcisions: False\n"
+      "    NumThreads: 1\n"
       "  Variables:\n"
       "    SpatialMetric: CustomSpatialMetric\n"
       "    Lapse: CustomLapse\n"

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Actions/Test_SetInitialData.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Actions/Test_SetInitialData.cpp
@@ -344,21 +344,19 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.GhValenciaDivClean.SetInitialData",
                                  evolution::dg::subcell::ActiveGrid::Subcell}) {
     test_set_initial_data(
         NumericInitialData{
-            "TestInitialData.h5",
-            "VolumeData",
-            0.,
-            {1.0e-9},
-            false,
+            importers::ImporterOptions{"TestInitialData.h5", "VolumeData", 0.,
+                                       Options::Auto<double>{1.0e-9}, false},
             gh::NumericInitialData::GhVars{"CustomSpacetimeMetric", "CustomPi",
                                            "CustomPhi"},
             {"CustomRho", "CustomUi", "CustomYe", "CustomB"},
             1.e-14},
         "NumericInitialData:\n"
-        "  FileGlob: TestInitialData.h5\n"
-        "  Subgroup: VolumeData\n"
-        "  ObservationValue: 0.\n"
-        "  ObservationValueEpsilon: 1e-9\n"
-        "  ElementsAreIdentical: False\n"
+        "  VolumeData:\n"
+        "    FileGlob: TestInitialData.h5\n"
+        "    Subgroup: VolumeData\n"
+        "    ObservationValue: 0.\n"
+        "    ObservationValueEpsilon: 1e-9\n"
+        "    ElementsAreIdentical: False\n"
         "  GhVariables:\n"
         "    SpacetimeMetric: CustomSpacetimeMetric\n"
         "    Pi: CustomPi\n"
@@ -371,22 +369,21 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.GhValenciaDivClean.SetInitialData",
         "  DensityCutoff: 1.e-14",
         true, active_grid);
     test_set_initial_data(
-        NumericInitialData{"TestInitialData.h5",
-                           "VolumeData",
-                           0.,
-                           std::nullopt,
-                           false,
-                           gh::NumericInitialData::AdmVars{
-                               "CustomSpatialMetric", "CustomLapse",
-                               "CustomShift", "CustomExtrinsicCurvature"},
-                           {"CustomRho", "CustomUi", 0.15, 0.},
-                           1.e-14},
+        NumericInitialData{
+            importers::ImporterOptions{"TestInitialData.h5", "VolumeData", 0.,
+                                       Options::Auto<double>{}, false},
+            gh::NumericInitialData::AdmVars{"CustomSpatialMetric",
+                                            "CustomLapse", "CustomShift",
+                                            "CustomExtrinsicCurvature"},
+            {"CustomRho", "CustomUi", 0.15, 0.},
+            1.e-14},
         "NumericInitialData:\n"
-        "  FileGlob: TestInitialData.h5\n"
-        "  Subgroup: VolumeData\n"
-        "  ObservationValue: 0.\n"
-        "  ObservationValueEpsilon: Auto\n"
-        "  ElementsAreIdentical: False\n"
+        "  VolumeData:\n"
+        "    FileGlob: TestInitialData.h5\n"
+        "    Subgroup: VolumeData\n"
+        "    ObservationValue: 0.\n"
+        "    ObservationValueEpsilon: Auto\n"
+        "    ElementsAreIdentical: False\n"
         "  GhVariables:\n"
         "    SpatialMetric: CustomSpatialMetric\n"
         "    Lapse: CustomLapse\n"

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Actions/Test_SetInitialData.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Actions/Test_SetInitialData.cpp
@@ -345,7 +345,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.GhValenciaDivClean.SetInitialData",
     test_set_initial_data(
         NumericInitialData{
             importers::ImporterOptions{"TestInitialData.h5", "VolumeData", 0.,
-                                       Options::Auto<double>{1.0e-9}, false},
+                                       Options::Auto<double>{1.0e-9}, false,
+                                       false, Options::Auto<size_t>{1}},
             gh::NumericInitialData::GhVars{"CustomSpacetimeMetric", "CustomPi",
                                            "CustomPhi"},
             {"CustomRho", "CustomUi", "CustomYe", "CustomB"},
@@ -357,6 +358,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.GhValenciaDivClean.SetInitialData",
         "    ObservationValue: 0.\n"
         "    ObservationValueEpsilon: 1e-9\n"
         "    ElementsAreIdentical: False\n"
+        "    ExtrapolateIntoExcisions: False\n"
+        "    NumThreads: 1\n"
         "  GhVariables:\n"
         "    SpacetimeMetric: CustomSpacetimeMetric\n"
         "    Pi: CustomPi\n"
@@ -371,7 +374,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.GhValenciaDivClean.SetInitialData",
     test_set_initial_data(
         NumericInitialData{
             importers::ImporterOptions{"TestInitialData.h5", "VolumeData", 0.,
-                                       Options::Auto<double>{}, false},
+                                       Options::Auto<double>{}, false, false,
+                                       Options::Auto<size_t>{1}},
             gh::NumericInitialData::AdmVars{"CustomSpatialMetric",
                                             "CustomLapse", "CustomShift",
                                             "CustomExtrinsicCurvature"},
@@ -384,6 +388,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.GhValenciaDivClean.SetInitialData",
         "    ObservationValue: 0.\n"
         "    ObservationValueEpsilon: Auto\n"
         "    ElementsAreIdentical: False\n"
+        "    ExtrapolateIntoExcisions: False\n"
+        "    NumThreads: 1\n"
         "  GhVariables:\n"
         "    SpatialMetric: CustomSpatialMetric\n"
         "    Lapse: CustomLapse\n"

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Actions/Test_NumericInitialData.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Actions/Test_NumericInitialData.cpp
@@ -244,7 +244,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.ValenciaDivClean.NumericInitialData",
   test_numeric_initial_data(
       NumericInitialData{
           importers::ImporterOptions{"TestInitialData.h5", "VolumeData", 0.,
-                                     Options::Auto<double>{1.0e-9}, false},
+                                     Options::Auto<double>{1.0e-9}, false,
+                                     false, Options::Auto<size_t>{1}},
           NumericInitialData::PrimitiveVars{"CustomRho", "CustomUi", "CustomYe",
                                             "CustomB"},
           1.e-14},
@@ -255,6 +256,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.ValenciaDivClean.NumericInitialData",
       "    ObservationValue: 0.\n"
       "    ObservationValueEpsilon: 1e-9\n"
       "    ElementsAreIdentical: False\n"
+      "    ExtrapolateIntoExcisions: False\n"
+      "    NumThreads: 1\n"
       "  Variables:\n"
       "    RestMassDensity: CustomRho\n"
       "    LowerSpatialFourVelocity: CustomUi\n"
@@ -264,7 +267,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.ValenciaDivClean.NumericInitialData",
   test_numeric_initial_data(
       NumericInitialData{
           importers::ImporterOptions{"TestInitialData.h5", "VolumeData", 0.,
-                                     Options::Auto<double>{}, false},
+                                     Options::Auto<double>{}, false, false,
+                                     Options::Auto<size_t>{1}},
           NumericInitialData::PrimitiveVars{"CustomRho", "CustomUi", 0.15, 0.},
           1.e-14},
       "NumericInitialData:\n"
@@ -274,6 +278,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.ValenciaDivClean.NumericInitialData",
       "    ObservationValue: 0.\n"
       "    ObservationValueEpsilon: Auto\n"
       "    ElementsAreIdentical: False\n"
+      "    ExtrapolateIntoExcisions: False\n"
+      "    NumThreads: 1\n"
       "  Variables:\n"
       "    RestMassDensity: CustomRho\n"
       "    LowerSpatialFourVelocity: CustomUi\n"

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Actions/Test_NumericInitialData.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Actions/Test_NumericInitialData.cpp
@@ -242,19 +242,19 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.ValenciaDivClean.NumericInitialData",
   register_factory_classes_with_charm<Metavariables>();
   EquationsOfState::register_derived_with_charm();
   test_numeric_initial_data(
-      NumericInitialData{"TestInitialData.h5",
-                         "VolumeData",
-                         0.,
-                         {1.0e-9},
-                         false,
-                         {"CustomRho", "CustomUi", "CustomYe", "CustomB"},
-                         1.e-14},
+      NumericInitialData{
+          importers::ImporterOptions{"TestInitialData.h5", "VolumeData", 0.,
+                                     Options::Auto<double>{1.0e-9}, false},
+          NumericInitialData::PrimitiveVars{"CustomRho", "CustomUi", "CustomYe",
+                                            "CustomB"},
+          1.e-14},
       "NumericInitialData:\n"
-      "  FileGlob: TestInitialData.h5\n"
-      "  Subgroup: VolumeData\n"
-      "  ObservationValue: 0.\n"
-      "  ObservationValueEpsilon: 1e-9\n"
-      "  ElementsAreIdentical: False\n"
+      "  VolumeData:\n"
+      "    FileGlob: TestInitialData.h5\n"
+      "    Subgroup: VolumeData\n"
+      "    ObservationValue: 0.\n"
+      "    ObservationValueEpsilon: 1e-9\n"
+      "    ElementsAreIdentical: False\n"
       "  Variables:\n"
       "    RestMassDensity: CustomRho\n"
       "    LowerSpatialFourVelocity: CustomUi\n"
@@ -262,19 +262,18 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.ValenciaDivClean.NumericInitialData",
       "    MagneticField: CustomB\n"
       "  DensityCutoff: 1.e-14");
   test_numeric_initial_data(
-      NumericInitialData{"TestInitialData.h5",
-                         "VolumeData",
-                         0.,
-                         std::nullopt,
-                         false,
-                         {"CustomRho", "CustomUi", 0.15, 0.},
-                         1.e-14},
+      NumericInitialData{
+          importers::ImporterOptions{"TestInitialData.h5", "VolumeData", 0.,
+                                     Options::Auto<double>{}, false},
+          NumericInitialData::PrimitiveVars{"CustomRho", "CustomUi", 0.15, 0.},
+          1.e-14},
       "NumericInitialData:\n"
-      "  FileGlob: TestInitialData.h5\n"
-      "  Subgroup: VolumeData\n"
-      "  ObservationValue: 0.\n"
-      "  ObservationValueEpsilon: Auto\n"
-      "  ElementsAreIdentical: False\n"
+      "  VolumeData:\n"
+      "    FileGlob: TestInitialData.h5\n"
+      "    Subgroup: VolumeData\n"
+      "    ObservationValue: 0.\n"
+      "    ObservationValueEpsilon: Auto\n"
+      "    ElementsAreIdentical: False\n"
       "  Variables:\n"
       "    RestMassDensity: CustomRho\n"
       "    LowerSpatialFourVelocity: CustomUi\n"

--- a/tests/Unit/Evolution/Systems/ScalarTensor/Actions/Test_SetInitialData.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarTensor/Actions/Test_SetInitialData.cpp
@@ -334,21 +334,20 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.ScalarTensor.NumericInitialData",
                   "[Unit][Evolution]") {
   register_factory_classes_with_charm<Metavariables>();
   test_set_initial_data(
-      NumericInitialData{"TestInitialData.h5",
-                         "VolumeData",
-                         0.,
-                         {1.0e-9},
-                         false,
-                         gh::NumericInitialData::GhVars{
-                             "CustomSpacetimeMetric", "CustomPi", "CustomPhi"},
-                         CurvedScalarWave::NumericInitialData::ScalarVars{
-                             "CustomPsi", "CustomScalarPi", "CustomScalarPhi"}},
+      NumericInitialData{
+          importers::ImporterOptions{"TestInitialData.h5", "VolumeData", 0.,
+                                     Options::Auto<double>{1.0e-9}, false},
+          gh::NumericInitialData::GhVars{"CustomSpacetimeMetric", "CustomPi",
+                                         "CustomPhi"},
+          CurvedScalarWave::NumericInitialData::ScalarVars{
+              "CustomPsi", "CustomScalarPi", "CustomScalarPhi"}},
       "NumericInitialData:\n"
-      "  FileGlob: TestInitialData.h5\n"
-      "  Subgroup: VolumeData\n"
-      "  ObservationValue: 0.\n"
-      "  ObservationValueEpsilon: 1e-9\n"
-      "  ElementsAreIdentical: False\n"
+      "  VolumeData:\n"
+      "    FileGlob: TestInitialData.h5\n"
+      "    Subgroup: VolumeData\n"
+      "    ObservationValue: 0.\n"
+      "    ObservationValueEpsilon: 1e-9\n"
+      "    ElementsAreIdentical: False\n"
       "  GhVariables:\n"
       "    SpacetimeMetric: CustomSpacetimeMetric\n"
       "    Pi: CustomPi\n"
@@ -360,18 +359,20 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.ScalarTensor.NumericInitialData",
       true);
   test_set_initial_data(
       NumericInitialData{
-          "TestInitialData.h5", "VolumeData", 0., std::nullopt, false,
+          importers::ImporterOptions{"TestInitialData.h5", "VolumeData", 0.,
+                                     Options::Auto<double>{}, false},
           gh::NumericInitialData::AdmVars{"CustomSpatialMetric", "CustomLapse",
                                           "CustomShift",
                                           "CustomExtrinsicCurvature"},
           CurvedScalarWave::NumericInitialData::ScalarVars{
               "CustomPsi", "CustomScalarPi", "CustomScalarPhi"}},
       "NumericInitialData:\n"
-      "  FileGlob: TestInitialData.h5\n"
-      "  Subgroup: VolumeData\n"
-      "  ObservationValue: 0.\n"
-      "  ObservationValueEpsilon: Auto\n"
-      "  ElementsAreIdentical: False\n"
+      "  VolumeData:\n"
+      "    FileGlob: TestInitialData.h5\n"
+      "    Subgroup: VolumeData\n"
+      "    ObservationValue: 0.\n"
+      "    ObservationValueEpsilon: Auto\n"
+      "    ElementsAreIdentical: False\n"
       "  GhVariables:\n"
       "    SpatialMetric: CustomSpatialMetric\n"
       "    Lapse: CustomLapse\n"

--- a/tests/Unit/Evolution/Systems/ScalarTensor/Actions/Test_SetInitialData.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarTensor/Actions/Test_SetInitialData.cpp
@@ -336,7 +336,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.ScalarTensor.NumericInitialData",
   test_set_initial_data(
       NumericInitialData{
           importers::ImporterOptions{"TestInitialData.h5", "VolumeData", 0.,
-                                     Options::Auto<double>{1.0e-9}, false},
+                                     Options::Auto<double>{1.0e-9}, false,
+                                     false, Options::Auto<size_t>{1}},
           gh::NumericInitialData::GhVars{"CustomSpacetimeMetric", "CustomPi",
                                          "CustomPhi"},
           CurvedScalarWave::NumericInitialData::ScalarVars{
@@ -348,6 +349,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.ScalarTensor.NumericInitialData",
       "    ObservationValue: 0.\n"
       "    ObservationValueEpsilon: 1e-9\n"
       "    ElementsAreIdentical: False\n"
+      "    ExtrapolateIntoExcisions: False\n"
+      "    NumThreads: 1\n"
       "  GhVariables:\n"
       "    SpacetimeMetric: CustomSpacetimeMetric\n"
       "    Pi: CustomPi\n"
@@ -360,7 +363,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.ScalarTensor.NumericInitialData",
   test_set_initial_data(
       NumericInitialData{
           importers::ImporterOptions{"TestInitialData.h5", "VolumeData", 0.,
-                                     Options::Auto<double>{}, false},
+                                     Options::Auto<double>{}, false, false,
+                                     Options::Auto<size_t>{1}},
           gh::NumericInitialData::AdmVars{"CustomSpatialMetric", "CustomLapse",
                                           "CustomShift",
                                           "CustomExtrinsicCurvature"},
@@ -373,6 +377,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.ScalarTensor.NumericInitialData",
       "    ObservationValue: 0.\n"
       "    ObservationValueEpsilon: Auto\n"
       "    ElementsAreIdentical: False\n"
+      "    ExtrapolateIntoExcisions: False\n"
+      "    NumThreads: 1\n"
       "  GhVariables:\n"
       "    SpatialMetric: CustomSpatialMetric\n"
       "    Lapse: CustomLapse\n"

--- a/tests/Unit/IO/Importers/Test_Tags.cpp
+++ b/tests/Unit/IO/Importers/Test_Tags.cpp
@@ -39,7 +39,9 @@ SPECTRE_TEST_CASE("Unit.IO.Importers.Tags", "[Unit][IO]") {
       "    Subgroup: data.group\n"
       "    ObservationValue: 1.\n"
       "    ObservationValueEpsilon: 1e-9\n"
-      "    ElementsAreIdentical: True");
+      "    ElementsAreIdentical: True\n"
+      "    ExtrapolateIntoExcisions: False\n"
+      "    NumThreads: 1");
   const auto& options =
       opts.get<importers::Tags::ImporterOptions<ExampleVolumeData>>();
   using tuples::get;

--- a/tests/Unit/IO/Importers/Test_VolumeDataReaderActions.cpp
+++ b/tests/Unit/IO/Importers/Test_VolumeDataReaderActions.cpp
@@ -121,7 +121,7 @@ void test_actions(const std::variant<double, importers::ObservationSelector>&
 
   ActionTesting::MockRuntimeSystem<metavars> runner{{importers::ImporterOptions{
       "TestVolumeData*.h5", "element_data", observation_selection,
-      Options::Auto<double>{}, true}}};
+      Options::Auto<double>{}, true, false, Options::Auto<size_t>{}}}};
 
   // Setup mock data file reader
   ActionTesting::emplace_nodegroup_component<reader_component>(

--- a/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm1D.yaml
+++ b/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm1D.yaml
@@ -34,6 +34,8 @@ Importers:
     ObservationValue: 1.
     ObservationValueEpsilon: Auto
     ElementsAreIdentical: False
+    ExtrapolateIntoExcisions: False
+    NumThreads: 1
 
 ResourceInfo:
   AvoidGlobalProc0: false

--- a/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm2D.yaml
+++ b/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm2D.yaml
@@ -23,6 +23,8 @@ Importers:
     ObservationValue: 2.
     ObservationValueEpsilon: Auto
     ElementsAreIdentical: False
+    ExtrapolateIntoExcisions: False
+    NumThreads: 1
 # [importer_options]
 
 ResourceInfo:

--- a/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm3D.yaml
+++ b/tests/Unit/IO/Importers/Test_VolumeDataReaderAlgorithm3D.yaml
@@ -73,6 +73,8 @@ Importers:
     ObservationValue: 3.
     ObservationValueEpsilon: Auto
     ElementsAreIdentical: False
+    ExtrapolateIntoExcisions: False
+    NumThreads: 1
 
 ResourceInfo:
   AvoidGlobalProc0: false


### PR DESCRIPTION
## Proposed changes

Uses important optimizations implemented in the exporter library:

- Reduce cost of mapping target points through the source domain using the `block_order` mechanism.
- Interpolate to all target points on the node at once, which increases the effect of the `block_order` mechanism further.

The unification with the exporter library also means that the following two options come to the importer for free:

- ExtrapolateIntoExcisions: can be useful for starting evolutions.
- NumThreads: Only has an effect if compiled with OMP. Then, it can be set away from 1 (current setting everywhere) to interpolate in parallel. However, there's a warning in the docstring that this can conflict with Charm++ parallelism, so should only be used if no other worker thread is active during importing (should be safe during initial data importing, but up to the user to enable if desired).

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
- In input files that import numeric data, wrap importer options in a `VolumeData:` block and add the new options `ExtrapolateIntoExcisions: False` and `NumThreads: 1`.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
