### PR TITLE
Speed up partial_derivatives for tensor product meshes

### DIFF
--- a/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.cpp
+++ b/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.cpp
@@ -404,6 +404,129 @@ bool logical_derivatives_fast_path(
   return true;
 }
 
+bool fused_partial_derivatives_fast_path(
+    double* const du, const double* const u,
+    const size_t number_of_independent_components, const Mesh<1>& mesh,
+    const std::array<const double*, 1>& inverse_jacobian) {
+  if (not fast_path_supports(mesh)) {
+    return false;
+  }
+  const size_t number_of_points = mesh.extents(0);
+  const PackedMatrix matrix_xi =
+      pack_matrix(Spectral::differentiation_matrix(mesh.slice_through(0)));
+  DataVector buffer{number_of_points};
+  double* const logical_xi = buffer.data();
+  const double* const jacobian_xi = inverse_jacobian[0];
+  for (size_t component = 0; component < number_of_independent_components;
+       ++component) {
+    const double* const u_component = u + (component * number_of_points);
+    dispatch_on_extent(number_of_points, [&](const auto extent) {
+      differentiate_first_dim<decltype(extent)::value>(logical_xi, u_component,
+                                                       matrix_xi.data(), 1);
+    });
+    double* const du_component = du + (component * number_of_points);
+    for (size_t p = 0; p < number_of_points; ++p) {
+      du_component[p] = jacobian_xi[p] * logical_xi[p];
+    }
+  }
+  return true;
+}
+
+bool fused_partial_derivatives_fast_path(
+    double* const du, const double* const u,
+    const size_t number_of_independent_components, const Mesh<2>& mesh,
+    const std::array<const double*, 4>& inverse_jacobian) {
+  if (not fast_path_supports(mesh)) {
+    return false;
+  }
+  const size_t n0 = mesh.extents(0);
+  const size_t n1 = mesh.extents(1);
+  const size_t number_of_points = n0 * n1;
+  const PackedMatrix matrix_xi =
+      pack_matrix(Spectral::differentiation_matrix(mesh.slice_through(0)));
+  const PackedMatrix matrix_eta =
+      pack_matrix(Spectral::differentiation_matrix(mesh.slice_through(1)));
+  DataVector buffer{2 * number_of_points};
+  double* const logical_xi = buffer.data();
+  double* const logical_eta = buffer.data() + number_of_points;
+  for (size_t component = 0; component < number_of_independent_components;
+       ++component) {
+    const double* const u_component = u + (component * number_of_points);
+    dispatch_on_extent(n0, [&](const auto extent) {
+      differentiate_first_dim<decltype(extent)::value>(logical_xi, u_component,
+                                                       matrix_xi.data(), n1);
+    });
+    dispatch_on_extent(n1, [&](const auto extent) {
+      differentiate_middle_dim_dispatch<decltype(extent)::value>(
+          logical_eta, u_component, matrix_eta.data(), n0, 1);
+    });
+    for (size_t i = 0; i < 2; ++i) {
+      double* const du_component =
+          du + ((component * 2 + i) * number_of_points);
+      const double* const jacobian_xi = inverse_jacobian[i];
+      const double* const jacobian_eta = inverse_jacobian[2 + i];
+      for (size_t p = 0; p < number_of_points; ++p) {
+        du_component[p] = (jacobian_xi[p] * logical_xi[p]) +
+                          (jacobian_eta[p] * logical_eta[p]);
+      }
+    }
+  }
+  return true;
+}
+
+bool fused_partial_derivatives_fast_path(
+    double* const du, const double* const u,
+    const size_t number_of_independent_components, const Mesh<3>& mesh,
+    const std::array<const double*, 9>& inverse_jacobian) {
+  if (not fast_path_supports(mesh)) {
+    return false;
+  }
+  const size_t n0 = mesh.extents(0);
+  const size_t n1 = mesh.extents(1);
+  const size_t n2 = mesh.extents(2);
+  const size_t number_of_points = n0 * n1 * n2;
+  const PackedMatrix matrix_xi =
+      pack_matrix(Spectral::differentiation_matrix(mesh.slice_through(0)));
+  const PackedMatrix matrix_eta =
+      pack_matrix(Spectral::differentiation_matrix(mesh.slice_through(1)));
+  const PackedMatrix matrix_zeta =
+      pack_matrix(Spectral::differentiation_matrix(mesh.slice_through(2)));
+  // Per-component logical-derivative buffers; small enough to stay resident
+  // in the core-private cache while the Jacobian contraction consumes them.
+  DataVector buffer{3 * number_of_points};
+  double* const logical_xi = buffer.data();
+  double* const logical_eta = buffer.data() + number_of_points;
+  double* const logical_zeta = buffer.data() + (2 * number_of_points);
+  for (size_t component = 0; component < number_of_independent_components;
+       ++component) {
+    const double* const u_component = u + (component * number_of_points);
+    dispatch_on_extent(n0, [&](const auto extent) {
+      differentiate_first_dim<decltype(extent)::value>(
+          logical_xi, u_component, matrix_xi.data(), n1 * n2);
+    });
+    dispatch_on_extent(n1, [&](const auto extent) {
+      differentiate_middle_dim_dispatch<decltype(extent)::value>(
+          logical_eta, u_component, matrix_eta.data(), n0, n2);
+    });
+    dispatch_on_extent(n2, [&](const auto extent) {
+      differentiate_middle_dim_dispatch<decltype(extent)::value>(
+          logical_zeta, u_component, matrix_zeta.data(), n0 * n1, 1);
+    });
+    for (size_t i = 0; i < 3; ++i) {
+      double* const du_component =
+          du + ((component * 3 + i) * number_of_points);
+      const double* const jacobian_xi = inverse_jacobian[i];
+      const double* const jacobian_eta = inverse_jacobian[3 + i];
+      const double* const jacobian_zeta = inverse_jacobian[6 + i];
+      for (size_t p = 0; p < number_of_points; ++p) {
+        du_component[p] = (jacobian_xi[p] * logical_xi[p]) +
+                          (jacobian_eta[p] * logical_eta[p]) +
+                          (jacobian_zeta[p] * logical_zeta[p]);
+      }
+    }
+  }
+  return true;
+}
 // NOLINTEND(cppcoreguidelines-pro-bounds-constant-array-index)
 // NOLINTEND(cppcoreguidelines-pro-bounds-pointer-arithmetic)
 }  // namespace partial_derivatives_detail

