### PR TITLE
Make CBCO input file h and p refinement format same as BCO

### DIFF
--- a/src/Domain/Creators/BinaryCompactObject.cpp
+++ b/src/Domain/Creators/BinaryCompactObject.cpp
@@ -75,6 +75,159 @@ create_grid_anchors(const std::array<double, 3>& center_a,
 
   return result;
 }
+
+void validate_initial_grid_points(
+    const Options::Context& context,
+    const BinaryCompactObject::InitialGridPoints::type&
+        initial_number_of_grid_points,
+    const std::unordered_set<std::string>& spherical_harmonic_shell_names) {
+  if (std::holds_alternative<
+          std::unordered_map<std::string, std::variant<std::array<size_t, 3>,
+                                                       std::array<size_t, 2>>>>(
+          initial_number_of_grid_points)) {
+    const auto& grid_points_map = std::get<
+        std::unordered_map<std::string, std::variant<std::array<size_t, 3>,
+                                                     std::array<size_t, 2>>>>(
+        initial_number_of_grid_points);
+    for (const auto& [block_name, extents] : grid_points_map) {
+      const bool is_spherical_harmonic_block =
+          spherical_harmonic_shell_names.contains(block_name);
+      if (is_spherical_harmonic_block) {
+        if (std::holds_alternative<std::array<size_t, 3>>(extents)) {
+          PARSE_ERROR(context, "Block '"
+                                   << block_name
+                                   << "' is a spherical-harmonic outer-shell "
+                                      "block. Specify its grid points as "
+                                      "[radial_points, L_max], not array<3>.");
+        }
+      } else {
+        if (std::holds_alternative<std::array<size_t, 2>>(extents)) {
+          if (not spherical_harmonic_shell_names.empty()) {
+            PARSE_ERROR(context,
+                        "Specifying 2 grid points for block '"
+                            << block_name
+                            << "' is only valid for spherical-harmonic "
+                               "outer-shell blocks (OuterShell0, etc.).");
+          } else {
+            PARSE_ERROR(
+                context,
+                "Specifying 2 grid points (block '"
+                    << block_name
+                    << "') is only valid when SphericalHarmonicsInWavezone "
+                       "is enabled.");
+          }
+        }
+      }
+    }
+  }
+}
+
+void validate_initial_refinement(
+    const Options::Context& context,
+    const BinaryCompactObject::InitialRefinement::type& initial_refinement,
+    const std::unordered_set<std::string>& spherical_harmonic_shell_names) {
+  if (std::holds_alternative<std::unordered_map<
+          std::string, std::variant<std::array<size_t, 3>, size_t>>>(
+          initial_refinement)) {
+    const auto& refinement_map = std::get<std::unordered_map<
+        std::string, std::variant<std::array<size_t, 3>, size_t>>>(
+        initial_refinement);
+    for (const auto& [block_name, ref] : refinement_map) {
+      const bool is_spherical_harmonic_block =
+          spherical_harmonic_shell_names.contains(block_name);
+      if (is_spherical_harmonic_block) {
+        if (std::holds_alternative<std::array<size_t, 3>>(ref)) {
+          PARSE_ERROR(context,
+                      "Block '"
+                          << block_name
+                          << "' is a spherical-harmonic outer-shell block. "
+                             "Specify its refinement as a single number "
+                             "(radial only), not array<3>. Angular "
+                             "h-refinement is not supported for these blocks.");
+        }
+      } else {
+        if (std::holds_alternative<size_t>(ref)) {
+          if (not spherical_harmonic_shell_names.empty()) {
+            PARSE_ERROR(context,
+                        "Per-block single-number refinement for block '"
+                            << block_name
+                            << "' is only valid for spherical-harmonic "
+                               "outer-shell blocks (OuterShell0, etc.).");
+          } else {
+            PARSE_ERROR(
+                context,
+                "Per-block single-number refinement in map syntax (block '"
+                    << block_name
+                    << "') is only valid when SphericalHarmonicsInWavezone "
+                       "is enabled.");
+          }
+        }
+      }
+    }
+  }
+}
+
+std::vector<std::array<size_t, 3>> set_initial_refinement(
+    const ExpandOverBlocks<std::array<size_t, 3>>& expand_over_blocks,
+    const BinaryCompactObject::InitialRefinement::type& initial_refinement) {
+  return std::visit(
+      [&expand_over_blocks]<typename V>(
+          const V& v) -> std::vector<std::array<size_t, 3>> {
+        if constexpr (std::is_same_v<
+                          V,
+                          std::unordered_map<
+                              std::string,
+                              std::variant<std::array<size_t, 3>, size_t>>>) {
+          const auto converted = [&v]() {
+            std::unordered_map<std::string, std::array<size_t, 3>> result;
+            for (const auto& [name, val] : v) {
+              if (std::holds_alternative<size_t>(val)) {
+                const size_t r = std::get<size_t>(val);
+                result[name] = {r, 0, 0};
+              } else {
+                result[name] = std::get<std::array<size_t, 3>>(val);
+              }
+            }
+            return result;
+          }();
+          return expand_over_blocks(converted);
+        } else {
+          return expand_over_blocks(v);
+        }
+      },
+      initial_refinement);
+}
+
+std::vector<std::array<size_t, 3>> set_initial_grid_points(
+    const ExpandOverBlocks<std::array<size_t, 3>>& expand_over_blocks,
+    const BinaryCompactObject::InitialGridPoints::type& initial_grid_points) {
+  return std::visit(
+      [&expand_over_blocks]<typename V>(
+          const V& v) -> std::vector<std::array<size_t, 3>> {
+        if constexpr (std::is_same_v<
+                          V, std::unordered_map<
+                                 std::string,
+                                 std::variant<std::array<size_t, 3>,
+                                              std::array<size_t, 2>>>>) {
+          const auto converted = [&v]() {
+            std::unordered_map<std::string, std::array<size_t, 3>> result;
+            for (const auto& [name, val] : v) {
+              if (std::holds_alternative<std::array<size_t, 2>>(val)) {
+                const auto& a2 = std::get<std::array<size_t, 2>>(val);
+                result[name] = {a2[0], a2[1], a2[1]};
+              } else {
+                result[name] = std::get<std::array<size_t, 3>>(val);
+              }
+            }
+            return result;
+          }();
+          return expand_over_blocks(converted);
+        } else {
+          return expand_over_blocks(v);
+        }
+      },
+      initial_grid_points);
+}
 }  // namespace bco
 
 bool BinaryCompactObject::Object::is_excised() const {
@@ -166,97 +319,19 @@ BinaryCompactObject::BinaryCompactObject(
     }
   }
 
