### PR TITLE
Support LDG infrastructure part one

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeHelpers.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeHelpers.hpp
@@ -6,6 +6,7 @@
 #include <type_traits>
 
 #include "Utilities/TMPL.hpp"
+#include "Utilities/TypeTraits/CreateGetTypeAliasOrDefault.hpp"
 #include "Utilities/TypeTraits/CreateHasTypeAlias.hpp"
 
 namespace evolution::dg::Actions::detail {
@@ -30,6 +31,8 @@ struct inverse_spatial_metric_tag_impl<true> {
 template <typename System>
 using inverse_spatial_metric_tag = typename inverse_spatial_metric_tag_impl<
     has_inverse_spatial_metric_tag_v<System>>::template f<System>;
+
+CREATE_GET_TYPE_ALIAS_OR_DEFAULT(auxiliary_variables)
 
 template <bool HasPrimitiveVars = false>
 struct get_primitive_vars {

--- a/src/Evolution/DiscontinuousGalerkin/InboxTags.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/InboxTags.cpp
@@ -16,8 +16,9 @@
 #include "Utilities/Gsl.hpp"
 
 namespace evolution::dg::Tags {
-template <size_t Dim, bool UseNodegroupDgElements>
-bool BoundaryCorrectionAndGhostCellsInbox<Dim, UseNodegroupDgElements>::
+template <size_t Dim, bool UseNodegroupDgElements, bool IsAuxiliary>
+bool BoundaryCorrectionAndGhostCellsInbox<Dim, UseNodegroupDgElements,
+                                          IsAuxiliary>::
     insert_into_inbox(
         const gsl::not_null<type_spsc*> inbox, const temporal_id& time_step_id,
         std::pair<DirectionalId<Dim>, evolution::dg::BoundaryData<Dim>> data) {
@@ -41,8 +42,9 @@ bool BoundaryCorrectionAndGhostCellsInbox<Dim, UseNodegroupDgElements>::
   return inbox->missing_messages.fetch_sub(1, std::memory_order_acq_rel) == 1;
 }
 
-template <size_t Dim, bool UseNodegroupDgElements>
-bool BoundaryCorrectionAndGhostCellsInbox<Dim, UseNodegroupDgElements>::
+template <size_t Dim, bool UseNodegroupDgElements, bool IsAuxiliary>
+bool BoundaryCorrectionAndGhostCellsInbox<Dim, UseNodegroupDgElements,
+                                          IsAuxiliary>::
     insert_into_inbox(
         const gsl::not_null<type_map*> inbox, const temporal_id& time_step_id,
         std::pair<DirectionalId<Dim>, evolution::dg::BoundaryData<Dim>> data) {
@@ -52,10 +54,11 @@ bool BoundaryCorrectionAndGhostCellsInbox<Dim, UseNodegroupDgElements>::
   return inbox->missing_messages == 0;
 }
 
-template <size_t Dim, bool UseNodegroupDgElements>
-std::string
-BoundaryCorrectionAndGhostCellsInbox<Dim, UseNodegroupDgElements>::output_inbox(
-    const type_spsc& inbox, const size_t padding_size) {
+template <size_t Dim, bool UseNodegroupDgElements, bool IsAuxiliary>
+std::string BoundaryCorrectionAndGhostCellsInbox<
+    Dim, UseNodegroupDgElements,
+    IsAuxiliary>::output_inbox(const type_spsc& inbox,
+                               const size_t padding_size) {
   std::stringstream ss{};
   const std::string pad(padding_size, ' ');
   ss << std::scientific << std::setprecision(16);
@@ -73,10 +76,11 @@ BoundaryCorrectionAndGhostCellsInbox<Dim, UseNodegroupDgElements>::output_inbox(
   return ss.str();
 }
 
-template <size_t Dim, bool UseNodegroupDgElements>
-std::string
-BoundaryCorrectionAndGhostCellsInbox<Dim, UseNodegroupDgElements>::output_inbox(
-    const type_map& inbox, const size_t padding_size) {
+template <size_t Dim, bool UseNodegroupDgElements, bool IsAuxiliary>
+std::string BoundaryCorrectionAndGhostCellsInbox<
+    Dim, UseNodegroupDgElements,
+    IsAuxiliary>::output_inbox(const type_map& inbox,
+                               const size_t padding_size) {
   std::stringstream ss{};
   const std::string pad(padding_size, ' ');
   ss << std::scientific << std::setprecision(16);
@@ -97,14 +101,16 @@ BoundaryCorrectionAndGhostCellsInbox<Dim, UseNodegroupDgElements>::output_inbox(
 
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 #define USE_NODEGROUP_DG_ELEMENTS(data) BOOST_PP_TUPLE_ELEM(1, data)
+#define IS_AUXILIARY(data) BOOST_PP_TUPLE_ELEM(2, data)
 
 #define INSTANTIATE(_, data)                            \
   template struct BoundaryCorrectionAndGhostCellsInbox< \
-      DIM(data), USE_NODEGROUP_DG_ELEMENTS(data)>;
+      DIM(data), USE_NODEGROUP_DG_ELEMENTS(data), IS_AUXILIARY(data)>;
 
-GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (true, false))
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3), (true, false), (true, false))
 
 #undef INSTANTIATE
+#undef IS_AUXILIARY
 #undef USE_NODEGROUP_DG_ELEMENTS
 #undef DIM
 }  // namespace evolution::dg::Tags

--- a/src/Evolution/DiscontinuousGalerkin/InboxTags.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/InboxTags.hpp
@@ -104,7 +104,7 @@ namespace evolution::dg::Tags {
  * `UseNodegroupDgElements` to `true`. The actions that use this tag check
  * that the parallel component and the `UseNodegroupDgElements` is consistent.
  */
-template <size_t Dim, bool UseNodegroupDgElements>
+template <size_t Dim, bool UseNodegroupDgElements, bool IsAuxiliary = false>
 struct BoundaryCorrectionAndGhostCellsInbox {
   using stored_type = evolution::dg::BoundaryData<Dim>;
 

--- a/src/Evolution/Initialization/NonconservativeSystem.hpp
+++ b/src/Evolution/Initialization/NonconservativeSystem.hpp
@@ -6,10 +6,13 @@
 #include <cstddef>
 #include <optional>
 #include <tuple>
+#include <type_traits>
 #include <utility>
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/TaggedTuple.hpp"
+#include "DataStructures/VariablesTag.hpp"
+#include "Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeHelpers.hpp"
 #include "Evolution/Initialization/InitialData.hpp"
 #include "Parallel/AlgorithmExecution.hpp"
 #include "Parallel/GlobalCache.hpp"
@@ -38,6 +41,8 @@ namespace Actions {
 /// DataBox changes:
 /// - Adds:
 ///   * System::variables_tag
+///   * `::Tags::Variables<System::auxiliary_variables>` (only if the system
+///     declares a non-empty `auxiliary_variables`)
 ///
 /// - Removes: nothing
 /// - Modifies: nothing
@@ -47,7 +52,16 @@ struct NonconservativeSystem {
                 "System is in flux conservative form");
   static constexpr size_t dim = System::volume_dim;
   using variables_tag = typename System::variables_tag;
-  using simple_tags = db::AddSimpleTags<variables_tag>;
+  using auxiliary_variables =
+      evolution::dg::Actions::detail::get_auxiliary_variables_or_default_t<
+          System, tmpl::list<>>;
+  static constexpr bool has_auxiliary_variables =
+      not std::is_same_v<auxiliary_variables, tmpl::list<>>;
+  using auxiliary_variables_tag = ::Tags::Variables<auxiliary_variables>;
+  using simple_tags = tmpl::conditional_t<
+      has_auxiliary_variables,
+      db::AddSimpleTags<variables_tag, auxiliary_variables_tag>,
+      db::AddSimpleTags<variables_tag>>;
   using compute_tags = db::AddComputeTags<>;
 
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
@@ -60,9 +74,17 @@ struct NonconservativeSystem {
       const ArrayIndex& /*array_index*/, ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) {
     using Vars = typename variables_tag::type;
-    Initialization::mutate_assign<simple_tags>(
-        make_not_null(&box),
-        Vars{db::get<domain::Tags::Mesh<dim>>(box).number_of_grid_points()});
+    const size_t number_of_grid_points =
+        db::get<domain::Tags::Mesh<dim>>(box).number_of_grid_points();
+    if constexpr (has_auxiliary_variables) {
+      using AuxVars = typename auxiliary_variables_tag::type;
+      Initialization::mutate_assign<simple_tags>(
+          make_not_null(&box), Vars{number_of_grid_points},
+          AuxVars{number_of_grid_points});
+    } else {
+      Initialization::mutate_assign<simple_tags>(make_not_null(&box),
+                                                 Vars{number_of_grid_points});
+    }
 
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InboxTags.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_InboxTags.cpp
@@ -47,10 +47,11 @@ evolution::dg::BoundaryData<Dim> make_boundary_data(const int label,
           std::nullopt};
 }
 
-template <size_t Dim, bool UseNodegroupDgElements>
+template <size_t Dim, bool UseNodegroupDgElements, bool IsAuxiliary = false>
 void test() {
   CAPTURE(Dim);
   CAPTURE(UseNodegroupDgElements);
+  CAPTURE(IsAuxiliary);
 
   const Slab slab(1.2, 3.4);
   const TimeStepId time_step_1(true, 5, slab.start());
@@ -68,7 +69,7 @@ void test() {
                                         element_lower};
 
   using Inbox = evolution::dg::Tags::BoundaryCorrectionAndGhostCellsInbox<
-      Dim, UseNodegroupDgElements>;
+      Dim, UseNodegroupDgElements, IsAuxiliary>;
 
   typename Inbox::type inbox{};
 
@@ -138,5 +139,11 @@ SPECTRE_TEST_CASE("Unit.Evolution.DG.InboxTags", "[Unit][Evolution]") {
   test<1, true>();
   test<2, true>();
   test<3, true>();
+  test<1, false, true>();
+  test<2, false, true>();
+  test<3, false, true>();
+  test<1, true, true>();
+  test<2, true, true>();
+  test<3, true, true>();
 }
 }  // namespace

--- a/tests/Unit/Evolution/Initialization/Test_NonconservativeSystem.cpp
+++ b/tests/Unit/Evolution/Initialization/Test_NonconservativeSystem.cpp
@@ -25,12 +25,17 @@ struct Var : db::SimpleTag {
   using type = Scalar<DataVector>;
 };
 
+struct AuxVar : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
 template <size_t Dim>
 struct System {
   static constexpr bool is_in_flux_conservative_form = false;
   static constexpr bool has_primitive_and_conservative_vars = false;
   static constexpr size_t volume_dim = Dim;
   using variables_tag = Tags::Variables<tmpl::list<Var>>;
+  using auxiliary_variables = tmpl::list<AuxVar>;
 };
 
 template <size_t Dim, typename Metavariables>
@@ -71,6 +76,11 @@ void test() {
   // The numerical value that the vars are set to is undefined, but the number
   // of grid points must be correct.
   CHECK(ActionTesting::get_databox_tag<comp, vars_tag>(runner, 0)
+            .number_of_grid_points() == mesh.number_of_grid_points());
+  // The auxiliary-variable storage is allocated alongside the evolved variables
+  // and sized to the mesh in the same way (values are likewise undefined).
+  using aux_vars_tag = Tags::Variables<tmpl::list<AuxVar>>;
+  CHECK(ActionTesting::get_databox_tag<comp, aux_vars_tag>(runner, 0)
             .number_of_grid_points() == mesh.number_of_grid_points());
 }
 


### PR DESCRIPTION
Update the DG infrastructure to support Local Discontinuous Galerkin (LDG) method, a spectral method for second-order hyperbolic PDEs. LDG requires two-pass boundary corrections: the first pass applies corrections to auxiliary (reduction) variables and the second pass applies corrections to physical (evolved) variables.

Does not change behaviors for any current system.

- InboxTags: add an `IsAuxiliary` template parameter (default `false`) to `BoundaryCorrectionAndGhostCellsInbox`, so the auxiliary pass can key its own boundary-correction inbox.
- ComputeTimeDerivativeHelpers: add a detect-or-default metafunction for a system's auxiliary variables.
- NonconservativeSystem: allocate `::Tags::Variables<auxiliary_variables>` alongside the evolved variables when a system declares a non-empty `auxiliary_variables`.

All additions are backward-compatible and dormant until a later change wires the auxiliary pass.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