--- a/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.cpp
+++ b/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.cpp
@@ -7,6 +7,7 @@
 #include <blaze/math/DynamicMatrix.h>
 #include <cstddef>
 #include <functional>
+#include <type_traits>
 #include <vector>
 
 #include "DataStructures/ComplexDataVector.hpp"
@@ -86,6 +87,325 @@ void apply_matrix_in_first_dim(std::complex<double>* result,
   //   raw_transpose(make_not_null(reinterpret_cast<double*>(result)),
   //                 buffer.data(), size, 2);
 }
+
+// NOLINTBEGIN(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+// NOLINTBEGIN(cppcoreguidelines-pro-bounds-constant-array-index)
+namespace {
+// Fixed-size differentiation kernels. Each kernel is templated on the extent
+// of the dimension it contracts over (needed at compile time so the
+// accumulators live in vector registers); every other extent is a runtime
+// batch count over unit-stride data. Written as plain FMA loops that
+// auto-vectorize (AVX-512/AVX2/NEON) with no BLAS packing and no transposes.
+
+// Largest extent handled by the fast path; larger meshes fall back to the
+// generic dgemm+transpose implementation.
+constexpr size_t fast_path_max_extent = 20;
+
+// Calls f(std::integral_constant<size_t, extent>{}) for extents in the
+// instantiated kernel range. Returns false outside the range so callers can
+// fall back to the generic implementation.
+template <typename F>
+bool dispatch_on_extent(const size_t extent, const F& f) {
+  switch (extent) {
+    case 2:
+      f(std::integral_constant<size_t, 2>{});
+      return true;
+    case 3:
+      f(std::integral_constant<size_t, 3>{});
+      return true;
+    case 4:
+      f(std::integral_constant<size_t, 4>{});
+      return true;
+    case 5:
+      f(std::integral_constant<size_t, 5>{});
+      return true;
+    case 6:
+      f(std::integral_constant<size_t, 6>{});
+      return true;
+    case 7:
+      f(std::integral_constant<size_t, 7>{});
+      return true;
+    case 8:
+      f(std::integral_constant<size_t, 8>{});
+      return true;
+    case 9:
+      f(std::integral_constant<size_t, 9>{});
+      return true;
+    case 10:
+      f(std::integral_constant<size_t, 10>{});
+      return true;
+    case 11:
+      f(std::integral_constant<size_t, 11>{});
+      return true;
+    case 12:
+      f(std::integral_constant<size_t, 12>{});
+      return true;
+    case 13:
+      f(std::integral_constant<size_t, 13>{});
+      return true;
+    case 14:
+      f(std::integral_constant<size_t, 14>{});
+      return true;
+    case 15:
+      f(std::integral_constant<size_t, 15>{});
+      return true;
+    case 16:
+      f(std::integral_constant<size_t, 16>{});
+      return true;
+    case 17:
+      f(std::integral_constant<size_t, 17>{});
+      return true;
+    case 18:
+      f(std::integral_constant<size_t, 18>{});
+      return true;
+    case 19:
+      f(std::integral_constant<size_t, 19>{});
+      return true;
+    case 20:
+      f(std::integral_constant<size_t, 20>{});
+      return true;
+    default:
+      return false;
+  }
+}
+
+// The kernels index the differentiation matrix with a column stride equal to
+// their compile-time extent, so the (tiny) matrix is copied out of blaze
+// storage (which may pad columns) once per call. A runtime column stride
+// measurably slows the kernels down with gcc.
+using PackedMatrix =
+    std::array<double, fast_path_max_extent * fast_path_max_extent>;
+
+PackedMatrix pack_matrix(const Matrix& matrix) {
+  PackedMatrix packed{};
+  const size_t extent = matrix.rows();
+  for (size_t k = 0; k < extent; ++k) {
+    for (size_t i = 0; i < extent; ++i) {
+      packed[i + (extent * k)] = matrix(i, k);
+    }
+  }
+  return packed;
+}
+
+// Differentiate along the first (fastest) logical dimension:
+// out(i, l) = sum_k D(i, k) u(k, l) for `number_of_lines` contiguous lines of
+// length N. The output line is accumulated in registers, one broadcast-FMA of
+// a matrix column per k.
+template <size_t N>
+void differentiate_first_dim(double* const out, const double* const u,
+                             const double* const matrix,
+                             const size_t number_of_lines) {
+  for (size_t line = 0; line < number_of_lines; ++line) {
+    const double* const u_line = u + (line * N);
+    double* const out_line = out + (line * N);
+    std::array<double, N> accumulator{};
+    for (size_t k = 0; k < N; ++k) {
+      const double u_k = u_line[k];
+      const double* const matrix_column = matrix + (k * N);
+      for (size_t i = 0; i < N; ++i) {
+        accumulator[i] += matrix_column[i] * u_k;
+      }
+    }
+    for (size_t i = 0; i < N; ++i) {
+      out_line[i] = accumulator[i];
+    }
+  }
+}
+
+// Differentiate along a middle or the slowest logical dimension with the
+// stride (the product of the extents of all faster dimensions) known at
+// compile time. The data is viewed as [batch][k][Stride] with the contracted
+// index k in the middle: out(s, i, b) = sum_k D(i, k) u(s, k, b). Each output
+// line of `Stride` values is accumulated in registers and stored exactly once
+// (a read-modify-write pass per k measured ~1.6x slower).
+template <size_t N, size_t Stride>
+void differentiate_middle_dim_small_stride(double* const out,
+                                           const double* const u,
+                                           const double* const matrix,
+                                           const size_t number_of_batches) {
+  for (size_t b = 0; b < number_of_batches; ++b) {
+    const double* const u_batch = u + (b * Stride * N);
+    double* const out_batch = out + (b * Stride * N);
+    for (size_t i = 0; i < N; ++i) {
+      std::array<double, Stride> accumulator{};
+      for (size_t k = 0; k < N; ++k) {
+        const double matrix_ik = matrix[i + (k * N)];
+        const double* const u_slice = u_batch + (k * Stride);
+        for (size_t x = 0; x < Stride; ++x) {
+          accumulator[x] += matrix_ik * u_slice[x];
+        }
+      }
+      double* const out_slice = out_batch + (i * Stride);
+      for (size_t x = 0; x < Stride; ++x) {
+        out_slice[x] = accumulator[x];
+      }
+    }
+  }
+}
+
+// One register-resident strip of width StripWidth for the runtime-stride
+// variant below: out_slice[s..s+W) = sum_k D(i,k) u(s.., k).
+template <size_t N, size_t StripWidth>
+void middle_dim_strip(double* const out_slice, const double* const u_batch,
+                      const double* const matrix, const size_t i,
+                      const size_t stride, const size_t s) {
+  std::array<double, StripWidth> accumulator{};
+  for (size_t k = 0; k < N; ++k) {
+    const double matrix_ik = matrix[i + (k * N)];
+    const double* const u_slice = u_batch + (k * stride) + s;
+    for (size_t j = 0; j < StripWidth; ++j) {
+      accumulator[j] += matrix_ik * u_slice[j];
+    }
+  }
+  for (size_t j = 0; j < StripWidth; ++j) {
+    out_slice[s + j] = accumulator[j];
+  }
+}
+
+// Runtime-stride variant, used when the stride exceeds the dispatch range
+// (i.e. for the slowest dimension of most meshes). Vectorized over the
+// contiguous fastest index in register-resident strips; the remainder after
+// the strips of 8 is handled by a 4/2/1 cascade of smaller strips so it stays
+// vectorized.
+template <size_t N>
+void differentiate_middle_dim(double* const out, const double* const u,
+                              const double* const matrix, const size_t stride,
+                              const size_t number_of_batches) {
+  for (size_t b = 0; b < number_of_batches; ++b) {
+    const double* const u_batch = u + (b * stride * N);
+    double* const out_batch = out + (b * stride * N);
+    for (size_t i = 0; i < N; ++i) {
+      double* const out_slice = out_batch + (i * stride);
+      size_t s = 0;
+      for (; s + 8 <= stride; s += 8) {
+        middle_dim_strip<N, 8>(out_slice, u_batch, matrix, i, stride, s);
+      }
+      if (s + 4 <= stride) {
+        middle_dim_strip<N, 4>(out_slice, u_batch, matrix, i, stride, s);
+        s += 4;
+      }
+      if (s + 2 <= stride) {
+        middle_dim_strip<N, 2>(out_slice, u_batch, matrix, i, stride, s);
+        s += 2;
+      }
+      if (s < stride) {
+        middle_dim_strip<N, 1>(out_slice, u_batch, matrix, i, stride, s);
+      }
+    }
+  }
+}
+
+// Differentiate along a middle or the slowest logical dimension, using the
+// compile-time-stride kernel whenever the stride is in dispatch range (always
+// true for the middle dimension when the fast path is active).
+template <size_t N>
+void differentiate_middle_dim_dispatch(double* const out, const double* const u,
+                                       const double* const matrix,
+                                       const size_t stride,
+                                       const size_t number_of_batches) {
+  const bool used_small_stride =
+      dispatch_on_extent(stride, [&](const auto stride_v) {
+        differentiate_middle_dim_small_stride<N, decltype(stride_v)::value>(
+            out, u, matrix, number_of_batches);
+      });
+  if (not used_small_stride) {
+    differentiate_middle_dim<N>(out, u, matrix, stride, number_of_batches);
+  }
+}
+
+template <size_t Dim>
+bool fast_path_supports(const Mesh<Dim>& mesh) {
+  for (size_t d = 0; d < Dim; ++d) {
+    if (mesh.basis(d) != Spectral::Basis::Legendre and
+        mesh.basis(d) != Spectral::Basis::Chebyshev) {
+      return false;
+    }
+    if (mesh.extents(d) < 2 or mesh.extents(d) > fast_path_max_extent) {
+      return false;
+    }
+  }
+  return true;
+}
+}  // namespace
+
+bool logical_derivatives_fast_path(
+    const std::array<double*, 1>& logical_derivs, const double* const u,
+    const size_t number_of_independent_components, const Mesh<1>& mesh) {
+  if (not fast_path_supports(mesh)) {
+    return false;
+  }
+  const PackedMatrix matrix_xi =
+      pack_matrix(Spectral::differentiation_matrix(mesh.slice_through(0)));
+  dispatch_on_extent(mesh.extents(0), [&](const auto extent) {
+    differentiate_first_dim<decltype(extent)::value>(
+        logical_derivs[0], u, matrix_xi.data(),
+        number_of_independent_components);
+  });
+  return true;
+}
+
+bool logical_derivatives_fast_path(
+    const std::array<double*, 2>& logical_derivs, const double* const u,
+    const size_t number_of_independent_components, const Mesh<2>& mesh) {
+  if (not fast_path_supports(mesh)) {
+    return false;
+  }
+  const size_t n0 = mesh.extents(0);
+  const size_t n1 = mesh.extents(1);
+  const PackedMatrix matrix_xi =
+      pack_matrix(Spectral::differentiation_matrix(mesh.slice_through(0)));
+  const PackedMatrix matrix_eta =
+      pack_matrix(Spectral::differentiation_matrix(mesh.slice_through(1)));
+  dispatch_on_extent(n0, [&](const auto extent) {
+    differentiate_first_dim<decltype(extent)::value>(
+        logical_derivs[0], u, matrix_xi.data(),
+        number_of_independent_components * n1);
+  });
+  dispatch_on_extent(n1, [&](const auto extent) {
+    differentiate_middle_dim_dispatch<decltype(extent)::value>(
+        logical_derivs[1], u, matrix_eta.data(), n0,
+        number_of_independent_components);
+  });
+  return true;
+}
+
+bool logical_derivatives_fast_path(
+    const std::array<double*, 3>& logical_derivs, const double* const u,
+    const size_t number_of_independent_components, const Mesh<3>& mesh) {
+  if (not fast_path_supports(mesh)) {
+    return false;
+  }
+  const size_t n0 = mesh.extents(0);
+  const size_t n1 = mesh.extents(1);
+  const size_t n2 = mesh.extents(2);
+  const PackedMatrix matrix_xi =
+      pack_matrix(Spectral::differentiation_matrix(mesh.slice_through(0)));
+  const PackedMatrix matrix_eta =
+      pack_matrix(Spectral::differentiation_matrix(mesh.slice_through(1)));
+  const PackedMatrix matrix_zeta =
+      pack_matrix(Spectral::differentiation_matrix(mesh.slice_through(2)));
+  // All three kernels batch over every component at once; for eta the batch
+  // also folds in the z-planes since the [comp][z] slabs are contiguous.
+  dispatch_on_extent(n0, [&](const auto extent) {
+    differentiate_first_dim<decltype(extent)::value>(
+        logical_derivs[0], u, matrix_xi.data(),
+        number_of_independent_components * n1 * n2);
+  });
+  dispatch_on_extent(n1, [&](const auto extent) {
+    differentiate_middle_dim_dispatch<decltype(extent)::value>(
+        logical_derivs[1], u, matrix_eta.data(), n0,
+        number_of_independent_components * n2);
+  });
+  dispatch_on_extent(n2, [&](const auto extent) {
+    differentiate_middle_dim_dispatch<decltype(extent)::value>(
+        logical_derivs[2], u, matrix_zeta.data(), n0 * n1,
+        number_of_independent_components);
+  });
+  return true;
+}
+
+// NOLINTEND(cppcoreguidelines-pro-bounds-constant-array-index)
+// NOLINTEND(cppcoreguidelines-pro-bounds-pointer-arithmetic)
 }  // namespace partial_derivatives_detail
 
 template <typename DataType, typename SymmList, typename IndexList, size_t Dim>

