### PR TITLE
Create CylindricalFlatEndcapInterior map

### DIFF
--- a/src/Domain/CoordinateMaps/CMakeLists.txt
+++ b/src/Domain/CoordinateMaps/CMakeLists.txt
@@ -14,6 +14,7 @@ spectre_target_sources(
   CylindricalEndcap.cpp
   CylindricalEndcapHelpers.cpp
   CylindricalFlatEndcap.cpp
+  CylindricalFlatEndcapInterior.cpp
   CylindricalFlatSide.cpp
   CylindricalSide.cpp
   DiscreteRotation.cpp
@@ -56,6 +57,7 @@ spectre_target_headers(
   CylindricalEndcap.hpp
   CylindricalEndcapHelpers.hpp
   CylindricalFlatEndcap.hpp
+  CylindricalFlatEndcapInterior.hpp
   CylindricalFlatSide.hpp
   CylindricalSide.hpp
   DiscreteRotation.hpp

--- a/src/Domain/CoordinateMaps/CylindricalFlatEndcapInterior.cpp
+++ b/src/Domain/CoordinateMaps/CylindricalFlatEndcapInterior.cpp
@@ -1,0 +1,206 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/CoordinateMaps/CylindricalFlatEndcapInterior.hpp"
+
+#include <cmath>
+#include <pup.h>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/FocallyLiftedFlatEndcap.hpp"
+#include "Domain/CoordinateMaps/FocallyLiftedMap.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/DereferenceWrapper.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Serialization/PupStlCpp11.hpp"
+
+namespace domain::CoordinateMaps {
+
+CylindricalFlatEndcapInterior::CylindricalFlatEndcapInterior(
+    const std::array<double, 3>& center_one,
+    const std::array<double, 3>& center_two,
+    const std::array<double, 3>& proj_center, const double z_sphere_extent,
+    const double radius_two) {
+  // Compute the flat disk radius from the desired sphere-cap extent.
+  //
+  // The focal projection from P through a disk rim point at radius r_disk
+  // and z = center_one[2] hits the sphere at z = z_sphere_extent.
+  // Parametrically the ray is: z(t) = proj_center[2] + t*(center_one[2] -
+  // proj_center[2]), with t=1 at the disk.  The sphere is reached at
+  //   t_sphere = (z_sphere_extent - proj_center[2])
+  //              / (center_one[2]  - proj_center[2]),
+  // and the transverse radius on the sphere is
+  //   r_rim = sqrt(radius_two^2 - (z_sphere_extent - center_two[2])^2).
+  // Therefore the disk radius is radius_one = r_rim / t_sphere.
+  const double t_sphere =
+      (z_sphere_extent - proj_center[2]) / (center_one[2] - proj_center[2]);
+  const double dz_extent = z_sphere_extent - center_two[2];
+  const double r_rim =
+      std::sqrt(radius_two * radius_two - dz_extent * dz_extent);
+  const double radius_one = r_rim / t_sphere;
+
+  // source_is_between_focus_and_target = true: the flat disk lies between
+  // the projection point P and the far wall of the sphere.
+  impl_ = FocallyLiftedMap<FocallyLiftedInnerMaps::FlatEndcap>(
+      center_two, proj_center, radius_two, true,
+      FocallyLiftedInnerMaps::FlatEndcap(center_one, radius_one));
+
+#ifdef SPECTRE_DEBUG
+  // There are two types of sanity checks here on the map parameters.
+  // 1) ASSERTS that guarantee that the map is invertible.
+  // 2) ASSERTS that guarantee that the map parameters fall within
+  //    the range tested by the unit tests (which is the range in which
+  //    the map is expected to be used).
+
+  ASSERT(
+      std::abs(dz_extent) < radius_two,
+      "z_sphere_extent ("
+          << z_sphere_extent
+          << ") must lie strictly on the sphere: "
+             "|z_sphere_extent - center_two[2]| must be less than radius_two ("
+          << radius_two << ").");
+
+  ASSERT(
+      t_sphere > 1.0,
+      "The focal parameter t_sphere ("
+          << t_sphere
+          << ") must be greater than 1, meaning the sphere is on the far side "
+             "of the disk from the projection point P.  Check that "
+             "z_sphere_extent ("
+          << z_sphere_extent << ") is beyond the disk at center_one[2] ("
+          << center_one[2] << ") from the projection point at proj_center[2] ("
+          << proj_center[2] << ").");
+
+  const double dist_proj = std::sqrt(square(center_two[0] - proj_center[0]) +
+                                     square(center_two[1] - proj_center[1]) +
+                                     square(center_two[2] - proj_center[2]));
+  ASSERT(dist_proj <= 0.95 * radius_two,
+         "The map has been tested only for the case when proj_center is "
+         "sufficiently inside the sphere (no closer than 95% of the way to "
+         "the surface).");
+
+  // The flat disk must lie inside the sphere, between 5% and 95% of
+  // radius_two below the sphere center (in z).  This is the interior analogue
+  // of CylindricalFlatEndcap's requirement that the flat disk lie outside the
+  // sphere.
+  ASSERT(center_one[2] >= center_two[2] - 0.95 * radius_two and
+             center_one[2] <= center_two[2] - 0.05 * radius_two,
+         "The map has only been tested for the case when the flat disk lies "
+         "inside the sphere, at least 5% of radius_two below the sphere "
+         "center and at most 95% of radius_two below it.");
+
+  ASSERT(center_one[2] < proj_center[2],
+         "The flat disk must be below the projection point (in z), so that "
+         "the flat disk lies between P and the far wall of the sphere.");
+
+  ASSERT(radius_one / radius_two <= 10.0 and radius_two / radius_one <= 10.0,
+         "The map has been tested only for the case when the ratio of "
+         "radius_one to radius_two is between 10 and 1/10.");
+
+  // Every point on the flat disk rim must lie strictly inside the sphere.
+  // The farthest rim point is at distance
+  //   sqrt((|xy_offset| + R1)^2 + dz_disk^2) from center_two,
+  // where xy_offset is the 2D separation of the disk and sphere centres and
+  // dz_disk = center_one[2] - center_two[2].  If this exceeds R2 then some
+  // rays from P through the disk hit the sphere at t < 1 (before the disk),
+  // violating source_is_between_focus_and_target = true and making the
+  // inverse undefined for those source points.
+  const double xy_offset = std::sqrt(square(center_one[0] - center_two[0]) +
+                                     square(center_one[1] - center_two[1]));
+  const double dz_disk = center_one[2] - center_two[2];
+  const double max_rim_dist =
+      std::sqrt(square(xy_offset + radius_one) + square(dz_disk));
+  ASSERT(max_rim_dist < radius_two,
+         "The entire flat disk rim must lie strictly inside the sphere.  "
+         "The farthest rim point is at distance "
+             << max_rim_dist << " from center_two, but radius_two is "
+             << radius_two
+             << ".  Reduce the x,y offset between center_one and center_two, "
+                "or reduce radius_one.");
+#endif
+}
+
+template <typename T>
+std::array<tt::remove_cvref_wrap_t<T>, 3>
+CylindricalFlatEndcapInterior::operator()(
+    const std::array<T, 3>& source_coords) const {
+  // Negate zbar so that zbar=+1 maps to the flat disk and zbar=-1 maps to
+  // the far sphere wall, keeping the Jacobian determinant positive.
+  return impl_.operator()(std::array<tt::remove_cvref_wrap_t<T>, 3>{
+      dereference_wrapper(source_coords[0]),
+      dereference_wrapper(source_coords[1]),
+      -dereference_wrapper(source_coords[2])});
+}
+
+std::optional<std::array<double, 3>> CylindricalFlatEndcapInterior::inverse(
+    const std::array<double, 3>& target_coords) const {
+  auto result = impl_.inverse(target_coords);
+  if (result) {
+    (*result)[2] = -(*result)[2];
+  }
+  return result;
+}
+
+template <typename T>
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame>
+CylindricalFlatEndcapInterior::jacobian(
+    const std::array<T, 3>& source_coords) const {
+  auto jac = impl_.jacobian(std::array<tt::remove_cvref_wrap_t<T>, 3>{
+      dereference_wrapper(source_coords[0]),
+      dereference_wrapper(source_coords[1]),
+      -dereference_wrapper(source_coords[2])});
+  // Chain rule: d/dzbar = -d/dzbar_eff, so negate column 2.
+  for (size_t i = 0; i < 3; ++i) {
+    jac.get(i, 2) = -jac.get(i, 2);
+  }
+  return jac;
+}
+
+template <typename T>
+tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame>
+CylindricalFlatEndcapInterior::inv_jacobian(
+    const std::array<T, 3>& source_coords) const {
+  auto inv_jac = impl_.inv_jacobian(std::array<tt::remove_cvref_wrap_t<T>, 3>{
+      dereference_wrapper(source_coords[0]),
+      dereference_wrapper(source_coords[1]),
+      -dereference_wrapper(source_coords[2])});
+  // Chain rule: dzbar/dx^i = -dzbar_eff/dx^i, so negate row 2.
+  for (size_t i = 0; i < 3; ++i) {
+    inv_jac.get(2, i) = -inv_jac.get(2, i);
+  }
+  return inv_jac;
+}
+
+void CylindricalFlatEndcapInterior::pup(PUP::er& p) { p | impl_; }
+
+bool operator==(const CylindricalFlatEndcapInterior& lhs,
+                const CylindricalFlatEndcapInterior& rhs) {
+  return lhs.impl_ == rhs.impl_;
+}
+
+bool operator!=(const CylindricalFlatEndcapInterior& lhs,
+                const CylindricalFlatEndcapInterior& rhs) {
+  return not(lhs == rhs);
+}
+
+#define DTYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                                 \
+  template std::array<tt::remove_cvref_wrap_t<DTYPE(data)>, 3>               \
+  CylindricalFlatEndcapInterior::operator()(                                 \
+      const std::array<DTYPE(data), 3>& source_coords) const;                \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 3, Frame::NoFrame> \
+  CylindricalFlatEndcapInterior::jacobian(                                   \
+      const std::array<DTYPE(data), 3>& source_coords) const;                \
+  template tnsr::Ij<tt::remove_cvref_wrap_t<DTYPE(data)>, 3, Frame::NoFrame> \
+  CylindricalFlatEndcapInterior::inv_jacobian(                               \
+      const std::array<DTYPE(data), 3>& source_coords) const;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (double, DataVector,
+                                      std::reference_wrapper<const double>,
+                                      std::reference_wrapper<const DataVector>))
+
+#undef DTYPE
+#undef INSTANTIATE
+
+}  // namespace domain::CoordinateMaps

--- a/src/Domain/CoordinateMaps/CylindricalFlatEndcapInterior.hpp
+++ b/src/Domain/CoordinateMaps/CylindricalFlatEndcapInterior.hpp
@@ -1,0 +1,167 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <limits>
+#include <optional>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/CoordinateMaps/FocallyLiftedFlatEndcap.hpp"
+#include "Domain/CoordinateMaps/FocallyLiftedMap.hpp"
+#include "Utilities/TypeTraits/RemoveReferenceWrapper.hpp"
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace domain::CoordinateMaps {
+
+/*!
+ * \ingroup CoordinateMapsGroup
+ *
+ * \brief Map from a 3D unit right cylinder to a volume that connects
+ *  a flat circular disk (lying inside a sphere) to the far wall of
+ *  that sphere.
+ *
+ * \details This is the "interior" counterpart to `CylindricalFlatEndcap`.
+ * The two maps are identical in structure — both use `FocallyLiftedMap`
+ * with `FocallyLiftedInnerMaps::FlatEndcap` — but differ in which
+ * intersection of the projecting ray with the sphere is chosen:
+ *
+ * - `CylindricalFlatEndcap`: the flat disk lies *outside* the sphere
+ *   (the sphere is between \f$P\f$ and the flat disk), so
+ *   `source_is_between_focus_and_target = false`.
+ * - `CylindricalFlatEndcapInterior`: the flat disk lies *inside* the
+ *   sphere (the flat disk is between \f$P\f$ and the sphere's far wall),
+ *   so `source_is_between_focus_and_target = true`.
+ *
+ * Consider a 2D circle in 3D space normal to the \f$z\f$ axis with
+ * (3D) center \f$C_1\f$, a sphere with center \f$C_2\f$ and radius
+ * \f$R_2\f$, and a projection point \f$P\f$.
+ *
+ * The parameter \f$z_\mathrm{extent}\f$ specifies the \f$z\f$-coordinate
+ * (in the map's frame) of the rim circle where the spherical face of the
+ * block meets the adjacent hollow-cylinder block.  This single number
+ * determines the radius \f$R_1\f$ of the flat disk:
+ *
+ * \f{align}{
+ *   t &= \frac{z_\mathrm{extent} - P_z}{C_1^z - P_z}, \\
+ *   r_\mathrm{rim} &= \sqrt{R_2^2 - (z_\mathrm{extent} - C_2^z)^2}, \\
+ *   R_1 &= \frac{r_\mathrm{rim}}{t}.
+ * \f}
+ *
+ * CylindricalFlatEndcapInterior maps a 3D unit right cylinder
+ * \f$(\bar{x},\bar{y},\bar{z})\f$ with \f$-1\leq\bar{z}\leq 1\f$ and
+ * \f$\bar{x}^2+\bar{y}^2\leq 1\f$ so that:
+ * - \f$\bar{z}=+1\f$ maps to the interior of the disk of radius
+ *   \f$R_1\f$ centred at \f$C_1\f$.
+ * - \f$\bar{z}=-1\f$ maps to the portion of the sphere on the *far* side
+ *   of the flat disk from \f$P\f$.
+ * - Curves of constant \f$(\bar{x},\bar{y})\f$ are portions of lines
+ *   passing through \f$P\f$.
+ * - The rim of the disk (\f$\bar{x}^2+\bar{y}^2=1\f$ on \f$\bar{z}=-1\f$)
+ *   maps to the circle at \f$z = z_\mathrm{extent}\f$ on the sphere.
+ *
+ * Note that the \f$\bar{z}\f$ orientation is the *opposite* of
+ * `CylindricalFlatEndcap`: here \f$\bar{z}=+1\f$ is the flat disk and
+ * \f$\bar{z}=-1\f$ is the sphere.  This reversal is necessary to keep the
+ * Jacobian determinant positive, because the flat disk sits at a larger
+ * physical \f$z\f$ than the far sphere wall.
+ *
+ * CylindricalFlatEndcapInterior is intended for the Pill domain, where
+ * the filled-cylinder endcap blocks have their flat face (\f$\bar{z}=+1\f$)
+ * at the end of the inner cubed-cylinder region (inside the outer domain
+ * sphere) and their spherical face (\f$\bar{z}=-1\f$) on the outer domain
+ * sphere.
+ *
+ * ### Requirements on map parameters
+ *
+ * - \f$P\f$ is sufficiently inside the sphere:
+ *   \f$|P - C_2| \leq 0.95\,R_2\f$.
+ * - The flat disk lies inside the sphere, at least 5 % of \f$R_2\f$ below
+ *   \f$C_2^z\f$ and at most 95 % of \f$R_2\f$ below \f$C_2^z\f$:
+ *   \f[
+ *     C_2^z - 0.95\,R_2 \;\leq\; C_1^z \;\leq\; C_2^z - 0.05\,R_2.
+ *   \f]
+ * - The flat disk is below the projection point: \f$C_1^z < P^z\f$.
+ * - \f$z_\mathrm{extent}\f$ lies strictly on the sphere:
+ *   \f$|z_\mathrm{extent} - C_2^z| < R_2\f$.
+ * - The focal parameter satisfies \f$t > 1\f$ (the sphere is beyond the
+ *   disk from \f$P\f$).
+ * - The ratio \f$R_1/R_2\f$ is between 1/10 and 10.
+ * - The entire flat disk rim lies strictly inside the sphere:
+ *   \f[
+ *     \sqrt{\bigl(\sqrt{(C_1^x-C_2^x)^2+(C_1^y-C_2^y)^2}+R_1\bigr)^2
+ *           +(C_1^z-C_2^z)^2} < R_2.
+ *   \f]
+ *   This is required for the inverse to be defined everywhere: if any rim
+ *   point were outside the sphere, the corresponding ray from \f$P\f$ would
+ *   hit the sphere before reaching the disk (\f$t_\mathrm{sphere}<1\f$),
+ *   violating the `source_is_between_focus_and_target` assumption.
+ */
+class CylindricalFlatEndcapInterior {
+ public:
+  static constexpr size_t dim = 3;
+
+  /*!
+   * \brief Construct the map.
+   *
+   * \param center_one Center of the flat disk (\f$C_1\f$).
+   * \param center_two Center of the outer sphere (\f$C_2\f$).
+   * \param proj_center Projection point \f$P\f$.
+   * \param z_sphere_extent z-coordinate of the rim circle where the spherical
+   *   face meets the adjacent hollow-cylinder block.  This determines the flat
+   *   disk radius \f$R_1\f$ via the focal projection.
+   * \param radius_two Radius of the outer sphere \f$R_2\f$.
+   */
+  CylindricalFlatEndcapInterior(const std::array<double, 3>& center_one,
+                                const std::array<double, 3>& center_two,
+                                const std::array<double, 3>& proj_center,
+                                double z_sphere_extent, double radius_two);
+
+  CylindricalFlatEndcapInterior() = default;
+  ~CylindricalFlatEndcapInterior() = default;
+  CylindricalFlatEndcapInterior(CylindricalFlatEndcapInterior&&) = default;
+  CylindricalFlatEndcapInterior(const CylindricalFlatEndcapInterior&) = default;
+  CylindricalFlatEndcapInterior& operator=(
+      const CylindricalFlatEndcapInterior&) = default;
+  CylindricalFlatEndcapInterior& operator=(CylindricalFlatEndcapInterior&&) =
+      default;
+
+  template <typename T>
+  std::array<tt::remove_cvref_wrap_t<T>, 3> operator()(
+      const std::array<T, 3>& source_coords) const;
+
+  std::optional<std::array<double, 3>> inverse(
+      const std::array<double, 3>& target_coords) const;
+
+  template <typename T>
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> jacobian(
+      const std::array<T, 3>& source_coords) const;
+
+  template <typename T>
+  tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> inv_jacobian(
+      const std::array<T, 3>& source_coords) const;
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p);
+
+  static bool is_identity() { return false; }
+
+  static constexpr bool supports_hessian{false};
+
+ private:
+  friend bool operator==(const CylindricalFlatEndcapInterior& lhs,
+                         const CylindricalFlatEndcapInterior& rhs);
+  FocallyLiftedMap<FocallyLiftedInnerMaps::FlatEndcap> impl_;
+};
+
+bool operator!=(const CylindricalFlatEndcapInterior& lhs,
+                const CylindricalFlatEndcapInterior& rhs);
+
+}  // namespace domain::CoordinateMaps

