### PR TITLE
Add error message for nonmonotonic times in WorldtubeBufferUpdater

### DIFF
--- a/src/Evolution/Systems/Cce/WorldtubeBufferUpdater.cpp
+++ b/src/Evolution/Systems/Cce/WorldtubeBufferUpdater.cpp
@@ -97,6 +97,16 @@ void set_time_buffer_and_lmax(const gsl::not_null<DataVector*> time_buffer,
 
   for (size_t i = 0; i < data_table_dimensions[0]; ++i) {
     (*time_buffer)[i] = time_matrix(i, 0);
+    if (i > 0 and not((*time_buffer)[i - 1] < (*time_buffer)[i])) {
+      ERROR("Times in "
+            << data.subfile_path()
+            << " are not strictly increasing as required. The adjacent "
+               "times at indices "
+            << i - 1 << " and " << i << " are " << (*time_buffer)[i - 1]
+            << " and " << (*time_buffer)[i]
+            << ". Remove duplicate or overlapping time rows before using "
+               "this worldtube data for interpolation.");
+    }
   }
 
   if (is_modal_data) {

--- a/tests/Unit/Evolution/Systems/Cce/Test_WorldtubeData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_WorldtubeData.cpp
@@ -1147,6 +1147,29 @@ void test_bondi_worldtube_buffer_updater(const gsl::not_null<Generator*> gen) {
         gen, extraction_radius_in_filename, time_varies_fastest);
   }
 }
+
+void test_nonmonotonic_times_error() {
+  const std::string filename = "NonMonotonicTimes_CceR0100.h5";
+  if (file_system::check_if_file_exists(filename)) {
+    file_system::rm(filename, true);
+  }
+
+  {
+    h5::H5File<h5::AccessType::ReadWrite> h5_file{filename};
+    auto& lapse = h5_file.insert<h5::Dat>(
+        "/Lapse", std::vector<std::string>{"Time", "Y_0,0"}, 0);
+
+    lapse.append(std::vector<double>{0.0, 1.0});
+    lapse.append(std::vector<double>{2.0, 1.0});
+    lapse.append(std::vector<double>{1.0, 1.0});
+  }
+
+  CHECK_THROWS_WITH(
+      (MetricWorldtubeH5BufferUpdater<ComplexModalVector>{
+          filename, std::optional<double>{100.0}, true}),
+      Catch::Matchers::ContainsSubstring(
+          "Times in /Lapse are not strictly increasing as required."));
+}
 }  // namespace
 
 // An increased timeout because this test seems to have high variance in
@@ -1195,6 +1218,10 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.ReadBoundaryDataH5",
                                                 BondiBufferUpdater>(
         make_not_null(&gen));
     test_bondi_data_manager_du_dr_j();
+  }
+  {
+    INFO("Testing monotonically increasing times");
+    test_nonmonotonic_times_error();
   }
 }
 }  // namespace Cce


### PR DESCRIPTION
## Proposed changes

Addresses issue #7219 by adding an error message for nonmonotonically increasing times in Worldtube data. As described in the issue, the `BarycentricRationalSpanInterpolator` in `WorldtubeBufferUpdater` expects monotonically increasing times, but this was not previously checked. 

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [X] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [X] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.