### PR TITLE
Enable AhC adaptive criteria and change termination criteria in pipeline

### DIFF
--- a/support/Pipelines/Bbh/Inspiral.py
+++ b/support/Pipelines/Bbh/Inspiral.py
@@ -109,6 +109,15 @@ def _constraint_damping_params(
     }
 
 
+# Mirror SpEC's TerminateBelowThisL rule"
+def _common_horizon_lmax_threshold(mass_ratio: float) -> int:
+    if mass_ratio > 10.0:
+        return 40
+    if mass_ratio > 4.0:
+        return 21 + int((mass_ratio - 4.0) * 19.99 / 6.0)
+    return 20
+
+
 def inspiral_parameters(
     id_input_file: dict,
     id_metadata: dict,
@@ -234,6 +243,9 @@ def inspiral_parameters(
         # mass ratio 6 to evolve through inspiral stably.
         "ExtraRadRef": round(mass_ratio / 2.0) - 1 if (mass_ratio > 2.0) else 0,
         "ExtraRadPoints": round(mass_ratio / 5.0) if (mass_ratio > 5.0) else 0,
+        "CommonHorizonLMaxThreshold": _common_horizon_lmax_threshold(
+            mass_ratio
+        ),
     }
 
     # Initial functions of time (set from ID or load from evolution data)
@@ -385,6 +397,9 @@ def inspiral_parameters_spec(
         # mass ratio 6 to evolve through inspiral stably.
         "ExtraRadRef": round(mass_ratio / 2.0) - 1 if (mass_ratio > 2.0) else 0,
         "ExtraRadPoints": round(mass_ratio / 5.0) if (mass_ratio > 5.0) else 0,
+        "CommonHorizonLMaxThreshold": _common_horizon_lmax_threshold(
+            mass_ratio
+        ),
     }
 
     # Constraint damping parameters

--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -520,7 +520,7 @@ BbhCompletionCriteria:
   MaxCommonHorizonSuccesses: 100
   GaugeConstraintLinfThreshold: 1.0
   ThreeIndexConstraintLinfThreshold: 1.0
-  CommonHorizonLMaxThreshold: 8
+  CommonHorizonLMaxThreshold: {{ CommonHorizonLMaxThreshold }}
   ConstraintCheckVerbose: false
 
 ApparentHorizons:
@@ -555,6 +555,10 @@ ApparentHorizons:
     BlocksForHorizonFind: ["ObjectBShell", "ObjectBCube"]
   ObservationAhC:
     Criteria:
+      - Residual:
+          MinResidual: 1.0e-4
+          MaxResidual: 1.0e-3
+          MinResolutionL: 6
     InitialGuess:
       LMax: 33
       Radius: 10.0

--- a/tests/support/Pipelines/Bbh/Test_Inspiral.py
+++ b/tests/support/Pipelines/Bbh/Test_Inspiral.py
@@ -14,6 +14,7 @@ from spectre.Informer import unit_test_build_path
 from spectre.Pipelines.Bbh.InitialData import generate_id
 from spectre.Pipelines.Bbh.Inspiral import (
     INSPIRAL_INPUT_FILE_TEMPLATE,
+    _common_horizon_lmax_threshold,
     inspiral_parameters,
     start_inspiral_command,
 )
@@ -107,6 +108,7 @@ class TestInspiral(unittest.TestCase):
         self.assertEqual(params["IncreaseThreshold"], 1.5 / 130 * 2e-3)
         self.assertEqual(params["SizeAMaxTimescale"], 20)
         self.assertEqual(params["SizeBMaxTimescale"], 20)
+        self.assertEqual(params["CommonHorizonLMaxThreshold"], 20)
         # Constraint damping
         self.assertEqual(params["Gamma0Constant"], 0.01)
         self.assertEqual(params["Gamma0LeftAmplitude"], 4.0 / 0.4)
@@ -116,6 +118,21 @@ class TestInspiral(unittest.TestCase):
         self.assertEqual(params["Gamma0OriginAmplitude"], 0.75)
         self.assertEqual(params["Gamma0OriginWidth"], 50.0)
         self.assertEqual(params["Gamma1Width"], 200.0)
+
+    def test_common_horizon_lmax_threshold(self):
+        cases = [
+            (1.0, 20),
+            (4.0, 20),
+            (5.0, 24),
+            (10.0, 40),
+            (12.0, 40),
+        ]
+        for mass_ratio, expected in cases:
+            with self.subTest(mass_ratio=mass_ratio):
+                self.assertEqual(
+                    _common_horizon_lmax_threshold(mass_ratio),
+                    expected,
+                )
 
     def test_cli(self):
         common_args = [
@@ -150,6 +167,20 @@ class TestInspiral(unittest.TestCase):
         self.assertTrue(
             (self.test_dir / "Inspiral/Segment_0000/Inspiral.yaml").exists()
         )
+
+        with open(
+            self.test_dir / "Inspiral/Segment_0000/Inspiral.yaml",
+            "r",
+        ) as open_input_file:
+            docs = list(yaml.safe_load_all(open_input_file))
+
+        self.assertEqual(len(docs), 2)
+        _top_level_doc, inspiral_doc = docs
+        self.assertEqual(
+            inspiral_doc["BbhCompletionCriteria"]["CommonHorizonLMaxThreshold"],
+            20,
+        )
+
         # Test with pipeline directory and lev specified
         try:
             start_inspiral_command(


### PR DESCRIPTION
## Proposed changes

- Add residual criteria for AhC in Inspiral.yaml to enable apparent horizon adaptivity. Specific values taken from SpEC. 
- Change BbhCompletionCriteria: CommonHorizonLMaxThreshold to be dependent on logic taken from SpEC. 
- Add logic to Inspiral.py to calculate CommonHorizonLMaxThreshold based on SpEC logic. 
- Add assertion test in Test_Inspiral.py to test for various mass ratios.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [X] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [X] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

This PR depends conceptually on the ringdown mixed-`l_max` fix, since adaptive `AhC` resolution can otherwise trigger a ringdown transition failure when the fit window contains mixed resolutions. 
See PR #7471

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
