### PR TITLE
Support LDG infrastructure part two

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/Actions/PackageDataImpl.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/PackageDataImpl.hpp
@@ -83,4 +83,64 @@ double dg_package_data(
       tmpl::list<ProjectedFieldTagsForCorrection...>{},
       db::get<VolumeTags>(box)...);
 }
+
+// Used during the auxiliary pass for LDG schemes.
+template <typename System, typename BoundaryCorrection,
+          typename... PackagedFieldTags, typename... ProjectedFieldTags,
+          typename... ProjectedFieldTagsForCorrection, size_t Dim,
+          typename... VolumeArgs>
+double dg_auxiliary_package_data(
+    const gsl::not_null<Variables<tmpl::list<PackagedFieldTags...>>*>
+        packaged_data,
+    const BoundaryCorrection& boundary_correction,
+    const Variables<tmpl::list<ProjectedFieldTags...>>& projected_fields,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& unit_normal_covector,
+    const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
+        mesh_velocity,
+    tmpl::list<ProjectedFieldTagsForCorrection...> /*meta*/,
+    const VolumeArgs&... volume_args) {
+  std::optional<Scalar<DataVector>> normal_dot_mesh_velocity{};
+  if (mesh_velocity.has_value()) {
+    normal_dot_mesh_velocity =
+        dot_product(*mesh_velocity, unit_normal_covector);
+  }
+
+  if constexpr (evolution::dg::Actions::detail::
+                    has_inverse_spatial_metric_tag_v<System>) {
+    return boundary_correction.dg_auxiliary_package_data(
+        make_not_null(&get<PackagedFieldTags>(*packaged_data))...,
+        get<ProjectedFieldTagsForCorrection>(projected_fields)...,
+        unit_normal_covector,
+        get<evolution::dg::Actions::detail::NormalVector<Dim>>(
+            projected_fields),
+        mesh_velocity, normal_dot_mesh_velocity, volume_args...);
+  } else {
+    return boundary_correction.dg_auxiliary_package_data(
+        make_not_null(&get<PackagedFieldTags>(*packaged_data))...,
+        get<ProjectedFieldTagsForCorrection>(projected_fields)...,
+        unit_normal_covector, mesh_velocity, normal_dot_mesh_velocity,
+        volume_args...);
+  }
+}
+
+template <typename System, typename BoundaryCorrection,
+          typename... PackagedFieldTags, typename... ProjectedFieldTags,
+          typename... ProjectedFieldTagsForCorrection, size_t Dim,
+          typename... VolumeTags>
+double dg_auxiliary_package_data(
+    const gsl::not_null<Variables<tmpl::list<PackagedFieldTags...>>*>
+        packaged_data,
+    const BoundaryCorrection& boundary_correction,
+    const Variables<tmpl::list<ProjectedFieldTags...>>& projected_fields,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& unit_normal_covector,
+    const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
+        mesh_velocity,
+    const db::Access& box, tmpl::list<VolumeTags...> /*meta*/,
+    tmpl::list<ProjectedFieldTagsForCorrection...> /*meta*/) {
+  return dg_auxiliary_package_data<System>(
+      packaged_data, boundary_correction, projected_fields,
+      unit_normal_covector, mesh_velocity,
+      tmpl::list<ProjectedFieldTagsForCorrection...>{},
+      db::get<VolumeTags>(box)...);
+}
 }  // namespace evolution::dg::Actions::detail

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ComputeTimeDerivative.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ComputeTimeDerivative.cpp
@@ -72,9 +72,45 @@ struct BoundaryTerms {
     }
     return 1.0;
   }
+
+  // auxiliary-pass analogue of dg_package_field_tags / dg_package_data, copied
+  // and renamed for the LDG auxiliary communication pass.
+  using dg_auxiliary_package_field_tags = tmpl::list<Var1>;
+
+  double dg_auxiliary_package_data(
+      const gsl::not_null<Scalar<DataVector>*> out_normal_dot_flux_var1,
+      const gsl::not_null<Scalar<DataVector>*> out_var1,
+
+      const Scalar<DataVector>& var1,
+
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& flux_var1,
+
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_covector,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& normal_vector,
+      const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
+      /*mesh_velocity*/,
+      const std::optional<Scalar<DataVector>>& normal_dot_mesh_velocity) const {
+    *out_normal_dot_flux_var1 = dot_product(normal_covector, flux_var1);
+    *out_var1 = var1;
+
+    const DataVector normal_magnitude =
+        sqrt(get(dot_product(normal_covector, normal_vector)));
+    CHECK_ITERABLE_APPROX(DataVector(normal_magnitude.size(), 1.0),
+                          normal_magnitude);
+
+    if (normal_dot_mesh_velocity.has_value()) {
+      return max(1.0 - get(*normal_dot_mesh_velocity));
+    }
+    return 1.0;
+  }
 };
 
