### PR TITLE
CCE-fix: compute Dy(H) on demand as an observation compute tag

### DIFF
--- a/src/Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp
+++ b/src/Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp
@@ -190,10 +190,6 @@ struct CharacteristicEvolution {
       tmpl::transform<bondi_hypersurface_step_tags,
                       tmpl::bind<hypersurface_computation, tmpl::_1>>,
       Actions::FilterSwshVolumeQuantity<Tags::BondiH>,
-      // `Tags::Dy<Tags::BondiH>` is not an input to any hypersurface
-      // integration (unlike the other Bondi radial derivatives), so it is
-      // computed explicitly here, from the filtered `H`, for volume output.
-      ::Actions::MutateApply<PreSwshDerivatives<Tags::Dy<Tags::BondiH>>>,
       ::Actions::MutateApply<
           CalculateScriPlusValue<::Tags::dt<Tags::InertialRetardedTime>>>,
       Actions::CalculateScriInputs,
@@ -228,10 +224,6 @@ struct CharacteristicEvolution {
       tmpl::transform<bondi_hypersurface_step_tags,
                       tmpl::bind<hypersurface_computation, tmpl::_1>>,
       Actions::FilterSwshVolumeQuantity<Tags::BondiH>,
-      // `Tags::Dy<Tags::BondiH>` is not an input to any hypersurface
-      // integration (unlike the other Bondi radial derivatives), so it is
-      // computed explicitly here, from the filtered `H`, for volume output.
-      ::Actions::MutateApply<PreSwshDerivatives<Tags::Dy<Tags::BondiH>>>,
       tmpl::conditional_t<
           evolve_ccm, tmpl::list<>,
           tmpl::flatten<tmpl::list<

--- a/src/Evolution/Systems/Cce/Components/KleinGordonCharacteristicEvolution.hpp
+++ b/src/Evolution/Systems/Cce/Components/KleinGordonCharacteristicEvolution.hpp
@@ -113,10 +113,6 @@ struct KleinGordonCharacteristicEvolution
                       tmpl::bind<hypersurface_computation, tmpl::_1>>,
       klein_gordon_hypersurface_computation,
       Actions::FilterSwshVolumeQuantity<Tags::BondiH>,
-      // `Tags::Dy<Tags::BondiH>` is not an input to any hypersurface
-      // integration (unlike the other Bondi radial derivatives), so it is
-      // computed explicitly here, from the filtered `H`, for volume output.
-      ::Actions::MutateApply<PreSwshDerivatives<Tags::Dy<Tags::BondiH>>>,
       Actions::FilterSwshVolumeQuantity<Tags::KleinGordonPi>,
       ::Actions::MutateApply<
           CalculateScriPlusValue<::Tags::dt<Tags::InertialRetardedTime>>>,
@@ -169,10 +165,6 @@ struct KleinGordonCharacteristicEvolution
                       tmpl::bind<hypersurface_computation, tmpl::_1>>,
       klein_gordon_hypersurface_computation,
       Actions::FilterSwshVolumeQuantity<Tags::BondiH>,
-      // `Tags::Dy<Tags::BondiH>` is not an input to any hypersurface
-      // integration (unlike the other Bondi radial derivatives), so it is
-      // computed explicitly here, from the filtered `H`, for volume output.
-      ::Actions::MutateApply<PreSwshDerivatives<Tags::Dy<Tags::BondiH>>>,
       Actions::FilterSwshVolumeQuantity<Tags::KleinGordonPi>,
       compute_scri_quantities_and_observe,
       ::Actions::MutateApply<ChangeStepSize<

--- a/src/Evolution/Systems/Cce/Events/ObserveFields.hpp
+++ b/src/Evolution/Systems/Cce/Events/ObserveFields.hpp
@@ -234,28 +234,30 @@ class ObserveFields : public Event {
                 const std::vector<std::string>& variables_to_observe,
                 const Options::Context& context = {});
 
-  using compute_tags_for_observation_box =
-    tmpl::list<Tags::Psi0Compute, Tags::Psi1Compute, Tags::Psi2Compute,
-               Tags::SwshDerivativeCompute<Tags::BondiJ,
-                                                  Spectral::Swsh::Tags::Eth>,
-               Tags::SwshDerivativeCompute<Tags::BondiW,
-                                                  Spectral::Swsh::Tags::Eth>,
-               Tags::NewmanPenroseAlphaCompute, Tags::NewmanPenroseBetaCompute,
-               Tags::NewmanPenroseGammaCompute,
-               Tags::NewmanPenroseEpsilonCompute,
-               // Tags::NewmanPenroseKappaCompute,
-               // in our choice of tetrad, \kappa=0
-               Tags::NewmanPenroseTauCompute,
-               Tags::NewmanPenroseSigmaCompute, Tags::NewmanPenroseRhoCompute,
-               Tags::NewmanPenrosePiCompute, Tags::NewmanPenroseNuCompute,
-               Tags::NewmanPenroseMuCompute, Tags::NewmanPenroseLambdaCompute,
-               Tags::SwshDerivativeCompute<Tags::NewmanPenrosePi,
-                                                 Spectral::Swsh::Tags::Eth>,
-               Tags::SwshDerivativeCompute<Tags::NewmanPenrosePi,
-                                                 Spectral::Swsh::Tags::Ethbar>,
-               Tags::DyCompute<Tags::NewmanPenrosePi>,
-               Tags::DyCompute<Tags::NewmanPenroseMu>
-      >;
+  using compute_tags_for_observation_box = tmpl::list<
+      Tags::Psi0Compute, Tags::Psi1Compute, Tags::Psi2Compute,
+      Tags::SwshDerivativeCompute<Tags::BondiJ, Spectral::Swsh::Tags::Eth>,
+      Tags::SwshDerivativeCompute<Tags::BondiW, Spectral::Swsh::Tags::Eth>,
+      Tags::NewmanPenroseAlphaCompute, Tags::NewmanPenroseBetaCompute,
+      Tags::NewmanPenroseGammaCompute, Tags::NewmanPenroseEpsilonCompute,
+      // Tags::NewmanPenroseKappaCompute,
+      // in our choice of tetrad, \kappa=0
+      Tags::NewmanPenroseTauCompute, Tags::NewmanPenroseSigmaCompute,
+      Tags::NewmanPenroseRhoCompute, Tags::NewmanPenrosePiCompute,
+      Tags::NewmanPenroseNuCompute, Tags::NewmanPenroseMuCompute,
+      Tags::NewmanPenroseLambdaCompute,
+      Tags::SwshDerivativeCompute<Tags::NewmanPenrosePi,
+                                  Spectral::Swsh::Tags::Eth>,
+      Tags::SwshDerivativeCompute<Tags::NewmanPenrosePi,
+                                  Spectral::Swsh::Tags::Ethbar>,
+      Tags::DyCompute<Tags::NewmanPenrosePi>,
+      Tags::DyCompute<Tags::NewmanPenroseMu>,
+      // H is the final hypersurface quantity, so unlike the other
+      // Bondi variables its radial derivative is not needed by (and
+      // is not computed during) the hypersurface integration steps.
+      // It is only of interest as volume output, so it is computed
+      // on demand here rather than stored in the evolution DataBox.
+      Tags::DyCompute<Tags::BondiH>>;
 
   using return_tags = tmpl::list<>;
   using argument_tags = tmpl::list<::Tags::ObservationBox>;

--- a/src/Evolution/Systems/Cce/IntegrandInputSteps.hpp
+++ b/src/Evolution/Systems/Cce/IntegrandInputSteps.hpp
@@ -364,11 +364,18 @@ using all_transform_buffer_tags =
                    tmpl::_1>>>>;
 
 namespace detail {
+// `Tags::BondiH` contributes no additional tags: `H` itself is stored as the
+// time derivative of the evolved `J`, and its radial derivative is not needed
+// by any hypersurface integration step. `Tags::Dy<Tags::BondiH>` is computed
+// on demand for volume observation via `Tags::DyCompute<Tags::BondiH>` in
+// `Cce::Events::ObserveFields`, so it must not also be stored here (a compute
+// tag whose base tag is already in the DataBox is an error when building the
+// `ObservationBox`).
 template <typename Tag>
 struct additional_pre_swsh_derivative_tags_for {
-  using type = tmpl::conditional_t<std::is_same_v<Tag, Tags::BondiH>,
-                                   tmpl::list<Tags::Dy<Tag>>,
-                                   tmpl::list<Tag, Tags::Dy<Tag>>>;
+  using type =
+      tmpl::conditional_t<std::is_same_v<Tag, Tags::BondiH>, tmpl::list<>,
+                          tmpl::list<Tag, Tags::Dy<Tag>>>;
 };
 }  // namespace detail
 

--- a/tests/Unit/Evolution/Systems/Cce/Events/Test_ObserveFields.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Events/Test_ObserveFields.cpp
@@ -148,17 +148,18 @@ struct MockElement {
       Parallel::Phase::Initialization,
       tmpl::list<ActionTesting::InitializeDataBox<tmpl::push_back<
           tmpl::list_difference<
-            ObserveFields::available_tags_to_observe,
-            tmpl::list<
-              Tags::Psi0, Tags::Psi1, Tags::Psi2,
-              Tags::NewmanPenroseAlpha, Tags::NewmanPenroseBeta,
-              Tags::NewmanPenroseGamma, Tags::NewmanPenroseEpsilon,
-              // Tags::NewmanPenroseKappa, // in our tetrad, \kappa=0
-              Tags::NewmanPenroseTau, Tags::NewmanPenroseSigma,
-              Tags::NewmanPenroseRho,
-              Tags::NewmanPenrosePi, Tags::NewmanPenroseNu,
-              Tags::NewmanPenroseMu, Tags::NewmanPenroseLambda
-              >>,
+              ObserveFields::available_tags_to_observe,
+              tmpl::list<Tags::Psi0, Tags::Psi1, Tags::Psi2,
+                         Tags::NewmanPenroseAlpha, Tags::NewmanPenroseBeta,
+                         Tags::NewmanPenroseGamma, Tags::NewmanPenroseEpsilon,
+                         // Tags::NewmanPenroseKappa, // in our tetrad, \kappa=0
+                         Tags::NewmanPenroseTau, Tags::NewmanPenroseSigma,
+                         Tags::NewmanPenroseRho, Tags::NewmanPenrosePi,
+                         Tags::NewmanPenroseNu, Tags::NewmanPenroseMu,
+                         Tags::NewmanPenroseLambda,
+                         // provided by Tags::DyCompute<Tags::BondiH> in the
+                         // ObservationBox rather than stored in the DataBox
+                         Tags::Dy<Tags::BondiH>>>,
           Spectral::Swsh::Tags::Derivative<Tags::BondiBeta,
                                            Spectral::Swsh::Tags::Eth>,
           Spectral::Swsh::Tags::Derivative<Tags::Dy<Tags::BondiBeta>,
@@ -169,8 +170,7 @@ struct MockElement {
                                            Spectral::Swsh::Tags::Ethbar>,
           Spectral::Swsh::Tags::Derivative<Tags::BondiU,
                                            Spectral::Swsh::Tags::Eth>,
-          Tags::Exp2Beta,
-          Tags::BondiK, Tags::LMax, Tags::NumberOfRadialPoints,
+          Tags::Exp2Beta, Tags::BondiK, Tags::LMax, Tags::NumberOfRadialPoints,
           ::Tags::Time>>>>>;
 };
 
@@ -243,27 +243,22 @@ void test(const bool write_synchronously) {
   set_number(::Tags::Time{}, time);
   size_data(Tags::ComplexInertialRetardedTime{}, num_angular_grid_points);
 
-  tmpl::for_each<
-      tmpl::list<Tags::BondiJ, Tags::OneMinusY,
-                 Tags::Dy<Tags::BondiJ>, Tags::Dy<Tags::Dy<Tags::BondiJ>>,
-                 Tags::BondiK, Tags::BondiQ, Tags::Dy<Tags::BondiQ>,
-                 Tags::EthRDividedByR,
-                 Tags::BondiBeta, Tags::Dy<Tags::BondiBeta>,
-                 Tags::BondiH, Tags::Dy<Tags::BondiH>,
-                 Tags::BondiU, Tags::Dy<Tags::BondiU>,
-                 Tags::BondiW, Tags::Dy<Tags::BondiW>,
-                 Spectral::Swsh::Tags::Derivative<Tags::BondiBeta,
-                                                  Spectral::Swsh::Tags::Eth>,
-                 Spectral::Swsh::Tags::Derivative<Tags::Dy<Tags::BondiBeta>,
-                                                  Spectral::Swsh::Tags::Eth>,
-                 Spectral::Swsh::Tags::Derivative<Tags::BondiU,
-                                                  Spectral::Swsh::Tags::Ethbar>,
-                 Spectral::Swsh::Tags::Derivative<Tags::BondiJ,
-                                                  Spectral::Swsh::Tags::Ethbar>,
-                 Spectral::Swsh::Tags::Derivative<Tags::BondiU,
-                                                  Spectral::Swsh::Tags::Eth>,
-                 Tags::Exp2Beta,
-                 Tags::BondiR>>([&size_data](auto tag_v) {
+  tmpl::for_each<tmpl::list<
+      Tags::BondiJ, Tags::OneMinusY, Tags::Dy<Tags::BondiJ>,
+      Tags::Dy<Tags::Dy<Tags::BondiJ>>, Tags::BondiK, Tags::BondiQ,
+      Tags::Dy<Tags::BondiQ>, Tags::EthRDividedByR, Tags::BondiBeta,
+      Tags::Dy<Tags::BondiBeta>, Tags::BondiH, Tags::BondiU,
+      Tags::Dy<Tags::BondiU>, Tags::BondiW, Tags::Dy<Tags::BondiW>,
+      Spectral::Swsh::Tags::Derivative<Tags::BondiBeta,
+                                       Spectral::Swsh::Tags::Eth>,
+      Spectral::Swsh::Tags::Derivative<Tags::Dy<Tags::BondiBeta>,
+                                       Spectral::Swsh::Tags::Eth>,
+      Spectral::Swsh::Tags::Derivative<Tags::BondiU,
+                                       Spectral::Swsh::Tags::Ethbar>,
+      Spectral::Swsh::Tags::Derivative<Tags::BondiJ,
+                                       Spectral::Swsh::Tags::Ethbar>,
+      Spectral::Swsh::Tags::Derivative<Tags::BondiU, Spectral::Swsh::Tags::Eth>,
+      Tags::Exp2Beta, Tags::BondiR>>([&size_data](auto tag_v) {
     using tag = tmpl::type_from<decltype(tag_v)>;
     size_data(tag{}, num_volume_grid_points);
   });


### PR DESCRIPTION
Follow-up to #7353, which computed Tags::Dy<Tags::BondiH> eagerly in the evolution action lists every step, whether or not it was requested as volume output.

Since Dy(H) is not an input to any hypersurface integration and is only of interest as a volume diagnostic, compute it lazily instead via Tags::DyCompute<Tags::BondiH> in the ObservationBox of Cce::Events::ObserveFields, following the existing pattern used for the Weyl scalars and Newman-Penrose quantities. It is now evaluated only when 'Dy(H)' appears in VariablesToObserve.

This also removes Tags::Dy<Tags::BondiH> from the evolution DataBox storage (it has no other consumer), which both saves memory and is required for the ObservationBox: a compute tag whose base tag is already in the DataBox is an error.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
