### PR TITLE
Reduce Spectral compile time/memory

### DIFF
--- a/src/NumericalAlgorithms/Spectral/PrecomputedSpectralQuantity.hpp
+++ b/src/NumericalAlgorithms/Spectral/PrecomputedSpectralQuantity.hpp
@@ -9,7 +9,7 @@
 #include "NumericalAlgorithms/Spectral/MinimumNumberOfPoints.hpp"
 #include "NumericalAlgorithms/Spectral/Parity.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
-#include "Utilities/StaticCache.hpp"
+#include "Utilities/RuntimeCache.hpp"
 
 /// \cond
 namespace Spectral {
@@ -70,7 +70,8 @@ const auto& precomputed_spectral_quantity_with_parity(const size_t num_points,
 template <Basis BasisType, Quadrature QuadratureType,
           typename SpectralQuantityGenerator>
 const auto& precomputed_two_indexed_spectral_quantity(const size_t num_points,
-                                           const size_t m, const size_t N) {
+                                                      const size_t m,
+                                                      const size_t N) {
   constexpr size_t max_num_points =
       Spectral::maximum_number_of_points<BasisType>;
   constexpr size_t min_num_points =
@@ -80,14 +81,10 @@ const auto& precomputed_two_indexed_spectral_quantity(const size_t num_points,
          "points for this quadrature.");
   ASSERT(num_points <= max_num_points,
          "Exceeded maximum number of collocation points.");
-  // We compute the quantity for all possible `num_point`s the first time this
-  // function is called and keep the data around for the lifetime of the
-  // program. The computation is handled by the call operator of the
-  // `SpectralQuantityType` instance.
   static const auto precomputed_data =
-      make_static_cache<CacheRange<min_num_points, max_num_points + 1>,
-                        CacheRange<0_st, 2 * max_num_points - 1>,
-                        CacheRange<0_st, 2 * max_num_points - 1>>(
+      make_runtime_cache<CacheRange<min_num_points, max_num_points + 1>,
+                         CacheRange<size_t{0}, 2 * max_num_points - 1>,
+                         CacheRange<size_t{0}, 2 * max_num_points - 1>>(
           SpectralQuantityGenerator{});
   return precomputed_data(num_points, m, N);
 }

--- a/src/NumericalAlgorithms/Spectral/Projection.cpp
+++ b/src/NumericalAlgorithms/Spectral/Projection.cpp
@@ -33,7 +33,7 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Literals.hpp"
 #include "Utilities/MakeArray.hpp"
-#include "Utilities/StaticCache.hpp"
+#include "Utilities/RuntimeCache.hpp"
 
 namespace Spectral {
 namespace {
@@ -123,7 +123,7 @@ const Matrix& projection_matrix_child_to_parent(const Mesh<1>& child_mesh,
           {child_extent, child_basis, child_quadrature}, local_child_size);
       return blaze::trans(prolongation_operator);
     };
-    const static auto cache_legendre = make_static_cache<
+    const static auto cache_legendre = make_runtime_cache<
         CacheEnumeration<Quadrature, Quadrature::Gauss,
                          Quadrature::GaussLobatto>,
         CacheRange<2_st, max_points_l + 1>,
@@ -140,7 +140,7 @@ const Matrix& projection_matrix_child_to_parent(const Mesh<1>& child_mesh,
                                 local_child_size);
         });
     const static auto cache_fourier =
-        make_static_cache<CacheRange<2_st, max_points_f + 1>,
+        make_runtime_cache<CacheRange<2_st, max_points_f + 1>,
                           CacheRange<2_st, max_points_f + 1>>(
             [compute_matrix](const size_t n_parent, const size_t n_child) {
               return compute_matrix(Basis::Fourier, Quadrature::Equiangular,
@@ -192,7 +192,7 @@ const Matrix& projection_matrix_child_to_parent(const Mesh<1>& child_mesh,
             return projection;
           };
       const static auto cache_legendre =
-          make_static_cache<CacheEnumeration<Quadrature, Quadrature::Gauss,
+          make_runtime_cache<CacheEnumeration<Quadrature, Quadrature::Gauss,
                                              Quadrature::GaussLobatto>,
                             CacheRange<2_st, max_points_l + 1>,
                             CacheEnumeration<Quadrature, Quadrature::Gauss,
@@ -204,7 +204,7 @@ const Matrix& projection_matrix_child_to_parent(const Mesh<1>& child_mesh,
                                       Basis::Legendre, q_child, n_child);
               });
       const static auto cache_fourier =
-          make_static_cache<CacheRange<2_st, max_points_f + 1>,
+          make_runtime_cache<CacheRange<2_st, max_points_f + 1>,
                             CacheRange<2_st, max_points_f + 1>>(
               [compute_matrix](const size_t n_parent, const size_t n_child) {
                 return compute_matrix(Basis::Fourier, Quadrature::Equiangular,
@@ -221,7 +221,7 @@ const Matrix& projection_matrix_child_to_parent(const Mesh<1>& child_mesh,
     }
 
     case SegmentSize::UpperHalf: {
-      const static auto cache = make_static_cache<
+      const static auto cache = make_runtime_cache<
           CacheEnumeration<Quadrature, Quadrature::Gauss,
                            Quadrature::GaussLobatto>,
           CacheRange<2_st, max_points_l + 1>,
@@ -302,7 +302,7 @@ const Matrix& projection_matrix_child_to_parent(const Mesh<1>& child_mesh,
 
     case SegmentSize::LowerHalf: {
       const static auto cache =
-          make_static_cache<CacheEnumeration<Quadrature, Quadrature::Gauss,
+          make_runtime_cache<CacheEnumeration<Quadrature, Quadrature::Gauss,
                                              Quadrature::GaussLobatto>,
                             CacheRange<2_st, max_points_l + 1>,
                             CacheEnumeration<Quadrature, Quadrature::Gauss,
@@ -413,7 +413,7 @@ const Matrix& projection_matrix_parent_to_child(const Mesh<1>& parent_mesh,
   switch (size) {
     case SegmentSize::Full: {
       const static auto cache =
-          make_static_cache<CacheEnumeration<Quadrature, Quadrature::Gauss,
+          make_runtime_cache<CacheEnumeration<Quadrature, Quadrature::Gauss,
                                              Quadrature::GaussLobatto>,
                             CacheRange<2_st, max_points_l + 1>,
                             CacheEnumeration<Quadrature, Quadrature::Gauss,
@@ -426,7 +426,7 @@ const Matrix& projection_matrix_parent_to_child(const Mesh<1>& parent_mesh,
 
     case SegmentSize::UpperHalf: {
       const static auto cache =
-          make_static_cache<CacheEnumeration<Quadrature, Quadrature::Gauss,
+          make_runtime_cache<CacheEnumeration<Quadrature, Quadrature::Gauss,
                                              Quadrature::GaussLobatto>,
                             CacheRange<2_st, max_points_l + 1>,
                             CacheEnumeration<Quadrature, Quadrature::Gauss,
@@ -441,7 +441,7 @@ const Matrix& projection_matrix_parent_to_child(const Mesh<1>& parent_mesh,
 
     case SegmentSize::LowerHalf: {
       const static auto cache =
-          make_static_cache<CacheEnumeration<Quadrature, Quadrature::Gauss,
+          make_runtime_cache<CacheEnumeration<Quadrature, Quadrature::Gauss,
                                              Quadrature::GaussLobatto>,
                             CacheRange<2_st, max_points_l + 1>,
                             CacheEnumeration<Quadrature, Quadrature::Gauss,

--- a/src/Utilities/CMakeLists.txt
+++ b/src/Utilities/CMakeLists.txt
@@ -72,6 +72,7 @@ spectre_target_headers(
   Rational.hpp
   Registration.hpp
   Requires.hpp
+  RuntimeCache.hpp
   SetNumberOfGridPoints.hpp
   SnakeCase.hpp
   Spherepack.hpp

--- a/src/Utilities/RuntimeCache.hpp
+++ b/src/Utilities/RuntimeCache.hpp
@@ -1,0 +1,94 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <mutex>
+#include <optional>
+#include <type_traits>
+#include <utility>
+
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/StaticCache.hpp"
+#include "Utilities/TypeTraits/IsInteger.hpp"
+
+/// \ingroup UtilitiesGroup
+/// A cache that selects and lazily initializes entries at runtime.
+///
+/// Unlike `StaticCache`, this class does not instantiate the generator once for
+/// every combination of indices. This reduces compile time for large caches at
+/// the cost of runtime index calculation and synchronization.
+///
+/// \note `RuntimeCache` is tested in `Test_StaticCache.cpp`.
+template <typename Generator, typename T, typename... Ranges>
+class RuntimeCache {
+ public:
+  explicit RuntimeCache(Generator generator)
+      : generator_{std::move(generator)} {}
+
+  template <typename... Args>
+  const T& operator()(const Args... parameters) const {
+    static_assert(sizeof...(parameters) == sizeof...(Ranges),
+                  "Number of arguments must match number of ranges.");
+    size_t array_location = 0;
+    ((array_location = array_location * static_cast<size_t>(Ranges::size) +
+                       index<Ranges>(parameters)),
+     ...);
+    std::call_once(gsl::at(initialized_, array_location), [this, array_location,
+                                                           &parameters...]() {
+      gsl::at(cached_objects_, array_location)
+          .emplace(generator_(
+              static_cast<typename Ranges::value_type>(parameters)...));
+    });
+    return gsl::at(cached_objects_, array_location).value();
+  }
+
+ private:
+  template <typename Range, typename U>
+  static size_t index(const U parameter) {
+    if constexpr (std::is_enum_v<U>) {
+      static_assert(
+          std::is_same_v<typename Range::value_type, std::remove_cv_t<U>>,
+          "Mismatched enum parameter type and cached type.");
+      for (size_t i = 0; i < Range::size; ++i) {
+        if (parameter == gsl::at(Range::values, i)) {
+          return i;
+        }
+      }
+      ERROR("Uncached enumeration value: " << parameter);
+    } else {
+      static_assert(
+          tt::is_integer_v<std::remove_cv_t<U>>,
+          "The parameter passed for a CacheRange must be an integer type.");
+      if (UNLIKELY(
+              Range::start > static_cast<decltype(Range::start)>(parameter) or
+              static_cast<decltype(Range::start)>(parameter) >= Range::end)) {
+        ERROR("Index out of range: " << Range::start << " <= " << parameter
+                                     << " < " << Range::end);
+      }
+      return static_cast<size_t>(
+          static_cast<typename Range::value_type>(parameter) - Range::start);
+    }
+  }
+
+  static constexpr size_t number_of_entries =
+      (size_t{1} * ... * static_cast<size_t>(Ranges::size));
+  Generator generator_;
+  // NOLINTNEXTLINE(spectre-mutable)
+  mutable std::array<std::once_flag, number_of_entries> initialized_{};
+  // NOLINTNEXTLINE(spectre-mutable)
+  mutable std::array<std::optional<T>, number_of_entries> cached_objects_{};
+};
+
+/// \ingroup UtilitiesGroup
+/// Create a RuntimeCache, inferring the cached type from the generator.
+template <typename... Ranges, typename Generator>
+auto make_runtime_cache(Generator&& generator) {
+  using CachedType = std::remove_cvref_t<decltype(generator(
+      std::declval<typename Ranges::value_type>()...))>;
+  return RuntimeCache<std::remove_cvref_t<Generator>, CachedType, Ranges...>(
+      std::forward<Generator>(generator));
+}

--- a/tests/Unit/Utilities/Test_StaticCache.cpp
+++ b/tests/Unit/Utilities/Test_StaticCache.cpp
@@ -4,15 +4,19 @@
 #include "Framework/TestingFramework.hpp"
 
 #include <algorithm>
+#include <array>
+#include <atomic>
 #include <cstddef>
+#include <thread>
 #include <utility>
 #include <vector>
 
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/Literals.hpp"
 #include "Utilities/MakeString.hpp"
-#include "Utilities/StaticCache.hpp"
+#include "Utilities/RuntimeCache.hpp"
 
 namespace {
 enum class Color { Red, Green, Purple };
@@ -198,6 +202,58 @@ SPECTRE_TEST_CASE("Unit.Utilities.StaticCache", "[Utilities][Unit]") {
     }
   }
 
+  // RuntimeCache has the same lookup semantics as StaticCache, but avoids
+  // instantiating the generator for every combination of indices.
+  std::vector<std::pair<size_t, Color>> runtime_calls;
+  const auto runtime_cache = make_runtime_cache<
+      CacheRange<2_st, 5_st>,
+      CacheEnumeration<Color, Color::Red, Color::Green, Color::Purple>>(
+      [&runtime_calls](const size_t value, const Color color) {
+        runtime_calls.emplace_back(value, color);
+        return std::string{MakeString{} << value << color};
+      });
+  CHECK(runtime_calls.empty());
+  CHECK(runtime_cache(2, Color::Red) == "2Red");
+  CHECK(runtime_cache(4, Color::Purple) == "4Purple");
+  CHECK(runtime_calls.size() == 2);
+  CHECK(runtime_cache(2, Color::Red) == "2Red");
+  CHECK(runtime_calls.size() == 2);
+
+  size_t runtime_small_calls = 0;
+  const auto runtime_small_cache = make_runtime_cache([&runtime_small_calls]() {
+    ++runtime_small_calls;
+    return size_t{10};
+  });
+  CHECK(runtime_small_calls == 0);
+  CHECK(runtime_small_cache() == 10);
+  CHECK(runtime_small_cache() == 10);
+  CHECK(runtime_small_calls == 1);
+
+  std::atomic<size_t> concurrent_calls{0};
+  const auto concurrent_cache = make_runtime_cache<CacheRange<0_st, 1_st>>(
+      [&concurrent_calls](const size_t value) {
+        ++concurrent_calls;
+        return value + 10;
+      });
+  std::atomic<bool> start_concurrent_calls{false};
+  std::array<size_t, 8> concurrent_results{};
+  std::array<std::thread, 8> threads;
+  for (size_t i = 0; i < threads.size(); ++i) {
+    gsl::at(threads, i) = std::thread{
+        [&concurrent_cache, &concurrent_results, &start_concurrent_calls, i]() {
+          while (not start_concurrent_calls.load(std::memory_order_acquire)) {
+          }
+          gsl::at(concurrent_results, i) = concurrent_cache(0);
+        }};
+  }
+  start_concurrent_calls.store(true, std::memory_order_release);
+  for (auto& thread : threads) {
+    thread.join();
+  }
+  CHECK(std::all_of(concurrent_results.begin(), concurrent_results.end(),
+                    [](const size_t result) { return result == 10; }));
+  CHECK(concurrent_calls == 1);
+
 #ifdef SPECTRE_DEBUG
   CHECK_THROWS_WITH(
       (make_static_cache<CacheRange<3, 5>>([](const size_t x) { return x; })(
@@ -207,6 +263,14 @@ SPECTRE_TEST_CASE("Unit.Utilities.StaticCache", "[Utilities][Unit]") {
       (make_static_cache<CacheRange<3, 5>>([](const size_t x) { return x; })(
           5)),
       Catch::Matchers::ContainsSubstring("Index out of range: 3 <= 5 < 5"));
+  CHECK_THROWS_WITH(
+      (make_runtime_cache<CacheRange<3, 5>>([](const int x) { return x; })(
+          2)),
+      Catch::Matchers::ContainsSubstring("Index out of range: 3 <= 2 < 5"));
+  CHECK_THROWS_WITH(
+      (make_runtime_cache<CacheEnumeration<Color, Color::Red, Color::Green>>(
+          [](const Color color) { return color; })(Color::Purple)),
+      Catch::Matchers::ContainsSubstring("Uncached enumeration value: Purple"));
 #endif
 
   // Test that the passed callable is stored, so we don't get a


### PR DESCRIPTION
## Proposed changes

Large `StaticCache` instances generate a separate template specialization for
every combination of cache indices. This was particularly noticeable in the modal transformation and projection
matrix translation units.

## Changes

- Add `RuntimeCache`, which:
  - Uses the existing `CacheRange` and `CacheEnumeration` interfaces.
  - Flattens cache indices at runtime.
  - Lazily initializes each entry with `std::call_once`.
- Use `RuntimeCache` for the two-index spectral quantities.
- Use `RuntimeCache` for the large projection matrix caches.
- Add tests for range and enum lookup, lazy initialization, repeated access,
  error handling, and concurrent initialization.

`StaticCache` remains available for smaller caches where its compile-time
dispatch is not problematic.

## Compile-Time Results

| Translation unit | Before | After |
|---|---:|---:|
| `ModalToNodalMatrix.cpp`, syntax-only | 96.4 s | 1.47 s |
| `NodalToModalMatrix.cpp`, syntax-only | 97.8 s | 1.78 s |
| `Projection.cpp`, syntax-only | 27.0 s | 2.8 s |
| `Projection.cpp`, optimized | 247.2 s | approximately 5 s |

The optimized `Projection.cpp` object shrinks from 53 MB to 216 KB. Compiler
allocation for that translation unit drops from approximately 8 GB to under
400 MB.

The difference in speed is a few nanoseconds - unlikely to be measurable in any real application.