-template <size_t Dim>
+// `Auxiliary` selects which package-data path is exercised: the physical
+// `dg_package_data` (default) or the auxiliary-pass `dg_auxiliary_package_data`
+// (which dispatches to the boundary correction's `dg_auxiliary_package_data`
+// member). The setup and checks are identical; only the package-data call
+// differs.
+template <size_t Dim, bool Auxiliary = false>
 void test(const bool use_moving_mesh) {
   constexpr size_t number_of_grid_points = 5;
   MAKE_GENERATOR(gen);
@@ -124,25 +160,52 @@ void test(const bool use_moving_mesh) {
   }
 
   db::DataBox<tmpl::list<>> box{};
-  const double max_speed =
-      ::evolution::dg::Actions::detail::dg_package_data<System<Dim>>(
+  const double max_speed = [&]() {
+    if constexpr (Auxiliary) {
+      return ::evolution::dg::Actions::detail::dg_auxiliary_package_data<
+          System<Dim>>(
           make_not_null(&packaged_data), boundary_correction, projected_fields,
           unit_normal_covector, mesh_velocity, box, tmpl::list<>{},
           tmpl::list<Var1,
                      ::Tags::Flux<Var1, tmpl::size_t<Dim>, Frame::Inertial>>{});
+    } else {
+      return ::evolution::dg::Actions::detail::dg_package_data<System<Dim>>(
+          make_not_null(&packaged_data), boundary_correction, projected_fields,
+          unit_normal_covector, mesh_velocity, box, tmpl::list<>{},
+          tmpl::list<Var1,
+                     ::Tags::Flux<Var1, tmpl::size_t<Dim>, Frame::Inertial>>{});
+    }
+  }();
 
   Variables<tmpl::list<::Tags::NormalDotFlux<Var1>, Var1>>
       expected_packaged_data{number_of_grid_points};
-  const double expected_max_speed = boundary_correction.dg_package_data(
-      make_not_null(&get<::Tags::NormalDotFlux<Var1>>(expected_packaged_data)),
-      make_not_null(&get<Var1>(expected_packaged_data)),
-      get<Var1>(projected_fields),
-      get<::Tags::Flux<Var1, tmpl::size_t<Dim>, Frame::Inertial>>(
-          projected_fields),
-      unit_normal_covector,
-      get<::evolution::dg::Actions::detail::NormalVector<Dim>>(
-          projected_fields),
-      mesh_velocity, normal_dot_mesh_velocity);
+  const double expected_max_speed = [&]() {
+    if constexpr (Auxiliary) {
+      return boundary_correction.dg_auxiliary_package_data(
+          make_not_null(
+              &get<::Tags::NormalDotFlux<Var1>>(expected_packaged_data)),
+          make_not_null(&get<Var1>(expected_packaged_data)),
+          get<Var1>(projected_fields),
+          get<::Tags::Flux<Var1, tmpl::size_t<Dim>, Frame::Inertial>>(
+              projected_fields),
+          unit_normal_covector,
+          get<::evolution::dg::Actions::detail::NormalVector<Dim>>(
+              projected_fields),
+          mesh_velocity, normal_dot_mesh_velocity);
+    } else {
+      return boundary_correction.dg_package_data(
+          make_not_null(
+              &get<::Tags::NormalDotFlux<Var1>>(expected_packaged_data)),
+          make_not_null(&get<Var1>(expected_packaged_data)),
+          get<Var1>(projected_fields),
+          get<::Tags::Flux<Var1, tmpl::size_t<Dim>, Frame::Inertial>>(
+              projected_fields),
+          unit_normal_covector,
+          get<::evolution::dg::Actions::detail::NormalVector<Dim>>(
+              projected_fields),
+          mesh_velocity, normal_dot_mesh_velocity);
+    }
+  }();
 
   CHECK(max_speed == approx(expected_max_speed));
   CHECK_ITERABLE_APPROX(
@@ -151,6 +214,7 @@ void test(const bool use_moving_mesh) {
   CHECK_ITERABLE_APPROX(get<Var1>(packaged_data),
                         get<Var1>(expected_packaged_data));
 }
+
 }  // namespace WithInverseSpatialMetricTag
 
 template <SystemType system_type, bool UsePrims>
@@ -223,6 +287,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.DG.ComputeTimeDerivative",
 
   for (const bool use_moving_mesh : {true, false}) {
     WithInverseSpatialMetricTag::test<1>(use_moving_mesh);
+    WithInverseSpatialMetricTag::test<1, true>(use_moving_mesh);
   }
 }
 }  // namespace


### PR DESCRIPTION
Update the DG infrastructure to support Local Discontinuous Galerkin (LDG) method, a spectral method for second-order hyperbolic PDEs. LDG requires two-pass boundary corrections: the first pass applies corrections to auxiliary (reduction) variables and the second pass applies corrections to physical (evolved) variables.

Add `dg_auxiliary_package_data`, the auxiliary-communication-pass analogue of `dg_package_data`.

Does not change behaviors for any current system.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