--- a/src/Domain/CoordinateMaps/FocallyLiftedFlatEndcap.cpp
+++ b/src/Domain/CoordinateMaps/FocallyLiftedFlatEndcap.cpp
@@ -134,11 +134,27 @@ void FlatEndcap::dxbar_dsigma(
 std::optional<double> FlatEndcap::lambda_tilde(
     const std::array<double, 3>& parent_mapped_target_coords,
     const std::array<double, 3>& projection_point,
-    const bool /*source_is_between_focus_and_target*/) const {
-  const double result = (center_[2] - projection_point[2]) /
-                        (parent_mapped_target_coords[2] - projection_point[2]);
-  if (result < 1.0) {
+    const bool source_is_between_focus_and_target) const {
+  // Guard against division by zero: if the target and the projection point
+  // share the same z-coordinate, the ray from the projection point is
+  // parallel to the flat disk and never intersects it.
+  const double denom = parent_mapped_target_coords[2] - projection_point[2];
+  if (denom == 0.0) {
     return {};
+  }
+  const double result = (center_[2] - projection_point[2]) / denom;
+  if (source_is_between_focus_and_target) {
+    // Interior case: the flat disk lies between P and the target, so the
+    // scale factor from P to the flat disk is in (0, 1].
+    if (result <= 0.0 or result > 1.0) {
+      return {};
+    }
+  } else {
+    // Non-interior case: the flat disk lies beyond the sphere from P, so the
+    // scale factor from P to the flat disk is >= 1.
+    if (result < 1.0) {
+      return {};
+    }
   }
   return result;
 }

--- a/src/Domain/CoordinateMaps/FocallyLiftedFlatEndcap.hpp
+++ b/src/Domain/CoordinateMaps/FocallyLiftedFlatEndcap.hpp
@@ -108,11 +108,19 @@ namespace domain::CoordinateMaps::FocallyLiftedInnerMaps {
  *
  * \f{align} \tilde{\lambda} &= \frac{C^3-P^3}{x^3-P^3}.\f}
  *
- * For `FocallyLiftedInnerMaps::FlatEndcap`, \f$x^i\f$ is always between
- * \f$P^i\f$ and \f$x_0^i\f$, so \f$\tilde{\lambda}\ge 1\f$.
- * Therefore a default-constructed `std::optional<double>` is returned
- * if \f$\tilde{\lambda}\f$ is less than unity (meaning that \f$x^i\f$
- * is outside the range of the map).
+ * The valid range of \f$\tilde{\lambda}\f$ depends on whether the source
+ * lies between the focus and the target:
+ * - Non-interior case (`source_is_between_focus_and_target`=`false`):
+ * \f$x_0^i\f$ lies beyond \f$x^i\f$ from \f$P^i\f$, so \f$\tilde{\lambda}\ge
+ * 1\f$.  A default-constructed `std::optional<double>` is returned if
+ * \f$\tilde{\lambda}<1\f$.
+ * - Interior case (`source_is_between_focus_and_target`=`true`): \f$x_0^i\f$
+ * lies between \f$P^i\f$ and \f$x^i\f$, so \f$\tilde{\lambda}\in(0,1]\f$.  A
+ * default-constructed `std::optional<double>` is returned if
+ * \f$\tilde{\lambda}\le 0\f$ or \f$\tilde{\lambda}>1\f$. In both cases a
+ * default-constructed `std::optional<double>` is also returned if \f$x^3 =
+ * P^3\f$ (the ray from \f$P\f$ is parallel to the disk and never intersects
+ * it).
  *
  * ### deriv_lambda_tilde
  *

--- a/src/Domain/CoordinateMaps/FocallyLiftedMap.cpp
+++ b/src/Domain/CoordinateMaps/FocallyLiftedMap.cpp
@@ -16,6 +16,7 @@
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/DereferenceWrapper.hpp"
 #include "Utilities/EqualWithinRoundoff.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/MakeWithValue.hpp"
@@ -31,7 +32,20 @@ FocallyLiftedMap<InnerMap>::FocallyLiftedMap(
       proj_center_(proj_center),
       radius_(radius),
       source_is_between_focus_and_target_(source_is_between_focus_and_target),
-      inner_map_(std::move(inner_map)) {}
+      inner_map_(std::move(inner_map)) {
+#ifdef SPECTRE_DEBUG
+  if (source_is_between_focus_and_target) {
+    const double dist_proj = std::sqrt(square(proj_center[0] - center[0]) +
+                                       square(proj_center[1] - center[1]) +
+                                       square(proj_center[2] - center[2]));
+    ASSERT(dist_proj < radius,
+           "When source_is_between_focus_and_target is true, proj_center must "
+           "be strictly inside the sphere (|proj_center - center| < radius). "
+           "Got |proj_center - center| = "
+               << dist_proj << " and radius = " << radius);
+  }
+#endif
+}
 
 template <typename InnerMap>
 template <typename T>

--- a/src/Domain/CoordinateMaps/FocallyLiftedMapHelpers.cpp
+++ b/src/Domain/CoordinateMaps/FocallyLiftedMapHelpers.cpp
@@ -45,17 +45,35 @@ void scale_factor(const gsl::not_null<tt::remove_cvref_wrap_t<T>*>& result,
                    square(sphere_center[1] - proj_center[1]) +
                    square(sphere_center[2] - proj_center[2]) - square(radius);
   if (src_is_between_proj_and_target) {
-    // Here we assume that src_point is between proj_center and
-    // target_point.  There are three cases: 1) src and proj are both
-    // inside the sphere, 2) src and proj are both outside the sphere,
-    // and 3) proj is outside the sphere and src is inside the sphere.
-    // Note that a root of zero corresponds to target_point = proj_center,
-    // and a root of unity corresponds to target_point = src_point.
-    // To cover all 3 cases, we choose the smallest root that is
-    // greater than or equal to unity. This means for case 2) we are
-    // choosing the point closest to src.
+    // We want the root lambda > 1, i.e. the sphere intersection beyond
+    // src_point from proj_center (lambda=0 is proj_center, lambda=1 is
+    // src_point). The sign of c = |P−C|^2 − R^2 determines the root
+    // structure:
+    //
+    //  (1) P inside, src inside (c < 0): product of roots < 0, so one root
+    //      is positive (the far sphere wall, lambda > 1) and one is negative.
+    //      The smallest root > 0 is the correct one.
+    //
+    //  (2) P outside, src outside (c > 0), sphere beyond src: both roots are
+    //      > 1 (the two sphere-surface intersections past src). The smallest
+    //      root > 0 is the nearer intersection, which is what we want.
+    //
+    //  (3) P outside, src inside (c > 0): roots are lambda in (0,1) and
+    //      lambda>1; threshold 0 would return the wrong root. However,
+    //      FocallyLiftedMap asserts that proj_center is inside the sphere
+    //      whenever src_is_between_proj_and_target=true, so c < 0 always
+    //      holds for valid maps and this case never arises.
+    //
+    //  (4) P inside, src outside (c < 0, out-of-domain): one root is in
+    //      (0,1) and one is negative — no root >= 1 exists. We use threshold
+    //      0 (not 1) so that the positive root is returned rather than
+    //      crashing, giving graceful behavior when the map is evaluated at a
+    //      point outside the source domain.
+    //
+    // Cases (1) and (2) are the valid in-domain configurations; threshold 0
+    // handles both correctly and also gives graceful behavior for case (4).
     *result = smallest_root_greater_than_value_within_roundoff(
-        a, b, make_with_value<ReturnType>(a, c), 1.0);
+        a, b, make_with_value<ReturnType>(a, c), 0.0);
   } else {
     // Here we assume that target_point is between proj_center and
     // src_point. There are three cases: 1) proj is inside the sphere

--- a/tests/Unit/Domain/CoordinateMaps/CMakeLists.txt
+++ b/tests/Unit/Domain/CoordinateMaps/CMakeLists.txt
@@ -10,6 +10,7 @@ set(LIBRARY_SOURCES
   Test_CoordinateMap.cpp
   Test_CylindricalEndcap.cpp
   Test_CylindricalFlatEndcap.cpp
+  Test_CylindricalFlatEndcapInterior.cpp
   Test_CylindricalFlatSide.cpp
   Test_CylindricalSide.cpp
   Test_DiscreteRotation.cpp

--- a/tests/Unit/Domain/CoordinateMaps/Test_CylindricalFlatEndcapInterior.cpp
+++ b/tests/Unit/Domain/CoordinateMaps/Test_CylindricalFlatEndcapInterior.cpp
@@ -1,0 +1,219 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cmath>
+#include <random>
+
+#include "Domain/CoordinateMaps/CylindricalFlatEndcapInterior.hpp"
+#include "Helpers/Domain/CoordinateMaps/TestMapHelpers.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+
+namespace domain {
+namespace {
+
+void test_cylindrical_flat_endcap_interior() {
+  INFO("CylindricalFlatEndcapInterior");
+  MAKE_GENERATOR(gen);
+  std::uniform_real_distribution<> unit_dis(0.0, 1.0);
+  std::uniform_real_distribution<> interval_dis(-1.0, 1.0);
+  std::uniform_real_distribution<> angle_dis(0.0, 2.0 * M_PI);
+
+  // radius_two in [0.5, 1.0] to keep geometry well-conditioned.
+  const double radius_two = 0.5 + 0.5 * unit_dis(gen);
+  CAPTURE(radius_two);
+
+  // center_two anywhere.
+  const std::array<double, 3> center_two = {
+      interval_dis(gen), interval_dis(gen), interval_dis(gen)};
+  CAPTURE(center_two);
+
+  // Place the flat disk centre 7–90% of radius_two below the sphere centre
+  // in z, covering most of the 5–95% ASSERT range.  Keep x,y aligned with
+  // center_two so that the x,y offset check is trivially satisfied.
+  const double center_one_z =
+      center_two[2] - radius_two * (0.07 + 0.83 * unit_dis(gen));
+  const std::array<double, 3> center_one = {center_two[0], center_two[1],
+                                            center_one_z};
+  CAPTURE(center_one);
+
+  // Projection point: 30–85% of radius_two above the sphere centre, covering
+  // most of the dist_proj <= 0.95 * radius_two ASSERT range.
+  const double proj_scale = 0.30 + 0.55 * unit_dis(gen);
+  const std::array<double, 3> proj_center = {
+      center_two[0], center_two[1], center_two[2] + proj_scale * radius_two};
+  CAPTURE(proj_center);
+
+  // z_sphere_extent: must be below center_one_z (ensuring t_sphere > 1) and
+  // above center_two[2] - radius_two (staying on the sphere).  Compute the
+  // available gap between center_one_z and the sphere bottom and choose a
+  // fraction [0.1, 0.5] of it, guaranteeing the constraint holds even when
+  // center_one_z is placed deep (close to 90% of radius_two below center).
+  const double depth = center_two[2] - center_one_z;
+  const double available = radius_two - depth;
+  const double z_sphere_extent =
+      center_one_z - available * (0.1 + 0.4 * unit_dis(gen));
+  CAPTURE(z_sphere_extent);
+
+  const CoordinateMaps::CylindricalFlatEndcapInterior map(
+      center_one, center_two, proj_center, z_sphere_extent, radius_two);
+
+  test_suite_for_map_on_cylinder(map, 0.0, 1.0);
+
+  const Approx local_approx = Approx::custom().epsilon(1.0e-13).scale(1.0);
+
+  // Geometric check: the rim of the source cylinder at zbar=-1
+  // (i.e. source point (cos phi, sin phi, -1)) must map to the circle at
+  // z = z_sphere_extent on the outer sphere.
+  for (size_t i = 0; i < 5; ++i) {
+    const double phi = angle_dis(gen);
+    const std::array<double, 3> rim_point = {std::cos(phi), std::sin(phi),
+                                             -1.0};
+    const auto rim_image = map(rim_point);
+    // The image lies on the sphere of radius radius_two centred at center_two.
+    CHECK(std::sqrt(square(rim_image[0] - center_two[0]) +
+                    square(rim_image[1] - center_two[1]) +
+                    square(rim_image[2] - center_two[2])) ==
+          local_approx(radius_two));
+    // The z-coordinate equals z_sphere_extent.
+    CHECK(rim_image[2] == local_approx(z_sphere_extent));
+
+    // Geometric check: the flat face (zbar=+1) lies at z = center_one[2].
+    const double rho = unit_dis(gen);
+    const std::array<double, 3> flat_point = {rho * std::cos(phi),
+                                              rho * std::sin(phi), 1.0};
+    const auto flat_image = map(flat_point);
+    CHECK(flat_image[2] == local_approx(center_one[2]));
+  }
+}
+
+// Test with a non-zero x,y offset between center_one and center_two to
+// exercise the |C1 - C2| <= R1 + R2 ASSERT path.
+void test_cylindrical_flat_endcap_interior_offset() {
+  INFO("CylindricalFlatEndcapInterior with non-zero x,y offset");
+  const std::array<double, 3> center_two = {0.0, 0.0, 0.0};
+  const std::array<double, 3> center_one = {0.5, 0.3, -0.2};
+  const std::array<double, 3> proj_center = {0.0, 0.0, 0.3};
+  const double z_sphere_extent = -0.7;
+  const double radius_two = 1.0;
+
+  const CoordinateMaps::CylindricalFlatEndcapInterior map(
+      center_one, center_two, proj_center, z_sphere_extent, radius_two);
+
+  test_suite_for_map_on_cylinder(map, 0.0, 1.0);
+
+  const Approx local_approx = Approx::custom().epsilon(1.0e-10).scale(1.0);
+  MAKE_GENERATOR(gen);
+  std::uniform_real_distribution<> angle_dis(0.0, 2.0 * M_PI);
+  std::uniform_real_distribution<> unit_dis(0.0, 1.0);
+
+  // Reconstruct the flat-disk radius the constructor computed internally.
+  const double t_sphere_ref =
+      (z_sphere_extent - proj_center[2]) / (center_one[2] - proj_center[2]);
+  const double r_rim_ref =
+      std::sqrt(square(radius_two) - square(z_sphere_extent - center_two[2]));
+  const double radius_one = r_rim_ref / t_sphere_ref;
+
+  for (size_t i = 0; i < 5; ++i) {
+    const double phi = angle_dis(gen);
+    const auto rim_image = map(std::array{std::cos(phi), std::sin(phi), -1.0});
+
+    // Verify on sphere.
+    CHECK(std::sqrt(square(rim_image[0] - center_two[0]) +
+                    square(rim_image[1] - center_two[1]) +
+                    square(rim_image[2] - center_two[2])) ==
+          local_approx(radius_two));
+
+    // Analytically compute the expected z from the focal projection:
+    // disk point d = (R1*cos(phi)+C1_x, R1*sin(phi)+C1_y, C1_z)
+    // ray from P through d: P + t*(d - P)
+    // solve |P + t*(d-P) - C2|^2 = R2^2 for t (far root, t > 1).
+    const double vx =
+        radius_one * std::cos(phi) + center_one[0] - proj_center[0];
+    const double vy =
+        radius_one * std::sin(phi) + center_one[1] - proj_center[1];
+    const double vz = center_one[2] - proj_center[2];
+    const double ux = proj_center[0] - center_two[0];
+    const double uy = proj_center[1] - center_two[1];
+    const double uz = proj_center[2] - center_two[2];
+    const double v2 = vx * vx + vy * vy + vz * vz;
+    const double udotv = ux * vx + uy * vy + uz * vz;
+    const double u2 = ux * ux + uy * uy + uz * uz;
+    const double disc = udotv * udotv - v2 * (u2 - square(radius_two));
+    // Far intersection (source_is_between_focus_and_target = true means sphere
+    // is beyond the disk from P, so t > 1 and we take the + root).
+    const double t_intersect = (-udotv + std::sqrt(disc)) / v2;
+    const double z_expected = proj_center[2] + t_intersect * vz;
+    CHECK(rim_image[2] == local_approx(z_expected));
+
+    // Verify the flat face (zbar=+1) lies at z = center_one[2].
+    const double rho = unit_dis(gen);
+    const auto flat_image =
+        map(std::array{rho * std::cos(phi), rho * std::sin(phi), 1.0});
+    CHECK(flat_image[2] == local_approx(center_one[2]));
+  }
+}
+
+// Test a shallow-disk geometry where the radius_two / radius_one ratio is
+// large
+void test_cylindrical_flat_endcap_interior_large_ratio() {
+  INFO("CylindricalFlatEndcapInterior: large radius_two/radius_one ratio");
+  const std::array<double, 3> center_two = {0.0, 0.0, 0.0};
+  const std::array<double, 3> center_one = {0.0, 0.0, -0.1};
+  const std::array<double, 3> proj_center = {0.0, 0.0, 0.0};
+
+  const double z_sphere_extent = -0.625;
+  const double radius_two = 1.0;
+
+  const CoordinateMaps::CylindricalFlatEndcapInterior map(
+      center_one, center_two, proj_center, z_sphere_extent, radius_two);
+
+  test_suite_for_map_on_cylinder(map, 0.0, 1.0);
+}
+
+// Test a geometry where the projection point is far from the sphere center
+void test_cylindrical_flat_endcap_interior_large_dist_proj() {
+  INFO("CylindricalFlatEndcapInterior: large proj_center distance");
+  const std::array<double, 3> center_two = {0.0, 0.0, 0.0};
+  const std::array<double, 3> center_one = {0.0, 0.0, -0.5};
+  const std::array<double, 3> proj_center = {0.0, 0.0, 0.85};
+
+  const double z_sphere_extent = -0.7;
+  const double radius_two = 1.0;
+
+  const CoordinateMaps::CylindricalFlatEndcapInterior map(
+      center_one, center_two, proj_center, z_sphere_extent, radius_two);
+
+  test_suite_for_map_on_cylinder(map, 0.0, 1.0);
+}
+
+#ifdef SPECTRE_DEBUG
+void test_assert_proj_center_inside_sphere() {
+  INFO("FocallyLiftedMap asserts proj_center inside sphere");
+  // proj_center at distance 1.5 is outside the sphere of radius 1.0.
+  // impl_ is constructed before the CylindricalFlatEndcapInterior debug
+  // asserts, so the FocallyLiftedMap assert fires first.
+  CHECK_THROWS_WITH(
+      (CoordinateMaps::CylindricalFlatEndcapInterior{
+          {0.0, 0.0, -0.3}, {0.0, 0.0, 0.0}, {0.0, 0.0, 1.5}, -0.7, 1.0}),
+      Catch::Matchers::ContainsSubstring(
+          "proj_center must be strictly inside the sphere"));
+}
+#endif
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.CoordinateMaps.CylindricalFlatEndcapInterior",
+                  "[Domain][Unit]") {
+  test_cylindrical_flat_endcap_interior();
+  test_cylindrical_flat_endcap_interior_offset();
+  test_cylindrical_flat_endcap_interior_large_ratio();
+  test_cylindrical_flat_endcap_interior_large_dist_proj();
+#ifdef SPECTRE_DEBUG
+  test_assert_proj_center_inside_sphere();
+#endif
+  CHECK(not CoordinateMaps::CylindricalFlatEndcapInterior{}.is_identity());
+}
+}  // namespace domain


### PR DESCRIPTION

## Proposed changes

This maps a right cylinder to a shape where the bottom remains flat but the top surface conforms to a sphere. It is useful to transition between inner cubes and outer spherical shells with filled cylinders for binary NS domains.

<img width="1402" height="897" alt="Screenshot 2026-07-08 at 7 56 05 PM" src="https://github.com/user-attachments/assets/b714fdce-f3bd-4c0f-8705-750c78d3f3f6" />


<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