-  // Validate InitialGridPoints map entries.
-  // When SphericalHarmonicsInWavezone is enabled: spherical-harmonic shell
-  // entries must use array<2> {radial, L_max}; non-spherical-harmonic entries
-  // must use array<3>.
-  // When SphericalHarmonicsInWavezone is disabled: array<2> is not accepted
-  // anywhere.
-  if (std::holds_alternative<
-          std::unordered_map<std::string, std::variant<std::array<size_t, 3>,
-                                                       std::array<size_t, 2>>>>(
-          initial_number_of_grid_points)) {
-    const auto& grid_points_map = std::get<
-        std::unordered_map<std::string, std::variant<std::array<size_t, 3>,
-                                                     std::array<size_t, 2>>>>(
-        initial_number_of_grid_points);
-    for (const auto& [block_name, extents] : grid_points_map) {
-      const bool is_spherical_harmonic_block =
-          spherical_harmonic_shell_names.contains(block_name);
-      if (is_spherical_harmonic_block) {
-        if (std::holds_alternative<std::array<size_t, 3>>(extents)) {
-          PARSE_ERROR(context, "Block '"
-                                   << block_name
-                                   << "' is a spherical-harmonic outer-shell "
-                                      "block. Specify its grid points as "
-                                      "[radial_points, L_max], not array<3>.");
-        }
-      } else {
-        if (std::holds_alternative<std::array<size_t, 2>>(extents)) {
-          if (spherical_harmonics_in_wavezone_) {
-            PARSE_ERROR(context,
-                        "Specifying 2 grid points for block '"
-                            << block_name
-                            << "' is only valid for spherical-harmonic "
-                               "outer-shell blocks (OuterShell0, etc.).");
-          } else {
-            PARSE_ERROR(
-                context,
-                "Specifying 2 grid points (block '"
-                    << block_name
-                    << "') is only valid when SphericalHarmonicsInWavezone "
-                       "is enabled.");
-          }
-        }
-      }
-    }
-  }
-  // Validate InitialRefinement map entries.
-  // When SphericalHarmonicsInWavezone is enabled: spherical-harmonic shell
-  // entries must use size_t (radial only); array<3> is rejected on
-  // spherical-harmonic blocks even if angular components are zero.
-  // Non-spherical-harmonic entries must use array<3>.
-  // When SphericalHarmonicsInWavezone is disabled: size_t is not accepted
-  // anywhere.
-  if (std::holds_alternative<std::unordered_map<
-          std::string, std::variant<std::array<size_t, 3>, size_t>>>(
-          initial_refinement)) {
-    const auto& refinement_map = std::get<std::unordered_map<
-        std::string, std::variant<std::array<size_t, 3>, size_t>>>(
-        initial_refinement);
-    for (const auto& [block_name, ref] : refinement_map) {
-      const bool is_spherical_harmonic_block =
-          spherical_harmonic_shell_names.contains(block_name);
-      if (is_spherical_harmonic_block) {
-        if (std::holds_alternative<std::array<size_t, 3>>(ref)) {
-          PARSE_ERROR(context,
-                      "Block '"
-                          << block_name
-                          << "' is a spherical-harmonic outer-shell block. "
-                             "Specify its refinement as a single number "
-                             "(radial only), not array<3>. Angular "
-                             "h-refinement is not supported for these blocks.");
-        }
-      } else {
-        if (std::holds_alternative<size_t>(ref)) {
-          if (spherical_harmonics_in_wavezone_) {
-            PARSE_ERROR(context,
-                        "Per-block single-number refinement for block '"
-                            << block_name
-                            << "' is only valid for spherical-harmonic "
-                               "outer-shell blocks (OuterShell0, etc.).");
-          } else {
-            PARSE_ERROR(
-                context,
-                "Per-block single-number refinement in map syntax (block '"
-                    << block_name
-                    << "') is only valid when SphericalHarmonicsInWavezone "
-                       "is enabled.");
-          }
-        }
-      }
-    }
-  }
+  ASSERT(not(spherical_harmonics_in_wavezone_ and
+             spherical_harmonic_shell_names.empty()),
+         "SphericalHarmonicsInWavezone is enabled but the list of spherical "
+         "shell names is empty.");
+  ASSERT(spherical_harmonics_in_wavezone_ or
+             spherical_harmonic_shell_names.empty(),
+         "SphericalHarmonicsInWavezone is disabled but the list of spherical "
+         "shell names is non-empty.");
+
+  bco::validate_initial_refinement(context, initial_refinement,
+                                   spherical_harmonic_shell_names);
+  bco::validate_initial_grid_points(context, initial_number_of_grid_points,
+                                    spherical_harmonic_shell_names);
 
   // Calculate number of blocks
   // Object cubes and shells have 6 blocks each, for a total for 24 blocks.
@@ -508,74 +583,18 @@ BinaryCompactObject::BinaryCompactObject(
       block_names_, block_groups_};
 
   try {
-    initial_refinement_ = std::visit(
-        [&expand_over_blocks]<typename V>(
-            const V& v) -> std::vector<std::array<size_t, 3>> {
-          if constexpr (std::is_same_v<
-                            V,
-                            std::unordered_map<
-                                std::string,
-                                std::variant<std::array<size_t, 3>, size_t>>>) {
-            // Convert size_t entries to {r, 0, 0} for spherical harmonic
-            // blocks; array<3> entries are used unchanged.
-            const auto converted = [&v]() {
-              std::unordered_map<std::string, std::array<size_t, 3>> result;
-              for (const auto& [name, val] : v) {
-                if (std::holds_alternative<size_t>(val)) {
-                  const size_t r = std::get<size_t>(val);
-                  result[name] = {r, 0, 0};
-                } else {
-                  result[name] = std::get<std::array<size_t, 3>>(val);
-                }
-              }
-              return result;
-            }();
-            return expand_over_blocks(converted);
-          } else {
-            return expand_over_blocks(v);
-          }
-        },
-        initial_refinement);
+    initial_refinement_ =
+        bco::set_initial_refinement(expand_over_blocks, initial_refinement);
   } catch (const std::exception& error) {
     PARSE_ERROR(context, "Invalid 'InitialRefinement': " << error.what());
   }
   try {
-    initial_number_of_grid_points_ = std::visit(
-        [&expand_over_blocks]<typename V>(
-            const V& v) -> std::vector<std::array<size_t, 3>> {
-          if constexpr (std::is_same_v<
-                            V, std::unordered_map<
-                                   std::string,
-                                   std::variant<std::array<size_t, 3>,
-                                                std::array<size_t, 2>>>>) {
-            // Convert array<2>{r, L_max} entries to {r, l_max, m_max} =
-            // {r, L_max, L_max} for spherical harmonic blocks; array<3> entries
-            // are used unchanged. We store the (l_max, m_max) of the shell
-            // directly because ell is clear and unambiguous, whereas the number
-            // of collocation points implied by ell depends on the spectral
-            // implementation. The conversion to the number of collocation
-            // points is applied in initial_extents().
-            const auto converted = [&v]() {
-              std::unordered_map<std::string, std::array<size_t, 3>> result;
-              for (const auto& [name, val] : v) {
-                if (std::holds_alternative<std::array<size_t, 2>>(val)) {
-                  const auto& a2 = std::get<std::array<size_t, 2>>(val);
-                  result[name] = {a2[0], a2[1], a2[1]};
-                } else {
-                  result[name] = std::get<std::array<size_t, 3>>(val);
-                }
-              }
-              return result;
-            }();
-            return expand_over_blocks(converted);
-          } else {
-            return expand_over_blocks(v);
-          }
-        },
-        initial_number_of_grid_points);
+    initial_number_of_grid_points_ = bco::set_initial_grid_points(
+        expand_over_blocks, initial_number_of_grid_points);
   } catch (const std::exception& error) {
     PARSE_ERROR(context, "Invalid 'InitialGridPoints': " << error.what());
   }