--- a/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp
@@ -65,6 +65,23 @@ bool logical_derivatives_fast_path(const std::array<double*, 3>& logical_derivs,
                                    size_t number_of_independent_components,
                                    const Mesh<3>& mesh);
 
+// As above, but additionally contracts with the inverse Jacobian one
+// component at a time, so the logical derivatives stay cache-resident and are
+// never written to main memory. `du` must have room for
+// `Dim * number_of_independent_components` components laid out as
+// [component][derivative index][grid points], matching
+// `partial_derivatives_impl`. `inverse_jacobian[d * Dim + i]` must point to
+// the (logical d, inertial i) component. Returns false when the mesh is not
+// supported.
+bool fused_partial_derivatives_fast_path(
+    double* du, const double* u, size_t number_of_independent_components,
+    const Mesh<1>& mesh, const std::array<const double*, 1>& inverse_jacobian);
+bool fused_partial_derivatives_fast_path(
+    double* du, const double* u, size_t number_of_independent_components,
+    const Mesh<2>& mesh, const std::array<const double*, 4>& inverse_jacobian);
+bool fused_partial_derivatives_fast_path(
+    double* du, const double* u, size_t number_of_independent_components,
+    const Mesh<3>& mesh, const std::array<const double*, 9>& inverse_jacobian);
 }  // namespace partial_derivatives_detail
 
 /// @{

