### PR TITLE
GH TimeDerivative Optimizations

### DIFF
--- a/src/Evolution/Systems/GeneralizedHarmonic/DuDtTempTags.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/DuDtTempTags.hpp
@@ -85,5 +85,11 @@ template <size_t Dim>
 struct SpacetimeChristoffelFirstKindThirdIndexUp : db::SimpleTag {
   using type = tnsr::abC<DataVector, Dim, Frame::Inertial>;
 };
+
+/// \f$2H^a\f$
+template <size_t Dim>
+struct TwoGaugeHUp : db::SimpleTag {
+  using type = tnsr::A<DataVector, Dim, Frame::Inertial>;
+};
 }  // namespace Tags
 }  // namespace gh

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedHarmonic.cpp
@@ -18,7 +18,6 @@
 #include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/HalfPiPhiTwoNormals.hpp"
 #include "PointwiseFunctions/GeneralRelativity/DerivativesOfSpacetimeMetric.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/DerivSpatialMetric.hpp"
-#include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpacetimeDerivOfDetSpatialMetric.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpacetimeDerivativeOfSpacetimeMetric.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpatialDerivOfLapse.hpp"
 #include "PointwiseFunctions/GeneralRelativity/GeneralizedHarmonic/SpatialDerivOfShift.hpp"