+
   // Validate resolved grid points and refinement for spherical-harmonic
   // outer-shell blocks.
   if (spherical_harmonics_in_wavezone_) {

--- a/src/Domain/Creators/BinaryCompactObject.cpp
+++ b/src/Domain/Creators/BinaryCompactObject.cpp
@@ -96,8 +96,8 @@ void validate_initial_grid_points(
         if (std::holds_alternative<std::array<size_t, 3>>(extents)) {
           PARSE_ERROR(context, "Block '"
                                    << block_name
-                                   << "' is a spherical-harmonic outer-shell "
-                                      "block. Specify its grid points as "
+                                   << "' is a spherical-harmonic shell block. "
+                                      "Specify its grid points as "
                                       "[radial_points, L_max], not array<3>.");
         }
       } else {
@@ -107,14 +107,13 @@ void validate_initial_grid_points(
                         "Specifying 2 grid points for block '"
                             << block_name
                             << "' is only valid for spherical-harmonic "
-                               "outer-shell blocks (OuterShell0, etc.).");
+                               "shell blocks (OuterShell0, etc.).");
           } else {
             PARSE_ERROR(
                 context,
                 "Specifying 2 grid points (block '"
                     << block_name
-                    << "') is only valid when SphericalHarmonicsInWavezone "
-                       "is enabled.");
+                    << "') is only valid for spherical-harmonic shell blocks.");
           }
         }
       }
@@ -140,7 +139,7 @@ void validate_initial_refinement(
           PARSE_ERROR(context,
                       "Block '"
                           << block_name
-                          << "' is a spherical-harmonic outer-shell block. "
+                          << "' is a spherical-harmonic shell block. "
                              "Specify its refinement as a single number "
                              "(radial only), not array<3>. Angular "
                              "h-refinement is not supported for these blocks.");
@@ -152,14 +151,13 @@ void validate_initial_refinement(
                         "Per-block single-number refinement for block '"
                             << block_name
                             << "' is only valid for spherical-harmonic "
-                               "outer-shell blocks (OuterShell0, etc.).");
+                               "shell blocks (OuterShell0, etc.).");
           } else {
             PARSE_ERROR(
                 context,
                 "Per-block single-number refinement in map syntax (block '"
                     << block_name
-                    << "') is only valid when SphericalHarmonicsInWavezone "
-                       "is enabled.");
+                    << "') is only valid for spherical-harmonic shell blocks.");
           }
         }
       }

--- a/src/Domain/Creators/BinaryCompactObject.hpp
+++ b/src/Domain/Creators/BinaryCompactObject.hpp
@@ -53,6 +53,9 @@ class Frustum;
 template <typename SourceFrame, typename TargetFrame, typename... Maps>
 class CoordinateMap;
 
+template <typename T>
+struct ExpandOverBlocks;
+
 namespace FunctionsOfTime {
 class FunctionOfTime;
 }  // namespace FunctionsOfTime
@@ -67,23 +70,6 @@ struct BlockLogical;
 /// \endcond
 
 namespace domain::creators {
-namespace bco {
-/*!
- * \brief Create a set of centers of objects for the binary domains.
- *
- * \details Will add the following centers to the set:
- *
- * - Center: The origin
- * - CenterA: Center of object A
- * - CenterB: Center of object B
- *
- * \return Object required by the DomainCreator%s
- */
-std::unordered_map<std::string, tnsr::I<double, 3, Frame::Grid>>
-create_grid_anchors(const std::array<double, 3>& center_a,
-                    const std::array<double, 3>& center_b);
-}  // namespace bco
-
 /*!
  * \ingroup ComputationalDomainGroup
  *
@@ -659,4 +645,91 @@ class BinaryCompactObject : public DomainCreator<3> {
   bool spherical_harmonics_in_wavezone_ = false;
   bool use_worldtube_ = false;
 };
+
+namespace bco {
+/*!
+ * \brief Create a set of centers of objects for the binary domains.
+ *
+ * \details Will add the following centers to the set:
+ *
+ * - Center: The origin
+ * - CenterA: Center of object A
+ * - CenterB: Center of object B
+ *
+ * \return Object required by the DomainCreator%s
+ */
+std::unordered_map<std::string, tnsr::I<double, 3, Frame::Grid>>
+create_grid_anchors(const std::array<double, 3>& center_a,
+                    const std::array<double, 3>& center_b);
+
+/*!
+ * \brief Validate `InitialRefinement` map entries.
+ *
+ * \details Any spherical-harmonic block must use `size_t` (radial only).
+ * `array<3>` is rejected on spherical-harmonic blocks even if angular
+ * components are zero. Non-spherical-harmonic entries must use `array<3>`.
+ *
+ * \param context options context
+ * \param initial_refinement the initial refinement from options
+ * \param spherical_harmonic_shell_names the names of spherical shell blocks
+ * that use spherical harmonics
+ */
+void validate_initial_refinement(
+    const Options::Context& context,
+    const BinaryCompactObject::InitialRefinement::type& initial_refinement,
+    const std::unordered_set<std::string>& spherical_harmonic_shell_names);
+
+/*!
+ * \brief Validate `InitialGridPoints` map entries.
+ *
+ * \details Any spherical-harmonic shell block must use
+ * `array<2>{radial, L_max}`. Non-spherical-harmonic blocks must use `array<3>`.
+ *
+ * \param context options context
+ * \param initial_number_of_grid_points the initial grid points from options
+ * \param spherical_harmonic_shell_names the names of spherical shell blocks
+ * that use spherical harmonics
+ */
+void validate_initial_grid_points(
+    const Options::Context& context,
+    const BinaryCompactObject::InitialGridPoints::type&
+        initial_number_of_grid_points,
+    const std::unordered_set<std::string>& spherical_harmonic_shell_names);
+
+/*!
+ * \brief Convert `size_t` radial h refinement entries for spherical harmonic
+ * blocks to `{r, 0, 0}`
+ *
+ * \details All `array<3>` entries are unchanged.
+ *
+ * \param expand_over_blocks `ExpandOverBlocks` containing the block names and
+ * block groups
+ * \param initial_refinement the initial refinement from options
+ *
+ * \return converted refinement
+ */
+std::vector<std::array<size_t, 3>> set_initial_refinement(
+    const ExpandOverBlocks<std::array<size_t, 3>>& expand_over_blocks,
+    const BinaryCompactObject::InitialRefinement::type& initial_refinement);
+
+/*!
+ * \brief Convert `array<2>{r, l_max}` entries for spherical harmonic blocks to
+ * `{r, l_max, m_max}` = `{r, l_max, l_max}`
+ *
+ * \details All array<3> entries are used unchanged. We store the (l_max, m_max)
+ * of the shell directly because ell is clear and unambiguous, whereas the
+ * number of collocation points implied by ell depends on the spectral
+ * implementation. The conversion to the number of collocation points is applied
+ * in `initial_extents()`.
+ *
+ * \param expand_over_blocks `ExpandOverBlocks` containing the block names and
+ * block groups
+ * \param initial_grid_points the initial grid points from options
+ *
+ * \return converted grid points
+ */
+std::vector<std::array<size_t, 3>> set_initial_grid_points(
+    const ExpandOverBlocks<std::array<size_t, 3>>& expand_over_blocks,
+    const BinaryCompactObject::InitialGridPoints::type& initial_grid_points);
+}  // namespace bco
 }  // namespace domain::creators