--- a/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp
+++ b/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp
@@ -45,6 +45,26 @@ void apply_matrix_in_first_dim(std::complex<double>* result,
                                const std::complex<double>* input,
                                const Matrix& matrix, size_t size,
                                bool add_to_result = false);
+
+// Transpose-free differentiation along all logical dimensions using
+// fixed-size kernels (dispatched on the extent of the contracted dimension),
+// writing the logical derivatives directly without the dgemm+transpose
+// pipeline. Returns false when the mesh is not supported (basis other than
+// Legendre/Chebyshev, or an extent outside the instantiated kernel range);
+// the caller must then fall back to the generic implementation.
+bool logical_derivatives_fast_path(const std::array<double*, 1>& logical_derivs,
+                                   const double* u,
+                                   size_t number_of_independent_components,
+                                   const Mesh<1>& mesh);
+bool logical_derivatives_fast_path(const std::array<double*, 2>& logical_derivs,
+                                   const double* u,
+                                   size_t number_of_independent_components,
+                                   const Mesh<2>& mesh);
+bool logical_derivatives_fast_path(const std::array<double*, 3>& logical_derivs,
+                                   const double* u,
+                                   size_t number_of_independent_components,
+                                   const Mesh<3>& mesh);
+
 }  // namespace partial_derivatives_detail
 
 /// @{

