### PR TITLE
Support Variables specializations

### DIFF
--- a/src/DataStructures/CMakeLists.txt
+++ b/src/DataStructures/CMakeLists.txt
@@ -72,6 +72,7 @@ spectre_target_headers(
   TempBuffer.hpp
   Transpose.hpp
   Variables.hpp
+  VariablesDeclaration.hpp
   VariablesTag.hpp
   VectorImpl.hpp
   )

--- a/src/DataStructures/DataBox/PrefixHelpers.hpp
+++ b/src/DataStructures/DataBox/PrefixHelpers.hpp
@@ -3,11 +3,10 @@
 
 #pragma once
 
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
-template <typename TagsList>
-class Variables;
 namespace db {
 struct PrefixTag;
 struct SimpleTag;

--- a/src/DataStructures/DataBox/Prefixes.hpp
+++ b/src/DataStructures/DataBox/Prefixes.hpp
@@ -13,12 +13,8 @@
 #include "DataStructures/Tensor/IndexType.hpp"
 #include "DataStructures/Tensor/Metafunctions.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "Utilities/TypeTraits/IsA.hpp"
-
-/// \cond
-template <class>
-class Variables;
-/// \endcond
 
 namespace Tags {
 /// \ingroup DataBoxTagsGroup

--- a/src/DataStructures/Variables.hpp
+++ b/src/DataStructures/Variables.hpp
@@ -34,6 +34,7 @@
 #include "DataStructures/TaggedTuple.hpp"
 #include "DataStructures/Tensor/IndexType.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "Utilities/EqualWithinRoundoff.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/ForceInline.hpp"
@@ -50,8 +51,6 @@
 /// \cond
 template <typename X, typename Symm, typename IndexList>
 class Tensor;
-template <typename TagsList>
-class Variables;
 template <typename T, typename VectorType, size_t StaticSize>
 class VectorImpl;
 namespace Tags {
@@ -86,8 +85,8 @@ class Variables;
  * If the macro `SPECTRE_NAN_INIT` is defined, the contents are
  * initialized with `NaN`s.
  */
-template <typename... Tags>
-class Variables<tmpl::list<Tags...>> {
+template <typename... Tags, typename VectorType>
+class Variables<tmpl::list<Tags...>, VectorType> {
  public:
   using size_type = size_t;
   using difference_type = std::ptrdiff_t;
@@ -101,21 +100,17 @@ class Variables<tmpl::list<Tags...>> {
   static_assert((db::is_simple_tag_v<Tags> and ...));
   static_assert(tmpl2::flat_all_v<tt::is_a_v<Tensor, typename Tags::type>...>);
 
- private:
-  using first_tensors_type = typename tmpl::front<tags_list>::type::type;
-
  public:
-  static_assert(tmpl2::flat_all_v<std::is_same_v<typename Tags::type::type,
-                                                 first_tensors_type>...> or
+  static_assert(tmpl2::flat_all_v<
+                    std::is_same_v<typename Tags::type::type, VectorType>...> or
                     tmpl2::flat_all_v<is_spin_weighted_of_same_type_v<
-                        typename Tags::type::type, first_tensors_type>...>,
+                        typename Tags::type::type, VectorType>...>,
                 "All tensors stored in a single Variables must "
                 "have the same internal storage type.");
 
   using vector_type =
-      tmpl::conditional_t<is_any_spin_weighted_v<first_tensors_type>,
-                          typename first_tensors_type::value_type,
-                          first_tensors_type>;
+      tmpl::conditional_t<is_any_spin_weighted_v<VectorType>,
+                          typename VectorType::value_type, VectorType>;
   using value_type = typename vector_type::value_type;
   using pointer = value_type*;
   using const_pointer = const value_type*;
@@ -170,23 +165,25 @@ class Variables<tmpl::list<Tags...>> {
             Requires<tmpl2::flat_all<std::is_same<
                 db::remove_all_prefixes<WrappedTags>,
                 db::remove_all_prefixes<Tags>>::value...>::value> = nullptr>
-  explicit Variables(Variables<tmpl::list<WrappedTags...>>&& rhs);
+  explicit Variables(Variables<tmpl::list<WrappedTags...>, VectorType>&& rhs);
   template <typename... WrappedTags,
             Requires<tmpl2::flat_all<std::is_same<
                 db::remove_all_prefixes<WrappedTags>,
                 db::remove_all_prefixes<Tags>>::value...>::value> = nullptr>
-  Variables& operator=(Variables<tmpl::list<WrappedTags...>>&& rhs);
+  Variables& operator=(Variables<tmpl::list<WrappedTags...>, VectorType>&& rhs);
 
   template <typename... WrappedTags,
             Requires<tmpl2::flat_all<std::is_same<
                 db::remove_all_prefixes<WrappedTags>,
                 db::remove_all_prefixes<Tags>>::value...>::value> = nullptr>
-  explicit Variables(const Variables<tmpl::list<WrappedTags...>>& rhs);
+  explicit Variables(
+      const Variables<tmpl::list<WrappedTags...>, VectorType>& rhs);
   template <typename... WrappedTags,
             Requires<tmpl2::flat_all<std::is_same<
                 db::remove_all_prefixes<WrappedTags>,
                 db::remove_all_prefixes<Tags>>::value...>::value> = nullptr>
-  Variables& operator=(const Variables<tmpl::list<WrappedTags...>>& rhs);
+  Variables& operator=(
+      const Variables<tmpl::list<WrappedTags...>, VectorType>& rhs);
   /// @}
 
   /// \cond HIDDEN_SYMBOLS
@@ -261,12 +258,12 @@ class Variables<tmpl::list<Tags...>> {
   bool is_owning() const { return owning_; }
 
   // clang-tidy: redundant-declaration
-  template <typename Tag, typename TagList>
+  template <typename Tag, typename TagList, typename VT>
   friend constexpr typename Tag::type& get(  // NOLINT
-      Variables<TagList>& v);
-  template <typename Tag, typename TagList>
+      Variables<TagList, VT>& v);
+  template <typename Tag, typename TagList, typename VT>
   friend constexpr const typename Tag::type& get(  // NOLINT
-      const Variables<TagList>& v);
+      const Variables<TagList, VT>& v);
 
   /// Serialization for Charm++.
   // NOLINTNEXTLINE(google-runtime-references)
@@ -280,7 +277,8 @@ class Variables<tmpl::list<Tags...>> {
   /// \note There is no need for an rvalue overload because we need to copy into
   /// the contiguous array anyway
   template <typename... SubsetOfTags>
-  void assign_subset(const Variables<tmpl::list<SubsetOfTags...>>& vars) {
+  void assign_subset(
+      const Variables<tmpl::list<SubsetOfTags...>, VectorType>& vars) {
     EXPAND_PACK_LEFT_TO_RIGHT([this, &vars]() {
       if constexpr (tmpl::list_contains_v<tmpl::list<Tags...>, SubsetOfTags>) {
         get<SubsetOfTags>(*this) = get<SubsetOfTags>(vars);
@@ -388,17 +386,17 @@ class Variables<tmpl::list<Tags...>> {
 
   // Prevent the previous two declarations from implicitly converting
   // DataVectors and similar to Variables.
-  template <typename T, typename VectorType, size_t StaticSize>
-  Variables(const VectorImpl<T, VectorType, StaticSize>&) = delete;
-  template <typename T, typename VectorType, size_t StaticSize>
-  Variables& operator=(const VectorImpl<T, VectorType, StaticSize>&) = delete;
+  template <typename T, typename VT, size_t StaticSize>
+  Variables(const VectorImpl<T, VT, StaticSize>&) = delete;
+  template <typename T, typename VT, size_t StaticSize>
+  Variables& operator=(const VectorImpl<T, VT, StaticSize>&) = delete;
 
   template <typename... WrappedTags,
             Requires<tmpl2::flat_all<std::is_same_v<
                 db::remove_all_prefixes<WrappedTags>,
                 db::remove_all_prefixes<Tags>>...>::value> = nullptr>
   SPECTRE_ALWAYS_INLINE Variables& operator+=(
-      const Variables<tmpl::list<WrappedTags...>>& rhs) {
+      const Variables<tmpl::list<WrappedTags...>, VectorType>& rhs) {
     static_assert(
         (std::is_same_v<typename Tags::type, typename WrappedTags::type> and
          ...),
@@ -418,7 +416,7 @@ class Variables<tmpl::list<Tags...>> {
                 db::remove_all_prefixes<WrappedTags>,
                 db::remove_all_prefixes<Tags>>...>::value> = nullptr>
   SPECTRE_ALWAYS_INLINE Variables& operator-=(
-      const Variables<tmpl::list<WrappedTags...>>& rhs) {
+      const Variables<tmpl::list<WrappedTags...>, VectorType>& rhs) {
     static_assert(
         (std::is_same_v<typename Tags::type, typename WrappedTags::type> and
          ...),
@@ -444,7 +442,7 @@ class Variables<tmpl::list<Tags...>> {
   }
 
   template <
-      typename... WrappedTags,
+      typename... WrappedTags, typename VT,
       Requires<
           sizeof...(WrappedTags) == sizeof...(Tags) and
           tmpl2::flat_all_v<std::is_same_v<db::remove_all_prefixes<WrappedTags>,
@@ -455,7 +453,8 @@ class Variables<tmpl::list<Tags...>> {
 #endif
           > = nullptr>
   friend SPECTRE_ALWAYS_INLINE decltype(auto) operator+(
-      const Variables<tmpl::list<WrappedTags...>>& lhs, const Variables& rhs) {
+      const Variables<tmpl::list<WrappedTags...>, VT>& lhs,
+      const Variables& rhs) {
 #ifndef __CUDACC__
     // nvcc incorrectly hits this static_assert and variants of it, but using
     // the additional requires part above is fine.
@@ -478,7 +477,7 @@ class Variables<tmpl::list<Tags...>> {
   }
 
   template <
-      typename... WrappedTags,
+      typename... WrappedTags, typename VT,
       Requires<
           sizeof...(WrappedTags) == sizeof...(Tags) and
           tmpl2::flat_all_v<std::is_same_v<db::remove_all_prefixes<WrappedTags>,
@@ -489,7 +488,8 @@ class Variables<tmpl::list<Tags...>> {
 #endif
           > = nullptr>
   friend SPECTRE_ALWAYS_INLINE decltype(auto) operator-(
-      const Variables<tmpl::list<WrappedTags...>>& lhs, const Variables& rhs) {
+      const Variables<tmpl::list<WrappedTags...>, VT>& lhs,
+      const Variables& rhs) {
 #ifndef __CUDACC__
     // nvcc incorrectly hits this static_assert and variants of it, but using
     // the additional requires part above is fine.
@@ -571,7 +571,7 @@ class Variables<tmpl::list<Tags...>> {
     return blaze::equal<blaze::strict>(*lhs, rhs.variable_data_);
   }
 
-  template <class FriendTags>
+  template <class FriendTags, typename FriendVectorType>
   friend class Variables;
 
   std::array<value_type, number_of_independent_components>
@@ -594,8 +594,8 @@ class Variables<tmpl::list<Tags...>> {
 
 // The above Variables implementation doesn't work for an empty parameter pack,
 // so specialize here.
-template <>
-class Variables<tmpl::list<>> {
+template <typename VectorType>
+class Variables<tmpl::list<>, VectorType> {
  public:
   using tags_list = tmpl::list<>;
   static constexpr size_t number_of_independent_components = 0;
@@ -636,33 +636,38 @@ inline std::ostream& operator<<(std::ostream& os,
   return os << "{}";
 }
 
-template <typename... Tags>
-Variables<tmpl::list<Tags...>>::Variables() {
+template <typename... Tags, typename VectorType>
+Variables<tmpl::list<Tags...>, VectorType>::Variables() {
   add_reference_variable_data();
 }
 
-template <typename... Tags>
-Variables<tmpl::list<Tags...>>::Variables(const size_t number_of_grid_points) {
+template <typename... Tags, typename VectorType>
+Variables<tmpl::list<Tags...>, VectorType>::Variables(
+    const size_t number_of_grid_points) {
   initialize(number_of_grid_points);
 }
 
-template <typename... Tags>
-Variables<tmpl::list<Tags...>>::Variables(const size_t number_of_grid_points,
-                                          const value_type value) {
+template <typename... Tags, typename VectorType>
+Variables<tmpl::list<Tags...>, VectorType>::Variables(
+    const size_t number_of_grid_points, const value_type value) {
   initialize(number_of_grid_points, value);
 }
 
-template <typename... Tags>
-void Variables<tmpl::list<Tags...>>::initialize(
+template <typename... Tags, typename VectorType>
+void Variables<tmpl::list<Tags...>, VectorType>::initialize(
     const size_t number_of_grid_points) {
   if (number_of_grid_points_ == number_of_grid_points) {
     return;
   }
   if (UNLIKELY(not is_owning())) {
-    ERROR("Variables::initialize cannot be called on a non-owning Variables.  "
-          "This likely happened because of an attempted resize.  The current "
-          "number of grid points is " << number_of_grid_points_ << " and the "
-          "requested number is " << number_of_grid_points << ".");
+    ERROR(
+        "Variables::initialize cannot be called on a non-owning Variables.  "
+        "This likely happened because of an attempted resize.  The current "
+        "number of grid points is "
+        << number_of_grid_points_
+        << " and the "
+           "requested number is "
+        << number_of_grid_points << ".");
   }
   number_of_grid_points_ = number_of_grid_points;
   size_ = number_of_grid_points * number_of_independent_components;
@@ -678,26 +683,27 @@ void Variables<tmpl::list<Tags...>>::initialize(
 #endif  // SPECTRE_NAN_INIT
 }
 
-template <typename... Tags>
-void Variables<tmpl::list<Tags...>>::initialize(
+template <typename... Tags, typename VectorType>
+void Variables<tmpl::list<Tags...>, VectorType>::initialize(
     const size_t number_of_grid_points, const value_type value) {
   initialize(number_of_grid_points);
   std::fill(variable_data_.data(), variable_data_.data() + size_, value);
 }
 
 /// \cond HIDDEN_SYMBOLS
-template <typename... Tags>
-Variables<tmpl::list<Tags...>>::Variables(
-    const Variables<tmpl::list<Tags...>>& rhs) {
+template <typename... Tags, typename VectorType>
+Variables<tmpl::list<Tags...>, VectorType>::Variables(
+    const Variables<tmpl::list<Tags...>, VectorType>& rhs) {
   initialize(rhs.number_of_grid_points());
   variable_data_ =
       static_cast<const blaze::Vector<pointer_type, transpose_flag>&>(
           rhs.variable_data_);
 }
 
-template <typename... Tags>
-Variables<tmpl::list<Tags...>>& Variables<tmpl::list<Tags...>>::operator=(
-    const Variables<tmpl::list<Tags...>>& rhs) {
+template <typename... Tags, typename VectorType>
+Variables<tmpl::list<Tags...>, VectorType>&
+Variables<tmpl::list<Tags...>, VectorType>::operator=(
+    const Variables<tmpl::list<Tags...>, VectorType>& rhs) {
   if (&rhs == this) {
     return *this;
   }
@@ -708,8 +714,9 @@ Variables<tmpl::list<Tags...>>& Variables<tmpl::list<Tags...>>::operator=(
   return *this;
 }
 
-template <typename... Tags>
-Variables<tmpl::list<Tags...>>::Variables(Variables<tmpl::list<Tags...>>&& rhs)
+template <typename... Tags, typename VectorType>
+Variables<tmpl::list<Tags...>, VectorType>::Variables(
+    Variables<tmpl::list<Tags...>, VectorType>&& rhs)
     : variable_data_impl_dynamic_(std::move(rhs.variable_data_impl_dynamic_)),
       owning_(rhs.owning_),
       size_(rhs.size()),
@@ -725,9 +732,10 @@ Variables<tmpl::list<Tags...>>::Variables(Variables<tmpl::list<Tags...>>&& rhs)
   add_reference_variable_data();
 }
 
-template <typename... Tags>
-Variables<tmpl::list<Tags...>>& Variables<tmpl::list<Tags...>>::operator=(
-    Variables<tmpl::list<Tags...>>&& rhs) {
+template <typename... Tags, typename VectorType>
+Variables<tmpl::list<Tags...>, VectorType>&
+Variables<tmpl::list<Tags...>, VectorType>::operator=(
+    Variables<tmpl::list<Tags...>, VectorType>&& rhs) {
   if (this == &rhs) {
     return *this;
   }
@@ -748,13 +756,13 @@ Variables<tmpl::list<Tags...>>& Variables<tmpl::list<Tags...>>::operator=(
   return *this;
 }
 
-template <typename... Tags>
+template <typename... Tags, typename VectorType>
 template <typename... WrappedTags,
           Requires<tmpl2::flat_all<
               std::is_same<db::remove_all_prefixes<WrappedTags>,
                            db::remove_all_prefixes<Tags>>::value...>::value>>
-Variables<tmpl::list<Tags...>>::Variables(
-    const Variables<tmpl::list<WrappedTags...>>& rhs) {
+Variables<tmpl::list<Tags...>, VectorType>::Variables(
+    const Variables<tmpl::list<WrappedTags...>, VectorType>& rhs) {
   static_assert(
       (std::is_same_v<typename Tags::type, typename WrappedTags::type> and ...),
       "Tensor types do not match!");
@@ -764,13 +772,14 @@ Variables<tmpl::list<Tags...>>::Variables(
           rhs.variable_data_);
 }
 
-template <typename... Tags>
+template <typename... Tags, typename VectorType>
 template <typename... WrappedTags,
           Requires<tmpl2::flat_all<
               std::is_same<db::remove_all_prefixes<WrappedTags>,
                            db::remove_all_prefixes<Tags>>::value...>::value>>
-Variables<tmpl::list<Tags...>>& Variables<tmpl::list<Tags...>>::operator=(
-    const Variables<tmpl::list<WrappedTags...>>& rhs) {
+Variables<tmpl::list<Tags...>, VectorType>&
+Variables<tmpl::list<Tags...>, VectorType>::operator=(
+    const Variables<tmpl::list<WrappedTags...>, VectorType>& rhs) {
   static_assert(
       (std::is_same_v<typename Tags::type, typename WrappedTags::type> and ...),
       "Tensor types do not match!");
@@ -781,13 +790,13 @@ Variables<tmpl::list<Tags...>>& Variables<tmpl::list<Tags...>>::operator=(
   return *this;
 }
 
-template <typename... Tags>
+template <typename... Tags, typename VectorType>
 template <typename... WrappedTags,
           Requires<tmpl2::flat_all<
               std::is_same<db::remove_all_prefixes<WrappedTags>,
                            db::remove_all_prefixes<Tags>>::value...>::value>>
-Variables<tmpl::list<Tags...>>::Variables(
-    Variables<tmpl::list<WrappedTags...>>&& rhs)
+Variables<tmpl::list<Tags...>, VectorType>::Variables(
+    Variables<tmpl::list<WrappedTags...>, VectorType>&& rhs)
     : variable_data_impl_dynamic_(std::move(rhs.variable_data_impl_dynamic_)),
       owning_(rhs.owning_),
       size_(rhs.size()),
@@ -806,13 +815,14 @@ Variables<tmpl::list<Tags...>>::Variables(
   add_reference_variable_data();
 }
 
-template <typename... Tags>
+template <typename... Tags, typename VectorType>
 template <typename... WrappedTags,
           Requires<tmpl2::flat_all<
               std::is_same<db::remove_all_prefixes<WrappedTags>,
                            db::remove_all_prefixes<Tags>>::value...>::value>>
-Variables<tmpl::list<Tags...>>& Variables<tmpl::list<Tags...>>::operator=(
-    Variables<tmpl::list<WrappedTags...>>&& rhs) {
+Variables<tmpl::list<Tags...>, VectorType>&
+Variables<tmpl::list<Tags...>, VectorType>::operator=(
+    Variables<tmpl::list<WrappedTags...>, VectorType>&& rhs) {
   static_assert(
       (std::is_same_v<typename Tags::type, typename WrappedTags::type> and ...),
       "Tensor types do not match!");
@@ -833,14 +843,14 @@ Variables<tmpl::list<Tags...>>& Variables<tmpl::list<Tags...>>::operator=(
   return *this;
 }
 
-template <typename... Tags>
-Variables<tmpl::list<Tags...>>::Variables(const pointer start,
-                                          const size_t size) {
+template <typename... Tags, typename VectorType>
+Variables<tmpl::list<Tags...>, VectorType>::Variables(const pointer start,
+                                                      const size_t size) {
   set_data_ref(start, size);
 }
 
-template <typename... Tags>
-Variables<tmpl::list<Tags...>>::Variables(vector_type vector)
+template <typename... Tags, typename VectorType>
+Variables<tmpl::list<Tags...>, VectorType>::Variables(vector_type vector)
     : variable_data_impl_dynamic_(std::move(vector)),
       size_(variable_data_impl_dynamic_.size()),
       number_of_grid_points_(size_ / number_of_independent_components) {
@@ -861,8 +871,8 @@ Variables<tmpl::list<Tags...>>::Variables(vector_type vector)
   add_reference_variable_data();
 }
 
-template <typename... Tags>
-auto Variables<tmpl::list<Tags...>>::release() && -> vector_type {
+template <typename... Tags, typename VectorType>
+auto Variables<tmpl::list<Tags...>, VectorType>::release() && -> vector_type {
   ASSERT(is_owning(), "Cannot release storage from a non-owning Variables.");
   auto result = std::move(variable_data_impl_dynamic_);
   if (number_of_grid_points_ == 1) {
@@ -872,8 +882,8 @@ auto Variables<tmpl::list<Tags...>>::release() && -> vector_type {
   return result;
 }
 
-template <typename... Tags>
-void Variables<tmpl::list<Tags...>>::pup(PUP::er& p) {
+template <typename... Tags, typename VectorType>
+void Variables<tmpl::list<Tags...>, VectorType>::pup(PUP::er& p) {
   ASSERT(
       owning_,
       "Cannot pup a non-owning Variables! It may be reasonable to pack a "
@@ -895,8 +905,8 @@ void Variables<tmpl::list<Tags...>>::pup(PUP::er& p) {
  *
  * \tparam Tag the variable to return
  */
-template <typename Tag, typename TagList>
-constexpr typename Tag::type& get(Variables<TagList>& v) {
+template <typename Tag, typename TagList, typename VT>
+constexpr typename Tag::type& get(Variables<TagList, VT>& v) {
   static_assert(tmpl::list_contains_v<TagList, Tag>,
                 "Could not retrieve Tag from Variables. See the first "
                 "template parameter of the instantiation for what Tag is "
@@ -904,8 +914,8 @@ constexpr typename Tag::type& get(Variables<TagList>& v) {
                 "what Tags are available.");
   return tuples::get<Tag>(v.reference_variable_data_);
 }
-template <typename Tag, typename TagList>
-constexpr const typename Tag::type& get(const Variables<TagList>& v) {
+template <typename Tag, typename TagList, typename VT>
+constexpr const typename Tag::type& get(const Variables<TagList, VT>& v) {
   static_assert(tmpl::list_contains_v<TagList, Tag>,
                 "Could not retrieve Tag from Variables. See the first "
                 "template parameter of the instantiation for what Tag is "
@@ -915,25 +925,26 @@ constexpr const typename Tag::type& get(const Variables<TagList>& v) {
 }
 /// @}
 
-template <typename... Tags>
+template <typename... Tags, typename VectorType>
 template <typename VT, bool VF>
-Variables<tmpl::list<Tags...>>::Variables(
+Variables<tmpl::list<Tags...>, VectorType>::Variables(
     const blaze::DenseVector<VT, VF>& expression) {
   ASSERT((*expression).size() % number_of_independent_components == 0,
          "Invalid size " << (*expression).size() << " for a Variables with "
-         << number_of_independent_components << " components.");
+                         << number_of_independent_components << " components.");
   initialize((*expression).size() / number_of_independent_components);
   variable_data_ = expression;
 }
 
 /// \cond
-template <typename... Tags>
+template <typename... Tags, typename VectorType>
 template <typename VT, bool VF>
-Variables<tmpl::list<Tags...>>& Variables<tmpl::list<Tags...>>::operator=(
+Variables<tmpl::list<Tags...>, VectorType>&
+Variables<tmpl::list<Tags...>, VectorType>::operator=(
     const blaze::DenseVector<VT, VF>& expression) {
   ASSERT((*expression).size() % number_of_independent_components == 0,
          "Invalid size " << (*expression).size() << " for a Variables with "
-         << number_of_independent_components << " components.");
+                         << number_of_independent_components << " components.");
   initialize((*expression).size() / number_of_independent_components);
   variable_data_ = expression;
   return *this;
@@ -941,8 +952,8 @@ Variables<tmpl::list<Tags...>>& Variables<tmpl::list<Tags...>>::operator=(
 /// \endcond
 
 /// \cond HIDDEN_SYMBOLS
-template <typename... Tags>
-void Variables<tmpl::list<Tags...>>::add_reference_variable_data() {
+template <typename... Tags, typename VectorType>
+void Variables<tmpl::list<Tags...>, VectorType>::add_reference_variable_data() {
   if (is_owning()) {
     if (number_of_grid_points_ == 0) {
       variable_data_.clear();
@@ -976,10 +987,10 @@ void Variables<tmpl::list<Tags...>>::add_reference_variable_data() {
 }
 /// \endcond
 
-template <typename... Tags>
-Variables<tmpl::list<Tags...>>& operator*=(
-    Variables<tmpl::list<Tags...>>& lhs,
-    const typename Variables<tmpl::list<Tags...>>::vector_type& rhs) {
+template <typename... Tags, typename VT>
+Variables<tmpl::list<Tags...>, VT>& operator*=(
+    Variables<tmpl::list<Tags...>, VT>& lhs,
+    const typename Variables<tmpl::list<Tags...>, VT>::vector_type& rhs) {
   using value_type = typename Variables<tmpl::list<Tags...>>::value_type;
   ASSERT(lhs.number_of_grid_points() == rhs.size(),
          "Size mismatch in multiplication: " << lhs.number_of_grid_points()
@@ -995,28 +1006,28 @@ Variables<tmpl::list<Tags...>>& operator*=(
   return lhs;
 }
 
-template <typename... Tags>
-Variables<tmpl::list<Tags...>> operator*(
-    const Variables<tmpl::list<Tags...>>& lhs,
-    const typename Variables<tmpl::list<Tags...>>::vector_type& rhs) {
+template <typename... Tags, typename VT>
+Variables<tmpl::list<Tags...>, VT> operator*(
+    const Variables<tmpl::list<Tags...>, VT>& lhs,
+    const typename Variables<tmpl::list<Tags...>, VT>::vector_type& rhs) {
   auto result = lhs;
   result *= rhs;
   return result;
 }
 
-template <typename... Tags>
-Variables<tmpl::list<Tags...>> operator*(
-    const typename Variables<tmpl::list<Tags...>>::vector_type& lhs,
-    const Variables<tmpl::list<Tags...>>& rhs) {
+template <typename... Tags, typename VT>
+Variables<tmpl::list<Tags...>, VT> operator*(
+    const typename Variables<tmpl::list<Tags...>, VT>::vector_type& lhs,
+    const Variables<tmpl::list<Tags...>, VT>& rhs) {
   auto result = rhs;
   result *= lhs;
   return result;
 }
 
-template <typename... Tags>
-Variables<tmpl::list<Tags...>>& operator/=(
-    Variables<tmpl::list<Tags...>>& lhs,
-    const typename Variables<tmpl::list<Tags...>>::vector_type& rhs) {
+template <typename... Tags, typename VT>
+Variables<tmpl::list<Tags...>, VT>& operator/=(
+    Variables<tmpl::list<Tags...>, VT>& lhs,
+    const typename Variables<tmpl::list<Tags...>, VT>::vector_type& rhs) {
   ASSERT(lhs.number_of_grid_points() == rhs.size(),
          "Size mismatch in multiplication: " << lhs.number_of_grid_points()
                                              << " and " << rhs.size());
@@ -1032,18 +1043,19 @@ Variables<tmpl::list<Tags...>>& operator/=(
   return lhs;
 }
 
-template <typename... Tags>
-Variables<tmpl::list<Tags...>> operator/(
-    const Variables<tmpl::list<Tags...>>& lhs,
-    const typename Variables<tmpl::list<Tags...>>::vector_type& rhs) {
+template <typename... Tags, typename VT>
+Variables<tmpl::list<Tags...>, VT> operator/(
+    const Variables<tmpl::list<Tags...>, VT>& lhs,
+    const typename Variables<tmpl::list<Tags...>, VT>::vector_type& rhs) {
   auto result = lhs;
   result /= rhs;
   return result;
 }
 
-template <typename... Tags, Requires<sizeof...(Tags) != 0> = nullptr>
+template <typename... Tags, typename VT,
+          Requires<sizeof...(Tags) != 0> = nullptr>
 std::ostream& operator<<(std::ostream& os,
-                         const Variables<tmpl::list<Tags...>>& d) {
+                         const Variables<tmpl::list<Tags...>, VT>& d) {
   size_t count = 0;
   const auto helper = [&os, &d, &count](auto tag_v) {
     count++;
@@ -1058,17 +1070,17 @@ std::ostream& operator<<(std::ostream& os,
   return os;
 }
 
-template <typename TagsList>
-bool operator!=(const Variables<TagsList>& lhs,
-                const Variables<TagsList>& rhs) {
+template <typename TagsList, typename VT>
+bool operator!=(const Variables<TagsList, VT>& lhs,
+                const Variables<TagsList, VT>& rhs) {
   return not(lhs == rhs);
 }
 
-template <typename... TagsLhs, typename... TagsRhs,
+template <typename... TagsLhs, typename... TagsRhs, typename VT,
           Requires<not std::is_same<tmpl::list<TagsLhs...>,
                                     tmpl::list<TagsRhs...>>::value> = nullptr>
-void swap(Variables<tmpl::list<TagsLhs...>>& lhs,
-          Variables<tmpl::list<TagsRhs...>>& rhs) {
+void swap(Variables<tmpl::list<TagsLhs...>, VT>& lhs,
+          Variables<tmpl::list<TagsRhs...>, VT>& rhs) {
   Variables<tmpl::list<TagsLhs...>> temp{std::move(lhs)};
   lhs = std::move(rhs);
   rhs = std::move(temp);

--- a/src/DataStructures/VariablesDeclaration.hpp
+++ b/src/DataStructures/VariablesDeclaration.hpp
@@ -1,0 +1,28 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace detail {
+template <typename TagsList>
+struct get_vector_type {
+  using type = void;
+};
+
+template <typename Tag0, typename... Tags>
+struct get_vector_type<tmpl::list<Tag0, Tags...>> {
+  using type = typename Tag0::type::type;
+};
+}  // namespace detail
+
+/// Implementation of the Variables class that can be specialized for different
+/// vector types of the underlying tensors, e.g. DataVector or Kokkos::View.
+template <typename TagsList,
+          typename VectorType =
+              typename detail::get_vector_type<TagsList>::type>
+class Variables;
+/// \endcond

--- a/src/Domain/Structure/OrientationMapHelpers.hpp
+++ b/src/Domain/Structure/OrientationMapHelpers.hpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 #include <vector>
 
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
@@ -17,8 +18,6 @@ template <size_t VolumeDim>
 class OrientationMap;
 template <size_t>
 class Index;
-template <typename TagsList>
-class Variables;
 /// \endcond
 
 /// \ingroup ComputationalDomainGroup

--- a/src/Evolution/DgSubcell/Tags/Inactive.hpp
+++ b/src/Evolution/DgSubcell/Tags/Inactive.hpp
@@ -5,13 +5,9 @@
 
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "DataStructures/VariablesTag.hpp"
 #include "Evolution/DgSubcell/ActiveGrid.hpp"
-
-/// \cond
-template <typename TagsList>
-class Variables;
-/// \endcond
 
 namespace evolution::dg::subcell::Tags {
 /// Mark a tag as holding data for the inactive grid.

--- a/src/Evolution/DgSubcell/Tags/OnSubcellFaces.hpp
+++ b/src/Evolution/DgSubcell/Tags/OnSubcellFaces.hpp
@@ -5,13 +5,12 @@
 
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "DataStructures/VariablesTag.hpp"
 
 /// \cond
 template <typename X, typename Symm, typename IndexList>
 class Tensor;
-template <typename TagsList>
-class Variables;
 /// \endcond
 
 namespace evolution::dg::subcell::Tags {

--- a/src/Evolution/DgSubcell/Tags/OnSubcells.hpp
+++ b/src/Evolution/DgSubcell/Tags/OnSubcells.hpp
@@ -5,13 +5,12 @@
 
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "DataStructures/VariablesTag.hpp"
 
 /// \cond
 template <typename X, typename Symm, typename IndexList>
 class Tensor;
-template <typename TagsList>
-class Variables;
 /// \endcond
 
 namespace evolution::dg::subcell::Tags {

--- a/src/Evolution/Imex/CleanHistory.hpp
+++ b/src/Evolution/Imex/CleanHistory.hpp
@@ -3,12 +3,11 @@
 
 #pragma once
 
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
 class ImexTimeStepper;
-template <typename TagsList>
-class Variables;
 namespace Tags {
 template <typename StepperInterface>
 struct TimeStepper;

--- a/src/Evolution/Imex/SolveImplicitSector.hpp
+++ b/src/Evolution/Imex/SolveImplicitSector.hpp
@@ -7,6 +7,7 @@
 #include <type_traits>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "Evolution/Imex/Mode.hpp"
 #include "Evolution/Imex/Protocols/ImplicitSector.hpp"
 #include "Utilities/Gsl.hpp"
@@ -17,8 +18,6 @@
 class DataVector;
 class ImexTimeStepper;
 class TimeDelta;
-template <typename TagsList>
-class Variables;
 namespace Tags {
 struct TimeStep;
 template <typename StepperInterface>

--- a/src/Evolution/Particles/MonteCarlo/SwapGrTags.hpp
+++ b/src/Evolution/Particles/MonteCarlo/SwapGrTags.hpp
@@ -5,6 +5,7 @@
 
 #include <cstddef>
 
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "Domain/Tags.hpp"
 #include "Evolution/DgSubcell/ActiveGrid.hpp"
 #include "Evolution/DgSubcell/Tags/ActiveGrid.hpp"
@@ -20,8 +21,6 @@ namespace gsl {
 template <typename T>
 class not_null;
 }  // namespace gsl
-template <typename TagsList>
-class Variables;
 /// \endcond
 
 namespace Particles::MonteCarlo {

--- a/src/Evolution/Systems/Burgers/BoundaryConditions/Dirichlet.hpp
+++ b/src/Evolution/Systems/Burgers/BoundaryConditions/Dirichlet.hpp
@@ -10,6 +10,7 @@
 
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "Domain/BoundaryConditions/BoundaryCondition.hpp"
 #include "Evolution/BoundaryConditions/Type.hpp"
 #include "Evolution/Systems/Burgers/BoundaryConditions/BoundaryCondition.hpp"
@@ -26,8 +27,6 @@ class Direction;
 namespace PUP {
 class er;
 }  // namespace PUP
-template <typename>
-class Variables;
 /// \endcond
 
 namespace Burgers::BoundaryConditions {

--- a/src/Evolution/Systems/Burgers/FiniteDifference/MonotonisedCentral.hpp
+++ b/src/Evolution/Systems/Burgers/FiniteDifference/MonotonisedCentral.hpp
@@ -10,6 +10,7 @@
 
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "DataStructures/VariablesTag.hpp"
 #include "Domain/Structure/DirectionalIdMap.hpp"
 #include "Domain/Structure/Element.hpp"
@@ -31,8 +32,6 @@ template <size_t Dim>
 class ElementId;
 template <size_t Dim>
 class Mesh;
-template <typename TagsList>
-class Variables;
 namespace gsl {
 template <typename>
 class not_null;

--- a/src/Evolution/Systems/Burgers/FiniteDifference/ReconstructWork.hpp
+++ b/src/Evolution/Systems/Burgers/FiniteDifference/ReconstructWork.hpp
@@ -7,14 +7,13 @@
 #include <cstddef>
 #include <utility>
 
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "Domain/Structure/DirectionalIdMap.hpp"
 #include "Evolution/Systems/Burgers/Tags.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
 class DataVector;
-template <typename TagsList>
-class Variables;
 namespace gsl {
 template <typename>
 class not_null;

--- a/src/Evolution/Systems/Burgers/Subcell/GhostData.hpp
+++ b/src/Evolution/Systems/Burgers/Subcell/GhostData.hpp
@@ -5,12 +5,11 @@
 
 #include <cstddef>
 
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "Evolution/Systems/Burgers/Tags.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
-template <typename T>
-class Variables;
 namespace Tags {
 template <typename TagsList>
 struct Variables;

--- a/src/Evolution/Systems/Burgers/Subcell/SetInitialRdmpData.hpp
+++ b/src/Evolution/Systems/Burgers/Subcell/SetInitialRdmpData.hpp
@@ -7,6 +7,7 @@
 #include <tuple>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "Domain/Tags.hpp"
 #include "Evolution/DgSubcell/RdmpTciData.hpp"
 #include "Evolution/DgSubcell/Tags/ActiveGrid.hpp"
@@ -19,8 +20,6 @@
 /// \cond
 template <size_t Dim>
 class Mesh;
-template <typename TagsList>
-class Variables;
 /// \endcond
 
 namespace Burgers::subcell {

--- a/src/Evolution/Systems/Cce/BoundaryData.hpp
+++ b/src/Evolution/Systems/Cce/BoundaryData.hpp
@@ -10,14 +10,13 @@
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/SpinWeighted.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "Evolution/Systems/Cce/BoundaryDataTags.hpp"
 #include "Evolution/Systems/Cce/Tags.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
 class DataVector;
-template <typename TagsList>
-class Variables;
 namespace gsl {
 template <class T>
 class not_null;

--- a/src/Evolution/Systems/Ccz4/FiniteDifference/Derivatives.hpp
+++ b/src/Evolution/Systems/Ccz4/FiniteDifference/Derivatives.hpp
@@ -9,6 +9,7 @@
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/Tensor/IndexType.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/DirectionalId.hpp"
 #include "Domain/Structure/DirectionalIdMap.hpp"
@@ -22,8 +23,6 @@
 class DataVector;
 template <size_t Dim>
 class Mesh;
-template <typename TagsList>
-class Variables;
 namespace evolution::dg::subcell {
 class GhostData;
 }  // namespace evolution::dg::subcell

--- a/src/Evolution/Systems/Ccz4/FiniteDifference/Filter.hpp
+++ b/src/Evolution/Systems/Ccz4/FiniteDifference/Filter.hpp
@@ -9,6 +9,7 @@
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/Tensor/IndexType.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/DirectionalId.hpp"
 #include "Domain/Structure/DirectionalIdMap.hpp"
@@ -21,8 +22,6 @@
 class DataVector;
 template <size_t Dim>
 class Mesh;
-template <typename TagsList>
-class Variables;
 namespace evolution::dg::subcell {
 class GhostData;
 }  // namespace evolution::dg::subcell

--- a/src/Evolution/Systems/Ccz4/FiniteDifference/GhostData.hpp
+++ b/src/Evolution/Systems/Ccz4/FiniteDifference/GhostData.hpp
@@ -3,14 +3,13 @@
 
 #pragma once
 
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "DataStructures/VariablesTag.hpp"
 #include "Evolution/Systems/Ccz4/FiniteDifference/System.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
 class DataVector;
-template <typename T>
-class Variables;
 /// \endcond
 
 namespace Ccz4::fd {

--- a/src/Evolution/Systems/CurvedScalarWave/Tags.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Tags.hpp
@@ -11,12 +11,11 @@
 
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "Evolution/Systems/CurvedScalarWave/TagsDeclarations.hpp"
 
 /// \cond
 class DataVector;
-template <class>
-class Variables;
 /// \endcond
 
 /// \brief Option tags for the curved scalar wave system.

--- a/src/Evolution/Systems/ForceFree/FiniteDifference/AdaptiveOrder.hpp
+++ b/src/Evolution/Systems/ForceFree/FiniteDifference/AdaptiveOrder.hpp
@@ -13,6 +13,7 @@
 
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "DataStructures/VariablesTag.hpp"
 #include "Domain/Structure/DirectionalIdMap.hpp"
 #include "Domain/Tags.hpp"
@@ -39,8 +40,6 @@ template <size_t dim>
 class ElementId;
 template <size_t dim>
 class Mesh;
-template <typename recons_tags>
-class Variables;
 namespace gsl {
 template <typename>
 class not_null;

--- a/src/Evolution/Systems/ForceFree/FiniteDifference/MonotonisedCentral.hpp
+++ b/src/Evolution/Systems/ForceFree/FiniteDifference/MonotonisedCentral.hpp
@@ -11,6 +11,7 @@
 
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "DataStructures/VariablesTag.hpp"
 #include "Domain/Structure/DirectionalIdMap.hpp"
 #include "Domain/Tags.hpp"
@@ -36,8 +37,6 @@ template <size_t dim>
 class ElementId;
 template <size_t dim>
 class Mesh;
-template <typename recons_tags>
-class Variables;
 namespace gsl {
 template <typename>
 class not_null;

--- a/src/Evolution/Systems/ForceFree/FiniteDifference/ReconstructWork.hpp
+++ b/src/Evolution/Systems/ForceFree/FiniteDifference/ReconstructWork.hpp
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <utility>
 
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "Domain/Structure/DirectionalIdMap.hpp"
 #include "Evolution/DgSubcell/GhostData.hpp"
 #include "Evolution/Systems/ForceFree/FiniteDifference/Tags.hpp"
@@ -24,8 +25,6 @@ template <size_t Dim>
 class ElementId;
 template <size_t Dim>
 class Mesh;
-template <typename TagsList>
-class Variables;
 namespace gsl {
 template <typename>
 class not_null;

--- a/src/Evolution/Systems/ForceFree/FiniteDifference/Wcns5z.hpp
+++ b/src/Evolution/Systems/ForceFree/FiniteDifference/Wcns5z.hpp
@@ -11,6 +11,7 @@
 
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "DataStructures/VariablesTag.hpp"
 #include "Domain/Structure/DirectionalIdMap.hpp"
 #include "Domain/Tags.hpp"
@@ -37,8 +38,6 @@ template <size_t dim>
 class ElementId;
 template <size_t dim>
 class Mesh;
-template <typename recons_tags>
-class Variables;
 namespace gsl {
 template <typename>
 class not_null;

--- a/src/Evolution/Systems/ForceFree/Subcell/GhostData.hpp
+++ b/src/Evolution/Systems/ForceFree/Subcell/GhostData.hpp
@@ -6,12 +6,11 @@
 #include <cstddef>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "Evolution/Systems/ForceFree/Tags.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
-template <typename T>
-class Variables;
 namespace Tags {
 template <typename TagsList>
 struct Variables;

--- a/src/Evolution/Systems/ForceFree/Subcell/SetInitialRdmpData.hpp
+++ b/src/Evolution/Systems/ForceFree/Subcell/SetInitialRdmpData.hpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "Domain/Tags.hpp"
 #include "Evolution/DgSubcell/ActiveGrid.hpp"
 #include "Evolution/DgSubcell/RdmpTciData.hpp"
@@ -19,8 +20,6 @@
 class DataVector;
 template <size_t Dim>
 class Mesh;
-template <typename TagsList>
-class Variables;
 /// \endcond
 
 namespace ForceFree::subcell {

--- a/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Tags.hpp
@@ -11,7 +11,7 @@
 #include "Evolution/Systems/GeneralizedHarmonic/TagsDeclarations.hpp"
 #include "Evolution/Tags.hpp"
 #include "Options/String.hpp"
-#include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 
 namespace gh {
 namespace Tags {

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/ApplyTensorYlmFilter.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/ApplyTensorYlmFilter.hpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "Evolution/Systems/GrMhd/GhValenciaDivClean/System.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
 #include "NumericalAlgorithms/TensorYlm/ApplyFilter.hpp"
@@ -20,8 +21,6 @@ namespace gsl {
 template <typename T>
 class not_null;
 }  // namespace gsl
-template <typename TagsList>
-class Variables;
 /// \endcond
 
 namespace grmhd::GhValenciaDivClean::filter_detail {

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Derivatives.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Derivatives.hpp
@@ -9,6 +9,7 @@
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/Tensor/IndexType.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/DirectionalId.hpp"
 #include "Domain/Structure/DirectionalIdMap.hpp"
@@ -22,8 +23,6 @@
 class DataVector;
 template <size_t Dim>
 class Mesh;
-template <typename TagsList>
-class Variables;
 namespace evolution::dg::subcell {
 class GhostData;
 }  // namespace evolution::dg::subcell

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Filters.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Filters.hpp
@@ -9,6 +9,7 @@
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/Tensor/IndexType.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/DirectionalId.hpp"
 #include "Domain/Structure/DirectionalIdMap.hpp"
@@ -22,8 +23,6 @@
 class DataVector;
 template <size_t Dim>
 class Mesh;
-template <typename TagsList>
-class Variables;
 namespace evolution::dg::subcell {
 class GhostData;
 }  // namespace evolution::dg::subcell

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/ReconstructWork.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/ReconstructWork.hpp
@@ -9,6 +9,7 @@
 
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "Domain/Structure/DirectionalIdMap.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
 #include "Evolution/Systems/GrMhd/GhValenciaDivClean/Tags.hpp"
@@ -21,8 +22,6 @@
 
 /// \cond
 class DataVector;
-template <typename TagsList>
-class Variables;
 namespace gsl {
 template <typename>
 class not_null;

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Wcns5z.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Wcns5z.hpp
@@ -49,8 +49,6 @@ class not_null;
 namespace PUP {
 class er;
 }  // namespace PUP
-template <typename TagsList>
-class Variables;
 namespace evolution::dg::subcell {
 class GhostData;
 }  // namespace evolution::dg::subcell

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/FixConservativesAndComputePrims.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/FixConservativesAndComputePrims.hpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "Evolution/DgSubcell/Tags/Coordinates.hpp"
 #include "Evolution/Systems/GrMhd/GhValenciaDivClean/System.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/FixConservatives.hpp"
@@ -26,8 +27,6 @@ namespace gsl {
 template <typename T>
 class not_null;
 }  // namespace gsl
-template <typename TagsList>
-class Variables;
 /// \endcond
 
 namespace grmhd::GhValenciaDivClean::subcell {

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/PrimitiveGhostData.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/PrimitiveGhostData.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "DataStructures/VariablesTag.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
 #include "Evolution/Systems/GrMhd/GhValenciaDivClean/Tags.hpp"
@@ -13,8 +14,6 @@
 
 /// \cond
 class DataVector;
-template <typename T>
-class Variables;
 /// \endcond
 
 namespace grmhd::GhValenciaDivClean::subcell {

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/ResizeAndComputePrimitives.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/ResizeAndComputePrimitives.hpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "DataStructures/VariablesTag.hpp"
 #include "Domain/Tags.hpp"
 #include "Evolution/DgSubcell/ActiveGrid.hpp"
@@ -29,8 +30,6 @@ namespace gsl {
 template <typename T>
 class not_null;
 }  // namespace gsl
-template <typename TagsList>
-class Variables;
 /// \endcond
 
 namespace grmhd::GhValenciaDivClean::subcell {

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/MonotonicityPreserving5.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/MonotonicityPreserving5.hpp
@@ -12,6 +12,7 @@
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "Domain/Structure/DirectionalIdMap.hpp"
 #include "Domain/Tags.hpp"
 #include "Evolution/DgSubcell/Tags/GhostDataForReconstruction.hpp"
@@ -47,8 +48,6 @@ class not_null;
 namespace PUP {
 class er;
 }  // namespace PUP
-template <typename TagsList>
-class Variables;
 namespace evolution::dg::subcell {
 class GhostData;
 }  // namespace evolution::dg::subcell

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/MonotonisedCentral.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/MonotonisedCentral.hpp
@@ -11,6 +11,7 @@
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "Domain/Structure/DirectionalIdMap.hpp"
 #include "Domain/Tags.hpp"
 #include "Evolution/DgSubcell/Tags/GhostDataForReconstruction.hpp"
@@ -45,8 +46,6 @@ class not_null;
 namespace PUP {
 class er;
 }  // namespace PUP
-template <typename TagsList>
-class Variables;
 namespace evolution::dg::subcell {
 class GhostData;
 }  // namespace evolution::dg::subcell

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/PositivityPreservingAdaptiveOrder.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/PositivityPreservingAdaptiveOrder.hpp
@@ -9,6 +9,7 @@
 #include <memory>
 #include <utility>
 
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "DataStructures/VariablesTag.hpp"
 #include "Domain/Structure/DirectionalIdMap.hpp"
 #include "Domain/Tags.hpp"
@@ -44,8 +45,6 @@ class not_null;
 namespace PUP {
 class er;
 }  // namespace PUP
-template <typename TagsList>
-class Variables;
 namespace evolution::dg::subcell {
 class GhostData;
 }  // namespace evolution::dg::subcell

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/ReconstructWork.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/ReconstructWork.hpp
@@ -9,16 +9,15 @@
 
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "Domain/Structure/DirectionalIdMap.hpp"
-#include "Evolution/Systems/GrMhd/ValenciaDivClean/TagsDeclarations.hpp"
-#include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"
-#include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"
+#include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/Hydro/Tags.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
 class DataVector;
-template <typename TagsList>
-class Variables;
 namespace gsl {
 template <typename>
 class not_null;

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Wcns5z.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Wcns5z.hpp
@@ -9,6 +9,7 @@
 #include <memory>
 #include <utility>
 
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "DataStructures/VariablesTag.hpp"
 #include "Domain/Structure/DirectionalIdMap.hpp"
 #include "Domain/Tags.hpp"
@@ -42,8 +43,6 @@ class not_null;
 namespace PUP {
 class er;
 }  // namespace PUP
-template <typename TagsList>
-class Variables;
 namespace evolution::dg::subcell {
 class GhostData;
 }  // namespace evolution::dg::subcell

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Flattener.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Flattener.hpp
@@ -7,6 +7,7 @@
 #include <limits>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "DataStructures/VariablesTag.hpp"
 #include "Domain/Tags.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservativeOptions.hpp"
@@ -31,8 +32,6 @@ namespace gsl {
 template <typename T>
 class not_null;
 }  // namespace gsl
-template <typename TagsList>
-class Variables;
 /// \endcond
 
 namespace grmhd::ValenciaDivClean {

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/FixConservativesAndComputePrims.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/FixConservativesAndComputePrims.hpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/FixConservatives.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/PrimitiveFromConservativeOptions.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp"
@@ -25,8 +26,6 @@ namespace gsl {
 template <typename T>
 class not_null;
 }  // namespace gsl
-template <typename TagsList>
-class Variables;
 /// \endcond
 
 namespace grmhd::ValenciaDivClean::subcell {

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/PrimitiveGhostData.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/PrimitiveGhostData.hpp
@@ -3,14 +3,13 @@
 
 #pragma once
 
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "DataStructures/VariablesTag.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
 class DataVector;
-template <typename T>
-class Variables;
 /// \endcond
 
 namespace grmhd::ValenciaDivClean::subcell {

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/ResizeAndComputePrimitives.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/ResizeAndComputePrimitives.hpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "DataStructures/VariablesTag.hpp"
 #include "Domain/Tags.hpp"
 #include "Evolution/DgSubcell/ActiveGrid.hpp"
@@ -29,8 +30,6 @@ namespace gsl {
 template <typename T>
 class not_null;
 }  // namespace gsl
-template <typename TagsList>
-class Variables;
 /// \endcond
 
 namespace grmhd::ValenciaDivClean::subcell {

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/SetInitialRdmpData.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/SetInitialRdmpData.hpp
@@ -7,6 +7,7 @@
 #include <tuple>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "Domain/Tags.hpp"
 #include "Evolution/DgSubcell/RdmpTciData.hpp"
 #include "Evolution/DgSubcell/Tags/ActiveGrid.hpp"
@@ -21,8 +22,6 @@
 class DataVector;
 template <size_t Dim>
 class Mesh;
-template <typename TagsList>
-class Variables;
 /// \endcond
 
 namespace grmhd::ValenciaDivClean::subcell {

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/SwapGrTags.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/SwapGrTags.hpp
@@ -5,6 +5,7 @@
 
 #include <cstddef>
 
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "Domain/Tags.hpp"
 #include "Evolution/DgSubcell/ActiveGrid.hpp"
 #include "Evolution/DgSubcell/Tags/ActiveGrid.hpp"
@@ -20,8 +21,6 @@ namespace gsl {
 template <typename T>
 class not_null;
 }  // namespace gsl
-template <typename TagsList>
-class Variables;
 /// \endcond
 
 namespace grmhd::ValenciaDivClean::subcell {

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnDgGrid.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/TciOnDgGrid.hpp
@@ -7,6 +7,7 @@
 #include <tuple>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "DataStructures/VariablesTag.hpp"
 #include "Domain/Tags.hpp"
 #include "Evolution/DgSubcell/RdmpTciData.hpp"
@@ -36,8 +37,6 @@ namespace gsl {
 template <typename T>
 class not_null;
 }  // namespace gsl
-template <typename TagsList>
-class Variables;
 /// \endcond
 
 namespace grmhd::ValenciaDivClean::subcell {

--- a/src/Evolution/Systems/NewtonianEuler/FiniteDifference/MonotonisedCentral.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/FiniteDifference/MonotonisedCentral.hpp
@@ -10,6 +10,7 @@
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "DataStructures/VariablesTag.hpp"
 #include "Domain/Structure/DirectionalIdMap.hpp"
 #include "Domain/Tags.hpp"
@@ -39,8 +40,6 @@ class not_null;
 }  // namespace gsl
 template <size_t Dim>
 class Mesh;
-template <typename TagsList>
-class Variables;
 namespace evolution::dg::subcell {
 class GhostData;
 }  // namespace evolution::dg::subcell

--- a/src/Evolution/Systems/NewtonianEuler/FiniteDifference/ReconstructWork.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/FiniteDifference/ReconstructWork.hpp
@@ -7,12 +7,11 @@
 #include <cstddef>
 #include <utility>
 
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "Domain/Structure/DirectionalIdMap.hpp"
 
 /// \cond
 class DataVector;
-template <typename TagsList>
-class Variables;
 namespace gsl {
 template <typename>
 class not_null;

--- a/src/Evolution/Systems/NewtonianEuler/Subcell/PrimitiveGhostData.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Subcell/PrimitiveGhostData.hpp
@@ -5,14 +5,10 @@
 
 #include <cstddef>
 
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "DataStructures/VariablesTag.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"
 #include "Utilities/TMPL.hpp"
-
-/// \cond
-template <typename TagsList>
-class Variables;
-/// \endcond
 
 namespace NewtonianEuler::subcell {
 /*!

--- a/src/Evolution/Systems/NewtonianEuler/Subcell/PrimsAfterRollback.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Subcell/PrimsAfterRollback.hpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "DataStructures/VariablesTag.hpp"
 #include "Domain/Tags.hpp"
 #include "Evolution/DgSubcell/Tags/DidRollback.hpp"
@@ -26,8 +27,6 @@ namespace gsl {
 template <typename T>
 class not_null;
 }  // namespace gsl
-template <typename TagsList>
-class Variables;
 /// \endcond
 
 namespace NewtonianEuler::subcell {

--- a/src/Evolution/Systems/NewtonianEuler/Subcell/ResizeAndComputePrimitives.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Subcell/ResizeAndComputePrimitives.hpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "DataStructures/VariablesTag.hpp"
 #include "Domain/Tags.hpp"
 #include "Evolution/DgSubcell/ActiveGrid.hpp"
@@ -27,8 +28,6 @@ namespace gsl {
 template <typename T>
 class not_null;
 }  // namespace gsl
-template <typename TagsList>
-class Variables;
 /// \endcond
 
 namespace NewtonianEuler::subcell {

--- a/src/Evolution/Systems/NewtonianEuler/Subcell/SetInitialRdmpData.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Subcell/SetInitialRdmpData.hpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "Domain/Tags.hpp"
 #include "Evolution/DgSubcell/RdmpTciData.hpp"
 #include "Evolution/DgSubcell/Tags/ActiveGrid.hpp"
@@ -18,8 +19,6 @@
 class DataVector;
 template <size_t Dim>
 class Mesh;
-template <typename TagsList>
-class Variables;
 /// \endcond
 
 namespace NewtonianEuler::subcell {

--- a/src/Evolution/Systems/NewtonianEuler/Subcell/TciOnDgGrid.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Subcell/TciOnDgGrid.hpp
@@ -7,6 +7,7 @@
 #include <tuple>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "DataStructures/VariablesTag.hpp"
 #include "Domain/Tags.hpp"
 #include "Evolution/DgSubcell/RdmpTciData.hpp"
@@ -30,8 +31,6 @@ namespace gsl {
 template <typename T>
 class not_null;
 }  // namespace gsl
-template <typename T>
-class Variables;
 /// \endcond
 
 namespace NewtonianEuler::subcell {

--- a/src/Evolution/Systems/NewtonianEuler/Subcell/TciOnFdGrid.hpp
+++ b/src/Evolution/Systems/NewtonianEuler/Subcell/TciOnFdGrid.hpp
@@ -7,6 +7,7 @@
 #include <tuple>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "DataStructures/VariablesTag.hpp"
 #include "Domain/Tags.hpp"
 #include "Evolution/DgSubcell/RdmpTciData.hpp"
@@ -27,8 +28,6 @@ namespace gsl {
 template <typename T>
 class not_null;
 }  // namespace gsl
-template <typename TagsList>
-class Variables;
 /// \endcond
 
 namespace NewtonianEuler::subcell {

--- a/src/Evolution/Systems/ScalarAdvection/FiniteDifference/AoWeno.hpp
+++ b/src/Evolution/Systems/ScalarAdvection/FiniteDifference/AoWeno.hpp
@@ -11,6 +11,7 @@
 
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/VariablesTag.hpp"
 #include "Domain/Structure/DirectionalIdMap.hpp"
 #include "Domain/Tags.hpp"
 #include "Evolution/DgSubcell/Tags/GhostDataForReconstruction.hpp"
@@ -30,16 +31,10 @@ template <size_t Dim>
 class ElementId;
 template <size_t Dim>
 class Mesh;
-template <typename TagsList>
-class Variables;
 namespace gsl {
 template <typename>
 class not_null;
 }  // namespace gsl
-namespace Tags {
-template <typename TagsList>
-class Variables;
-}  // namespace Tags
 namespace PUP {
 class er;
 }  // namespace PUP

--- a/src/Evolution/Systems/ScalarAdvection/FiniteDifference/MonotonisedCentral.hpp
+++ b/src/Evolution/Systems/ScalarAdvection/FiniteDifference/MonotonisedCentral.hpp
@@ -10,6 +10,7 @@
 
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "DataStructures/VariablesTag.hpp"
 #include "Domain/Structure/DirectionalIdMap.hpp"
 #include "Domain/Structure/Element.hpp"
@@ -31,8 +32,6 @@ template <size_t Dim>
 class ElementId;
 template <size_t Dim>
 class Mesh;
-template <typename TagsList>
-class Variables;
 namespace gsl {
 template <typename>
 class not_null;

--- a/src/Evolution/Systems/ScalarAdvection/FiniteDifference/ReconstructWork.hpp
+++ b/src/Evolution/Systems/ScalarAdvection/FiniteDifference/ReconstructWork.hpp
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <utility>
 
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "Domain/Structure/DirectionalIdMap.hpp"
 #include "Evolution/Systems/ScalarAdvection/Tags.hpp"
 #include "Utilities/TMPL.hpp"
@@ -21,8 +22,6 @@ template <size_t Dim>
 class ElementId;
 template <size_t Dim>
 class Mesh;
-template <typename TagsList>
-class Variables;
 namespace gsl {
 template <typename>
 class not_null;

--- a/src/Evolution/Systems/ScalarAdvection/Subcell/GhostData.hpp
+++ b/src/Evolution/Systems/ScalarAdvection/Subcell/GhostData.hpp
@@ -5,12 +5,11 @@
 
 #include <cstddef>
 
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "Evolution/Systems/ScalarAdvection/Tags.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
-template <typename T>
-class Variables;
 namespace Tags {
 template <typename TagsList>
 struct Variables;

--- a/src/Evolution/Systems/ScalarAdvection/Subcell/SetInitialRdmpData.hpp
+++ b/src/Evolution/Systems/ScalarAdvection/Subcell/SetInitialRdmpData.hpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 #include <tuple>
 
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "Domain/Tags.hpp"
 #include "Evolution/DgSubcell/RdmpTciData.hpp"
 #include "Evolution/DgSubcell/Tags/ActiveGrid.hpp"
@@ -19,8 +20,6 @@
 /// \cond
 template <size_t Dim>
 class Mesh;
-template <typename TagsList>
-class Variables;
 /// \endcond
 
 namespace ScalarAdvection::subcell {

--- a/src/Evolution/Systems/ScalarWave/Characteristics.hpp
+++ b/src/Evolution/Systems/ScalarWave/Characteristics.hpp
@@ -9,6 +9,7 @@
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "Domain/FaceNormal.hpp"
 #include "Evolution/Systems/ScalarWave/Tags.hpp"
 #include "Utilities/Gsl.hpp"
@@ -16,9 +17,6 @@
 #include "Utilities/TMPL.hpp"
 
 /// \cond
-template <typename>
-class Variables;
-
 namespace Tags {
 template <typename Tag>
 struct Normalized;

--- a/src/NumericalAlgorithms/FiniteDifference/PartialDerivatives.hpp
+++ b/src/NumericalAlgorithms/FiniteDifference/PartialDerivatives.hpp
@@ -7,6 +7,7 @@
 #include <cstddef>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "Utilities/Gsl.hpp"
 
@@ -16,8 +17,6 @@ template <size_t Dim, typename T>
 class DirectionMap;
 template <size_t Dim>
 class Mesh;
-template <typename TagsList>
-class Variables;
 /// \endcond
 
 namespace fd {

--- a/src/NumericalAlgorithms/FiniteDifference/SecondPartialDerivatives.hpp
+++ b/src/NumericalAlgorithms/FiniteDifference/SecondPartialDerivatives.hpp
@@ -7,6 +7,7 @@
 #include <cstddef>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "Utilities/Gsl.hpp"
 
@@ -16,8 +17,6 @@ template <size_t Dim, typename T>
 class DirectionMap;
 template <size_t Dim>
 class Mesh;
-template <typename TagsList>
-class Variables;
 /// \endcond
 
 /*!

--- a/src/NumericalAlgorithms/LinearOperators/Divergence.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/Divergence.hpp
@@ -13,6 +13,7 @@
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataBox/TagName.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TypeTraits.hpp"
 #include "Utilities/TypeTraits/IsA.hpp"
@@ -21,15 +22,10 @@
 class DataVector;
 template <size_t Dim>
 class Mesh;
-template <typename TagsList>
-class Variables;
-
-namespace domain {
-namespace Tags {
+namespace domain::Tags {
 template <size_t Dim>
 struct Mesh;
-}  // namespace Tags
-}  // namespace domain
+}  // namespace domain::Tags
 /// \endcond
 
 namespace Tags {

--- a/src/NumericalAlgorithms/LinearOperators/Filters/FilledCylinder.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/Filters/FilledCylinder.hpp
@@ -13,6 +13,7 @@
 
 #include "DataStructures/Matrix.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "NumericalAlgorithms/LinearOperators/Filters/Filter.hpp"
 #include "Options/Auto.hpp"
 #include "Options/Context.hpp"
@@ -24,8 +25,6 @@
 class DataVector;
 template <size_t Dim>
 class Mesh;
-template <typename TagsList>
-class Variables;
 namespace PUP {
 class er;
 }  // namespace PUP

--- a/src/NumericalAlgorithms/LinearOperators/Filters/Filter.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/Filters/Filter.hpp
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Serialization/CharmPupable.hpp"
 #include "Utilities/TMPL.hpp"
@@ -21,8 +22,6 @@
 class DataVector;
 template <size_t Dim>
 class Mesh;
-template <typename TagsList>
-class Variables;
 /// \endcond
 
 namespace Filters {

--- a/src/NumericalAlgorithms/LinearOperators/Filters/HollowCylinder.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/Filters/HollowCylinder.hpp
@@ -12,6 +12,7 @@
 
 #include "DataStructures/Matrix.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "NumericalAlgorithms/LinearOperators/Filters/Filter.hpp"
 #include "Options/Auto.hpp"
 #include "Options/Context.hpp"
@@ -23,8 +24,6 @@
 class DataVector;
 template <size_t Dim>
 class Mesh;
-template <typename TagsList>
-class Variables;
 namespace PUP {
 class er;
 }  // namespace PUP

--- a/src/NumericalAlgorithms/LinearOperators/Filters/Hypercube.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/Filters/Hypercube.hpp
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "NumericalAlgorithms/LinearOperators/Filters/Filter.hpp"
 #include "NumericalAlgorithms/Spectral/Parity.hpp"
 #include "Options/Auto.hpp"
@@ -25,8 +26,6 @@ class DataVector;
 template <size_t Dim>
 class Mesh;
 class Matrix;
-template <typename TagsList>
-class Variables;
 /// \endcond
 
 namespace Filters {

--- a/src/NumericalAlgorithms/Spectral/FilteringB1.hpp
+++ b/src/NumericalAlgorithms/Spectral/FilteringB1.hpp
@@ -3,14 +3,13 @@
 
 #pragma once
 
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "Utilities/Gsl.hpp"
 
 /// \cond
 class Matrix;
 template <size_t>
 class Mesh;
-template <typename TagsList>
-class Variables;
 /// \endcond
 
 namespace Spectral::filtering {

--- a/src/NumericalAlgorithms/Spectral/FilteringB2.hpp
+++ b/src/NumericalAlgorithms/Spectral/FilteringB2.hpp
@@ -6,14 +6,13 @@
 #include <cstddef>
 #include <optional>
 
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "Utilities/Gsl.hpp"
 
 /// \cond
 class Matrix;
 template <size_t>
 class Mesh;
-template <typename TagsList>
-class Variables;
 /// \endcond
 
 namespace Spectral::filtering {

--- a/src/NumericalAlgorithms/Spectral/FilteringB3.hpp
+++ b/src/NumericalAlgorithms/Spectral/FilteringB3.hpp
@@ -5,14 +5,13 @@
 
 #include <cstddef>
 
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "Utilities/Gsl.hpp"
 
 /// \cond
 class DataVector;
 template <size_t Dim>
 class Mesh;
-template <typename TagsList>
-class Variables;
 /// \endcond
 
 namespace Spectral::filtering {

--- a/src/NumericalAlgorithms/TensorYlm/Filter.hpp
+++ b/src/NumericalAlgorithms/TensorYlm/Filter.hpp
@@ -8,13 +8,12 @@
 
 #include "DataStructures/SimpleSparseMatrix.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "NumericalAlgorithms/TensorYlm/TensorYlm.hpp"
 #include "Utilities/Gsl.hpp"
 
 /// \cond
 class DataVector;
-template <typename TagsList>
-class Variables;
 /// \endcond
 
 namespace ylm::TensorYlm {

--- a/src/ParallelAlgorithms/Interpolation/ComputeExcisionBoundaryVolumeQuantities.hpp
+++ b/src/ParallelAlgorithms/Interpolation/ComputeExcisionBoundaryVolumeQuantities.hpp
@@ -7,6 +7,7 @@
 
 #include "DataStructures/Tensor/IndexType.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "Domain/Tags.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
 #include "ParallelAlgorithms/Interpolation/Protocols/ComputeVarsToInterpolate.hpp"
@@ -19,8 +20,6 @@
 class DataVector;
 template <size_t Dim>
 class Mesh;
-template <typename VariablesTags>
-class Variables;
 namespace gsl {
 template <typename T>
 class not_null;

--- a/src/ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp
+++ b/src/ParallelAlgorithms/Interpolation/InterpolationTargetDetail.hpp
@@ -20,6 +20,7 @@
 #include "DataStructures/TaggedTuple.hpp"
 #include "DataStructures/Tensor/Metafunctions.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "DataStructures/VariablesTag.hpp"
 #include "Domain/BlockLogicalCoordinates.hpp"
 #include "Domain/CoordinateMaps/Composition.hpp"
@@ -72,8 +73,6 @@ struct Sphere;
 template <typename Id>
 struct LinkedMessageId;
 class TimeStepId;
-template <typename TagsList>
-struct Variables;
 /// \endcond
 
 namespace intrp::InterpolationTarget_detail {

--- a/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_DataBox.cpp
@@ -38,14 +38,13 @@
 #include "Utilities/Serialization/Serialize.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TypeTraits.hpp"
+#include "DataStructures/VariablesDeclaration.hpp"
 
 namespace db {
 template <typename TagsList>
 class DataBox;
 }  // namespace db
 struct NoSuchType;
-template <typename TagsList>
-class Variables;
 template <typename X, typename Symm, typename IndexList>
 class Tensor;
 

--- a/tests/Unit/DataStructures/DataBox/Test_PrefixHelpers.cpp
+++ b/tests/Unit/DataStructures/DataBox/Test_PrefixHelpers.cpp
@@ -4,6 +4,7 @@
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "DataStructures/VariablesTag.hpp"
 #include "Helpers/DataStructures/TestTags.hpp"
 #include "Utilities/NoSuchType.hpp"
@@ -11,8 +12,6 @@
 #include "Utilities/TypeTraits.hpp"
 
 class DataVector;
-template <typename TagsList>
-class Variables;
 
 namespace {
 using Var = TestHelpers::Tags::Scalar<>;
@@ -26,7 +25,9 @@ template <typename Tag>
 using Prefix2 = TestHelpers::Tags::Prefix2<Tag>;
 
 template <typename Arg0, typename Arg1, typename Arg2>
-struct SomeType;
+struct SomeType {
+  using type = void;
+};
 
 template <typename Tag, typename Arg1, typename Arg2>
 struct PrefixWithArgs : db::PrefixTag, db::SimpleTag {

--- a/tests/Unit/DataStructures/Test_Transpose.cpp
+++ b/tests/Unit/DataStructures/Test_Transpose.cpp
@@ -11,11 +11,9 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Transpose.hpp"
 #include "DataStructures/Variables.hpp"
+#include "DataStructures/VariablesDeclaration.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
-
-template <typename TagsList>
-class Variables;
 
 namespace {
 

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/Test_Tags.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/Test_Tags.cpp
@@ -20,11 +20,6 @@
 #include "Utilities/TMPL.hpp"
 
 namespace {
-struct DummyType {};
-struct DummyTag : db::SimpleTag {
-  using type = DummyType;
-};
-
 struct FieldTag : db::SimpleTag {
   using type = Scalar<DataVector>;
 };
@@ -32,12 +27,12 @@ struct FieldTag : db::SimpleTag {
 
 SPECTRE_TEST_CASE("Unit.AnalyticSolutions.Tags", "[Unit][PointwiseFunctions]") {
   // [analytic_name]
-  TestHelpers::db::test_prefix_tag<Tags::Analytic<DummyTag>>(
-      "Analytic(DummyTag)");
+  TestHelpers::db::test_prefix_tag<Tags::Analytic<FieldTag>>(
+      "Analytic(FieldTag)");
   // [analytic_name]
-  TestHelpers::db::test_prefix_tag<Tags::Error<DummyTag>>("Error(DummyTag)");
+  TestHelpers::db::test_prefix_tag<Tags::Error<FieldTag>>("Error(FieldTag)");
   TestHelpers::db::test_simple_tag<
-      Tags::AnalyticSolutions<tmpl::list<DummyTag>>>("AnalyticSolutions");
+      Tags::AnalyticSolutions<tmpl::list<FieldTag>>>("AnalyticSolutions");
   TestHelpers::db::test_compute_tag<Tags::ErrorsCompute<tmpl::list<FieldTag>>>(
       "Errors");
 


### PR DESCRIPTION
## Proposed changes

Allows to specialize the Variables class for different vector types, specifically for DataVector or Kokkos::View. This PR only adds a forward-declaration header to make this specialization possible. The next PR will add the specialization for Kokkos::View.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