--- a/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
+++ b/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
@@ -36,6 +36,7 @@
 #include "Domain/Structure/ObjectLabel.hpp"
 #include "Domain/Structure/OrientationMap.hpp"
 #include "NumericalAlgorithms/RootFinding/QuadraticEquation.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Spherepack.hpp"
 #include "Options/ParseError.hpp"
 
 namespace {
@@ -128,6 +129,25 @@ CylindricalBinaryCompactObject::CylindricalBinaryCompactObject(
         context,
         "Cannot have periodic boundary conditions with a binary domain");
   }
+
+  // Build the set of spherical-harmonic shell block groups and block names so
+  // the validation below can distinguish spherical-harmonic blocks from other
+  // blocks and block groups.
+  std::unordered_set<std::string> spherical_harmonic_shell_names{"OuterSphere",
+                                                                 "OuterShell0"};
+  if (include_inner_sphere_A) {
+    spherical_harmonic_shell_names.insert("InnerSphereA");
+    spherical_harmonic_shell_names.insert("InnerAShell0");
+  }
+  if (include_inner_sphere_B) {
+    spherical_harmonic_shell_names.insert("InnerSphereB");
+    spherical_harmonic_shell_names.insert("InnerBShell0");
+  }
+
+  bco::validate_initial_refinement(context, initial_refinement,
+                                   spherical_harmonic_shell_names);
+  bco::validate_initial_grid_points(context, initial_grid_points,
+                                    spherical_harmonic_shell_names);
 
   // The choices made below for the quantities xi, z_cutting_plane_,
   // and xi_min_sphere_e are the ones made in SpEC, and in the
@@ -307,62 +327,40 @@ CylindricalBinaryCompactObject::CylindricalBinaryCompactObject(
   }
   add_spherical_shell_name("Outer", "OuterSphere", 0);
 
-  // Expand initial refinement over all blocks
+  // For expanding initial refinement and grid points over all blocks
   const ExpandOverBlocks<std::array<size_t, 3>> expand_over_blocks{
       block_names_, block_groups_};
   try {
-    initial_refinement_ = std::visit(
-        [this, &expand_over_blocks, &first_inner_shell_A_block,
-         &first_inner_shell_B_block]<typename V>(
-            const V& v) -> std::vector<std::array<size_t, 3>> {
-          if constexpr (std::is_same_v<V, size_t>) {
-            std::vector<std::array<size_t, 3>> expanded = expand_over_blocks(v);
-
-            // If one size_t was used to globally define refinement throughout
-            // the domain, overwrite the refinement levels to be 0 just for the
-            // angular directions of the spherical shells since angular
-            // refinement doesn't make since for blocks with spherical
-            // harmonics. This allows the user to still easily specify a global
-            // refinement level instead of having to manually specify the same
-            // refinement for all directions of all block groups with the same
-            // number except spherical shell blocks.
-
-            if (include_inner_sphere_A_) {
-              // InnerAShell0
-              expanded[first_inner_shell_A_block][1] = 0;
-              expanded[first_inner_shell_A_block][2] = 0;
-            }
-            if (include_inner_sphere_B_) {
-              // InnerBShell0
-              expanded[first_inner_shell_B_block][1] = 0;
-              expanded[first_inner_shell_B_block][2] = 0;
-            }
-            // OuterShell0
-            expanded[first_outer_shell_block][1] = 0;
-            expanded[first_outer_shell_block][2] = 0;
-
-            return expanded;
-          } else {
-            (void)first_inner_shell_A_block;
-            (void)first_inner_shell_B_block;
-            (void)first_outer_shell_block;
-
-            return expand_over_blocks(v);
-          }
-        },
-        initial_refinement);
-
+    initial_refinement_ =
+        bco::set_initial_refinement(expand_over_blocks, initial_refinement);
+    // If a global single-number refinement was used, post-process the spherical
+    // shell entries to make the angular directions have h refinement = 0.
+    if (std::holds_alternative<size_t>(initial_refinement)) {
+      if (include_inner_sphere_A) {
+        // InnerAShell0
+        initial_refinement_[first_inner_shell_A_block][1] = 0;
+        initial_refinement_[first_inner_shell_A_block][2] = 0;
+      }
+      if (include_inner_sphere_B) {
+        // InnerBShell0
+        initial_refinement_[first_inner_shell_B_block][1] = 0;
+        initial_refinement_[first_inner_shell_B_block][2] = 0;
+      }
+      // OuterShell0
+      initial_refinement_[first_outer_shell_block][1] = 0;
+      initial_refinement_[first_outer_shell_block][2] = 0;
+    }
   } catch (const std::exception& error) {
     PARSE_ERROR(context, "Invalid 'InitialRefinement': " << error.what());
   }