--- a/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp
+++ b/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp
@@ -664,6 +664,22 @@ void partial_derivatives(
     partial_derivatives_of_u.initialize(mesh.number_of_grid_points());
   }
 
+  if constexpr (std::is_same_v<ValueType, double>) {
+    std::array<const double*, Dim * Dim> inverse_jacobian_pointers{};
+    for (size_t d = 0; d < Dim; ++d) {
+      for (size_t i = 0; i < Dim; ++i) {
+        gsl::at(inverse_jacobian_pointers, d * Dim + i) =
+            inverse_jacobian.get(d, i).data();
+      }
+    }
+    if (partial_derivatives_detail::fused_partial_derivatives_fast_path(
+            partial_derivatives_of_u.data(), u.data(),
+            Variables<DerivativeTags>::number_of_independent_components, mesh,
+            inverse_jacobian_pointers)) {
+      return;
+    }
+  }
+
   const size_t vars_size =
       u.number_of_grid_points() *
       Variables<DerivativeTags>::number_of_independent_components;

--- a/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp
+++ b/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp
@@ -851,6 +851,14 @@ struct LogicalImpl<1, VariableTags, DerivativeTags> {
             "for logical_partial_derivative.");
       }
     } else {
+      if constexpr (std::is_same_v<ValueType, double>) {
+        if (logical_derivatives_fast_path(
+                logical_partial_derivatives_of_u, u.data(),
+                Variables<DerivativeTags>::number_of_independent_components,
+                mesh)) {
+          return;
+        }
+      }
       const Matrix& differentiation_matrix_xi =
           Spectral::differentiation_matrix(mesh.slice_through(0));
       apply_matrix_in_first_dim(logical_partial_derivatives_of_u[0], u.data(),
@@ -1033,6 +1041,14 @@ struct LogicalImpl<2, VariableTags, DerivativeTags> {
       }
     } else {
       auto& logical_partial_derivatives_of_u = *logical_du;
+      if constexpr (std::is_same_v<ValueType, double>) {
+        if (logical_derivatives_fast_path(
+                logical_partial_derivatives_of_u, u.data(),
+                Variables<DerivativeTags>::number_of_independent_components,
+                mesh)) {
+          return;
+        }
+      }
       const size_t deriv_size =
           Variables<DerivativeTags>::number_of_independent_components *
           u.number_of_grid_points();
@@ -1307,6 +1323,14 @@ struct LogicalImpl<3, VariableTags, DerivativeTags> {
               Variables<T>::number_of_independent_components,
           "Temporary buffer in logical partial derivatives is too small");
       auto& logical_partial_derivatives_of_u = *logical_du;
+      if constexpr (std::is_same_v<ValueType, double>) {
+        if (logical_derivatives_fast_path(
+                logical_partial_derivatives_of_u, u.data(),
+                Variables<DerivativeTags>::number_of_independent_components,
+                mesh)) {
+          return;
+        }
+      }
       const Matrix& differentiation_matrix_xi =
           Spectral::differentiation_matrix(mesh.slice_through(0));
       const size_t deriv_size =

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
@@ -12,6 +12,7 @@
 #include <string>
 #include <type_traits>
 
+#include "DataStructures/ApplyMatrices.hpp"
 #include "DataStructures/ComplexDataVector.hpp"
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
@@ -21,6 +22,7 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Index.hpp"
 #include "DataStructures/IndexIterator.hpp"
+#include "DataStructures/Matrix.hpp"
 #include "DataStructures/Tags/TempTensor.hpp"
 #include "DataStructures/Tensor/Metafunctions.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
@@ -42,6 +44,7 @@
 #include "Evolution/DgSubcell/Tags/ObserverMesh.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
 #include "Helpers/NumericalAlgorithms/Spectral/DiskTestFunctions.hpp"
 #include "Helpers/NumericalAlgorithms/SphericalHarmonics/YlmTestFunctions.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
@@ -50,6 +53,7 @@
 #include "NumericalAlgorithms/Spectral/BasisFunctions/Fourier.hpp"
 #include "NumericalAlgorithms/Spectral/BasisFunctions/Zernike.hpp"
 #include "NumericalAlgorithms/Spectral/CollocationPoints.hpp"
+#include "NumericalAlgorithms/Spectral/DifferentiationMatrix.hpp"
 #include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
 #include "NumericalAlgorithms/Spectral/MaximumNumberOfPoints.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
@@ -2064,7 +2068,91 @@ void test_partial_derivatives_zernikeb1_cartoon(const size_t n_x) {
   const Approx local_approx = Approx::custom().epsilon(1e-12).scale(1.0);
   CHECK_VARIABLES_CUSTOM_APPROX(computed_d_vars, expected_d_vars, local_approx);
 }
+
+// Compares the fixed-size fast-path kernels (used automatically by
+// `logical_partial_derivatives` and `partial_derivatives` for
+// Legendre/Chebyshev meshes with all extents in [2, 20]) against the generic
+// dgemm+transpose pipeline, via `apply_matrices`, on random data for every
+// extent the kernels are instantiated for. The two implementations sum in a
+// different order, so agreement is to roundoff rather than bitwise.
+template <size_t Dim>
+void test_fast_path_vs_generic() {
+  MAKE_GENERATOR(gen);
+  std::uniform_real_distribution<double> dist{-1.0, 1.0};
+  using vars_tags = two_vars<DataVector, Dim>;
+  constexpr size_t number_of_components =
+      Variables<vars_tags>::number_of_independent_components;
+  const Approx local_approx = Approx::custom().epsilon(1e-10).scale(1.0);
+  for (size_t extent = 2; extent <= 20; ++extent) {
+    std::array<size_t, Dim> extents{};
+    extents[0] = extent;
+    if constexpr (Dim > 1) {
+      extents[1] = extent == 20 ? 20 : extent + 1;
+    }
+    if constexpr (Dim > 2) {
+      extents[2] = extent == 2 ? 2 : extent - 1;
+    }
+    const Mesh<Dim> mesh{extents, Spectral::Basis::Legendre,
+                         Spectral::Quadrature::GaussLobatto};
+    const size_t number_of_grid_points = mesh.number_of_grid_points();
+    Variables<vars_tags> u{number_of_grid_points};
+    fill_with_random_values(make_not_null(&u), make_not_null(&gen),
+                            make_not_null(&dist));
+    InverseJacobian<DataVector, Dim, Frame::ElementLogical, Frame::Grid>
+        inverse_jacobian{number_of_grid_points};
+    fill_with_random_values(make_not_null(&inverse_jacobian),
+                            make_not_null(&gen), make_not_null(&dist));
+
+    // Reference logical derivatives from the generic infrastructure; empty
+    // matrices act as the identity in apply_matrices.
+    std::array<Variables<vars_tags>, Dim> expected_logical{};
+    for (size_t d = 0; d < Dim; ++d) {
+      gsl::at(expected_logical, d).initialize(number_of_grid_points);
+      std::array<Matrix, Dim> matrices{};
+      gsl::at(matrices, d) =
+          Spectral::differentiation_matrix(mesh.slice_through(d));
+      apply_matrices(make_not_null(&gsl::at(expected_logical, d)), matrices, u,
+                     mesh.extents());
+    }
+    const auto logical_derivs = logical_partial_derivatives<vars_tags>(u, mesh);
+    for (size_t d = 0; d < Dim; ++d) {
+      CHECK_VARIABLES_CUSTOM_APPROX(gsl::at(logical_derivs, d),
+                                    gsl::at(expected_logical, d), local_approx);
+    }
+
+    // Reference full derivatives: contract the reference logical derivatives
+    // with the inverse Jacobian.
+    using deriv_tags = db::wrap_tags_in<Tags::deriv, vars_tags,
+                                        tmpl::size_t<Dim>, Frame::Grid>;
+    Variables<deriv_tags> expected_du{number_of_grid_points};
+    for (size_t c = 0; c < number_of_components; ++c) {
+      for (size_t i = 0; i < Dim; ++i) {
+        DataVector expected_component{
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+            expected_du.data() + ((c * Dim + i) * number_of_grid_points),
+            number_of_grid_points};
+        expected_component = 0.0;
+        for (size_t d = 0; d < Dim; ++d) {
+          const DataVector logical_component{
+              // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+              gsl::at(expected_logical, d).data() + (c * number_of_grid_points),
+              number_of_grid_points};
+          expected_component += inverse_jacobian.get(d, i) * logical_component;
+        }
+      }
+    }
+    const auto du = partial_derivatives<vars_tags>(u, mesh, inverse_jacobian);
+    CHECK_VARIABLES_CUSTOM_APPROX(du, expected_du, local_approx);
+  }
+}
 }  // namespace
+
+SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.PartialDerivs.FastPath",
+                  "[NumericalAlgorithms][LinearOperators][Unit]") {
+  test_fast_path_vs_generic<1>();
+  test_fast_path_vs_generic<2>();
+  test_fast_path_vs_generic<3>();
+}
 
 // [[Timeout, 60]]
 SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.LogicalDerivs",