@@ -113,9 +112,6 @@ void damped_harmonic_impl(
       ::Tags::TempScalar<9>, ::Tags::TempScalar<10>, ::Tags::TempScalar<11>,
       ::Tags::TempScalar<12>, ::Tags::TempScalar<13>, ::Tags::TempScalar<14>,
       ::Tags::Tempa<15, SpatialDim, Frame>,
-      ::Tags::Tempa<16, SpatialDim, Frame>,
-      ::Tags::Tempa<17, SpatialDim, Frame>,
-      ::Tags::Tempa<18, SpatialDim, Frame>,
       ::Tags::Tempa<19, SpatialDim, Frame>,
       ::Tags::Tempa<20, SpatialDim, Frame>,
       ::Tags::Tempa<21, SpatialDim, Frame>,
@@ -129,7 +125,7 @@ void damped_harmonic_impl(
       ::Tags::Tempab<35, SpatialDim, Frame>,
       ::Tags::Tempa<36, SpatialDim, Frame>,
       ::Tags::Tempab<37, SpatialDim, Frame>, ::Tags::TempScalar<38>,
-      ::Tags::Tempa<39, SpatialDim, Frame>, ::Tags::TempScalar<40>,
+      ::Tags::Tempa<39, SpatialDim, Frame>,
       ::Tags::Tempa<41, SpatialDim, Frame>, ::Tags::TempScalar<42>,
       ::Tags::Tempa<43, SpatialDim, Frame>, ::Tags::TempScalar<44>,
       ::Tags::TempScalar<45>, ::Tags::TempScalar<46>, ::Tags::TempScalar<47>>>
@@ -142,12 +138,9 @@ void damped_harmonic_impl(
   auto& mu_S = get<::Tags::TempScalar<10>>(buffer);
   auto& mu_L2 = get<::Tags::TempScalar<11>>(buffer);
   auto& mu_S_over_lapse = get<::Tags::TempScalar<12>>(buffer);
-  auto& mu1 = get<::Tags::TempScalar<13>>(buffer);
-  auto& mu2 = get<::Tags::TempScalar<14>>(buffer);
-  auto& d4_weight = get<::Tags::Tempa<15, SpatialDim, Frame>>(buffer);
-  auto& d4_RW_L1 = get<::Tags::Tempa<16, SpatialDim, Frame>>(buffer);
-  auto& d4_RW_S = get<::Tags::Tempa<17, SpatialDim, Frame>>(buffer);
-  auto& d4_RW_L2 = get<::Tags::Tempa<18, SpatialDim, Frame>>(buffer);
+  auto& weighted_amp_L1 = get<::Tags::TempScalar<13>>(buffer);
+  auto& weighted_amp_S = get<::Tags::TempScalar<14>>(buffer);
+  auto& d4_rollon_weight = get<::Tags::Tempa<15, SpatialDim, Frame>>(buffer);
   auto& d4_mu_S = get<::Tags::Tempa<19, SpatialDim, Frame>>(buffer);
   auto& d4_mu1 = get<::Tags::Tempa<20, SpatialDim, Frame>>(buffer);
   auto& d4_mu2 = get<::Tags::Tempa<21, SpatialDim, Frame>>(buffer);
@@ -165,9 +158,9 @@ void damped_harmonic_impl(
 
   auto& dt_lapse = get<::Tags::TempScalar<38>>(buffer);
   auto& d_lapse_by_lapse = get<::Tags::Tempa<39, SpatialDim, Frame>>(buffer);
-  auto& det_spatial_metric = get<::Tags::TempScalar<40>>(buffer);
-  auto& d_g_by_det = get<::Tags::Tempa<41, SpatialDim, Frame>>(buffer);
-  auto& logfac = get<::Tags::TempScalar<42>>(buffer);
+  auto& d4_log_det_spatial_metric =
+      get<::Tags::Tempa<41, SpatialDim, Frame>>(buffer);
+  auto& weighted_amp_L2 = get<::Tags::TempScalar<42>>(buffer);
   auto& d_logfac = get<::Tags::Tempa<43, SpatialDim, Frame>>(buffer);
   auto& prefac_log = get<::Tags::TempScalar<44>>(buffer);
 
@@ -183,17 +176,6 @@ void damped_harmonic_impl(
                       spacetime_metric.get(i + 1, j + 1), 0, num_points);
     }
   }
-  // We need \f$ \partial_a \gamma_{bi} = \partial_a g_{bi} \f$. Here we
-  // use `derivatives_of_spacetime_metric` to get \f$ \partial_a g_{bc}\f$
-  // instead, and use only the derivatives of \f$ \gamma_{bi}\f$.
-  const tnsr::ii<DataVector, SpatialDim, Frame> d0_spatial_metric{};
-  for (size_t i = 0; i < SpatialDim; ++i) {
-    for (size_t j = i; j < SpatialDim; ++j) {
-      make_const_view(make_not_null(&d0_spatial_metric.get(i, j)),
-                      d4_spacetime_metric.get(0, i + 1, j + 1), 0, num_points);
-    }
-  }
-
   // commonly used terms
   constexpr auto exp_fac_1 = 0.5;
   constexpr auto exp_fac_2 = 0.;
@@ -217,18 +199,16 @@ void damped_harmonic_impl(
   get(pow3) = integer_pow(get(log_fac_2), exp_L2);
 
   // coeffs that enter gauge source function
-  get(mu_L1) = amp_coef_L1 * roll_on * get(weight) * get(pow1);
-  get(mu_S) = amp_coef_S * roll_on * get(weight) * get(pow2);
-  get(mu_L2) = amp_coef_L2 * roll_on * get(weight) * get(pow3);
+  get(weighted_amp_L1) = amp_coef_L1 * roll_on * get(weight);
+  get(weighted_amp_S) = amp_coef_S * roll_on * get(weight);
+  get(weighted_amp_L2) = amp_coef_L2 * roll_on * get(weight);
+  get(mu_L1) = get(weighted_amp_L1) * get(pow1);
+  get(mu_S) = get(weighted_amp_S) * get(pow2);
+  get(mu_L2) = get(weighted_amp_L2) * get(pow3);
   get(mu_S_over_lapse) = get(mu_S) * get(one_over_lapse);
 
-  // Calc \f$ \mu_1 = \mu_{L1} \log(\sqrt{\gamma}/\alpha) = R W
-  // \log(\sqrt{\gamma}/\alpha)^5\f$
-  get(mu1) = get(mu_L1) * get(log_fac_1);
-
-  // Calc \f$ \mu_2 = \mu_{L2} \log(1/\alpha) = R W \log(1/\alpha)^5\f$
-  get(mu2) = get(mu_L2) * get(log_fac_2);
-
+  // Calc \f$ \mu_1 + \mu_2 =
+  // \mu_{L1} \log(\sqrt{\gamma}/\alpha) + \mu_{L2} \log(1/\alpha) \f$.
   get(prefac) = get(mu_L1) * get(log_fac_1) + get(mu_L2) * get(log_fac_2);
 
   // Compute g_{ai} shift^i
@@ -258,20 +238,13 @@ void damped_harmonic_impl(
 
   // Calc \f$ \partial_a [R W] \f$
   DampedHarmonicGauge_detail::spacetime_deriv_of_spatial_weight_function<
-      DataVector, SpatialDim, Frame>(make_not_null(&d4_weight), coords, sigma_r,
-                                     weight);
-  d4_RW_L1 = d4_weight;
-  d4_RW_S = d4_weight;
-  d4_RW_L2 = d4_weight;
+      DataVector, SpatialDim, Frame>(make_not_null(&d4_rollon_weight), coords,
+                                     sigma_r, weight);
   if constexpr (UseRollon) {
     for (size_t a = 0; a < SpatialDim + 1; ++a) {
-      d4_RW_L1.get(a) *= roll_on;
-      d4_RW_S.get(a) *= roll_on;
-      d4_RW_L2.get(a) *= roll_on;
+      d4_rollon_weight.get(a) *= roll_on;
     }
-    get<0>(d4_RW_L1) += get(weight) * d0_roll_on;
-    get<0>(d4_RW_S) += get(weight) * d0_roll_on;
-    get<0>(d4_RW_L2) += get(weight) * d0_roll_on;
+    get<0>(d4_rollon_weight) += get(weight) * d0_roll_on;
   }
   tenex::evaluate(make_not_null(&dt_lapse),
                   lapse() * (lapse() * half_pi_two_normals() -
@@ -280,26 +253,38 @@ void damped_harmonic_impl(
   for (size_t i = 0; i < SpatialDim; ++i) {
     d_lapse_by_lapse.get(i + 1) = -half_phi_two_normals.get(i);
   }
-  get(det_spatial_metric) = square(get(sqrt_det_spatial_metric));
-  spacetime_deriv_of_det_spatial_metric<DataVector, SpatialDim, Frame>(
-      make_not_null(&d_g_by_det), sqrt_det_spatial_metric,
-      inverse_spatial_metric, d0_spatial_metric, phi);
+  // Compute \f$\partial_a \ln(\det\gamma) = \gamma^{jk}\partial_a
+  // \gamma_{jk}\f$ directly from the spatial-spatial block of the spacetime
+  // metric derivative
+  // \f$\partial_a\gamma_{jk} = \partial_a g_{jk}\f$. This avoids computing
+  // \f$\partial_a(\det\gamma)\f$ and dividing by \f$\det\gamma\f$ (the multiply
+  // and divide cancel), and also avoids the buffer allocation and metric-
+  // derivative copy inside `spacetime_deriv_of_det_spatial_metric`.
   for (size_t a = 0; a < SpatialDim + 1; ++a) {
-    d_g_by_det.get(a) = d_g_by_det.get(a) / get(det_spatial_metric);
-  }
-  const auto spacetime_deriv_of_power_log_factor_metric_lapse =
-      [&d_lapse_by_lapse, &d_g_by_det, &lapse, &sqrt_det_spatial_metric,
-       &prefac_log, &d_logfac,
-       &logfac](gsl::not_null<tnsr::a<DataVector, SpatialDim, Frame>*> result,
-                double g_exponent, int exponent) -> void {
-    for (size_t a = 0; a < SpatialDim + 1; ++a) {
-      d_logfac.get(a) =
-          g_exponent * d_g_by_det.get(a) - d_lapse_by_lapse.get(a);
+    d4_log_det_spatial_metric.get(a) =
+        inverse_spatial_metric.get(0, 0) * d4_spacetime_metric.get(a, 1, 1);
+    for (size_t j = 0; j < SpatialDim; ++j) {
+      for (size_t k = j; k < SpatialDim; ++k) {
+        if (j != 0 or k != 0) {
+          d4_log_det_spatial_metric.get(a) +=
+              (j == k ? 1.0 : 2.0) * inverse_spatial_metric.get(j, k) *
+              d4_spacetime_metric.get(a, j + 1, k + 1);
+        }
+      }
     }
-    DampedHarmonicGauge_detail::log_factor_metric_lapse(
-        make_not_null(&logfac), lapse, sqrt_det_spatial_metric, g_exponent);
-    get(prefac_log) =
-        static_cast<double>(exponent) * integer_pow(get(logfac), exponent - 1);
+  }
+
+  const auto spacetime_deriv_of_power_log_factor_metric_lapse =
+      [&d_lapse_by_lapse, &d4_log_det_spatial_metric, &prefac_log, &d_logfac](
+          gsl::not_null<tnsr::a<DataVector, SpatialDim, Frame>*> result,
+          const Scalar<DataVector>& log_factor, double g_exponent,
+          int exponent) -> void {
+    for (size_t a = 0; a < SpatialDim + 1; ++a) {
+      d_logfac.get(a) = g_exponent * d4_log_det_spatial_metric.get(a) -
+                        d_lapse_by_lapse.get(a);
+    }
+    get(prefac_log) = static_cast<double>(exponent) *
+                      integer_pow(get(log_factor), exponent - 1);
     for (size_t a = 0; a < SpatialDim + 1; ++a) {
       result->get(a) = get(prefac_log) * d_logfac.get(a);
     }
@@ -311,11 +296,11 @@ void damped_harmonic_impl(
   // \partial_a \mu_2 = \partial_a(A_L2 R_L2 W
   //                               \log(1/\alpha)^{1+c_{L2}})
   spacetime_deriv_of_power_log_factor_metric_lapse(
-      make_not_null(&d4_log_fac_mu1), exp_fac_1, exp_L1 + 1);
+      make_not_null(&d4_log_fac_mu1), log_fac_1, exp_fac_1, exp_L1 + 1);
   spacetime_deriv_of_power_log_factor_metric_lapse(
-      make_not_null(&d4_log_fac_muS), exp_fac_1, exp_S);
+      make_not_null(&d4_log_fac_muS), log_fac_1, exp_fac_1, exp_S);
   spacetime_deriv_of_power_log_factor_metric_lapse(
-      make_not_null(&d4_log_fac_mu2), exp_fac_2, exp_L2 + 1);
+      make_not_null(&d4_log_fac_mu2), log_fac_2, exp_fac_2, exp_L2 + 1);
 
   get(pow1) *= get(log_fac_1) * amp_coef_L1;
   get(pow2) *= amp_coef_S;
@@ -323,14 +308,14 @@ void damped_harmonic_impl(
 
   for (size_t a = 0; a < SpatialDim + 1; ++a) {
     // \f$ \partial_a \mu_1 \f$
-    d4_mu1.get(a) = get(pow1) * d4_RW_L1.get(a) +
-                    amp_coef_L1 * roll_on * get(weight) * d4_log_fac_mu1.get(a);
+    d4_mu1.get(a) = get(pow1) * d4_rollon_weight.get(a) +
+                    get(weighted_amp_L1) * d4_log_fac_mu1.get(a);
     // \f$ \partial_a \mu_{S} \f$
-    d4_mu_S.get(a) = d4_RW_S.get(a) * get(pow2) +
-                     amp_coef_S * roll_on * get(weight) * d4_log_fac_muS.get(a);
+    d4_mu_S.get(a) = d4_rollon_weight.get(a) * get(pow2) +
+                     get(weighted_amp_S) * d4_log_fac_muS.get(a);
     // \f$ \partial_a \mu_2 \f$
-    d4_mu2.get(a) = get(pow3) * d4_RW_L2.get(a) +
-                    amp_coef_L2 * roll_on * get(weight) * d4_log_fac_mu2.get(a);
+    d4_mu2.get(a) = get(pow3) * d4_rollon_weight.get(a) +
+                    get(weighted_amp_L2) * d4_log_fac_mu2.get(a);
   }
 
   const tnsr::ijj<DataVector, SpatialDim, Frame> d3_spatial_metric{};
@@ -368,13 +353,13 @@ void damped_harmonic_impl(
   // Calc \f$ \partial_a T2 \f$
   get<0>(dT2) = -(get<0>(d4_mu1) + get<0>(d4_mu2)) * get(lapse)
                 // Note:  \f$ \partial_a n_b = {-\partial_a lapse, 0, 0, 0} \f$
-                - (get(mu1) + get(mu2)) * get<0>(d4_muS_over_lapse);
+                - get(prefac) * get<0>(d4_muS_over_lapse);
 
   for (size_t i = 0; i < SpatialDim; ++i) {
     dT2.get(i + 1) =
         -(d4_mu1.get(i + 1) + d4_mu2.get(i + 1)) * get(lapse)
         // Note:  \f$ \partial_a n_b = {-\partial_a lapse, 0, 0, 0} \f$
-        + (get(mu1) + get(mu2)) * get(lapse) * half_phi_two_normals.get(i);
+        + get(prefac) * get(lapse) * half_phi_two_normals.get(i);
   }
 
   // \f[ \partial_a (\mu_S/\alpha) = (1/\alpha) \partial_a \mu_{S}
@@ -389,13 +374,13 @@ void damped_harmonic_impl(
   //  0.5 * n^a n^b Pi_{ab}
   //  0.5 * n^a n^b Phi_{iab}
   // so we reuse that work by taking them as arguments.
-  get<0>(d4_muS_over_lapse) *= -get(mu_S) * get(one_over_lapse);
+  get<0>(d4_muS_over_lapse) *= -get(mu_S_over_lapse);
   get<0>(d4_muS_over_lapse) += get<0>(d4_mu_S);
   get<0>(d4_muS_over_lapse) *= get(one_over_lapse);
   for (size_t i = 0; i < SpatialDim; ++i) {
     d4_muS_over_lapse.get(i + 1) =
-        get(one_over_lapse) *
-        (d4_mu_S.get(i + 1) + get(mu_S) * half_phi_two_normals.get(i));
+        get(one_over_lapse) * d4_mu_S.get(i + 1) +
+        get(mu_S_over_lapse) * half_phi_two_normals.get(i);
   }
 
   // Calc \f$ \partial_a T3 \f$ (note minus sign)

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedWaveHelpers.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/DampedWaveHelpers.cpp
@@ -26,8 +26,8 @@ template <typename DataType, size_t SpatialDim, typename Frame>
 void spatial_weight_function(const gsl::not_null<Scalar<DataType>*> weight,
                              const tnsr::I<DataType, SpatialDim, Frame>& coords,
                              const double sigma_r) {
-  const auto r_squared = dot_product(coords, coords);
-  get(*weight) = exp(-get(r_squared) / pow<2>(sigma_r));
+  dot_product(weight, coords, coords);
+  get(*weight) = exp(-get(*weight) / pow<2>(sigma_r));
 }
 
 template <typename DataType, size_t SpatialDim, typename Frame>

--- a/src/Evolution/Systems/GeneralizedHarmonic/TimeDerivative.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/TimeDerivative.hpp
@@ -100,9 +100,8 @@ namespace gh {
  * `evolution::dg::Actions::detail::volume_terms()`.
  *
  * \warning When using harmonic gauge,
- * gr::Tags::SqrtDetSpatialMetric<DataVector> and
- * gr::Tags::SpacetimeChristoffelSecondKind<Dim, Frame::Inertial, DataVector>
- * are not computed. In Debug mode, they are filled with with signaling NaNs.
+ * gr::Tags::SqrtDetSpatialMetric<DataVector> is not computed. In Debug mode,
+ * it is filled with signaling NaNs.
  */
 template <class AllSolutionsForChristoffelAnalytic, size_t Dim>
 struct TimeDerivative {
@@ -125,7 +124,6 @@ struct TimeDerivative {
       gr::Tags::SqrtDetSpatialMetric<DataVector>,
       gr::Tags::InverseSpacetimeMetric<DataVector, Dim>,
       gr::Tags::SpacetimeChristoffelFirstKind<DataVector, Dim>,
-      gr::Tags::SpacetimeChristoffelSecondKind<DataVector, Dim>,
       gr::Tags::TraceSpacetimeChristoffelFirstKind<DataVector, Dim>,
       gr::Tags::SpacetimeNormalVector<DataVector, Dim>>;
   using argument_tags =
@@ -172,7 +170,6 @@ struct TimeDerivative {
       gsl::not_null<Scalar<DataVector>*> sqrt_det_spatial_metric,
       gsl::not_null<tnsr::AA<DataVector, Dim>*> inverse_spacetime_metric,
       gsl::not_null<tnsr::abb<DataVector, Dim>*> christoffel_first_kind,
-      gsl::not_null<tnsr::Abb<DataVector, Dim>*> christoffel_second_kind,
       gsl::not_null<tnsr::a<DataVector, Dim>*> trace_christoffel,
       gsl::not_null<tnsr::A<DataVector, Dim>*> normal_spacetime_vector,
       const tnsr::iaa<DataVector, Dim>& d_spacetime_metric,

--- a/src/Evolution/Systems/GeneralizedHarmonic/TimeDerivative.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/TimeDerivative.hpp
@@ -102,6 +102,9 @@ namespace gh {
  * \warning When using harmonic gauge,
  * gr::Tags::SqrtDetSpatialMetric<DataVector> is not computed. In Debug mode,
  * it is filled with signaling NaNs.
+ *
+ * \warning When using harmonic gauge, Tags::TwoGaugeHUp is not computed. In
+ * Debug mode, it is filled with signaling NaNs.
  */
 template <class AllSolutionsForChristoffelAnalytic, size_t Dim>
 struct TimeDerivative {
@@ -124,8 +127,7 @@ struct TimeDerivative {
       gr::Tags::SqrtDetSpatialMetric<DataVector>,
       gr::Tags::InverseSpacetimeMetric<DataVector, Dim>,
       gr::Tags::SpacetimeChristoffelFirstKind<DataVector, Dim>,
-      gr::Tags::TraceSpacetimeChristoffelFirstKind<DataVector, Dim>,
-      gr::Tags::SpacetimeNormalVector<DataVector, Dim>>;
+      Tags::TwoGaugeHUp<Dim>, gr::Tags::SpacetimeNormalVector<DataVector, Dim>>;
   using argument_tags =
       tmpl::list<gr::Tags::SpacetimeMetric<DataVector, Dim>,
                  Tags::Pi<DataVector, Dim>, Tags::Phi<DataVector, Dim>,
@@ -170,7 +172,7 @@ struct TimeDerivative {
       gsl::not_null<Scalar<DataVector>*> sqrt_det_spatial_metric,
       gsl::not_null<tnsr::AA<DataVector, Dim>*> inverse_spacetime_metric,
       gsl::not_null<tnsr::abb<DataVector, Dim>*> christoffel_first_kind,
-      gsl::not_null<tnsr::a<DataVector, Dim>*> trace_christoffel,
+      gsl::not_null<tnsr::A<DataVector, Dim>*> two_gauge_h_up,
       gsl::not_null<tnsr::A<DataVector, Dim>*> normal_spacetime_vector,
       const tnsr::iaa<DataVector, Dim>& d_spacetime_metric,
       const tnsr::iaa<DataVector, Dim>& d_pi,

--- a/src/Evolution/Systems/GeneralizedHarmonic/TimeDerivative.tpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/TimeDerivative.tpp
@@ -8,7 +8,6 @@
 #include <cstddef>
 
 #include "DataStructures/DataVector.hpp"
-#include "DataStructures/Tensor/EagerMath/RaiseOrLowerIndex.hpp"
 #include "DataStructures/Tensor/EagerMath/Trace.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Evolution/DiscontinuousGalerkin/TimeDerivativeDecisions.hpp"
@@ -66,7 +65,6 @@ TimeDerivative<AllSolutionsForChristoffelAnalytic, Dim>::apply(
     const gsl::not_null<Scalar<DataVector>*> sqrt_det_spatial_metric,
     const gsl::not_null<tnsr::AA<DataVector, Dim>*> inverse_spacetime_metric,
     const gsl::not_null<tnsr::abb<DataVector, Dim>*> christoffel_first_kind,
-    const gsl::not_null<tnsr::Abb<DataVector, Dim>*> christoffel_second_kind,
     const gsl::not_null<tnsr::a<DataVector, Dim>*> trace_christoffel,
     const gsl::not_null<tnsr::A<DataVector, Dim>*> normal_spacetime_vector,
     const tnsr::iaa<DataVector, Dim>& d_spacetime_metric,
@@ -113,21 +111,19 @@ TimeDerivative<AllSolutionsForChristoffelAnalytic, Dim>::apply(
     }
   }
 
-  const std::optional da_spacetime_metric{tnsr::abb<DataVector, Dim>{}};
+  const tnsr::abb<DataVector, Dim> da_spacetime_metric{};
   for (size_t a = 0; a < Dim + 1; ++a) {
     for (size_t b = a; b < Dim + 1; ++b) {
-      make_const_view(make_not_null(&da_spacetime_metric.value().get(0, a, b)),
+      make_const_view(make_not_null(&da_spacetime_metric.get(0, a, b)),
                       dt_spacetime_metric->get(a, b), 0, number_of_points);
       for (size_t i = 0; i < Dim; ++i) {
-        make_const_view(
-            make_not_null(&da_spacetime_metric.value().get(i + 1, a, b)),
-            phi.get(i, a, b), 0, number_of_points);
+        make_const_view(make_not_null(&da_spacetime_metric.get(i + 1, a, b)),
+                        phi.get(i, a, b), 0, number_of_points);
       }
     }
   }
 
-  gr::christoffel_first_kind(christoffel_first_kind,
-                             da_spacetime_metric.value());
+  gr::christoffel_first_kind(christoffel_first_kind, da_spacetime_metric);
   trace_last_indices(trace_christoffel, *christoffel_first_kind,
                      *inverse_spacetime_metric);
   gr::spacetime_normal_vector(normal_spacetime_vector, *lapse, *shift);
@@ -260,12 +256,10 @@ TimeDerivative<AllSolutionsForChristoffelAnalytic, Dim>::apply(
   if (not using_harmonic_gauge) {
     // Compute gauge condition.
     get(*sqrt_det_spatial_metric) = sqrt(get(*det_spatial_metric));
-    raise_or_lower_first_index(christoffel_second_kind, *christoffel_first_kind,
-                               *inverse_spacetime_metric);
   }
   gauges::dispatch<AllSolutionsForChristoffelAnalytic, Dim>(
       gauge_function, spacetime_deriv_gauge_function, *lapse, *shift,
-      *sqrt_det_spatial_metric, *inverse_spatial_metric, *da_spacetime_metric,
+      *sqrt_det_spatial_metric, *inverse_spatial_metric, da_spacetime_metric,
       *half_pi_two_normals, *half_phi_two_normals, spacetime_metric, phi, mesh,
       time, inertial_coords, inverse_jacobian, gauge_condition);
   if (not using_harmonic_gauge) {
@@ -273,6 +267,20 @@ TimeDerivative<AllSolutionsForChristoffelAnalytic, Dim>::apply(
     // the other temporary tags.
     for (size_t nu = 0; nu < Dim + 1; ++nu) {
       gauge_constraint->get(nu) += gauge_function->get(nu);
+    }
+
+    // Reuse `trace_christoffel` as scratch space for 2 H^a.  This avoids
+    // constructing the full Christoffel symbol of the second kind just to
+    // contract it with H_a below.
+    for (size_t alpha = 0; alpha < Dim + 1; ++alpha) {
+      trace_christoffel->get(alpha) = 2.0 *
+                                      inverse_spacetime_metric->get(alpha, 0) *
+                                      gauge_function->get(0);
+      for (size_t beta = 1; beta < Dim + 1; ++beta) {
+        trace_christoffel->get(alpha) +=
+            2.0 * inverse_spacetime_metric->get(alpha, beta) *
+            gauge_function->get(beta);
+      }
     }
   }
 
@@ -282,12 +290,6 @@ TimeDerivative<AllSolutionsForChristoffelAnalytic, Dim>::apply(
     get(*normal_dot_gauge_constraint) +=
         normal_spacetime_vector->get(mu) * gauge_constraint->get(mu);
   }
-
-  // Invalidate da_spacetime_metric since we will be modifying some of the
-  // data it points to.
-  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
-  const_cast<std::optional<tnsr::abb<DataVector, Dim>>&>(da_spacetime_metric) =
-      std::nullopt;
 
   // Here are the actual equations
 
@@ -346,9 +348,8 @@ TimeDerivative<AllSolutionsForChristoffelAnalytic, Dim>::apply(
       for (size_t delta = 0; delta < Dim + 1; ++delta) {
         dt_pi->get(mu, nu) -= 2 * pi.get(mu, delta) * pi_2_up->get(nu, delta);
         if (not using_harmonic_gauge) {
-          dt_pi->get(mu, nu) += 2 *
-                                christoffel_second_kind->get(delta, mu, nu) *
-                                gauge_function->get(delta);
+          dt_pi->get(mu, nu) += christoffel_first_kind->get(delta, mu, nu) *
+                                trace_christoffel->get(delta);
         }
         for (size_t n = 0; n < Dim; ++n) {
           dt_pi->get(mu, nu) +=

--- a/src/Evolution/Systems/GeneralizedHarmonic/TimeDerivative.tpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/TimeDerivative.tpp
@@ -8,7 +8,6 @@
 #include <cstddef>
 
 #include "DataStructures/DataVector.hpp"
-#include "DataStructures/Tensor/EagerMath/Trace.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Evolution/DiscontinuousGalerkin/TimeDerivativeDecisions.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/DuDtTempTags.hpp"
@@ -124,8 +123,6 @@ TimeDerivative<AllSolutionsForChristoffelAnalytic, Dim>::apply(
   }
 
   gr::christoffel_first_kind(christoffel_first_kind, da_spacetime_metric);
-  trace_last_indices(trace_christoffel, *christoffel_first_kind,
-                     *inverse_spacetime_metric);
   gr::spacetime_normal_vector(normal_spacetime_vector, *lapse, *shift);
 
   get(*gamma1gamma2) = get(gamma1) * get(gamma2);
@@ -180,6 +177,16 @@ TimeDerivative<AllSolutionsForChristoffelAnalytic, Dim>::apply(
               christoffel_first_kind->get(mu, nu, beta);
         }
       }
+      // The trace of the Christoffel symbol of the first kind,
+      // \f$g^{bc}\Gamma_{abc} = \Gamma_{ab}{}^{b}\f$, is the diagonal (in the
+      // traced-and-raised index) of `christoffel_first_kind_3_up`. Accumulate
+      // it here to avoid a separate full contraction over the metric.
+      if (nu == 0) {
+        gauge_constraint->get(mu) = christoffel_first_kind_3_up->get(mu, 0, 0);
+      } else {
+        gauge_constraint->get(mu) +=
+            christoffel_first_kind_3_up->get(mu, nu, nu);
+      }
     }
   }
 
@@ -233,7 +240,6 @@ TimeDerivative<AllSolutionsForChristoffelAnalytic, Dim>::apply(
   const DataVector& gamma1p1 = get(*gamma1_plus_1);
 
   for (size_t mu = 0; mu < Dim + 1; ++mu) {
-    gauge_constraint->get(mu) = trace_christoffel->get(mu);
     for (size_t nu = mu; nu < Dim + 1; ++nu) {
       shift_dot_three_index_constraint->get(mu, nu) =
           get<0>(*shift) * three_index_constraint->get(0, mu, nu);

--- a/src/Evolution/Systems/GeneralizedHarmonic/TimeDerivative.tpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/TimeDerivative.tpp
@@ -64,7 +64,7 @@ TimeDerivative<AllSolutionsForChristoffelAnalytic, Dim>::apply(
     const gsl::not_null<Scalar<DataVector>*> sqrt_det_spatial_metric,
     const gsl::not_null<tnsr::AA<DataVector, Dim>*> inverse_spacetime_metric,
     const gsl::not_null<tnsr::abb<DataVector, Dim>*> christoffel_first_kind,
-    const gsl::not_null<tnsr::a<DataVector, Dim>*> trace_christoffel,
+    const gsl::not_null<tnsr::A<DataVector, Dim>*> two_gauge_h_up,
     const gsl::not_null<tnsr::A<DataVector, Dim>*> normal_spacetime_vector,
     const tnsr::iaa<DataVector, Dim>& d_spacetime_metric,
     const tnsr::iaa<DataVector, Dim>& d_pi,
@@ -110,19 +110,21 @@ TimeDerivative<AllSolutionsForChristoffelAnalytic, Dim>::apply(
     }
   }
 
-  const tnsr::abb<DataVector, Dim> da_spacetime_metric{};
+  const std::optional da_spacetime_metric{tnsr::abb<DataVector, Dim>{}};
   for (size_t a = 0; a < Dim + 1; ++a) {
     for (size_t b = a; b < Dim + 1; ++b) {
-      make_const_view(make_not_null(&da_spacetime_metric.get(0, a, b)),
+      make_const_view(make_not_null(&da_spacetime_metric.value().get(0, a, b)),
                       dt_spacetime_metric->get(a, b), 0, number_of_points);
       for (size_t i = 0; i < Dim; ++i) {
-        make_const_view(make_not_null(&da_spacetime_metric.get(i + 1, a, b)),
-                        phi.get(i, a, b), 0, number_of_points);
+        make_const_view(
+            make_not_null(&da_spacetime_metric.value().get(i + 1, a, b)),
+            phi.get(i, a, b), 0, number_of_points);
       }
     }
   }
 
-  gr::christoffel_first_kind(christoffel_first_kind, da_spacetime_metric);
+  gr::christoffel_first_kind(christoffel_first_kind,
+                             da_spacetime_metric.value());
   gr::spacetime_normal_vector(normal_spacetime_vector, *lapse, *shift);
 
   get(*gamma1gamma2) = get(gamma1) * get(gamma2);
@@ -265,7 +267,7 @@ TimeDerivative<AllSolutionsForChristoffelAnalytic, Dim>::apply(
   }
   gauges::dispatch<AllSolutionsForChristoffelAnalytic, Dim>(
       gauge_function, spacetime_deriv_gauge_function, *lapse, *shift,
-      *sqrt_det_spatial_metric, *inverse_spatial_metric, da_spacetime_metric,
+      *sqrt_det_spatial_metric, *inverse_spatial_metric, *da_spacetime_metric,
       *half_pi_two_normals, *half_phi_two_normals, spacetime_metric, phi, mesh,
       time, inertial_coords, inverse_jacobian, gauge_condition);
   if (not using_harmonic_gauge) {
@@ -275,15 +277,14 @@ TimeDerivative<AllSolutionsForChristoffelAnalytic, Dim>::apply(
       gauge_constraint->get(nu) += gauge_function->get(nu);
     }
 
-    // Reuse `trace_christoffel` as scratch space for 2 H^a.  This avoids
-    // constructing the full Christoffel symbol of the second kind just to
-    // contract it with H_a below.
+    // Computing 2 H^a avoids constructing the full Christoffel symbol of the
+    // second kind just to contract it with H_a below.
     for (size_t alpha = 0; alpha < Dim + 1; ++alpha) {
-      trace_christoffel->get(alpha) = 2.0 *
-                                      inverse_spacetime_metric->get(alpha, 0) *
-                                      gauge_function->get(0);
+      two_gauge_h_up->get(alpha) = 2.0 *
+                                   inverse_spacetime_metric->get(alpha, 0) *
+                                   gauge_function->get(0);
       for (size_t beta = 1; beta < Dim + 1; ++beta) {
-        trace_christoffel->get(alpha) +=
+        two_gauge_h_up->get(alpha) +=
             2.0 * inverse_spacetime_metric->get(alpha, beta) *
             gauge_function->get(beta);
       }
@@ -296,6 +297,12 @@ TimeDerivative<AllSolutionsForChristoffelAnalytic, Dim>::apply(
     get(*normal_dot_gauge_constraint) +=
         normal_spacetime_vector->get(mu) * gauge_constraint->get(mu);
   }
+
+  // Invalidate da_spacetime_metric since we will be modifying some of the
+  // data it points to.
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+  const_cast<std::optional<tnsr::abb<DataVector, Dim>>&>(da_spacetime_metric) =
+      std::nullopt;
 
   // Here are the actual equations
 
@@ -355,7 +362,7 @@ TimeDerivative<AllSolutionsForChristoffelAnalytic, Dim>::apply(
         dt_pi->get(mu, nu) -= 2 * pi.get(mu, delta) * pi_2_up->get(nu, delta);
         if (not using_harmonic_gauge) {
           dt_pi->get(mu, nu) += christoffel_first_kind->get(delta, mu, nu) *
-                                trace_christoffel->get(delta);
+                                two_gauge_h_up->get(delta);
         }
         for (size_t n = 0; n < Dim; ++n) {
           dt_pi->get(mu, nu) +=

--- a/src/Evolution/Systems/ScalarTensor/TimeDerivative.cpp
+++ b/src/Evolution/Systems/ScalarTensor/TimeDerivative.cpp
@@ -76,7 +76,6 @@ evolution::dg::TimeDerivativeDecisions<3> TimeDerivative::apply(
     const gsl::not_null<Scalar<DataVector>*> sqrt_det_spatial_metric,
     const gsl::not_null<tnsr::AA<DataVector, dim>*> inverse_spacetime_metric,
     const gsl::not_null<tnsr::abb<DataVector, dim>*> christoffel_first_kind,
-    const gsl::not_null<tnsr::Abb<DataVector, dim>*> christoffel_second_kind,
     const gsl::not_null<tnsr::a<DataVector, dim>*> trace_christoffel,
     const gsl::not_null<tnsr::A<DataVector, dim>*> normal_spacetime_vector,
 
@@ -140,8 +139,7 @@ evolution::dg::TimeDerivativeDecisions<3> TimeDerivative::apply(
           three_index_constraint, phi_1_up, phi_3_up,
           christoffel_first_kind_3_up, lapse, shift, inverse_spatial_metric,
           det_spatial_metric, sqrt_det_spatial_metric, inverse_spacetime_metric,
-          christoffel_first_kind, christoffel_second_kind, trace_christoffel,
-          normal_spacetime_vector,
+          christoffel_first_kind, trace_christoffel, normal_spacetime_vector,
 
           // GH argument variables
           d_spacetime_metric, d_pi, d_phi, spacetime_metric, pi, phi, gamma0,

--- a/src/Evolution/Systems/ScalarTensor/TimeDerivative.cpp
+++ b/src/Evolution/Systems/ScalarTensor/TimeDerivative.cpp
@@ -76,7 +76,7 @@ evolution::dg::TimeDerivativeDecisions<3> TimeDerivative::apply(
     const gsl::not_null<Scalar<DataVector>*> sqrt_det_spatial_metric,
     const gsl::not_null<tnsr::AA<DataVector, dim>*> inverse_spacetime_metric,
     const gsl::not_null<tnsr::abb<DataVector, dim>*> christoffel_first_kind,
-    const gsl::not_null<tnsr::a<DataVector, dim>*> trace_christoffel,
+    const gsl::not_null<tnsr::A<DataVector, dim>*> two_gauge_h_up,
     const gsl::not_null<tnsr::A<DataVector, dim>*> normal_spacetime_vector,
 
     // Scalar temporal variables
@@ -139,7 +139,7 @@ evolution::dg::TimeDerivativeDecisions<3> TimeDerivative::apply(
           three_index_constraint, phi_1_up, phi_3_up,
           christoffel_first_kind_3_up, lapse, shift, inverse_spatial_metric,
           det_spatial_metric, sqrt_det_spatial_metric, inverse_spacetime_metric,
-          christoffel_first_kind, trace_christoffel, normal_spacetime_vector,
+          christoffel_first_kind, two_gauge_h_up, normal_spacetime_vector,
 
           // GH argument variables
           d_spacetime_metric, d_pi, d_phi, spacetime_metric, pi, phi, gamma0,

--- a/src/Evolution/Systems/ScalarTensor/TimeDerivative.hpp
+++ b/src/Evolution/Systems/ScalarTensor/TimeDerivative.hpp
@@ -114,7 +114,6 @@ struct TimeDerivative {
       gsl::not_null<Scalar<DataVector>*> sqrt_det_spatial_metric,
       gsl::not_null<tnsr::AA<DataVector, dim>*> inverse_spacetime_metric,
       gsl::not_null<tnsr::abb<DataVector, dim>*> christoffel_first_kind,
-      gsl::not_null<tnsr::Abb<DataVector, dim>*> christoffel_second_kind,
       gsl::not_null<tnsr::a<DataVector, dim>*> trace_christoffel,
       gsl::not_null<tnsr::A<DataVector, dim>*> normal_spacetime_vector,
 

--- a/src/Evolution/Systems/ScalarTensor/TimeDerivative.hpp
+++ b/src/Evolution/Systems/ScalarTensor/TimeDerivative.hpp
@@ -114,7 +114,7 @@ struct TimeDerivative {
       gsl::not_null<Scalar<DataVector>*> sqrt_det_spatial_metric,
       gsl::not_null<tnsr::AA<DataVector, dim>*> inverse_spacetime_metric,
       gsl::not_null<tnsr::abb<DataVector, dim>*> christoffel_first_kind,
-      gsl::not_null<tnsr::a<DataVector, dim>*> trace_christoffel,
+      gsl::not_null<tnsr::A<DataVector, dim>*> two_gauge_h_up,
       gsl::not_null<tnsr::A<DataVector, dim>*> normal_spacetime_vector,
 
       // Scalar temporal variables

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_DuDt.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_DuDt.cpp
@@ -624,7 +624,6 @@ void test_compute_dudt(const gsl::not_null<Generator*> generator) {
       gr::Tags::SqrtDetSpatialMetric<DataVector>,
       gr::Tags::InverseSpacetimeMetric<DataVector, Dim>,
       gr::Tags::SpacetimeChristoffelFirstKind<DataVector, Dim>,
-      gr::Tags::SpacetimeChristoffelSecondKind<DataVector, Dim>,
       gr::Tags::TraceSpacetimeChristoffelFirstKind<DataVector, Dim>,
       gr::Tags::SpacetimeNormalVector<DataVector, Dim>>>
       buffer(mesh.number_of_grid_points());
@@ -666,9 +665,6 @@ void test_compute_dudt(const gsl::not_null<Generator*> generator) {
           &get<gr::Tags::InverseSpacetimeMetric<DataVector, Dim>>(buffer)),
       make_not_null(
           &get<gr::Tags::SpacetimeChristoffelFirstKind<DataVector, Dim>>(
-              buffer)),
-      make_not_null(
-          &get<gr::Tags::SpacetimeChristoffelSecondKind<DataVector, Dim>>(
               buffer)),
       make_not_null(
           &get<gr::Tags::TraceSpacetimeChristoffelFirstKind<DataVector, Dim>>(
@@ -765,9 +761,6 @@ void test_compute_dudt(const gsl::not_null<Generator*> generator) {
           &get<gr::Tags::SpacetimeChristoffelFirstKind<DataVector, Dim>>(
               buffer)),
       make_not_null(
-          &get<gr::Tags::SpacetimeChristoffelSecondKind<DataVector, Dim>>(
-              buffer)),
-      make_not_null(
           &get<gr::Tags::TraceSpacetimeChristoffelFirstKind<DataVector, Dim>>(
               buffer)),
       make_not_null(
@@ -818,9 +811,6 @@ void test_compute_dudt(const gsl::not_null<Generator*> generator) {
           &get<gr::Tags::InverseSpacetimeMetric<DataVector, Dim>>(buffer)),
       make_not_null(
           &get<gr::Tags::SpacetimeChristoffelFirstKind<DataVector, Dim>>(
-              buffer)),
-      make_not_null(
-          &get<gr::Tags::SpacetimeChristoffelSecondKind<DataVector, Dim>>(
               buffer)),
       make_not_null(
           &get<gr::Tags::TraceSpacetimeChristoffelFirstKind<DataVector, Dim>>(

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_DuDt.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_DuDt.cpp
@@ -624,7 +624,7 @@ void test_compute_dudt(const gsl::not_null<Generator*> generator) {
       gr::Tags::SqrtDetSpatialMetric<DataVector>,
       gr::Tags::InverseSpacetimeMetric<DataVector, Dim>,
       gr::Tags::SpacetimeChristoffelFirstKind<DataVector, Dim>,
-      gr::Tags::TraceSpacetimeChristoffelFirstKind<DataVector, Dim>,
+      gh::Tags::TwoGaugeHUp<Dim>,
       gr::Tags::SpacetimeNormalVector<DataVector, Dim>>>
       buffer(mesh.number_of_grid_points());
 
@@ -666,9 +666,7 @@ void test_compute_dudt(const gsl::not_null<Generator*> generator) {
       make_not_null(
           &get<gr::Tags::SpacetimeChristoffelFirstKind<DataVector, Dim>>(
               buffer)),
-      make_not_null(
-          &get<gr::Tags::TraceSpacetimeChristoffelFirstKind<DataVector, Dim>>(
-              buffer)),
+      make_not_null(&get<gh::Tags::TwoGaugeHUp<Dim>>(buffer)),
       make_not_null(
           &get<gr::Tags::SpacetimeNormalVector<DataVector, Dim>>(buffer)),
       d_spacetime_metric, d_pi, d_phi, spacetime_metric, pi, phi, gamma0,
@@ -679,6 +677,13 @@ void test_compute_dudt(const gsl::not_null<Generator*> generator) {
   CHECK_ITERABLE_APPROX(get<gh::Tags::ConstraintGamma2>(buffer), gamma2);
   CHECK_ITERABLE_APPROX((get<gh::Tags::GaugeH<DataVector, Dim>>(buffer)),
                         gauge_h);
+  auto expected_two_gauge_h_up =
+      raise_or_lower_index(gauge_h, inverse_spacetime_metric);
+  for (auto& component : expected_two_gauge_h_up) {
+    component *= 2.0;
+  }
+  CHECK_ITERABLE_APPROX(get<gh::Tags::TwoGaugeHUp<Dim>>(buffer),
+                        expected_two_gauge_h_up);
   Approx custom_approx = Approx::custom().epsilon(1.e-10);
   CHECK_ITERABLE_CUSTOM_APPROX(
       (get<gh::Tags::SpacetimeDerivGaugeH<DataVector, Dim>>(buffer)),
@@ -760,9 +765,7 @@ void test_compute_dudt(const gsl::not_null<Generator*> generator) {
       make_not_null(
           &get<gr::Tags::SpacetimeChristoffelFirstKind<DataVector, Dim>>(
               buffer)),
-      make_not_null(
-          &get<gr::Tags::TraceSpacetimeChristoffelFirstKind<DataVector, Dim>>(
-              buffer)),
+      make_not_null(&get<gh::Tags::TwoGaugeHUp<Dim>>(buffer)),
       make_not_null(
           &get<gr::Tags::SpacetimeNormalVector<DataVector, Dim>>(buffer)),
       d_spacetime_metric, d_pi, d_phi, spacetime_metric, pi, phi, gamma0,
@@ -812,9 +815,7 @@ void test_compute_dudt(const gsl::not_null<Generator*> generator) {
       make_not_null(
           &get<gr::Tags::SpacetimeChristoffelFirstKind<DataVector, Dim>>(
               buffer)),
-      make_not_null(
-          &get<gr::Tags::TraceSpacetimeChristoffelFirstKind<DataVector, Dim>>(
-              buffer)),
+      make_not_null(&get<gh::Tags::TwoGaugeHUp<Dim>>(buffer)),
       make_not_null(
           &get<gr::Tags::SpacetimeNormalVector<DataVector, Dim>>(buffer)),
       d_spacetime_metric, d_pi, d_phi, spacetime_metric, pi, phi, gamma0,

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_DuDtTempTags.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Test_DuDtTempTags.cpp
@@ -34,6 +34,7 @@ void test_simple_tags() {
   TestHelpers::db::test_simple_tag<
       gh::Tags::SpacetimeChristoffelFirstKindThirdIndexUp<Dim>>(
       "SpacetimeChristoffelFirstKindThirdIndexUp");
+  TestHelpers::db::test_simple_tag<gh::Tags::TwoGaugeHUp<Dim>>("TwoGaugeHUp");
 }
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.GeneralizedHarmonic.DuDtTempTags",

--- a/tests/Unit/Evolution/Systems/ScalarTensor/Test_TimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarTensor/Test_TimeDerivative.cpp
@@ -178,9 +178,6 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.ScalarTensor.TimeDerivative",
               &get<gr::Tags::SpacetimeChristoffelFirstKind<DataVector, 3>>(
                   expected_temp_variables)),
           make_not_null(
-              &get<gr::Tags::SpacetimeChristoffelSecondKind<DataVector, 3>>(
-                  expected_temp_variables)),
-          make_not_null(
               &get<gr::Tags::TraceSpacetimeChristoffelFirstKind<DataVector, 3>>(
                   expected_temp_variables)),
           make_not_null(&get<gr::Tags::SpacetimeNormalVector<DataVector, 3>>(
@@ -341,9 +338,6 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.ScalarTensor.TimeDerivative",
           temp_variables)),
       make_not_null(
           &get<gr::Tags::SpacetimeChristoffelFirstKind<DataVector, 3>>(
-              temp_variables)),
-      make_not_null(
-          &get<gr::Tags::SpacetimeChristoffelSecondKind<DataVector, 3>>(
               temp_variables)),
       make_not_null(
           &get<gr::Tags::TraceSpacetimeChristoffelFirstKind<DataVector, 3>>(

--- a/tests/Unit/Evolution/Systems/ScalarTensor/Test_TimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarTensor/Test_TimeDerivative.cpp
@@ -178,8 +178,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.ScalarTensor.TimeDerivative",
               &get<gr::Tags::SpacetimeChristoffelFirstKind<DataVector, 3>>(
                   expected_temp_variables)),
           make_not_null(
-              &get<gr::Tags::TraceSpacetimeChristoffelFirstKind<DataVector, 3>>(
-                  expected_temp_variables)),
+              &get<gh::Tags::TwoGaugeHUp<3>>(expected_temp_variables)),
           make_not_null(&get<gr::Tags::SpacetimeNormalVector<DataVector, 3>>(
               expected_temp_variables)),
           // GH gradient tags
@@ -339,9 +338,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.ScalarTensor.TimeDerivative",
       make_not_null(
           &get<gr::Tags::SpacetimeChristoffelFirstKind<DataVector, 3>>(
               temp_variables)),
-      make_not_null(
-          &get<gr::Tags::TraceSpacetimeChristoffelFirstKind<DataVector, 3>>(
-              temp_variables)),
+      make_not_null(&get<gh::Tags::TwoGaugeHUp<3>>(temp_variables)),
       make_not_null(
           &get<gr::Tags::SpacetimeNormalVector<DataVector, 3>>(temp_variables)),
       // Scalar temporaries

--- a/tests/Unit/Helpers/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/VerifyGrSolution.hpp
+++ b/tests/Unit/Helpers/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/VerifyGrSolution.hpp
@@ -12,7 +12,6 @@
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
-#include "DataStructures/Tensor/EagerMath/RaiseOrLowerIndex.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
@@ -178,8 +177,6 @@ void verify_time_independent_einstein_solution(
       gr::inverse_spacetime_metric(lapse, shift, upper_spatial_metric);
   const auto christoffel_first_kind =
       gr::christoffel_first_kind(d4_spacetime_metric);
-  const auto christoffel_second_kind = raise_or_lower_first_index(
-      christoffel_first_kind, upper_spacetime_metric);
   const auto trace_christoffel_first_kind =
       trace_last_indices(christoffel_first_kind, upper_spacetime_metric);
   const auto normal_vector = gr::spacetime_normal_vector(lapse, shift);
@@ -235,7 +232,6 @@ void verify_time_independent_einstein_solution(
       gr::Tags::SqrtDetSpatialMetric<DataVector>,
       gr::Tags::InverseSpacetimeMetric<DataVector, 3>,
       gr::Tags::SpacetimeChristoffelFirstKind<DataVector, 3>,
-      gr::Tags::SpacetimeChristoffelSecondKind<DataVector, 3>,
       gr::Tags::TraceSpacetimeChristoffelFirstKind<DataVector, 3>,
       gr::Tags::SpacetimeNormalVector<DataVector, 3>,
       gr::Tags::DerivativesOfSpacetimeMetric<DataVector, 3>>>
@@ -277,9 +273,6 @@ void verify_time_independent_einstein_solution(
           &get<gr::Tags::InverseSpacetimeMetric<DataVector, 3>>(buffer)),
       make_not_null(
           &get<gr::Tags::SpacetimeChristoffelFirstKind<DataVector, 3>>(buffer)),
-      make_not_null(
-          &get<gr::Tags::SpacetimeChristoffelSecondKind<DataVector, 3>>(
-              buffer)),
       make_not_null(
           &get<gr::Tags::TraceSpacetimeChristoffelFirstKind<DataVector, 3>>(
               buffer)),

--- a/tests/Unit/Helpers/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/VerifyGrSolution.hpp
+++ b/tests/Unit/Helpers/PointwiseFunctions/AnalyticSolutions/GeneralRelativity/VerifyGrSolution.hpp
@@ -232,8 +232,7 @@ void verify_time_independent_einstein_solution(
       gr::Tags::SqrtDetSpatialMetric<DataVector>,
       gr::Tags::InverseSpacetimeMetric<DataVector, 3>,
       gr::Tags::SpacetimeChristoffelFirstKind<DataVector, 3>,
-      gr::Tags::TraceSpacetimeChristoffelFirstKind<DataVector, 3>,
-      gr::Tags::SpacetimeNormalVector<DataVector, 3>,
+      gh::Tags::TwoGaugeHUp<3>, gr::Tags::SpacetimeNormalVector<DataVector, 3>,
       gr::Tags::DerivativesOfSpacetimeMetric<DataVector, 3>>>
       buffer(mesh.number_of_grid_points());
 
@@ -273,9 +272,7 @@ void verify_time_independent_einstein_solution(
           &get<gr::Tags::InverseSpacetimeMetric<DataVector, 3>>(buffer)),
       make_not_null(
           &get<gr::Tags::SpacetimeChristoffelFirstKind<DataVector, 3>>(buffer)),
-      make_not_null(
-          &get<gr::Tags::TraceSpacetimeChristoffelFirstKind<DataVector, 3>>(
-              buffer)),
+      make_not_null(&get<gh::Tags::TwoGaugeHUp<3>>(buffer)),
       make_not_null(
           &get<gr::Tags::SpacetimeNormalVector<DataVector, 3>>(buffer)),
       d_spacetime_metric, d_pi, d_phi, spacetime_metric, pi, phi, gamma0,


### PR DESCRIPTION
## Proposed changes

I had GPT 5.5 try to see if it could find some more smaller optimizations. 

On an Apple M4 Pro, this speeds up an evaluation of 1000 points by about 11% on single core, on a CaltchHPC core (x86) the speedup is about 13%.

Next, I was going to have Fable check if tiling makes the rhs or partial_derivatives faster though this would be a more involved change.



### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [x] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