+  // Validate angular h-refinement == 0 in spherical shell blocks
   if (include_inner_sphere_A_) {
-    // validate angular h-refinement == 0 in spherical shell blocks
     if (gsl::at(initial_refinement_, first_inner_shell_A_block)[1] != 0 or
         gsl::at(initial_refinement_, first_inner_shell_A_block)[2] != 0) {
       PARSE_ERROR(context,
                   "Angular h-refinement is not supported for "
                   "spherical-harmonic inner-shell blocks. Specify refinement "
-                  "for InnerSphereA as [radial_refinement, 0, 0].");
+                  "for InnerSphereA as a single number.");
     }
   }
   if (include_inner_sphere_B_) {
@@ -371,7 +369,7 @@ CylindricalBinaryCompactObject::CylindricalBinaryCompactObject(
       PARSE_ERROR(context,
                   "Angular h-refinement is not supported for "
                   "spherical-harmonic inner-shell blocks. Specify refinement "
-                  "for InnerSphereB as [radial_refinement, 0, 0].");
+                  "for InnerSphereB as a single number.");
     }
   }
   if (gsl::at(initial_refinement_, first_outer_shell_block)[1] != 0 or
@@ -379,75 +377,66 @@ CylindricalBinaryCompactObject::CylindricalBinaryCompactObject(
     PARSE_ERROR(context,
                 "Angular h-refinement is not supported for "
                 "spherical-harmonic outer-shell blocks. Specify refinement "
-                "as [radial_refinement, 0, 0].");
+                "for OuterSphere as a single number.");
   }
 
-  size_t inner_sphere_A_l_max = 0;
-  size_t inner_sphere_A_m_max = 0;
-  size_t inner_sphere_B_l_max = 0;
-  size_t inner_sphere_B_m_max = 0;
-  size_t outer_sphere_l_max = 0;
-  size_t outer_sphere_m_max = 0;
-
   try {
-    initial_grid_points_ = std::visit(expand_over_blocks, initial_grid_points);
-
-    inner_sphere_A_l_max = initial_grid_points_[first_inner_shell_A_block][1];
-    inner_sphere_A_m_max = initial_grid_points_[first_inner_shell_A_block][2];
-
-    inner_sphere_B_l_max = initial_grid_points_[first_inner_shell_B_block][1];
-    inner_sphere_B_m_max = initial_grid_points_[first_inner_shell_B_block][2];
-
-    outer_sphere_l_max =
-        initial_grid_points_[first_outer_shell_block][1];
-    outer_sphere_m_max = initial_grid_points_[first_outer_shell_block][2];
-
-    // For spherical-harmonic shell blocks, initial_number_of_grid_points_
-    // stores {n_radial, l_max, m_max}. Convert (l_max, m_max) to the number of
-    // collocation points the spherical-harmonic basis uses in each angular
-    // direction.
-
-    // InnerAShell0
-    initial_grid_points_[first_inner_shell_A_block][1] =
-        ylm::Spherepack::n_theta_points(inner_sphere_A_l_max);
-    initial_grid_points_[first_inner_shell_A_block][2] =
-        ylm::Spherepack::n_phi_points(inner_sphere_A_m_max);
-    // InnerBShell0
-    initial_grid_points_[first_inner_shell_B_block][1] =
-        ylm::Spherepack::n_theta_points(inner_sphere_B_l_max);
-    initial_grid_points_[first_inner_shell_B_block][2] =
-        ylm::Spherepack::n_phi_points(inner_sphere_B_m_max);
-    // OuterShell0
-    initial_grid_points_[first_outer_shell_block][1] =
-        ylm::Spherepack::n_theta_points(outer_sphere_l_max);
-    initial_grid_points_[first_outer_shell_block][2] =
-        ylm::Spherepack::n_phi_points(outer_sphere_m_max);
+    initial_grid_points_ =
+        bco::set_initial_grid_points(expand_over_blocks, initial_grid_points);
   } catch (const std::exception& error) {
     PARSE_ERROR(context, "Invalid 'InitialGridPoints': " << error.what());
   }