### PR DESCRIPTION
# Add a transpose-free fast path for partial derivatives

## Proposed changes

`logical_partial_derivatives` and `partial_derivatives` are among the hottest
kernels. This PR replaces their dgemm-and-transpose pipeline with fixed-size differentiation kernels for
Legendre/Chebyshev meshes with extents in [2, 20], and fuses the
inverse-Jacobian contraction into `partial_derivatives`. All other bases
(spherical harmonic, Zernike), extents outside the kernel range, and
complex-valued `Variables` fall back to the existing implementation unchanged.

### What is different

The current 3D implementation applies the 1D differentiation matrices via
`dgemm`, transposing the full `Variables` before and after the matrix apply
for the second and third dimensions (four ~400 KB transposes per call at
order 10 with 50 components). The new implementation:

- **Differentiates each dimension in place, without transposes.** The first
  (fastest) dimension accumulates each output line in vector registers with
  one broadcast-FMA per matrix column; the other dimensions accumulate
  register-resident lines over the contiguous fastest index. The kernels are
  plain unit-stride FMA loops that auto-vectorize (AVX2/AVX-512/NEON), with
  no BLAS calls.
- **Only the extent of the contracted dimension is a compile-time template
  parameter** (dispatched by a switch over 2–20), so arbitrary anisotropic
  meshes are supported by three independent per-dimension dispatches. The
  small differentiation matrices are packed into compile-time-strided buffers
  once per call, which measurably helps gcc's code generation.
