### PR TITLE
Create Filters::FilledSphere

### DIFF
--- a/src/NumericalAlgorithms/LinearOperators/Filters/CMakeLists.txt
+++ b/src/NumericalAlgorithms/LinearOperators/Filters/CMakeLists.txt
@@ -9,6 +9,8 @@ spectre_target_headers(
   Factory.hpp
   FilledCylinder.hpp
   FilledCylinder.tpp
+  FilledSphere.hpp
+  FilledSphere.tpp
   Filter.hpp
   HollowCylinder.hpp
   HollowCylinder.tpp

--- a/src/NumericalAlgorithms/LinearOperators/Filters/Factory.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/Filters/Factory.hpp
@@ -28,10 +28,11 @@ namespace Filters {
  * `Filters::HollowCylinder` and `Filters::FilledCylinder` are included for
  * `Dim == 3`.
  *
- * Note: `Filters::SphericalShell` is not included here because it requires
- * system-specific instantiation of `ylm::TensorYlm::apply_tensor_ylm_filter`.
- * Executables that support it must add it to their `factory_classes` manually
- * and include the appropriate system-specific header.
+ * Note: `Filters::SphericalShell` and `Filters::FilledSphere` are not included
+ * here because they require system-specific instantiation of
+ * `ylm::TensorYlm::apply_tensor_ylm_filter`. Executables that support them
+ * must add them to their `factory_classes` manually and include the
+ * appropriate system-specific header.
  */
 template <size_t Dim, typename TagList>
 using all_filters = tmpl::append<

--- a/src/NumericalAlgorithms/LinearOperators/Filters/FilledSphere.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/Filters/FilledSphere.hpp
@@ -1,0 +1,296 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <optional>
+#include <pup.h>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/Variables.hpp"
+#include "NumericalAlgorithms/LinearOperators/Filters/Filter.hpp"
+#include "NumericalAlgorithms/TensorYlm/Filter.hpp"
+#include "NumericalAlgorithms/TensorYlm/TensorYlm.hpp"
+#include "Options/Auto.hpp"
+#include "Options/Context.hpp"
+#include "Options/String.hpp"
+#include "Utilities/Gsl.hpp"
+
+/// \cond
+template <size_t Dim>
+class Mesh;
+/// \endcond
+
+namespace Filters {
+/*!
+ * \ingroup DiscontinuousGalerkinGroup
+ * \brief A modal filter for filled-sphere elements: a top-$\ell$ Heaviside
+ * cutoff in the angular direction plus optional smooth exponential roll-offs
+ * in both the angular $\ell$ direction and the radial direction.
+ *
+ * Concrete implementation of `Filters::Filter` for filled-sphere elements,
+ * driven by the DG filtering action. See `Filters::Filter` for the framing of
+ * volume vs. boundary application, the substep / every-N-steps cadence
+ * controls, and the `blocks_to_filter` semantics.
+ *
+ * For each component of the tensors in `TagList`, the filter rescales the
+ * Spherepack-normalized angular modal coefficients $c_{\ell'}$ as
+ *
+ * \f{align*}{
+ *  c_{\ell'} \to c_{\ell'} \exp\!\left[-36 \left(\frac{\ell'}
+ *  {\ell^+_{\mathrm{cut}}+1}\right)^{2\sigma_a}\right],
+ * \f}
+ *
+ * where $\ell^+_{\mathrm{cut}} = \ell_{\mathrm{max}} -$ `NumModesToKill` is
+ * the largest angular mode that is retained and $\sigma_a$ is the
+ * `AngularHalfPower` option. With the fixed coefficient 36 and $\sigma_a$ in
+ * the typical range 28-32 the angular filter is smooth below
+ * $\ell^+_{\mathrm{cut}}$ and reduces to a sharp Heaviside cutoff as
+ * $\sigma_a \to \infty$. When `AngularHalfPower` is `None`, only the
+ * Heaviside cutoff is applied. See `ylm::TensorYlm` for the derivation of
+ * the underlying angular filter.
+ *
+ * When `RadialHalfPower` has a value $\sigma_r$, an additional exponential
+ * filter operation is applied. The radial modal coefficients $c_i$ are rescaled
+ * as
+ *
+ * \f{align*}{
+ *  c_i \to c_i \exp\!\left[-36 \left(\frac{n_i}{N_r}\right)^{2\sigma_r}\right],
+ * \f}
+ *
+ * where $n_i = \lfloor (\ell + 2 n_\mathrm{jac}) / 2 \rfloor$
+ * ($n_\mathrm{jac}$ is the radial Jacobi index) and $N_r$ is
+ * the radial basis degree (radial extent minus one). When `RadialHalfPower` is
+ * `None`, the radial direction is left untouched.
+ *
+ * #### Design decision:
+ *
+ * - The exponential coefficient is hardcoded to 36, matching the choice in
+ * `SphericalShell` and `Hypercube`. `FilledSphere` is the
+ * `Filters::Filter`-based implementation that plugs into the filtering action
+ * and supports per-block selection together with independent volume- and
+ * boundary-filtering cadences. It is intended for filled-sphere blocks, which
+ * store Spherepack-normalized spherical-harmonic modes.
+ */
+template <typename TagList>
+class FilledSphere : public Filter<3, TagList> {
+ public:
+  /// \brief The number of top $\ell$ modes to set to zero.
+  struct NumModesToKill {
+    using type = size_t;
+    static constexpr Options::String help =
+        "The number of top ell modes to set to zero.";
+  };
+
+  /*!
+   * \brief Half of the exponent $\sigma_a$ in the smooth exponential roll-off
+   * applied to the angular $\ell$ modes below the top-$\ell$ cutoff.
+   *
+   * \f{align*}{
+   *  c_{\ell'} \to c_{\ell'} \exp\left[-36 \left(\frac{\ell'}
+   *  {\ell^+_{\mathrm{cut}}+1}\right)^{2\sigma_a}\right]
+   * \f}
+   *
+   * If `None`, only the Heaviside top-$\ell$ cutoff is applied to the
+   * angular modes.
+   */
+  struct AngularHalfPower {
+    using type = Options::Auto<size_t, Options::AutoLabel::None>;
+    static constexpr Options::String help =
+        "The half-power sigma for the angular ell-mode exponential roll-off. "
+        "If None, only the top-ell Heaviside cutoff is applied.";
+  };
+
+  /*!
+   * \brief Half of the exponent $\sigma_r$ in the smooth exponential
+   * roll-off applied to the radial modal coefficients.
+   *
+   * \f{align*}{
+   *  c_i \to c_i \exp\!\left[-36
+   * \left(\frac{n_i}{N_r}\right)^{2\sigma_r}\right],
+   * \f}
+   *
+   * where $n_i = \lfloor (\ell + 2 n_\mathrm{jac}) / 2 \rfloor$
+   * ($n_\mathrm{jac}$ is the radial Jacobi index) and $N_r$  is the radial
+   * basis degree. If `None`, the radial direction is not filtered.
+   */
+  struct RadialHalfPower {
+    using type = Options::Auto<size_t, Options::AutoLabel::None>;
+    static constexpr Options::String help =
+        "The half-power sigma for the radial exponential filter. "
+        "If None, no radial filtering is applied.";
+  };
+
+  /// \brief Enable (true) or disable (false) the filter
+  struct Enable {
+    using type = bool;
+    static constexpr Options::String help = {"Enable the filter"};
+  };
+
+  /// \brief Which blocks the filter should be applied to.
+  struct BlocksToFilter {
+    using type =
+        Options::Auto<std::vector<std::string>, Options::AutoLabel::All>;
+    static constexpr Options::String help = {
+        "List of blocks or block groups to apply filtering to. All other "
+        "blocks will have no filtering. You can also specify 'All' to do "
+        "filtering in all blocks of the domain that are filled spheres."};
+  };
+
+  /// \brief Apply the volume filter inside every Runge-Kutta substep
+  /// instead of only at whole-step boundaries.
+  struct VolumeFilterOnSubstep {
+    using type = bool;
+    static constexpr Options::String help = {
+        "Enable the volume filter on every substep."};
+  };
+
+  /// \brief Apply the boundary correction filter inside every Runge-Kutta
+  /// substep instead of only at whole-step boundaries.
+  struct BoundaryCorrectionFilterOnSubstep {
+    using type = bool;
+    static constexpr Options::String help = {
+        "Enable the boundary filter on every substep."};
+  };
+
+  /// \brief Apply the volume filter once every `N` steps. `None`
+  /// (`std::nullopt`) disables the every-N-steps trigger.
+  ///
+  /// \note Currently the check for whether to filter on every `N` steps is done
+  /// relative to the start of the current Slab. This means that for GTS,
+  /// independent of the value of `N` for every `N` steps, every step has a
+  /// filter applied since GTS has one step per slab.
+  struct VolumeFilterEveryNSteps {
+    using type = Options::Auto<size_t, Options::AutoLabel::None>;
+    static constexpr Options::String help = {
+        "Enable the volume filter on every N steps. 'None' to disable."};
+  };
+
+  /// \brief Apply the boundary correction filter once every `N` steps. `None`
+  /// (`std::nullopt`) disables the every-N-steps trigger.
+  ///
+  /// \note Currently the check for whether to filter on every `N` steps is done
+  /// relative to the start of the current Slab. This means that for GTS,
+  /// independent of the value of `N` for every `N` steps, every step has a
+  /// filter applied since GTS has one step per slab.
+  struct BoundaryCorrectionFilterEveryNSteps {
+    using type = Options::Auto<size_t, Options::AutoLabel::None>;
+    static constexpr Options::String help = {
+        "Enable the boundary filter on every N steps. 'None' to disable."};
+  };
+
+  using options =
+      tmpl::list<NumModesToKill, AngularHalfPower, RadialHalfPower, Enable,
+                 BlocksToFilter, VolumeFilterOnSubstep,
+                 BoundaryCorrectionFilterOnSubstep, VolumeFilterEveryNSteps,
+                 BoundaryCorrectionFilterEveryNSteps>;
+
+  static constexpr Options::String help = {
+      "A filled-sphere filter applying a top-ell Heaviside cutoff in the "
+      "angular direction with optional smooth exponential roll-offs in both "
+      "the angular ell direction and the radial direction."};
+
+  FilledSphere() = default;
+
+  FilledSphere(size_t num_modes_to_kill,
+               std::optional<size_t> angular_half_power,
+               std::optional<size_t> radial_half_power, bool enable,
+               const std::optional<std::vector<std::string>>& blocks_to_filter,
+               bool volume_filter_on_substep, bool boundary_filter_on_substep,
+               std::optional<size_t> volume_filter_every_n_steps,
+               std::optional<size_t> boundary_filter_every_n_steps,
+               const Options::Context& context = {});
+
+  WRAPPED_PUPable_decl_base_template(  // NOLINT
+      SINGLE_ARG(Filter<3, TagList>), FilledSphere);
+  explicit FilledSphere(CkMigrateMessage* msg) : Filter<3, TagList>(msg) {}
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p) override;
+
+  std::unique_ptr<Filter<3, TagList>> get_clone() const override;
+
+  bool apply_volume_filter_on_substep() const override;
+  bool apply_volume_filter_on_this_step(size_t step_number) const override;
+
+  bool apply_boundary_filter_on_substep() const override;
+  bool apply_boundary_filter_on_this_step(size_t step_number) const override;
+
+  bool need_jacobians() const override { return true; }
+
+  bool supports_mesh(const Mesh<3>& mesh) const override;
+
+  std::string name() const override { return "FilledSphere"; }
+
+  const std::optional<std::vector<size_t>>& blocks_to_filter() const override;
+
+  void set_blocks_to_filter(
+      const std::vector<std::string>& all_block_names,
+      const std::unordered_map<std::string, std::unordered_set<std::string>>&
+          block_groups) override;
+
+  void apply_in_volume(
+      gsl::not_null<Variables<TagList>*> vars, const Mesh<3>& mesh,
+      const std::optional<
+          InverseJacobian<DataVector, 3, Frame::Grid, Frame::Inertial>>&
+          inv_jac_grid_to_inertial,
+      const std::optional<
+          Jacobian<DataVector, 3, Frame::Grid, Frame::Inertial>>&
+          jac_grid_to_inertial) const override;
+
+  void apply_on_boundary(
+      gsl::not_null<Variables<TagList>*> vars, const Mesh<2>& mesh,
+      const std::optional<
+          InverseJacobian<DataVector, 3, Frame::Grid, Frame::Inertial>>&
+          inv_jac_grid_to_inertial,
+      const std::optional<
+          Jacobian<DataVector, 3, Frame::Grid, Frame::Inertial>>&
+          jac_grid_to_inertial) const override;
+
+  bool is_equal(const Filter<3, TagList>& other) const override;
+
+ private:
+  template <typename LocalTagList>
+  // NOLINTNEXTLINE(readability-redundant-declaration)
+  friend bool operator==(const FilledSphere<LocalTagList>& lhs,
+                         const FilledSphere<LocalTagList>& rhs);
+
+  size_t num_modes_to_kill_{0};
+  std::optional<size_t> angular_half_power_{std::nullopt};
+  std::optional<size_t> radial_half_power_{std::nullopt};
+  bool enable_{true};
+  std::optional<std::vector<std::string>> blocks_and_groups_to_filter_{};
+  std::optional<std::vector<size_t>> blocks_to_filter_{};
+  bool volume_filter_on_substep_{false};
+  bool boundary_filter_on_substep_{false};
+  std::optional<size_t> volume_filter_every_n_steps_{std::nullopt};
+  std::optional<size_t> boundary_filter_every_n_steps_{std::nullopt};
+
+  // Use Spherepack normalization because the variables are stored as Spherepack
+  // modes
+  static constexpr ylm::TensorYlm::CoefficientNormalization normalization_ =
+      ylm::TensorYlm::CoefficientNormalization::Spherepack;
+  // Caches and memory buffers
+  // NOLINTNEXTLINE(spectre-mutable)
+  mutable size_t cached_l_max_{0};
+  // NOLINTNEXTLINE(spectre-mutable)
+  mutable ylm::TensorYlm::FilterMatrixHolder filter_matrices_{};
+  // NOLINTNEXTLINE(spectre-mutable)
+  mutable Variables<TagList> angular_temp_storage_{};
+  // NOLINTNEXTLINE(spectre-mutable)
+  mutable DataVector radial_temp_storage_{};
+};
+
+template <typename TagList>
+bool operator==(const FilledSphere<TagList>& lhs,
+                const FilledSphere<TagList>& rhs);
+
+template <typename TagList>
+bool operator!=(const FilledSphere<TagList>& lhs,
+                const FilledSphere<TagList>& rhs);
+}  // namespace Filters

--- a/src/NumericalAlgorithms/LinearOperators/Filters/FilledSphere.tpp
+++ b/src/NumericalAlgorithms/LinearOperators/Filters/FilledSphere.tpp
@@ -1,0 +1,303 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "NumericalAlgorithms/LinearOperators/Filters/FilledSphere.hpp"
+
+#include <array>
+#include <optional>
+#include <pup_stl.h>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "Domain/Structure/BlockGroups.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/FilteringB3.hpp"
+#include "NumericalAlgorithms/Spectral/FilteringB3.tpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Spherepack.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/SpherepackCache.hpp"
+#include "NumericalAlgorithms/TensorYlm/Filter.hpp"
+#include "Options/ParseError.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/Serialization/PupStlCpp17.hpp"
+
+namespace Filters {
+template <typename TagList>
+FilledSphere<TagList>::FilledSphere(
+    const size_t num_modes_to_kill,
+    const std::optional<size_t> angular_half_power,
+    const std::optional<size_t> radial_half_power, const bool enable,
+    const std::optional<std::vector<std::string>>& blocks_to_filter,
+    const bool volume_filter_on_substep, const bool boundary_filter_on_substep,
+    const std::optional<size_t> volume_filter_every_n_steps,
+    const std::optional<size_t> boundary_filter_every_n_steps,
+    const Options::Context& context)
+    : num_modes_to_kill_(num_modes_to_kill),
+      angular_half_power_(angular_half_power),
+      radial_half_power_(radial_half_power),
+      enable_(enable),
+      volume_filter_on_substep_(volume_filter_on_substep),
+      boundary_filter_on_substep_(boundary_filter_on_substep),
+      volume_filter_every_n_steps_(volume_filter_every_n_steps),
+      boundary_filter_every_n_steps_(boundary_filter_every_n_steps) {
+  if (blocks_to_filter.has_value()) {
+    blocks_and_groups_to_filter_ = std::vector<std::string>{};
+    std::unordered_set<std::string> seen{};
+    for (const std::string& block_name : blocks_to_filter.value()) {
+      if (not seen.emplace(block_name).second) {
+        PARSE_ERROR(context,
+                    "Duplicate block name '"
+                        << block_name
+                        << "' found when creating a FilledSphere filter.");
+      }
+      blocks_and_groups_to_filter_->push_back(block_name);
+    }
+  }
+}
+
+template <typename TagList>
+void FilledSphere<TagList>::pup(PUP::er& p) {
+  Filter<3, TagList>::pup(p);
+  p | num_modes_to_kill_;
+  p | angular_half_power_;
+  p | radial_half_power_;
+  p | enable_;
+  p | blocks_and_groups_to_filter_;
+  p | blocks_to_filter_;
+  p | volume_filter_on_substep_;
+  p | boundary_filter_on_substep_;
+  p | volume_filter_every_n_steps_;
+  p | boundary_filter_every_n_steps_;
+}
+
+template <typename TagList>
+std::unique_ptr<Filter<3, TagList>> FilledSphere<TagList>::get_clone() const {
+  return std::make_unique<FilledSphere>(*this);
+}
+
+template <typename TagList>
+bool FilledSphere<TagList>::apply_volume_filter_on_substep() const {
+  return enable_ and volume_filter_on_substep_;
+}
+
+template <typename TagList>
+bool FilledSphere<TagList>::apply_volume_filter_on_this_step(
+    const size_t step_number) const {
+  if (not enable_) {
+    return false;
+  }
+  if (volume_filter_every_n_steps_.has_value()) {
+    return step_number % volume_filter_every_n_steps_.value() == 0;
+  } else {
+    return false;
+  }
+}
+
+template <typename TagList>
+bool FilledSphere<TagList>::apply_boundary_filter_on_substep() const {
+  return enable_ and boundary_filter_on_substep_;
+}
+
+template <typename TagList>
+bool FilledSphere<TagList>::apply_boundary_filter_on_this_step(
+    const size_t step_number) const {
+  if (not enable_) {
+    return false;
+  }
+  if (boundary_filter_every_n_steps_.has_value()) {
+    return step_number % boundary_filter_every_n_steps_.value() == 0;
+  } else {
+    return false;
+  }
+}
+
+template <typename TagList>
+const std::optional<std::vector<size_t>>&
+FilledSphere<TagList>::blocks_to_filter() const {
+  return blocks_to_filter_;
+}
+
+template <typename TagList>
+void FilledSphere<TagList>::set_blocks_to_filter(
+    const std::vector<std::string>& all_block_names,
+    const std::unordered_map<std::string, std::unordered_set<std::string>>&
+        block_groups) {
+  if (not blocks_and_groups_to_filter_.has_value()) {
+    blocks_to_filter_ = std::nullopt;
+    return;
+  }
+  if (all_block_names.empty()) {
+    ERROR(
+        "The domain chosen doesn't use block names, but the filter has "
+        "specified block names to use.");
+  }
+  blocks_to_filter_ = domain::block_ids_from_names(
+      blocks_and_groups_to_filter_.value(), all_block_names, block_groups);
+}
+
+template <typename TagList>
+bool FilledSphere<TagList>::supports_mesh(const Mesh<3>& mesh) const {
+  return mesh.basis() == make_array<3>(Spectral::Basis::ZernikeB3) and
+         mesh.quadrature() == std::array{Spectral::Quadrature::GaussRadauUpper,
+                                         Spectral::Quadrature::Gauss,
+                                         Spectral::Quadrature::Equiangular} and
+         (mesh.extents(0) == mesh.extents(1) / 2 + 1 and
+          2 * mesh.extents(1) - 1 == mesh.extents(2));
+}
+
+template <typename TagList>
+void FilledSphere<TagList>::apply_in_volume(
+    const gsl::not_null<Variables<TagList>*> vars, const Mesh<3>& mesh,
+    const std::optional<
+        InverseJacobian<DataVector, 3, Frame::Grid, Frame::Inertial>>&
+        inv_jac_grid_to_inertial,
+    const std::optional<Jacobian<DataVector, 3, Frame::Grid, Frame::Inertial>>&
+        jac_grid_to_inertial) const {
+  if (not inv_jac_grid_to_inertial.has_value()) {
+    ERROR(
+        "The inv_jac_grid_to_inertial must be set when using the "
+        "FilledSphere filter.");
+  }
+  if (not jac_grid_to_inertial.has_value()) {
+    ERROR(
+        "The jac_grid_to_inertial must be set when using the "
+        "FilledSphere filter.");
+  }
+  const size_t radial_extents = mesh.extents(0);
+  const size_t l_max = mesh.extents(1) - 1;
+
+  // Cache the angular filter matrices
+  if (cached_l_max_ != l_max) {
+    fill_tensor_ylm_filters<TagList>(make_not_null(&filter_matrices_), l_max,
+                                     num_modes_to_kill_, angular_half_power_,
+                                     normalization_);
+    cached_l_max_ = l_max;
+  }
+
+  // angular_temp_storage_ is used by apply_tensor_ylm_filter and must hold
+  // exactly radial_extents * n_spectral grid points per component.
+  const size_t n_spectral = ::ylm::get_spherepack_cache(l_max).spectral_size();
+  const size_t needed_temp_size = radial_extents * n_spectral;
+  if (angular_temp_storage_.number_of_grid_points() != needed_temp_size) {
+    angular_temp_storage_.initialize(needed_temp_size);
+  }
+
+  // Apply the angular filter. apply_tensor_ylm_filter expects
+  //   3rd arg: InverseJacobian<Inertial, Grid> (== Jacobian<Grid, Inertial>)
+  //   4th arg: InverseJacobian<Grid, Inertial>
+  apply_tensor_ylm_filter(vars, make_not_null(&angular_temp_storage_),
+                          jac_grid_to_inertial.value(),
+                          inv_jac_grid_to_inertial.value(), filter_matrices_,
+                          l_max, radial_extents);
+
+  // Apply the optional radial exponential filter. This operation commutes
+  // with angular filtering, and swapping the order gave identical output to
+  // at least 5e-12. A separate raw buffer is needed because the
+  // radial filter's internal layout (spec + gather + modal regions) is
+  // incompatible with the per-component Variables stride expected by
+  // apply_tensor_ylm_filter.
+  if (radial_half_power_.has_value()) {
+    constexpr size_t n_components =
+        Variables<TagList>::number_of_independent_components;
+    const size_t needed_radial_buf_size =
+        n_components * n_spectral * radial_extents +
+        2 * (2 * l_max + 1) * n_components * radial_extents;
+    if (radial_temp_storage_.size() < needed_radial_buf_size) {
+      radial_temp_storage_.destructive_resize(needed_radial_buf_size);
+    }
+    Spectral::filtering::zernike_b3_ball_radial_exponential_filter(
+        vars, make_not_null(&radial_temp_storage_), mesh, 36.0,
+        static_cast<unsigned>(*radial_half_power_));
+  }
+}
+
+template <typename TagList>
+void FilledSphere<TagList>::apply_on_boundary(
+    const gsl::not_null<Variables<TagList>*> vars, const Mesh<2>& mesh,
+    const std::optional<
+        InverseJacobian<DataVector, 3, Frame::Grid, Frame::Inertial>>&
+        inv_jac_grid_to_inertial,
+    const std::optional<Jacobian<DataVector, 3, Frame::Grid, Frame::Inertial>>&
+        jac_grid_to_inertial) const {
+  // The mortar infrastructure converts the ZernikeB3 face to SphericalHarmonic
+  // before calling the boundary filter.
+  if (mesh.basis(0) != Spectral::Basis::SphericalHarmonic or
+      mesh.basis(1) != Spectral::Basis::SphericalHarmonic) {
+    ERROR(
+        "FilledSphere filter called on a face mesh whose angular dimensions "
+        "do not use the SphericalHarmonic basis. Got basis ("
+        << mesh.basis(0) << ", " << mesh.basis(1) << ").");
+  }
+  if (not inv_jac_grid_to_inertial.has_value()) {
+    ERROR(
+        "The inv_jac_grid_to_inertial must be set when using the "
+        "FilledSphere filter.");
+  }
+  if (not jac_grid_to_inertial.has_value()) {
+    ERROR(
+        "The jac_grid_to_inertial must be set when using the "
+        "FilledSphere filter.");
+  }
+  const size_t l_max = mesh.extents(0) - 1;
+
+  // Cache the angular filter matrices
+  if (cached_l_max_ != l_max) {
+    fill_tensor_ylm_filters<TagList>(make_not_null(&filter_matrices_), l_max,
+                                     num_modes_to_kill_, angular_half_power_,
+                                     normalization_);
+    cached_l_max_ = l_max;
+  }
+
+  const size_t needed_temp_size =
+      ::ylm::get_spherepack_cache(l_max).spectral_size();
+  if (angular_temp_storage_.number_of_grid_points() != needed_temp_size) {
+    angular_temp_storage_.initialize(needed_temp_size);
+  }
+
+  apply_tensor_ylm_filter(
+      vars, make_not_null(&angular_temp_storage_), jac_grid_to_inertial.value(),
+      inv_jac_grid_to_inertial.value(), filter_matrices_, l_max, 1);
+}
+
+template <typename TagList>
+bool operator==(const FilledSphere<TagList>& lhs,
+                const FilledSphere<TagList>& rhs) {
+  return lhs.num_modes_to_kill_ == rhs.num_modes_to_kill_ and
+         lhs.angular_half_power_ == rhs.angular_half_power_ and
+         lhs.radial_half_power_ == rhs.radial_half_power_ and
+         lhs.enable_ == rhs.enable_ and
+         lhs.blocks_and_groups_to_filter_ ==
+             rhs.blocks_and_groups_to_filter_ and
+         lhs.blocks_to_filter_ == rhs.blocks_to_filter_ and
+         lhs.volume_filter_on_substep_ == rhs.volume_filter_on_substep_ and
+         lhs.boundary_filter_on_substep_ == rhs.boundary_filter_on_substep_ and
+         lhs.volume_filter_every_n_steps_ ==
+             rhs.volume_filter_every_n_steps_ and
+         lhs.boundary_filter_every_n_steps_ ==
+             rhs.boundary_filter_every_n_steps_;
+}
+
+template <typename TagList>
+bool operator!=(const FilledSphere<TagList>& lhs,
+                const FilledSphere<TagList>& rhs) {
+  return not(lhs == rhs);
+}
+
+template <typename TagList>
+bool FilledSphere<TagList>::is_equal(const Filter<3, TagList>& other) const {
+  const auto* const other_filled_sphere =
+      dynamic_cast<const FilledSphere<TagList>*>(&other);
+  if (other_filled_sphere == nullptr) {
+    return false;
+  }
+  return *this == *other_filled_sphere;
+}
+
+template <typename TagList>
+PUP::able::PUP_ID FilledSphere<TagList>::my_PUP_ID = 0;  // NOLINT
+}  // namespace Filters

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_LinearOperators")
 
 set(LIBRARY_SOURCES
   Filters/Test_FilledCylinder.cpp
+  Filters/Test_FilledSphere.cpp
   Filters/Test_HollowCylinder.cpp
   Filters/Test_Hypercube.cpp
   Filters/Test_None.cpp

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Filters/Test_FilledSphere.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Filters/Test_FilledSphere.cpp
@@ -1,0 +1,910 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <random>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/Identity.hpp"
+#include "Domain/Creators/DomainCreator.hpp"
+#include "Domain/Creators/OptionTags.hpp"
+#include "Domain/Creators/Tags/Domain.hpp"
+#include "Domain/Domain.hpp"
+#include "Evolution/Systems/CurvedScalarWave/ApplyTensorYlmFilter.hpp"
+#include "Evolution/Systems/CurvedScalarWave/Tags.hpp"
+#include "Evolution/Tags/Filter.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "NumericalAlgorithms/LinearOperators/Filters/FilledSphere.hpp"
+#include "NumericalAlgorithms/LinearOperators/Filters/FilledSphere.tpp"
+#include "NumericalAlgorithms/LinearOperators/Filters/Filter.hpp"
+#include "NumericalAlgorithms/LinearOperators/Filters/None.hpp"
+#include "NumericalAlgorithms/LinearOperators/Filters/None.tpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/BasisFunctionValue.hpp"
+#include "NumericalAlgorithms/Spectral/CollocationPoints.hpp"
+#include "NumericalAlgorithms/Spectral/Filtering.hpp"
+#include "NumericalAlgorithms/Spectral/FilteringB3.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Spherepack.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/SpherepackCache.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/SpherepackIterator.hpp"
+#include "NumericalAlgorithms/TensorYlm/Filter.hpp"
+#include "Utilities/GetOutput.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+using namespace std::string_literals;
+
+constexpr size_t volume_dim = 3;
+constexpr size_t num_blocks = 4;
+
+using TagList = ylm::TensorYlm::filter_detail::csw_vars_list<Frame::Inertial>;
+using FilledSphereFilter = Filters::FilledSphere<TagList>;
+
+std::vector<std::string> domain_block_names() {
+  std::vector<std::string> block_names(num_blocks);
+  for (size_t i = 0; i < num_blocks; ++i) {
+    block_names[i] = "Block" + get_output(i);
+  }
+  return block_names;
+}
+
+std::unordered_map<std::string, std::unordered_set<std::string>>
+domain_block_groups() {
+  std::unordered_map<std::string, std::unordered_set<std::string>> groups{};
+  groups["Group1"] = std::unordered_set<std::string>{{"Block1"s}};
+  groups["Group2"] = std::unordered_set<std::string>{{"Block1"s}, {"Block2"s}};
+  return groups;
+}
+
+Domain<volume_dim> make_domain() {
+  using Identity = domain::CoordinateMaps::Identity<volume_dim>;
+  using Map =
+      domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial, Identity>;
+  register_classes_with_charm(tmpl::list<Map>{});
+  std::vector<std::unique_ptr<domain::CoordinateMapBase<
+      Frame::BlockLogical, Frame::Inertial, volume_dim>>>
+      maps{num_blocks};
+  for (size_t i = 0; i < num_blocks; ++i) {
+    maps[i] = std::make_unique<Map>(Identity{});
+  }
+  return Domain<volume_dim>{
+      std::move(maps), {}, domain_block_names(), domain_block_groups()};
+}
+
+class TestCreator : public DomainCreator<volume_dim> {
+ public:
+  explicit TestCreator(const bool use_block_names = true)
+      : use_block_names_(use_block_names) {}
+
+  Domain<volume_dim> create_domain() const override { return make_domain(); }
+  std::vector<std::string> block_names() const override {
+    return use_block_names_ ? domain_block_names() : std::vector<std::string>{};
+  }
+  std::unordered_map<std::string, std::unordered_set<std::string>>
+  block_groups() const override {
+    return use_block_names_
+               ? domain_block_groups()
+               : std::unordered_map<std::string,
+                                    std::unordered_set<std::string>>{};
+  }
+  std::vector<DirectionMap<
+      volume_dim,
+      std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
+  external_boundary_conditions() const override {
+    ERROR("Not implemented for TestCreator");
+  }
+  std::vector<std::array<size_t, volume_dim>> initial_extents() const override {
+    ERROR("Not implemented for TestCreator");
+  }
+  std::vector<std::array<size_t, volume_dim>> initial_refinement_levels()
+      const override {
+    ERROR("Not implemented for TestCreator");
+  }
+  auto functions_of_time(const std::unordered_map<std::string, double>&
+                         /*initial_expiration_times*/
+                         = {}) const
+      -> std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>> override {
+    ERROR("Not implemented for TestCreator");
+  }
+
+ private:
+  bool use_block_names_;
+};
+
+struct Metavars {
+  static constexpr size_t volume_dim = ::volume_dim;
+  struct factory_creation {
+    using factory_classes = tmpl::map<
+        tmpl::pair<::DomainCreator<volume_dim>, tmpl::list<TestCreator>>>;
+  };
+};
+
+FilledSphereFilter make_filter(
+    const size_t num_modes_to_kill,
+    const std::optional<size_t> angular_half_power,
+    const std::optional<size_t> radial_half_power, const bool enable,
+    const std::optional<std::vector<std::string>>& blocks_to_filter,
+    const bool volume_filter_on_substep, const bool boundary_filter_on_substep,
+    const std::optional<size_t> volume_filter_every_n_steps,
+    const std::optional<size_t> boundary_filter_every_n_steps) {
+  return FilledSphereFilter{num_modes_to_kill,
+                            angular_half_power,
+                            radial_half_power,
+                            enable,
+                            blocks_to_filter,
+                            volume_filter_on_substep,
+                            boundary_filter_on_substep,
+                            volume_filter_every_n_steps,
+                            boundary_filter_every_n_steps};
+}
+
+void test_is_equal() {
+  INFO("is_equal");
+  using Base = Filters::Filter<3, TagList>;
+  const std::optional<std::vector<std::string>> blocks{
+      std::vector<std::string>{"Block0", "Block1"}};
+
+  const auto a = make_filter(1, std::nullopt, std::nullopt, true, blocks, false,
+                             false, std::nullopt, std::nullopt);
+  const auto b = make_filter(1, std::nullopt, std::nullopt, true, blocks, false,
+                             false, std::nullopt, std::nullopt);
+  const auto c = make_filter(2, std::nullopt, std::nullopt, true, blocks, false,
+                             false, std::nullopt, std::nullopt);
+
+  CHECK(a.is_equal(b));
+  CHECK(b.is_equal(a));
+  CHECK_FALSE(a.is_equal(c));
+
+  // Via abstract base pointer (the primary AMR use case).
+  const std::unique_ptr<Base> pa = std::make_unique<FilledSphereFilter>(a);
+  const std::unique_ptr<Base> pb = std::make_unique<FilledSphereFilter>(b);
+  const std::unique_ptr<Base> pc = std::make_unique<FilledSphereFilter>(c);
+  CHECK(pa->is_equal(*pb));
+  CHECK_FALSE(pa->is_equal(*pc));
+
+  // A FilledSphere filter is never equal to a different concrete type.
+  const std::unique_ptr<Base> pnone =
+      std::make_unique<Filters::None<3, TagList>>(std::nullopt);
+  CHECK_FALSE(a.is_equal(*pnone));
+  CHECK_FALSE(pa->is_equal(*pnone));
+  // Symmetry: None is also not equal to FilledSphere.
+  CHECK_FALSE(pnone->is_equal(*pa));
+  CHECK_FALSE(pnone->is_equal(*pb));
+}
+
+void test_construction_and_accessors() {
+  INFO("Construction and accessors");
+  const std::vector<std::string> blocks{"Block0", "Group1"};
+  const std::optional<std::vector<std::string>> blocks_opt{blocks};
+
+  const auto filter =
+      make_filter(2, 16, 8, true, blocks_opt, false, true, std::nullopt, 4);
+
+  CHECK(filter.need_jacobians());
+  // Before set_blocks_to_filter the resolved IDs are not available.
+  CHECK_FALSE(filter.blocks_to_filter().has_value());
+
+  // After resolution: Block0->0, Group1 expands to Block1->1 -> sorted {0,1}.
+  auto filter_resolved = filter;
+  filter_resolved.set_blocks_to_filter(domain_block_names(),
+                                       domain_block_groups());
+  REQUIRE(filter_resolved.blocks_to_filter().has_value());
+  // NOLINTBEGIN(bugprone-unchecked-optional-access)
+  CHECK(filter_resolved.blocks_to_filter().value() ==
+        std::vector<size_t>{0, 1});
+  // NOLINTEND(bugprone-unchecked-optional-access)
+
+  CHECK_FALSE(filter.apply_volume_filter_on_substep());
+  CHECK(filter.apply_boundary_filter_on_substep());
+
+  for (const size_t step : {size_t{0}, size_t{1}, size_t{7}, size_t{42}}) {
+    CHECK_FALSE(filter.apply_volume_filter_on_this_step(step));
+  }
+  CHECK(filter.apply_boundary_filter_on_this_step(0));
+  CHECK_FALSE(filter.apply_boundary_filter_on_this_step(1));
+  CHECK_FALSE(filter.apply_boundary_filter_on_this_step(2));
+  CHECK(filter.apply_boundary_filter_on_this_step(4));
+  CHECK(filter.apply_boundary_filter_on_this_step(8));
+
+  const auto unrestricted =
+      make_filter(0, std::nullopt, std::nullopt, true, std::nullopt, true,
+                  false, 1, std::nullopt);
+  CHECK_FALSE(unrestricted.blocks_to_filter().has_value());
+  CHECK(unrestricted.apply_volume_filter_on_substep());
+  CHECK_FALSE(unrestricted.apply_boundary_filter_on_substep());
+  CHECK(unrestricted.apply_volume_filter_on_this_step(0));
+  CHECK(unrestricted.apply_volume_filter_on_this_step(98));
+
+  // Each constructor parameter independently flips.
+  const auto base = make_filter(2, 16, 8, true, blocks_opt, false, false, 2, 5);
+  CHECK(base == make_filter(2, 16, 8, true, blocks_opt, false, false, 2, 5));
+  CHECK_FALSE(base !=
+              make_filter(2, 16, 8, true, blocks_opt, false, false, 2, 5));
+  CHECK(base != make_filter(3, 16, 8, true, blocks_opt, false, false, 2, 5));
+  CHECK(base != make_filter(2, 12, 8, true, blocks_opt, false, false, 2, 5));
+  CHECK(base !=
+        make_filter(2, std::nullopt, 8, true, blocks_opt, false, false, 2, 5));
+  CHECK(base != make_filter(2, 16, 4, true, blocks_opt, false, false, 2, 5));
+  CHECK(base !=
+        make_filter(2, 16, std::nullopt, true, blocks_opt, false, false, 2, 5));
+  CHECK(base != make_filter(2, 16, 8, false, blocks_opt, false, false, 2, 5));
+  CHECK(base != make_filter(2, 16, 8, true, std::nullopt, false, false, 2, 5));
+  CHECK(base != make_filter(2, 16, 8, true, blocks_opt, true, false, 2, 5));
+  CHECK(base != make_filter(2, 16, 8, true, blocks_opt, false, true, 2, 5));
+  CHECK(base !=
+        make_filter(2, 16, 8, true, blocks_opt, false, false, std::nullopt, 5));
+  CHECK(base !=
+        make_filter(2, 16, 8, true, blocks_opt, false, false, 2, std::nullopt));
+
+  // Duplicate block names rejected at construction.
+  CHECK_THROWS_WITH(
+      (FilledSphereFilter{
+          2, 16, 8, true,
+          std::optional<std::vector<std::string>>{{"Block0", "Block0"}}, false,
+          false, std::nullopt, std::nullopt}),
+      Catch::Matchers::ContainsSubstring("Duplicate block name"));
+}
+
+void test_pup_round_trip() {
+  INFO("Serialization");
+  const auto filter =
+      make_filter(2, 16, 8, true,
+                  std::optional<std::vector<std::string>>{{"Block0", "Group2"}},
+                  true, false, 4, std::nullopt);
+  ::test_serialization(filter);
+
+  using Base = Filters::Filter<volume_dim, TagList>;
+  using Derived = FilledSphereFilter;
+  register_classes_with_charm<Derived>();
+  const std::unique_ptr<Base> base = std::make_unique<Derived>(filter);
+  const std::unique_ptr<Base> pupped_base = serialize_and_deserialize(base);
+  REQUIRE(dynamic_cast<const Derived*>(pupped_base.get()) != nullptr);
+  CHECK(dynamic_cast<const Derived&>(*pupped_base) == filter);
+
+  // A filter with both half-powers as nullopt also round-trips cleanly.
+  const auto heaviside =
+      make_filter(1, std::nullopt, std::nullopt, true, std::nullopt, false,
+                  false, std::nullopt, std::nullopt);
+  ::test_serialization(heaviside);
+}
+
+Mesh<volume_dim> make_ball_mesh(const size_t ell_max) {
+  return Mesh<volume_dim>{
+      {(ell_max + 3) / 2, ell_max + 1, (2 * ell_max) + 1},
+      {Spectral::Basis::ZernikeB3, Spectral::Basis::ZernikeB3,
+       Spectral::Basis::ZernikeB3},
+      {Spectral::Quadrature::GaussRadauUpper, Spectral::Quadrature::Gauss,
+       Spectral::Quadrature::Equiangular}};
+}
+
+// Random Spherepack-modal Variables, restricted to valid (l <= ell_max - rank)
+// modes, then transformed to the nodal collocation grid.
+Variables<TagList> random_nodal_vars(const size_t radial_extents,
+                                     const size_t ell_max,
+                                     std::mt19937& generator) {
+  const auto& ylm = ::ylm::get_spherepack_cache(ell_max);
+  Variables<TagList> modal_vars(ylm.spectral_size() * radial_extents, 0.0);
+  std::uniform_real_distribution<double> dist{-1.0, 1.0};
+  ylm::SpherepackIterator it(ell_max, ell_max, radial_extents, true);
+  tmpl::for_each<TagList>(
+      [&modal_vars, &it, &dist, &generator, ell_max](auto tag_v) {
+        using Tag = tmpl::type_from<decltype(tag_v)>;
+        auto& tensor = get<Tag>(modal_vars);
+        for (auto& component : tensor) {
+          for (size_t offset = 0; offset < it.stride(); ++offset) {
+            for (it.reset(); it; ++it) {
+              if (it.l() <= ell_max - tensor.rank()) {
+                component[it() + offset] = dist(generator);
+              }
+            }
+          }
+        }
+      });
+  Variables<TagList> nodal_vars(ylm.physical_size() * radial_extents);
+  ylm::TensorYlm::filter_detail::modal_to_nodal_ylm(
+      make_not_null(&nodal_vars), modal_vars, ylm, radial_extents);
+  return nodal_vars;
+}
+
+// Diagonally-dominant random Jacobians so that the inverse exists.
+void make_jacobians(
+    gsl::not_null<InverseJacobian<DataVector, 3, Frame::Grid, Frame::Inertial>*>
+        inv_jac_grid_to_inertial,
+    gsl::not_null<Jacobian<DataVector, 3, Frame::Grid, Frame::Inertial>*>
+        jac_grid_to_inertial,
+    const size_t physical_grid_points, std::mt19937& generator) {
+  std::uniform_real_distribution<double> dist{-1.0, 1.0};
+  std::uniform_real_distribution<double> positive_dist{0.5, 1.0};
+  // Build that random matrix first, then invert to get its sibling.
+  InverseJacobian<DataVector, 3, Frame::Inertial, Frame::Grid>
+      inv_jac_inertial_to_grid(physical_grid_points);
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = 0; j < 3; ++j) {
+      inv_jac_inertial_to_grid.get(i, j) = 0.05 * dist(generator);
+    }
+    inv_jac_inertial_to_grid.get(i, i) += positive_dist(generator);
+  }
+  Scalar<DataVector> det(physical_grid_points);
+  determinant_and_inverse(make_not_null(&det), inv_jac_grid_to_inertial,
+                          inv_jac_inertial_to_grid);
+  // Copy component-wise: Jacobian<Grid, Inertial> and InverseJacobian<Inertial,
+  // Grid> are typedef-equivalent in their tensor structure.
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = 0; j < 3; ++j) {
+      jac_grid_to_inertial->get(i, j) = inv_jac_inertial_to_grid.get(i, j);
+    }
+  }
+}
+
+void test_apply_in_volume() {
+  INFO("apply_in_volume");
+  const Approx custom_approx = Approx::custom().epsilon(5.0e-12);
+
+  constexpr size_t ell_max = 6;
+  const auto& ylm = ::ylm::get_spherepack_cache(ell_max);
+  const Mesh<volume_dim> mesh = make_ball_mesh(ell_max);
+  const size_t radial_extents = mesh.extents(0);
+  const size_t physical_grid_points = ylm.physical_size() * radial_extents;
+  REQUIRE(mesh.number_of_grid_points() == physical_grid_points);
+
+  MAKE_GENERATOR(generator);
+  const auto initial_vars =
+      random_nodal_vars(radial_extents, ell_max, generator);
+
+  InverseJacobian<DataVector, 3, Frame::Grid, Frame::Inertial>
+      inv_jac_grid_to_inertial(physical_grid_points);
+  Jacobian<DataVector, 3, Frame::Grid, Frame::Inertial> jac_grid_to_inertial(
+      physical_grid_points);
+  make_jacobians(make_not_null(&inv_jac_grid_to_inertial),
+                 make_not_null(&jac_grid_to_inertial), physical_grid_points,
+                 generator);
+
+  // Helper: directly compute the expected output via the same building blocks
+  // FilledSphere uses internally.
+  const auto expected_after = [&](const size_t num_modes_to_kill,
+                                  const std::optional<size_t> angular_half,
+                                  const std::optional<size_t> radial_half) {
+    Variables<TagList> vars = initial_vars;
+    Variables<TagList> temp(ylm.spectral_size() * radial_extents);
+    ylm::TensorYlm::FilterMatrixHolder filter_matrices;
+    ylm::TensorYlm::fill_tensor_ylm_filters<TagList>(
+        make_not_null(&filter_matrices), ell_max, num_modes_to_kill,
+        angular_half, ylm::TensorYlm::CoefficientNormalization::Spherepack);
+    ylm::TensorYlm::apply_tensor_ylm_filter(
+        make_not_null(&vars), make_not_null(&temp), jac_grid_to_inertial,
+        inv_jac_grid_to_inertial, filter_matrices, ell_max, radial_extents);
+    if (radial_half.has_value()) {
+      Spectral::filtering::zernike_b3_ball_radial_exponential_filter(
+          make_not_null(&vars), mesh, 36.0,
+          static_cast<unsigned>(*radial_half));
+    }
+    return vars;
+  };
+
+  const auto run_filter = [&](const FilledSphereFilter& filter) {
+    Variables<TagList> vars = initial_vars;
+    filter.apply_in_volume(make_not_null(&vars), mesh, inv_jac_grid_to_inertial,
+                           jac_grid_to_inertial);
+    return vars;
+  };
+
+  // Case 1: angular Heaviside-only (no smooth roll-off, no radial filter).
+  {
+    INFO("Heaviside-only angular filter");
+    const auto filter =
+        make_filter(2, std::nullopt, std::nullopt, true, std::nullopt, false,
+                    false, std::nullopt, std::nullopt);
+    const auto vars = run_filter(filter);
+    const auto expected = expected_after(2, std::nullopt, std::nullopt);
+    CHECK_VARIABLES_CUSTOM_APPROX(vars, expected, custom_approx);
+  }
+
+  // Case 2: angular smooth roll-off + radial filter both active.
+  {
+    INFO("Both angular and radial smooth filters");
+    const auto filter = make_filter(2, 16, 8, true, std::nullopt, false, false,
+                                    std::nullopt, std::nullopt);
+    const auto vars = run_filter(filter);
+    const auto expected = expected_after(2, 16, 8);
+    CHECK_VARIABLES_CUSTOM_APPROX(vars, expected, custom_approx);
+  }
+
+  // Case 3: radial filter only, no angular cutoff.
+  {
+    INFO("Radial-only filter (num_modes_to_kill = 0)");
+    const auto filter = make_filter(0, std::nullopt, 4, true, std::nullopt,
+                                    false, false, std::nullopt, std::nullopt);
+    const auto vars = run_filter(filter);
+    const auto expected = expected_after(0, std::nullopt, 4);
+    CHECK_VARIABLES_CUSTOM_APPROX(vars, expected, custom_approx);
+  }
+
+  // Case 4: FilledSphere::apply_in_volume errors when jacobians are absent.
+#ifdef SPECTRE_DEBUG
+  {
+    INFO("Missing jacobian arguments cause an error");
+    const auto filter =
+        make_filter(0, std::nullopt, std::nullopt, true, std::nullopt, false,
+                    false, std::nullopt, std::nullopt);
+    Variables<TagList> vars = initial_vars;
+    CHECK_THROWS_WITH(
+        filter.apply_in_volume(make_not_null(&vars), mesh, std::nullopt,
+                               jac_grid_to_inertial),
+        Catch::Matchers::ContainsSubstring("inv_jac_grid_to_inertial"));
+    CHECK_THROWS_WITH(
+        filter.apply_in_volume(make_not_null(&vars), mesh,
+                               inv_jac_grid_to_inertial, std::nullopt),
+        Catch::Matchers::ContainsSubstring("jac_grid_to_inertial"));
+  }
+#endif
+}
+
+void test_apply_on_boundary() {
+  INFO("apply_on_boundary");
+  const Approx custom_approx = Approx::custom().epsilon(5.0e-12);
+
+  constexpr size_t ell_max = 4;
+  const auto& ylm = ::ylm::get_spherepack_cache(ell_max);
+  const size_t physical_grid_points = ylm.physical_size();
+
+  // Outer radial face of a filled sphere element: theta x phi, both
+  // SphericalHarmonic (after mortar conversion from ZernikeB3).
+  const Mesh<2> face_mesh = make_ball_mesh(ell_max).on_interface(0);
+  REQUIRE(face_mesh.number_of_grid_points() == physical_grid_points);
+
+  MAKE_GENERATOR(generator);
+  // radial_extents = 1 gives physical_size grid points, matching the face mesh.
+  const auto initial_vars = random_nodal_vars(1, ell_max, generator);
+
+  InverseJacobian<DataVector, 3, Frame::Grid, Frame::Inertial>
+      inv_jac_grid_to_inertial(physical_grid_points);
+  Jacobian<DataVector, 3, Frame::Grid, Frame::Inertial> jac_grid_to_inertial(
+      physical_grid_points);
+  make_jacobians(make_not_null(&inv_jac_grid_to_inertial),
+                 make_not_null(&jac_grid_to_inertial), physical_grid_points,
+                 generator);
+
+  // Direct computation of expected output: angular filter with radial_extents=1
+  // (no radial filter on a face).
+  const auto expected_after = [&](const size_t num_modes_to_kill,
+                                  const std::optional<size_t> angular_half) {
+    Variables<TagList> vars = initial_vars;
+    Variables<TagList> temp(ylm.spectral_size());
+    ylm::TensorYlm::FilterMatrixHolder filter_matrices;
+    ylm::TensorYlm::fill_tensor_ylm_filters<TagList>(
+        make_not_null(&filter_matrices), ell_max, num_modes_to_kill,
+        angular_half, ylm::TensorYlm::CoefficientNormalization::Spherepack);
+    ylm::TensorYlm::apply_tensor_ylm_filter(
+        make_not_null(&vars), make_not_null(&temp), jac_grid_to_inertial,
+        inv_jac_grid_to_inertial, filter_matrices, ell_max, 1);
+    return vars;
+  };
+
+  const auto run_filter = [&](const FilledSphereFilter& filter) {
+    Variables<TagList> vars = initial_vars;
+    filter.apply_on_boundary(make_not_null(&vars), face_mesh,
+                             inv_jac_grid_to_inertial, jac_grid_to_inertial);
+    return vars;
+  };
+
+  // Case 1: Heaviside-only angular filter on boundary.
+  {
+    INFO("Heaviside-only angular filter");
+    const auto filter =
+        make_filter(2, std::nullopt, std::nullopt, true, std::nullopt, false,
+                    false, std::nullopt, std::nullopt);
+    CHECK_VARIABLES_CUSTOM_APPROX(
+        run_filter(filter), expected_after(2, std::nullopt), custom_approx);
+  }
+
+  // Case 2: smooth angular roll-off on boundary (RadialHalfPower is ignored on
+  // a face).
+  {
+    INFO("Smooth angular filter");
+    const auto filter = make_filter(2, 16, 8, true, std::nullopt, false, false,
+                                    std::nullopt, std::nullopt);
+    CHECK_VARIABLES_CUSTOM_APPROX(run_filter(filter), expected_after(2, 16),
+                                  custom_approx);
+  }
+
+#ifdef SPECTRE_DEBUG
+  {
+    INFO("Non-SphericalHarmonic face mesh errors");
+    const Mesh<2> legendre_face{
+        {4, 5},
+        make_array<2>(Spectral::Basis::Legendre),
+        {Spectral::Quadrature::Gauss, Spectral::Quadrature::GaussLobatto}};
+    Variables<TagList> vars = initial_vars;
+    const auto filter =
+        make_filter(2, std::nullopt, std::nullopt, true, std::nullopt, false,
+                    false, std::nullopt, std::nullopt);
+    CHECK_THROWS_WITH(
+        filter.apply_on_boundary(make_not_null(&vars), legendre_face,
+                                 std::nullopt, std::nullopt),
+        Catch::Matchers::ContainsSubstring(
+            "FilledSphere filter called on a face mesh"));
+  }
+  {
+    INFO("Missing jacobian arguments cause an error");
+    const auto filter =
+        make_filter(2, std::nullopt, std::nullopt, true, std::nullopt, false,
+                    false, std::nullopt, std::nullopt);
+    Variables<TagList> vars = initial_vars;
+    CHECK_THROWS_WITH(
+        filter.apply_on_boundary(make_not_null(&vars), face_mesh, std::nullopt,
+                                 jac_grid_to_inertial),
+        Catch::Matchers::ContainsSubstring("inv_jac_grid_to_inertial"));
+    CHECK_THROWS_WITH(
+        filter.apply_on_boundary(make_not_null(&vars), face_mesh,
+                                 inv_jac_grid_to_inertial, std::nullopt),
+        Catch::Matchers::ContainsSubstring("jac_grid_to_inertial"));
+  }
+#endif
+}
+
+void test_supports_mesh() {
+  INFO("supports_mesh");
+  const auto filter = make_filter(2, 16, 8, true, std::nullopt, false, false,
+                                  std::nullopt, std::nullopt);
+
+  CHECK(filter.supports_mesh(Mesh<3>(
+      {3, 4, 7}, make_array<3>(Spectral::Basis::ZernikeB3),
+      {Spectral::Quadrature::GaussRadauUpper, Spectral::Quadrature::Gauss,
+       Spectral::Quadrature::Equiangular})));
+
+  const auto shell_mesh = [](const Spectral::Basis radial_basis,
+                             const Spectral::Quadrature radial_quadrature) {
+    return Mesh<3>{std::array<size_t, 3>{4, 2, 3},
+                   std::array<Spectral::Basis, 3>{
+                       radial_basis, Spectral::Basis::SphericalHarmonic,
+                       Spectral::Basis::SphericalHarmonic},
+                   std::array<Spectral::Quadrature, 3>{
+                       radial_quadrature, Spectral::Quadrature::Gauss,
+                       Spectral::Quadrature::Equiangular}};
+  };
+
+  CHECK_FALSE(filter.supports_mesh(
+      shell_mesh(Spectral::Basis::Legendre, Spectral::Quadrature::Gauss)));
+  CHECK_FALSE(filter.supports_mesh(shell_mesh(
+      Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto)));
+  CHECK_FALSE(filter.supports_mesh(
+      shell_mesh(Spectral::Basis::Chebyshev, Spectral::Quadrature::Gauss)));
+  CHECK_FALSE(filter.supports_mesh(shell_mesh(
+      Spectral::Basis::Chebyshev, Spectral::Quadrature::GaussLobatto)));
+  CHECK_FALSE(filter.supports_mesh(
+      shell_mesh(Spectral::Basis::Fourier, Spectral::Quadrature::Equiangular)));
+
+  CHECK_FALSE(filter.supports_mesh(
+      Mesh<3>{4, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss}));
+
+  const auto b3_mesh = [](const size_t n_r, const size_t n_theta,
+                          const size_t n_phi) {
+    return Mesh<3>{
+        std::array<size_t, 3>{n_r, n_theta, n_phi},
+        make_array<3>(Spectral::Basis::ZernikeB3),
+        std::array<Spectral::Quadrature, 3>{
+            Spectral::Quadrature::GaussRadauUpper, Spectral::Quadrature::Gauss,
+            Spectral::Quadrature::Equiangular}};
+  };
+
+  // Wrong radial count
+  CHECK_FALSE(filter.supports_mesh(b3_mesh(2, 4, 7)));
+  CHECK_FALSE(filter.supports_mesh(b3_mesh(4, 4, 7)));
+
+  // Inconsistend angular counts
+  CHECK_FALSE(filter.supports_mesh(b3_mesh(3, 4, 5)));
+}
+
+void test_option_parsing() {
+  INFO("Option parsing");
+  using Filter = FilledSphereFilter;
+  using tags = tmpl::list<OptionTags::Filter<Filter>,
+                          domain::OptionTags::DomainCreator<volume_dim>>;
+
+  Options::Parser<tags> parser("");
+  parser.parse(
+      "DomainCreator:\n"
+      "  TestCreator\n"
+      "Filtering:\n"
+      "  FilledSphere:\n"
+      "    NumModesToKill: 2\n"
+      "    AngularHalfPower: 16\n"
+      "    RadialHalfPower: 8\n"
+      "    Enable: True\n"
+      "    BlocksToFilter:\n"
+      "      - Block0\n"
+      "      - Group1\n"
+      "    VolumeFilterOnSubstep: False\n"
+      "    BoundaryCorrectionFilterOnSubstep: True\n"
+      "    VolumeFilterEveryNSteps: 5\n"
+      "    BoundaryCorrectionFilterEveryNSteps: None\n");
+  const auto parsed =
+      parser.template get<OptionTags::Filter<Filter>, Metavars>();
+  const auto expected =
+      make_filter(2, 16, 8, true,
+                  std::optional<std::vector<std::string>>{{"Block0", "Group1"}},
+                  false, true, 5, std::nullopt);
+  CHECK(parsed == expected);
+  CHECK_FALSE(parsed != expected);
+
+  // Heaviside-only: AngularHalfPower and RadialHalfPower both None.
+  Options::Parser<tags> heaviside_parser("");
+  heaviside_parser.parse(
+      "DomainCreator:\n"
+      "  TestCreator\n"
+      "Filtering:\n"
+      "  FilledSphere:\n"
+      "    NumModesToKill: 1\n"
+      "    AngularHalfPower: None\n"
+      "    RadialHalfPower: None\n"
+      "    Enable: True\n"
+      "    BlocksToFilter: All\n"
+      "    VolumeFilterOnSubstep: True\n"
+      "    BoundaryCorrectionFilterOnSubstep: False\n"
+      "    VolumeFilterEveryNSteps: None\n"
+      "    BoundaryCorrectionFilterEveryNSteps: 7\n");
+  const auto heaviside =
+      heaviside_parser.template get<OptionTags::Filter<Filter>, Metavars>();
+  CHECK_FALSE(heaviside.blocks_to_filter().has_value());
+  CHECK(heaviside.apply_volume_filter_on_substep());
+  CHECK_FALSE(heaviside.apply_boundary_filter_on_substep());
+  CHECK(heaviside.apply_boundary_filter_on_this_step(7));
+  CHECK_FALSE(heaviside.apply_boundary_filter_on_this_step(8));
+
+  // Duplicate block names rejected by the option parser.
+  Options::Parser<tags> dup_parser("");
+  dup_parser.parse(
+      "DomainCreator:\n"
+      "  TestCreator\n"
+      "Filtering:\n"
+      "  FilledSphere:\n"
+      "    NumModesToKill: 2\n"
+      "    AngularHalfPower: 16\n"
+      "    RadialHalfPower: 8\n"
+      "    Enable: True\n"
+      "    BlocksToFilter:\n"
+      "      - Block0\n"
+      "      - Block0\n"
+      "    VolumeFilterOnSubstep: False\n"
+      "    BoundaryCorrectionFilterOnSubstep: False\n"
+      "    VolumeFilterEveryNSteps: None\n"
+      "    BoundaryCorrectionFilterEveryNSteps: None\n");
+  CHECK_THROWS_WITH(
+      (dup_parser.template get<OptionTags::Filter<Filter>, Metavars>()),
+      Catch::Matchers::ContainsSubstring("Duplicate block name"));
+
+  // Invalid block name caught by set_blocks_to_filter.
+  auto invalid_filter =
+      make_filter(0, std::nullopt, std::nullopt, true,
+                  std::optional<std::vector<std::string>>{{"NotABlock"}}, false,
+                  false, std::nullopt, std::nullopt);
+  CHECK_THROWS_AS(invalid_filter.set_blocks_to_filter(domain_block_names(),
+                                                      domain_block_groups()),
+                  std::invalid_argument);
+
+  // A domain that doesn't expose block names is rejected when blocks are
+  // specified.
+  CHECK_THROWS_WITH(
+      make_filter(0, std::nullopt, std::nullopt, true,
+                  std::optional<std::vector<std::string>>{{"Block0"}}, false,
+                  false, std::nullopt, std::nullopt)
+          .set_blocks_to_filter({}, {}),
+      Catch::Matchers::ContainsSubstring("doesn't use block names"));
+}
+// Build the physical-space DataVector for the pure B3 mode (n_jacobi, l)
+// using SPHEREPACK offset s.
+DataVector pure_b3_mode_phys(const Mesh<volume_dim>& mesh,
+                             const size_t n_jacobi, const size_t l,
+                             const size_t s) {
+  const size_t n_r = mesh.extents(0);
+  const size_t l_max = mesh.extents(1) - 1;
+  const size_t n_phys = mesh.number_of_grid_points();
+  const auto& ylm = ylm::get_spherepack_cache(l_max);
+  const size_t n_spectral = ylm.spectral_size();
+  const DataVector& radial_pts =
+      Spectral::collocation_points<Spectral::Basis::ZernikeB3,
+                                   Spectral::Quadrature::GaussRadauUpper>(n_r);
+  const DataVector radial_profile =
+      Spectral::compute_basis_function_value<Spectral::Basis::ZernikeB3>(
+          l + 2 * n_jacobi, l, radial_pts);
+  std::vector<double> spec_buf(n_spectral * n_r, 0.0);
+  for (size_t i_r = 0; i_r < n_r; ++i_r) {
+    spec_buf[s * n_r + i_r] = radial_profile[i_r];
+  }
+  DataVector phys(n_phys);
+  ylm.spec_to_phys_all_offsets(make_not_null(phys.data()),
+                               make_not_null(spec_buf.data()), n_r);
+  return phys;
+}
+
+// Return the SPHEREPACK offset for angular degree l0, first m=0 mode.
+size_t spherepack_offset_for_l(const size_t l_max, const size_t l0) {
+  ylm::SpherepackIterator iter{l_max, l_max};
+  while (iter) {
+    if (iter.l() == l0 and iter.m() == 0) {
+      return iter();
+    }
+    ++iter;
+  }
+  ERROR("No mode found for l=" << l0 << " in SpherepackIterator");
+}
+
+void test_angular_filter_heaviside() {
+  INFO("Heaviside angular filter kills l=l_max, preserves l=0");
+  const size_t l_max = 2;
+  const auto mesh = make_ball_mesh(l_max);
+  const size_t n_phys = mesh.number_of_grid_points();
+
+  MAKE_GENERATOR(generator);
+  InverseJacobian<DataVector, 3, Frame::Grid, Frame::Inertial> inv_jac(n_phys);
+  Jacobian<DataVector, 3, Frame::Grid, Frame::Inertial> jac(n_phys);
+  make_jacobians(make_not_null(&inv_jac), make_not_null(&jac), n_phys,
+                 generator);
+
+  // l=l_max mode should be zeroed.
+  {
+    const DataVector top_mode = pure_b3_mode_phys(
+        mesh, 0, l_max, spherepack_offset_for_l(l_max, l_max));
+    Variables<TagList> vars{n_phys, 0.0};
+    get(get<CurvedScalarWave::Tags::Psi>(vars)) = top_mode;
+
+    FilledSphereFilter{1,     std::nullopt, std::nullopt,
+                       true,  std::nullopt, false,
+                       false, std::nullopt, std::nullopt}
+        .apply_in_volume(make_not_null(&vars), mesh,
+                         std::make_optional(inv_jac), std::make_optional(jac));
+
+    CHECK_VARIABLES_APPROX(vars, (Variables<TagList>{n_phys, 0.0}));
+  }
+
+  // l=0 mode (below the cut) should be preserved.
+  {
+    const DataVector low_mode =
+        pure_b3_mode_phys(mesh, 0, 0, spherepack_offset_for_l(l_max, 0));
+    Variables<TagList> vars{n_phys, 0.0};
+    get(get<CurvedScalarWave::Tags::Psi>(vars)) = low_mode;
+    const Variables<TagList> vars_orig = vars;
+
+    FilledSphereFilter{1,     std::nullopt, std::nullopt,
+                       true,  std::nullopt, false,
+                       false, std::nullopt, std::nullopt}
+        .apply_in_volume(make_not_null(&vars), mesh,
+                         std::make_optional(inv_jac), std::make_optional(jac));
+
+    CHECK_VARIABLES_APPROX(vars, vars_orig);
+  }
+}
+
+void test_angular_filter_per_mode() {
+  INFO("Heaviside angular filter: per-mode preservation and zeroing");
+  const std::vector<size_t> mesh_sizes{3, 4, 5, 6, 7, 8};
+  const std::vector<size_t> fl_values{0, 1, 2};
+
+  MAKE_GENERATOR(generator);
+
+  for (const size_t l_max : mesh_sizes) {
+    CAPTURE(l_max);
+    const auto mesh = make_ball_mesh(l_max);
+    const size_t n_phys = mesh.number_of_grid_points();
+    const size_t n_r_max = 2 * mesh.extents(0) - 2;
+
+    InverseJacobian<DataVector, 3, Frame::Grid, Frame::Inertial> inv_jac(
+        n_phys);
+    Jacobian<DataVector, 3, Frame::Grid, Frame::Inertial> jac(n_phys);
+    make_jacobians(make_not_null(&inv_jac), make_not_null(&jac), n_phys,
+                   generator);
+
+    const Variables<TagList> zero{n_phys, 0.0};
+
+    for (const size_t fl : fl_values) {
+      CAPTURE(fl);
+      ylm::SpherepackIterator iter{l_max, l_max};
+      while (iter) {
+        const size_t l = iter.l();
+        const size_t s = iter();
+        const size_t spectral_size_l = (n_r_max - l + 2) / 2;
+        CAPTURE(l);
+        CAPTURE(s);
+        const auto filter = FilledSphereFilter{
+            fl,    std::nullopt, std::nullopt, true,        std::nullopt,
+            false, false,        std::nullopt, std::nullopt};
+        for (size_t n_jacobi = 0; n_jacobi < spectral_size_l; ++n_jacobi) {
+          CAPTURE(n_jacobi);
+          const DataVector mode = pure_b3_mode_phys(mesh, n_jacobi, l, s);
+          Variables<TagList> vars{n_phys, 0.0};
+          get(get<CurvedScalarWave::Tags::Psi>(vars)) = mode;
+          const Variables<TagList> vars_orig = vars;
+
+          filter.apply_in_volume(make_not_null(&vars), mesh,
+                                 std::make_optional(inv_jac),
+                                 std::make_optional(jac));
+
+          if (l + fl <= l_max) {
+            CHECK_VARIABLES_APPROX(vars, vars_orig);
+          } else {
+            CHECK_VARIABLES_APPROX(vars, zero);
+          }
+        }
+        ++iter;
+      }
+    }
+
+    // fl=0, rank-1 tensor: modes with l < l_max are preserved exactly.
+    // Modes at l=l_max are excluded: for rank-1 fill_filter runs the
+    // Wigner-3j loop at lprime=l_max+1, adding a non-zero correction to
+    // the l=l_max block (triangle rule |l-lprime|<=1).
+    {
+      ylm::SpherepackIterator vec_iter{l_max, l_max};
+      const auto filter = FilledSphereFilter{0,     std::nullopt, std::nullopt,
+                                             true,  std::nullopt, false,
+                                             false, std::nullopt, std::nullopt};
+      while (vec_iter) {
+        const size_t l = vec_iter.l();
+        const size_t s = vec_iter();
+        if (l < l_max) {
+          const size_t spectral_size_l = (n_r_max - l + 2) / 2;
+          for (size_t n_jacobi = 0; n_jacobi < spectral_size_l; ++n_jacobi) {
+            const DataVector mode = pure_b3_mode_phys(mesh, n_jacobi, l, s);
+            Variables<TagList> vars{n_phys, 0.0};
+            auto& vec =
+                get<CurvedScalarWave::Tags::Phi<3, Frame::Inertial>>(vars);
+            for (size_t i = 0; i < 3; ++i) {
+              vec.get(i) = mode;
+            }
+            const Variables<TagList> vars_orig = vars;
+
+            filter.apply_in_volume(make_not_null(&vars), mesh,
+                                   std::make_optional(inv_jac),
+                                   std::make_optional(jac));
+
+            CHECK_VARIABLES_APPROX(vars, vars_orig);
+          }
+        }
+        ++vec_iter;
+      }
+    }
+  }
+}
+
+}  // namespace
+
+// [[TimeOut, 20]]
+SPECTRE_TEST_CASE(
+    "Unit.NumericalAlgorithms.LinearOperators.Filter.FilledSphere",
+    "[NumericalAlgorithms][LinearOperators][Unit]") {
+  // Testing the FilledSphere class and Filter infrastructure
+  test_is_equal();
+  test_construction_and_accessors();
+  test_pup_round_trip();
+  test_apply_in_volume();
+  test_apply_on_boundary();
+  test_supports_mesh();
+  test_option_parsing();
+  // Testing the correctness of the angular filter itself
+  test_angular_filter_heaviside();
+  test_angular_filter_per_mode();
+}


### PR DESCRIPTION
## Proposed changes

Concrete Filters::Filter implementation for filled-sphere elements. This class is very similar to Spherical Shells, using identical options and diverging by adding a radial filter buffer.

The test file for this both covers the typical `Filters`-style checks as well as some sanity checks for the combined radial + angular filtering, as it is not necessarily obvious that the angular filtering can be done solely with existing spherical harmonic infrastructure (even though SpEC does this, it wasn't obvious to me)

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