-  // A spherical-harmonic shell is fully specified by a single ell, so
-  // l_max must equal m_max.
-  if (inner_sphere_A_l_max != inner_sphere_A_m_max) {
-    PARSE_ERROR(
-        context,
-        "Spherical-harmonic inner-shell blocks must have L_max = M_max. "
-        "Specify grid points for InnerSphereA as [radial_points, L_max, "
-        "L_max].");
+  // Validate angular grid points in spherical shell blocks. A
+  // spherical-harmonic shell is fully specified by a single ell, so l_max must
+  // equal m_max.
+  if (include_inner_sphere_A_) {
+    if (initial_grid_points_[first_inner_shell_A_block][1] !=
+        initial_grid_points_[first_inner_shell_A_block][2]) {
+      PARSE_ERROR(
+          context,
+          "Spherical-harmonic inner-shell blocks must have L_max = M_max. "
+          "Specify grid points for InnerSphereA as [radial_points, L_max].");
+    }
+    // For spherical-harmonic outer-shell blocks, initial_number_of_grid_points_
+    // stores {n_radial, l_max, m_max}. Convert (l_max, m_max) to the number of
+    // collocation points the spherical-harmonic basis uses in each angular
+    // direction.
+    initial_grid_points_[first_inner_shell_A_block][1] =
+        ylm::Spherepack::n_theta_points(
+            gsl::at(initial_grid_points_, first_inner_shell_A_block)[1]);
+    initial_grid_points_[first_inner_shell_A_block][2] =
+        ylm::Spherepack::n_phi_points(
+            gsl::at(initial_grid_points_, first_inner_shell_A_block)[2]);
   }
-  if (inner_sphere_B_l_max != inner_sphere_B_m_max) {
-    PARSE_ERROR(
-        context,
-        "Spherical-harmonic inner-shell blocks must have L_max = M_max. "
-        "Specify grid points for InnerSphereB as [radial_points, L_max, "
-        "L_max].");
+  if (include_inner_sphere_B_) {
+    if (initial_grid_points_[first_inner_shell_B_block][1] !=
+        initial_grid_points_[first_inner_shell_B_block][2]) {
+      PARSE_ERROR(
+          context,
+          "Spherical-harmonic inner-shell blocks must have L_max = M_max. "
+          "Specify grid points for InnerSphereB as [radial_points, L_max].");
+    }
+    initial_grid_points_[first_inner_shell_B_block][1] =
+        ylm::Spherepack::n_theta_points(
+            gsl::at(initial_grid_points_, first_inner_shell_B_block)[1]);
+    initial_grid_points_[first_inner_shell_B_block][2] =
+        ylm::Spherepack::n_phi_points(
+            gsl::at(initial_grid_points_, first_inner_shell_B_block)[2]);
   }
-  if (outer_sphere_l_max != outer_sphere_m_max) {
+  if (initial_grid_points_[first_outer_shell_block][1] !=
+      initial_grid_points_[first_outer_shell_block][2]) {
     PARSE_ERROR(
         context,
         "Spherical-harmonic outer-shell blocks must have L_max = M_max. "
-        "Specify grid points for OuterSphere as [radial_points, L_max, "
-        "L_max].");
+        "Specify grid points for OuterSphere as [radial_points, L_max].");
   }
+
+  initial_grid_points_[first_outer_shell_block][1] =
+      ylm::Spherepack::n_theta_points(
+          gsl::at(initial_grid_points_, first_outer_shell_block)[1]);
+  initial_grid_points_[first_outer_shell_block][2] =
+      ylm::Spherepack::n_phi_points(
+          gsl::at(initial_grid_points_, first_outer_shell_block)[2]);
 
   // Now we must change the initial refinement and initial grid points
   // for certain blocks, because the [r, theta, perp] directions do

--- a/src/Domain/Creators/CylindricalBinaryCompactObject.hpp
+++ b/src/Domain/Creators/CylindricalBinaryCompactObject.hpp
@@ -50,6 +50,9 @@ class UniformCylindricalSide;
 template <typename SourceFrame, typename TargetFrame, typename... Maps>
 class CoordinateMap;
 
+template <typename T>
+struct ExpandOverBlocks;
+
 namespace FunctionsOfTime {
 class FunctionOfTime;
 }  // namespace FunctionsOfTime
@@ -232,34 +235,36 @@ class CylindricalBinaryCompactObject : public DomainCreator<3> {
   };
 
   struct InitialRefinement {
-    using type =
-        std::variant<size_t, std::array<size_t, 3>,
-                     std::vector<std::array<size_t, 3>>,
-                     std::unordered_map<std::string, std::array<size_t, 3>>>;
+    using type = std::variant<
+        size_t, std::array<size_t, 3>, std::vector<std::array<size_t, 3>>,
+        std::unordered_map<std::string, std::array<size_t, 3>>,
+        std::unordered_map<std::string,
+                           std::variant<std::array<size_t, 3>, size_t>>>;
     static constexpr Options::String help = {
         "Initial refinement level. Specify one of: a single number, a list "
         "representing [r, theta, perp], or such a list for every block in the "
         "domain. Here 'r' is the radial direction normal to the inner and "
         "outer boundaries, 'theta' is the periodic direction, and 'perp' is "
         "the third direction. Note that for spherical shell block groups "
-        "(e.g. 'OuterSphere'), the angular refinement levels must be specified "
-        "as zero. The exception is if a single number is specified for global "
-        "refinement, the angular refinement for 'OuterSphere' blocks will be "
-        "set to 0 for you."};
+        "('InnerSphereA', 'InnerSphereB', and 'OuterSphere'), you must instead "
+        "specify refinement as a single value representing radial refinement."};
   };
   struct InitialGridPoints {
-    using type =
-        std::variant<size_t, std::array<size_t, 3>,
-                     std::vector<std::array<size_t, 3>>,
-                     std::unordered_map<std::string, std::array<size_t, 3>>>;
+    using type = std::variant<
+        size_t, std::array<size_t, 3>, std::vector<std::array<size_t, 3>>,
+        std::unordered_map<std::string, std::array<size_t, 3>>,
+        std::unordered_map<std::string, std::variant<std::array<size_t, 3>,
+                                                     std::array<size_t, 2>>>>;
     static constexpr Options::String help = {
         "Initial number of grid points. Specify one of: a single number, a "
         "list representing [r, theta, perp], or such a list for every block in "
         "the domain. Here 'r' is the radial direction normal to the inner and "
         "outer boundaries, 'theta' is the periodic direction, and 'perp' is "
-        "the third direction. The exception to this is that for blocks in "
-        "'OuterSphere', the list represents [r, l_max, m_max]. Note that for "
-        "these blocks, l_max must be equal to m_max."};
+        "the third direction. The exception to this is that for spherical "
+        "shell blocks groups ('InnerSphereA', 'InnerSphereB', 'OuterSphere'),"
+        "you must instead specify grid points as [r, L_max]. The exception to "
+        "this is if a single number is specified for global initial grid "
+        "points."};
   };
 
   struct BoundaryConditions {

--- a/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_BinaryCompactObject.cpp
@@ -1003,7 +1003,7 @@ void test_parse_errors() {
           Distribution::Linear, 120.0, false, false, std::nullopt,
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
-          "only valid when SphericalHarmonicsInWavezone is enabled"));
+          "only valid for spherical-harmonic shell blocks"));
   CHECK_THROWS_WITH(
       domain::creators::BinaryCompactObject(
           Object{0.5, 0.8, 1.0, {{create_inner_boundary_condition()}}, false},
@@ -1016,7 +1016,7 @@ void test_parse_errors() {
           Distribution::Linear, 120.0, false, false, std::nullopt,
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
-          "only valid when SphericalHarmonicsInWavezone is enabled"));
+          "only valid for spherical-harmonic shell blocks"));
   // Note: the boundary condition-related parse errors are checked in the
   // test_connectivity function.
 }
@@ -1295,7 +1295,7 @@ void test_spherical_harmonics_wavezone() {
           std::nullopt, create_outer_boundary_condition(),
           Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
-          "only valid for spherical-harmonic outer-shell blocks"));
+          "only valid for spherical-harmonic shell blocks"));
   // Map grid points with array<2> on a non-SH block -> pre-expansion error.
   CHECK_THROWS_WITH(
       domain::creators::BinaryCompactObject(
@@ -1308,7 +1308,7 @@ void test_spherical_harmonics_wavezone() {
           Distribution::Linear, 120.0, true, false, std::nullopt,
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
-          "only valid for spherical-harmonic outer-shell blocks"));
+          "only valid for spherical-harmonic shell blocks"));
 }
 
 template <domain::ObjectLabel Object>

--- a/tests/Unit/Domain/Creators/Test_CylindricalBinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_CylindricalBinaryCompactObject.cpp
@@ -17,6 +17,7 @@
 #include <tuple>
 #include <unordered_map>
 #include <utility>