- **`partial_derivatives` processes one tensor component at a time and
  contracts with the inverse Jacobian immediately**, while that component's
  three logical derivatives are still resident in the core-private cache.
  The logical derivatives are never written to main memory, removing the
  full-`Variables` round trip between differentiation and the frame
  transformation.

### Why it is faster

Profiling (Apple M4 and a 2×28-core Xeon 8276 node) showed the kernel is
*not* limited by the transposes alone: for a 10x10x10 grid,
`dgemm`'s packing overhead dominates and OpenBLAS reaches only ~⅓ of FLOP
peak while also staying far below memory bandwidth. Fixed-size kernels avoid
the packing entirely, and the fusion removes ~2.4 MB of memory traffic per
call (order 10, 3D, 50 components). The traffic reduction matters most in
production, where all cores contend for shared cache/DRAM bandwidth: the old
pipeline slows down by 2.3× when every core of a Xeon node runs the kernel
concurrently, while the fused fast path degrades by only ~15%.

### Measurements

Order 10, 3D, 50 components, 1000 grid
points as measured on my laptop and a dedicated CaltechHPC node:

| | before | after | speedup |
|---|---|---|---|
| `logical_partial_derivatives` (M4) | 146 µs | 79 µs | 1.85× |
| `partial_derivatives` (M4) | 215 µs | 114 µs | 1.89× |
| `partial_derivatives` (Xeon 8276, 1 core) | 547 µs | 469 µs | 1.17× |
| `partial_derivatives` (Xeon 8276, all 56 cores concurrently) | 1261 µs | 526 µs | **2.40×** |

Speedups of 1.4–2.1× hold across orders 4–18 on M4. In a production q=2 BBH
inspiral on 2 CaltechHPC nodes, this change alone raised the steady-state run
speed from ~41–42 M/h to ~45–46 M/h (**≈ +10%**); a larger gain can likely be realized by reducing core idle time.

### Correctness

- The fast-path results agree with the previous implementation to roundoff
  (the summation order differs from `dgemm`'s; max relative difference
  ~1e-12 on random data, and the analytic-polynomial test sweeps pass
  unchanged).
- A new test case compares both fast paths against the generic
  dgemm+transpose pipeline (driven independently through `apply_matrices`)
  on random data with a random inverse Jacobian, for **every** dispatched
  extent in 1D, 2D, and 3D with anisotropic meshes. This also keeps the
  generic implementation covered now that the existing sweeps mostly
  exercise the fast path.