+#include <variant>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
@@ -40,6 +41,7 @@
 #include "Helpers/Domain/Creators/TestHelpers.hpp"
 #include "Helpers/Domain/DomainTestHelpers.hpp"
 #include "Informer/InfoFromBuild.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Spherepack.hpp"
 #include "Utilities/CartesianProduct.hpp"
 #include "Utilities/GetOutput.hpp"
 #include "Utilities/MakeArray.hpp"
@@ -231,10 +233,9 @@ std::string create_option_string(
                                      get_output(value) + "," +
                                      get_output(value) + "]";
         const std::string shell_same =
-            is_h_refinement ? ("[" + get_output(value) + ", 0, 0]") : same;
+            is_h_refinement ? get_output(value) : same;
         const std::string shell_one_more =
-            is_h_refinement ? ("[" + get_output(value + 1) + ", 0, 0]")
-                            : one_more;
+            is_h_refinement ? get_output(value + 1) : one_more;
         std::string result{};
         if (include_extra) {
           result += "\n    Outer: " + one_more;
@@ -601,18 +602,47 @@ void test_parse_errors() {
 }
 
 // This matches the structure in the option string
-std::unordered_map<std::string, std::array<size_t, 3>> make_initial_structure(
-    const bool is_h_refinement, const size_t initial_value,
-    const bool include_inner_sphere_A, const bool include_inner_sphere_B) {
-  std::unordered_map<std::string, std::array<size_t, 3>> initial_map;
+std::unordered_map<std::string, std::variant<std::array<size_t, 3>, size_t>>
+make_initial_refinement(const size_t initial_value,
+                        const bool include_inner_sphere_A,
+                        const bool include_inner_sphere_B) {
+  std::unordered_map<std::string, std::variant<std::array<size_t, 3>, size_t>>
+      initial_map;
   const std::array<size_t, 3> same{initial_value, initial_value, initial_value};
   const std::array<size_t, 3> one_more{initial_value + 1, initial_value,
                                        initial_value};
-  const std::array<size_t, 3> shell_same =
-      is_h_refinement ? std::array<size_t, 3>{initial_value, 0, 0} : same;
-  const std::array<size_t, 3> shell_one_more =
-      is_h_refinement ? std::array<size_t, 3>{initial_value + 1, 0, 0}
-                      : one_more;
+  const size_t shell_same = initial_value;
+  const size_t shell_one_more = initial_value + 1;
+
+  initial_map["Outer"] = one_more;
+  initial_map["InnerA"] = same;
+  initial_map["InnerB"] = one_more;
+  if (include_inner_sphere_A) {
+    initial_map["InnerSphereA"] = shell_same;
+  }
+  if (include_inner_sphere_B) {
+    initial_map["InnerSphereB"] = shell_same;
+  }
+  initial_map["OuterSphere"] = shell_one_more;
+
+  return initial_map;
+}
+
+// This matches the structure in the option string
+std::unordered_map<std::string,
+                   std::variant<std::array<size_t, 3>, std::array<size_t, 2>>>
+make_initial_grid_points(const size_t initial_value,
+                         const bool include_inner_sphere_A,
+                         const bool include_inner_sphere_B) {
+  std::unordered_map<std::string,
+                     std::variant<std::array<size_t, 3>, std::array<size_t, 2>>>
+      initial_map;
+  const std::array<size_t, 3> same{initial_value, initial_value, initial_value};
+  const std::array<size_t, 3> one_more{initial_value + 1, initial_value,
+                                       initial_value};
+  const std::array<size_t, 2> shell_same{initial_value, initial_value};
+  const std::array<size_t, 2> shell_one_more{initial_value + 1, initial_value};
+
   initial_map["Outer"] = one_more;
   initial_map["InnerA"] = same;
   initial_map["InnerB"] = one_more;
@@ -686,14 +716,14 @@ void test_cylindrical_bbh() {
     CylBCO::InitialGridPoints::type initial_grid_points{};
 
     if (with_additional_outer_radial_refinement) {
-      initial_refinement = make_initial_structure(
-          true, refinement, include_inner_sphere_A, include_inner_sphere_B);
+      initial_refinement = make_initial_refinement(
+          refinement, include_inner_sphere_A, include_inner_sphere_B);
     } else {
       initial_refinement = refinement;
     }
     if (with_additional_grid_points) {
-      initial_grid_points = make_initial_structure(
-          false, grid_points, include_inner_sphere_A, include_inner_sphere_B);
+      initial_grid_points = make_initial_grid_points(
+          grid_points, include_inner_sphere_A, include_inner_sphere_B);
     } else {
       initial_grid_points = grid_points;
     }
@@ -732,11 +762,152 @@ void test_cylindrical_bbh() {
         cyl_binary_compact_object, with_boundary_conditions);
   }
 }
+
+// Make sure initial refinement and initial grid points for different blocks
+// are set to the correct values based on the input
+void test_initial_extents_and_refinement() {
+  using RefinementMap =
+      std::unordered_map<std::string,
+                         std::variant<std::array<size_t, 3>, size_t>>;
+  using GridPointsMap = std::unordered_map<
+      std::string, std::variant<std::array<size_t, 3>, std::array<size_t, 2>>>;
+
+  const std::array<double, 3> center_A{{2.0, 0.05, 0.0}};
+  const std::array<double, 3> center_B{{-2.0, 0.05, 0.0}};
+  const double radius_A = 1.0;
+  const double radius_B = radius_A;
+  const bool include_inner_sphere_A = true;
+  const bool include_inner_sphere_B = true;
+  const double outer_radius = 100.0;
+  const bool use_equiangular_map = false;
+
+  // Set h and p refinement globally with one number
+  const size_t global_refinement = 1;
+  const size_t global_grid_points = 12;
+
+  // Set h and p refinement locally per block group
+  const RefinementMap local_refinement =
+      RefinementMap{{"InnerA", std::array<size_t, 3>{1, 1, 1}},
+                    {"InnerB", std::array<size_t, 3>{2, 2, 2}},
+                    {"Outer", std::array<size_t, 3>{2, 2, 2}},
+                    {"InnerSphereA", size_t{0}},
+                    {"InnerSphereB", size_t{1}},
+                    {"OuterSphere", size_t{2}}};
+  const GridPointsMap local_grid_points =
+      GridPointsMap{{"InnerA", std::array<size_t, 3>{5, 5, 5}},
+                    {"InnerB", std::array<size_t, 3>{7, 7, 7}},
+                    {"Outer", std::array<size_t, 3>{9, 9, 9}},
+                    {"InnerSphereA", std::array<size_t, 2>{4, 6}},
+                    {"InnerSphereB", std::array<size_t, 2>{6, 8}},
+                    {"OuterSphere", std::array<size_t, 2>{8, 10}}};
+
+  // Domain created from global h and p refinement
+  const auto cbco_global_creator =
+      domain::creators::CylindricalBinaryCompactObject(
+          center_A, center_B, radius_A, radius_B, include_inner_sphere_A,
+          include_inner_sphere_B, outer_radius, use_equiangular_map,
+          global_refinement, global_grid_points, std::nullopt,
+          create_inner_boundary_condition(), create_outer_boundary_condition(),
+          Options::Context{false, {}, 1, 1});
+  const std::vector<std::array<size_t, 3>> global_initial_refinement_levels =
+      cbco_global_creator.initial_refinement_levels();
+  const std::vector<std::array<size_t, 3>> global_initial_extents =
+      cbco_global_creator.initial_extents();
+  const Domain<3> cbco_global = cbco_global_creator.create_domain();
+  const auto& blocks_local = cbco_global.blocks();
+
+  // Domain created from local h and p refinement
+  const auto cbco_local_creator =
+      domain::creators::CylindricalBinaryCompactObject(
+          center_A, center_B, radius_A, radius_B, include_inner_sphere_A,
+          include_inner_sphere_B, outer_radius, use_equiangular_map,
+          local_refinement, local_grid_points, std::nullopt,
+          create_inner_boundary_condition(), create_outer_boundary_condition(),
+          Options::Context{false, {}, 1, 1});
+  const std::vector<std::array<size_t, 3>> local_initial_refinement_levels =
+      cbco_local_creator.initial_refinement_levels();
+  const std::vector<std::array<size_t, 3>> local_initial_extents =
+      cbco_local_creator.initial_extents();
+  const Domain<3> cbco_local = cbco_local_creator.create_domain();
+  const auto& blocks_global = cbco_local.blocks();
+
+  // Expected block groups containing block names
+  const auto& [_, block_groups] =
+      block_names_and_groups(include_inner_sphere_A, include_inner_sphere_B);
+
+  for (size_t i = 0; i < blocks_global.size(); i++) {
+    const std::string block_name_global = gsl::at(blocks_global, i).name();
+    const std::string block_name_local = gsl::at(blocks_local, i).name();
+    ASSERT(block_name_global == block_name_local,
+           "This test assumes both test domains have the same block names in "
+           "the same order.");
+
+    std::array<size_t, 3> expected_refinement_from_global{};
+    std::array<size_t, 3> expected_extents_from_global{};
+    std::array<size_t, 3> expected_refinement_from_local{};
+    std::array<size_t, 3> expected_extents_from_local{};
+    // Set expected h and p refinement
+    if (block_groups.at("InnerSphereA").contains(block_name_global)) {
+      expected_refinement_from_global = {{1, 0, 0}};
+      expected_extents_from_global = {{12, ylm::Spherepack::n_theta_points(12),
+                                       ylm::Spherepack::n_phi_points(12)}};
+      expected_refinement_from_local = {{0, 0, 0}};
+      expected_extents_from_local = {{4, ylm::Spherepack::n_theta_points(6),
+                                      ylm::Spherepack::n_phi_points(6)}};
+    } else if (block_groups.at("InnerSphereB").contains(block_name_global)) {
+      expected_refinement_from_global = {{1, 0, 0}};
+      expected_extents_from_global = {{12, ylm::Spherepack::n_theta_points(12),
+                                       ylm::Spherepack::n_phi_points(12)}};
+      expected_refinement_from_local = {{1, 0, 0}};
+      expected_extents_from_local = {{6, ylm::Spherepack::n_theta_points(8),
+                                      ylm::Spherepack::n_phi_points(8)}};
+    } else if (block_groups.at("OuterSphere").contains(block_name_global)) {
+      expected_refinement_from_global = {{1, 0, 0}};
+      expected_extents_from_global = {{12, ylm::Spherepack::n_theta_points(12),
+                                       ylm::Spherepack::n_phi_points(12)}};
+      expected_refinement_from_local = {{2, 0, 0}};
+      expected_extents_from_local = {{8, ylm::Spherepack::n_theta_points(10),
+                                      ylm::Spherepack::n_phi_points(10)}};
+    } else if (block_groups.at("InnerA").contains(block_name_global)) {
+      expected_refinement_from_global = {{1, 1, 1}};
+      expected_extents_from_global = {{12, 12, 12}};
+      expected_refinement_from_local = {{1, 1, 1}};
+      expected_extents_from_local = {{5, 5, 5}};
+    } else if (block_groups.at("InnerB").contains(block_name_global)) {
+      expected_refinement_from_global = {{1, 1, 1}};
+      expected_extents_from_global = {{12, 12, 12}};
+      expected_refinement_from_local = {{2, 2, 2}};
+      expected_extents_from_local = {{7, 7, 7}};
+    } else if (block_groups.at("Outer").contains(block_name_global)) {
+      expected_refinement_from_global = {{1, 1, 1}};
+      expected_extents_from_global = {{12, 12, 12}};
+      expected_refinement_from_local = {{2, 2, 2}};
+      expected_extents_from_local = {{9, 9, 9}};
+    } else {
+      ERROR("Block name not found in block groups.");
+    }
+
+    // Get actual h and p refinement constructed
+    const auto& refinement_from_global =
+        gsl::at(global_initial_refinement_levels, i);
+    const auto& extents_from_global = gsl::at(global_initial_extents, i);
+    const auto& refinement_from_local =
+        gsl::at(local_initial_refinement_levels, i);
+    const auto& extents_from_local = gsl::at(local_initial_extents, i);
+
+    // Check constructed vs expected h and p refinement
+    CHECK(refinement_from_global == expected_refinement_from_global);
+    CHECK(extents_from_global == expected_extents_from_global);
+    CHECK(refinement_from_local == expected_refinement_from_local);
+    CHECK(extents_from_local == expected_extents_from_local);
+  }
+}
 }  // namespace
 
 // [[TimeOut, 80]]
 SPECTRE_TEST_CASE("Unit.Domain.Creators.CylindricalBinaryCompactObject",
                   "[Domain][Unit]") {
+  test_initial_extents_and_refinement();
   test_cylindrical_bbh();
   test_parse_errors();
 }


### PR DESCRIPTION
## Proposed changes

This makes it so that you must specify the right number of values for h and p refinement for spherical shells in CBCO, just as BCO does:
- spherical shell block h refinement: must be specified as a single number `r` (for number of radial points)
- spherical shell block p refinement: must be specified as `[r, L_max]`

The first commit just factors out BCO logic that handles the validation and assignment of h and p refinement, the second commit actually updates CBCO to have it use this same logic

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
