### PR TITLE
Support LDG infrastructure part three

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp
@@ -416,6 +416,12 @@ ComputeTimeDerivative<Dim, EvolutionSystem, DgStepChoosers, LocalTimeStepping,
   using flux_variables = typename EvolutionSystem::flux_variables;
   using compute_volume_time_derivative_terms =
       typename EvolutionSystem::compute_volume_time_derivative_terms;
+  // Systems may declare an `auxiliary_variables` type alias whose first
+  // derivatives are needed by the volume terms. The detect-or-default
+  // metafunction yields an empty list for systems without it.
+  using auxiliary_variables =
+      detail::get_auxiliary_variables_or_default_t<EvolutionSystem,
+                                                   tmpl::list<>>;
 
   const Mesh<Dim>& mesh = db::get<::domain::Tags::Mesh<Dim>>(box);
   const Element<Dim>& element = db::get<domain::Tags::Element<Dim>>(box);
@@ -584,32 +590,77 @@ ComputeTimeDerivative<Dim, EvolutionSystem, DgStepChoosers, LocalTimeStepping,
           box);
     }
   }
-  db::mutate_apply<
-      tmpl::list<dt_variables_tag>,
-      typename compute_volume_time_derivative_terms::argument_tags>(
-      [&dg_formulation, &div_fluxes, &det_inverse_jacobian,
-       &div_mesh_velocity = db::get<::domain::Tags::DivMeshVelocity>(box),
-       &evolved_variables = db::get<variables_tag>(box),
-       &inertial_coordinates =
-           db::get<domain::Tags::Coordinates<Dim, Frame::Inertial>>(box),
-       &logical_to_inertial_inv_jacobian =
-           db::get<::domain::Tags::InverseJacobian<Dim, Frame::ElementLogical,
-                                                   Frame::Inertial>>(box),
-       &mesh, &mesh_velocity = db::get<::domain::Tags::MeshVelocity<Dim>>(box),
-       &partial_derivs, &temporaries, &volume_fluxes](
-          const gsl::not_null<Variables<
-              db::wrap_tags_in<::Tags::dt, typename variables_tag::tags_list>>*>
-              dt_vars_ptr,
-          const auto&... time_derivative_args) {
-        detail::volume_terms<compute_volume_time_derivative_terms>(
-            dt_vars_ptr, make_not_null(&volume_fluxes),
-            make_not_null(&partial_derivs), make_not_null(&temporaries),
-            make_not_null(&div_fluxes), evolved_variables, dg_formulation, mesh,
-            inertial_coordinates, logical_to_inertial_inv_jacobian,
-            det_inverse_jacobian, mesh_velocity, div_mesh_velocity,
-            time_derivative_args...);
-      },
-      make_not_null(&box));
+  if constexpr (tmpl::size<auxiliary_variables>::value != 0) {
+    static_assert(
+        tmpl::size<tmpl::list_difference<
+                partial_derivative_tags,
+                tmpl::append<typename variables_tag::tags_list,
+                             auxiliary_variables>>>::value == 0,
+        "Every gradient variable must be an evolved variable (in "
+        "variables_tag) or an auxiliary variable (in auxiliary_variables); "
+        "otherwise it is not populated in the combined differentiation "
+        "source.");
+    Variables<detail::evolved_and_auxiliary_vars_tags<EvolutionSystem>>
+        evolved_and_auxiliary_vars{mesh.number_of_grid_points()};
+    evolved_and_auxiliary_vars.assign_subset(db::get<variables_tag>(box));
+    evolved_and_auxiliary_vars.assign_subset(
+        db::get<::Tags::Variables<auxiliary_variables>>(box));
+    db::mutate_apply<
+        tmpl::list<dt_variables_tag>,
+        typename compute_volume_time_derivative_terms::argument_tags>(
+        [&dg_formulation, &div_fluxes, &det_inverse_jacobian,
+         &div_mesh_velocity = db::get<::domain::Tags::DivMeshVelocity>(box),
+         &evolved_and_auxiliary_vars,
+         &inertial_coordinates =
+             db::get<domain::Tags::Coordinates<Dim, Frame::Inertial>>(box),
+         &logical_to_inertial_inv_jacobian =
+             db::get<::domain::Tags::InverseJacobian<Dim, Frame::ElementLogical,
+                                                     Frame::Inertial>>(box),
+         &mesh,
+         &mesh_velocity = db::get<::domain::Tags::MeshVelocity<Dim>>(box),
+         &partial_derivs, &temporaries,
+         &volume_fluxes](const gsl::not_null<Variables<db::wrap_tags_in<
+                             ::Tags::dt, typename variables_tag::tags_list>>*>
+                             dt_vars_ptr,
+                         const auto&... time_derivative_args) {
+          detail::volume_terms<compute_volume_time_derivative_terms>(
+              dt_vars_ptr, make_not_null(&volume_fluxes),
+              make_not_null(&partial_derivs), make_not_null(&temporaries),
+              make_not_null(&div_fluxes), evolved_and_auxiliary_vars,
+              dg_formulation, mesh, inertial_coordinates,
+              logical_to_inertial_inv_jacobian, det_inverse_jacobian,
+              mesh_velocity, div_mesh_velocity, time_derivative_args...);
+        },
+        make_not_null(&box));
+  } else {
+    db::mutate_apply<
+        tmpl::list<dt_variables_tag>,
+        typename compute_volume_time_derivative_terms::argument_tags>(
+        [&dg_formulation, &div_fluxes, &det_inverse_jacobian,
+         &div_mesh_velocity = db::get<::domain::Tags::DivMeshVelocity>(box),
+         &evolved_variables = db::get<variables_tag>(box),
+         &inertial_coordinates =
+             db::get<domain::Tags::Coordinates<Dim, Frame::Inertial>>(box),
+         &logical_to_inertial_inv_jacobian =
+             db::get<::domain::Tags::InverseJacobian<Dim, Frame::ElementLogical,
+                                                     Frame::Inertial>>(box),
+         &mesh,
+         &mesh_velocity = db::get<::domain::Tags::MeshVelocity<Dim>>(box),
+         &partial_derivs, &temporaries,
+         &volume_fluxes](const gsl::not_null<Variables<db::wrap_tags_in<
+                             ::Tags::dt, typename variables_tag::tags_list>>*>
+                             dt_vars_ptr,
+                         const auto&... time_derivative_args) {
+          detail::volume_terms<compute_volume_time_derivative_terms>(
+              dt_vars_ptr, make_not_null(&volume_fluxes),
+              make_not_null(&partial_derivs), make_not_null(&temporaries),
+              make_not_null(&div_fluxes), evolved_variables, dg_formulation,
+              mesh, inertial_coordinates, logical_to_inertial_inv_jacobian,
+              det_inverse_jacobian, mesh_velocity, div_mesh_velocity,
+              time_derivative_args...);
+        },
+        make_not_null(&box));
+  }
 
   const Variables<detail::get_primitive_vars_tags_from_system<EvolutionSystem>>*
       primitive_vars{nullptr};

--- a/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeHelpers.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeHelpers.hpp
@@ -34,6 +34,14 @@ using inverse_spatial_metric_tag = typename inverse_spatial_metric_tag_impl<
 
 CREATE_GET_TYPE_ALIAS_OR_DEFAULT(auxiliary_variables)
 
+// `gradient_variables` is prepended since `partial_derivatives` requires the
+// differentiated tags to be the *leading* tags of the source `Variables`.
+template <typename System>
+using evolved_and_auxiliary_vars_tags = tmpl::remove_duplicates<
+    tmpl::append<typename System::gradient_variables,
+                 typename System::variables_tag::tags_list,
+                 get_auxiliary_variables_or_default_t<System, tmpl::list<>>>>;
+
 template <bool HasPrimitiveVars = false>
 struct get_primitive_vars {
   template <typename BoundaryCorrection>

--- a/src/Evolution/DiscontinuousGalerkin/Actions/VolumeTermsImpl.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/VolumeTermsImpl.hpp
@@ -61,8 +61,8 @@ namespace evolution::dg::Actions::detail {
  */
 template <typename ComputeVolumeTimeDerivativeTerms, size_t Dim,
           typename... TimeDerivativeArguments, typename... VariablesTags,
-          typename... PartialDerivTags, typename... FluxVariablesTags,
-          typename... TemporaryTags>
+          typename... SourceVarsTags, typename... PartialDerivTags,
+          typename... FluxVariablesTags, typename... TemporaryTags>
 void volume_terms(
     const gsl::not_null<Variables<tmpl::list<::Tags::dt<VariablesTags>...>>*>
         dt_vars_ptr,
@@ -79,7 +79,7 @@ void volume_terms(
         Variables<tmpl::list<::Tags::div<::Tags::Flux<
             FluxVariablesTags, tmpl::size_t<Dim>, Frame::Inertial>>...>>*>
         div_fluxes,
-    const Variables<tmpl::list<VariablesTags...>>& evolved_vars,
+    const Variables<tmpl::list<SourceVarsTags...>>& source_vars,
     const ::dg::Formulation dg_formulation, const Mesh<Dim>& mesh,
     [[maybe_unused]] const tnsr::I<DataVector, Dim, Frame::Inertial>&
         inertial_coordinates,

--- a/src/Evolution/DiscontinuousGalerkin/Actions/VolumeTermsImpl.tpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/VolumeTermsImpl.tpp
@@ -73,8 +73,8 @@ namespace evolution::dg::Actions::detail {
  */
 template <typename ComputeVolumeTimeDerivativeTerms, size_t Dim,
           typename... TimeDerivativeArguments, typename... VariablesTags,
-          typename... PartialDerivTags, typename... FluxVariablesTags,
-          typename... TemporaryTags>
+          typename... SourceVarsTags, typename... PartialDerivTags,
+          typename... FluxVariablesTags, typename... TemporaryTags>
 void volume_terms(
     const gsl::not_null<Variables<tmpl::list<::Tags::dt<VariablesTags>...>>*>
         dt_vars_ptr,
@@ -91,7 +91,8 @@ void volume_terms(
         Variables<tmpl::list<::Tags::div<::Tags::Flux<
             FluxVariablesTags, tmpl::size_t<Dim>, Frame::Inertial>>...>>*>
         div_fluxes,
-    const Variables<tmpl::list<VariablesTags...>>& evolved_vars,
+    const Variables<tmpl::list<SourceVarsTags...>>&
+        source_vars,
     const ::dg::Formulation dg_formulation, const Mesh<Dim>& mesh,
     [[maybe_unused]] const tnsr::I<DataVector, Dim, Frame::Inertial>&
         inertial_coordinates,
@@ -118,7 +119,7 @@ void volume_terms(
 
   // Compute d_i u_\alpha for nonconservative products
   if constexpr (has_partial_derivs) {
-    partial_derivatives(partial_derivs, evolved_vars, mesh,
+    partial_derivatives(partial_derivs, source_vars, mesh,
                         logical_to_inertial_inverse_jacobian,
                         inertial_coordinates);
   }
@@ -161,7 +162,7 @@ void volume_terms(
       goto end_of_flux_mesh_velocity;  // NOLINT(cppcoreguidelines-avoid-goto)
     }
     tmpl::for_each<flux_variables>([&div_mesh_velocity, &dt_vars_ptr,
-                                    &evolved_vars, &mesh_velocity,
+                                    &source_vars, &mesh_velocity,
                                     &volume_fluxes](auto tag_v) {
       // Modify fluxes for moving mesh
       using var_tag = typename decltype(tag_v)::type;
@@ -185,7 +186,7 @@ void volume_terms(
 
         // We now need to index flux(i,j) -= u(j) * v_g(i)
         flux_var[flux_var_storage_index] -=
-            get<var_tag>(evolved_vars).get(var_tensor_index) *
+            get<var_tag>(source_vars).get(var_tensor_index) *
             mesh_velocity->get(flux_index);
       }
 
@@ -195,7 +196,7 @@ void volume_terms(
            dt_var_storage_index < dt_var.size(); ++dt_var_storage_index) {
         // This is S -> S - u d_i v^i_g
         dt_var[dt_var_storage_index] -=
-            get<var_tag>(evolved_vars)[dt_var_storage_index] *
+            get<var_tag>(source_vars)[dt_var_storage_index] *
             get(*div_mesh_velocity);
       }
     });

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ComputeTimeDerivative.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ComputeTimeDerivative.cpp
@@ -224,6 +224,13 @@ void test_wrapper() {
   test<system_type, UsePrims, 3>();
 }
 
+template <SystemType system_type>
+void test_LDG_wrapper() {
+  test_LDG<system_type, 1>();
+  test_LDG<system_type, 2>();
+  test_LDG<system_type, 3>();
+}
+
 // [[TimeOut, 10]]
 SPECTRE_TEST_CASE("Unit.Evolution.DG.ComputeTimeDerivative",
                   "[Unit][Evolution][Actions]") {
@@ -284,6 +291,10 @@ SPECTRE_TEST_CASE("Unit.Evolution.DG.ComputeTimeDerivative",
   test_wrapper<SystemType::Nonconservative, false>();
   test_wrapper<SystemType::Mixed, false>();
   test_wrapper<SystemType::Mixed, true>();
+
+  // Testing the local discontinuous Galerkin infrastructure
+  test_LDG_wrapper<SystemType::Nonconservative>();
+  test_LDG_wrapper<SystemType::Mixed>();
 
   for (const bool use_moving_mesh : {true, false}) {
     WithInverseSpatialMetricTag::test<1>(use_moving_mesh);

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.hpp
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.hpp
@@ -10,4 +10,7 @@
 namespace TestHelpers::evolution::dg::Actions {
 template <SystemType system_type, bool UsePrims, size_t Dim>
 void test();
+
+template <SystemType system_type, size_t Dim>
+void test_LDG();
 }  // namespace TestHelpers::evolution::dg::Actions

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
@@ -112,6 +112,11 @@ struct Var3 : db::SimpleTag {
   using type = Scalar<DataVector>;
 };
 
+// Used only by the `HasAux` system configuration below.
+struct VarAux : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
 struct PrimVar1 : db::SimpleTag {
   using type = Scalar<DataVector>;
 };
@@ -359,6 +364,118 @@ struct TimeDerivativeTerms {
     return {true};
   }
   /// [dt_mp]
+};
+
+// Time-derivative terms for the auxiliary (LDG) configurations. These reuse the
+// `TimeDerivativeTerms` and add a contribution from the `VarAux`. This lets the
+// test verify that the auxiliary variable's derivative reaches the volume
+// time-derivative terms. LDG systems are second order and thus cannot be
+// purely conservative, so we only test the nonconservative and mixed
+// configurations here.
+template <size_t Dim>
+struct LdgTimeDerivativeTerms {
+  using temporary_tags = tmpl::list<Var3Squared>;
+  using argument_tags = tmpl::list<Var1, Var2<Dim>, Var3>;
+
+  // Nonconservative + auxiliary: gradient_variables = [Var1, Var2, VarAux] and
+  // there are no fluxes. The partial-derivative arguments follow
+  // gradient_variables order (Var1, Var2, then VarAux).
+  static ::evolution::dg::TimeDerivativeDecisions<Dim> apply(
+      const gsl::not_null<Scalar<DataVector>*> dt_var1,
+      const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> dt_var2,
+
+      const gsl::not_null<Scalar<DataVector>*> square_var3,
+
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& d_var1,
+      const tnsr::iJ<DataVector, Dim, Frame::Inertial>& d_var2,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& d_var_aux,
+
+      const Scalar<DataVector>& var1,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& var2,
+      const Scalar<DataVector>& var3) {
+    TimeDerivativeTerms<Dim, SystemType::Nonconservative, false>::apply(
+        dt_var1, dt_var2, square_var3, d_var1, d_var2, var1, var2, var3);
+    add_ldg_contribution(dt_var1, d_var_aux);
+    return {true};
+  }
+
+  // Mixed + auxiliary: gradient_variables = [Var1, VarAux] and flux_variables =
+  // [Var2]. Var2 evolves through its flux (into `flux_var2`), Var1 through a
+  // nonconservative product using `d_var1`, and `d_var_aux` is the
+  // differentiated auxiliary variable. This exercises the auxiliary volume
+  // differentiation coexisting with the flux-divergence path.
+  static ::evolution::dg::TimeDerivativeDecisions<Dim> apply(
+      const gsl::not_null<Scalar<DataVector>*> dt_var1,
+      const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> dt_var2,
+
+      const gsl::not_null<tnsr::IJ<DataVector, Dim, Frame::Inertial>*>
+          flux_var2,
+
+      const gsl::not_null<Scalar<DataVector>*> square_var3,
+
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& d_var1,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& d_var_aux,
+
+      const Scalar<DataVector>& var1,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& var2,
+      const Scalar<DataVector>& var3) {
+    TimeDerivativeTerms<Dim, SystemType::Mixed, false>::apply(
+        dt_var1, dt_var2, flux_var2, square_var3, d_var1, var1, var2, var3);
+    add_ldg_contribution(dt_var1, d_var_aux);
+    return {true};
+  }
+
+ private:
+  static void add_ldg_contribution(
+      const gsl::not_null<Scalar<DataVector>*> dt_var1,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& d_var_aux) {
+    for (size_t d = 0; d < Dim; ++d) {
+      get(*dt_var1) += d_var_aux.get(d);
+    }
+  }
+};
+
+template <size_t Dim>
+struct LdgTimeDerivativeTermsWithVariables : public ::evolution::PassVariables {
+  using base = LdgTimeDerivativeTerms<Dim>;
+  using temporary_tags = typename base::temporary_tags;
+  using argument_tags = typename base::argument_tags;
+
+  using dt_var1 = ::Tags::dt<Var1>;
+  using dt_var2 = ::Tags::dt<Var2<Dim>>;
+  using flux_var2 = ::Tags::Flux<Var2<Dim>, tmpl::size_t<Dim>, Frame::Inertial>;
+
+  // Nonconservative + auxiliary (no fluxes).
+  static ::evolution::dg::TimeDerivativeDecisions<Dim> apply(
+      const gsl::not_null<Variables<tmpl::list<dt_var1, dt_var2>>*> dt_vars,
+      const gsl::not_null<Variables<tmpl::list<Var3Squared>>*> temporaries,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& d_var1,
+      const tnsr::iJ<DataVector, Dim, Frame::Inertial>& d_var2,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& d_var_aux,
+      const Scalar<DataVector>& var1,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& var2,
+      const Scalar<DataVector>& var3) {
+    base::apply(get<dt_var1>(dt_vars), get<dt_var2>(dt_vars),
+                get<Var3Squared>(temporaries), d_var1, d_var2, d_var_aux, var1,
+                var2, var3);
+    return {true};
+  }
+
+  // Mixed + auxiliary (Var2 carries a flux).
+  static ::evolution::dg::TimeDerivativeDecisions<Dim> apply(
+      const gsl::not_null<Variables<tmpl::list<dt_var1, dt_var2>>*> dt_vars,
+      const gsl::not_null<Variables<tmpl::list<flux_var2>>*> flux_vars,
+      const gsl::not_null<Variables<tmpl::list<Var3Squared>>*> temporaries,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& d_var1,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& d_var_aux,
+      const Scalar<DataVector>& var1,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& var2,
+      const Scalar<DataVector>& var3) {
+    base::apply(get<dt_var1>(dt_vars), get<dt_var2>(dt_vars),
+                get<flux_var2>(flux_vars), get<Var3Squared>(temporaries),
+                d_var1, d_var_aux, var1, var2, var3);
+    return {true};
+  }
 };
 
 template <size_t Dim, SystemType system_type, bool HasPrimitiveVars>
@@ -852,7 +969,7 @@ template <size_t Dim>
 size_t DemandOutgoingCharSpeeds<Dim>::number_of_times_called = 0;
 
 template <size_t Dim, SystemType system_type, bool HasPrimitiveVariables,
-          bool PassVariables>
+          bool PassVariables, bool HasAux = false>
 struct System {
   static constexpr bool has_primitive_and_conservative_vars =
       HasPrimitiveVariables;
@@ -861,23 +978,36 @@ struct System {
   using boundary_conditions_base = BoundaryCondition<Dim>;
 
   using variables_tag = Tags::Variables<tmpl::list<Var1, Var2<Dim>>>;
+  // Auxiliary variables: present only for the `HasAux` configuration,
+  // which is used to test the LDG infrastructure.
+  using auxiliary_variables =
+      tmpl::conditional_t<HasAux, tmpl::list<VarAux>, tmpl::list<>>;
   using flux_variables = tmpl::conditional_t<
       system_type == SystemType::Conservative, tmpl::list<Var1, Var2<Dim>>,
       tmpl::conditional_t<system_type == SystemType::Nonconservative,
                           tmpl::list<>, tmpl::list<Var2<Dim>>>>;
-  using gradient_variables = tmpl::conditional_t<
+  using base_gradient_variables = tmpl::conditional_t<
       system_type == SystemType::Conservative, tmpl::list<>,
       tmpl::conditional_t<system_type == SystemType::Nonconservative,
                           tmpl::list<Var1, Var2<Dim>>, tmpl::list<Var1>>>;
+  using gradient_variables =
+      tmpl::conditional_t<HasAux,
+                          tmpl::push_back<base_gradient_variables, VarAux>,
+                          base_gradient_variables>;
   using primitive_variables_tag =
       Tags::Variables<tmpl::list<PrimVar1, PrimVar2<Dim>>>;
 
   using compute_volume_time_derivative_terms = tmpl::conditional_t<
-      PassVariables,
-      TimeDerivativeTermsWithVariables<Dim, system_type,
-                                       has_primitive_and_conservative_vars>,
-      TimeDerivativeTerms<Dim, system_type,
-                          has_primitive_and_conservative_vars>>;
+      HasAux,
+      tmpl::conditional_t<PassVariables,
+                          LdgTimeDerivativeTermsWithVariables<Dim>,
+                          LdgTimeDerivativeTerms<Dim>>,
+      tmpl::conditional_t<
+          PassVariables,
+          TimeDerivativeTermsWithVariables<Dim, system_type,
+                                           has_primitive_and_conservative_vars>,
+          TimeDerivativeTerms<Dim, system_type,
+                              has_primitive_and_conservative_vars>>>;
 
   using normal_dot_fluxes = NonconservativeNormalDotFlux<Dim>;
 };
@@ -900,6 +1030,12 @@ struct component {
       ::evolution::dg::Tags::Quadrature, variables_tag,
       db::add_tag_prefix<::Tags::dt, variables_tag>,
       ::Tags::HistoryEvolvedVariables<variables_tag>, Var3,
+      tmpl::conditional_t<
+          (tmpl::size<
+               typename Metavariables::system::auxiliary_variables>::value > 0),
+          ::Tags::Variables<
+              typename Metavariables::system::auxiliary_variables>,
+          tmpl::list<>>,
       domain::Tags::Mesh<Metavariables::volume_dim>,
       ::domain::Tags::FunctionsOfTimeInitialize,
       domain::CoordinateMaps::Tags::CoordinateMap<Metavariables::volume_dim,
@@ -971,7 +1107,7 @@ struct component {
 
 template <size_t Dim, SystemType SystemTypeIn, bool LocalTimeStepping,
           bool UseMovingMesh, bool HasPrimitiveVariables, bool PassVariables,
-          bool UseNodegroupDgElements>
+          bool UseNodegroupDgElements, bool HasAux = false>
 struct Metavariables {
   static constexpr size_t volume_dim = Dim;
   static constexpr SystemType system_type = SystemTypeIn;
@@ -980,7 +1116,7 @@ struct Metavariables {
   static constexpr bool pass_variables = PassVariables;
   static constexpr bool use_nodegroup_dg_elements = UseNodegroupDgElements;
   using system =
-      System<Dim, system_type, HasPrimitiveVariables, pass_variables>;
+      System<Dim, system_type, HasPrimitiveVariables, pass_variables, HasAux>;
   using normal_dot_numerical_flux =
       Tags::NumericalFlux<BoundaryTerms<Dim, HasPrimitiveVariables>>;
   using const_global_cache_tags =
@@ -1021,7 +1157,7 @@ double dg_package_data(
 
 template <bool LocalTimeStepping, bool UseMovingMesh, size_t Dim,
           SystemType system_type, bool HasPrims, bool PassVariables,
-          bool UseNodegroupDgElements>
+          bool UseNodegroupDgElements, bool HasAux = false>
 void test_impl(const Spectral::Quadrature quadrature,
                const ::dg::Formulation dg_formulation) {
   CAPTURE(LocalTimeStepping);
@@ -1030,11 +1166,12 @@ void test_impl(const Spectral::Quadrature quadrature,
   CAPTURE(system_type);
   CAPTURE(HasPrims);
   CAPTURE(PassVariables);
+  CAPTURE(HasAux);
   CAPTURE(quadrature);
   CAPTURE(dg_formulation);
   using metavars =
       Metavariables<Dim, system_type, LocalTimeStepping, UseMovingMesh,
-                    HasPrims, PassVariables, UseNodegroupDgElements>;
+                    HasPrims, PassVariables, UseNodegroupDgElements, HasAux>;
   register_classes_with_charm<TimeSteppers::AdamsBashforth>();
   register_factory_classes_with_charm<metavars>();
 
@@ -1237,6 +1374,13 @@ void test_impl(const Spectral::Quadrature quadrature,
     get(var3)[i] = 5.0;
     get(var3)[i + 1] = 6.0;
   }
+  Variables<tmpl::list<VarAux>> aux_vars{mesh.number_of_grid_points()};
+  if constexpr (HasAux) {
+    get(get<VarAux>(aux_vars)) = 0.0;
+    for (size_t d = 0; d < Dim; ++d) {
+      get(get<VarAux>(aux_vars)) += (d + 1.0) * inertial_coords.get(d);
+    }
+  }
   using dt_variables_tags = tmpl::list<::Tags::dt<Var1>, ::Tags::dt<Var2<Dim>>>;
   Variables<dt_variables_tags> dt_evolved_vars{mesh.number_of_grid_points()};
   const ::TimeSteppers::History<decltype(evolved_vars)> history{1};
@@ -1324,62 +1468,81 @@ void test_impl(const Spectral::Quadrature quadrature,
                      std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
       functions_of_time{};
 
-  ActionTesting::emplace_component_and_initialize<component<metavars>>(
-      &runner, self_id,
-      {time_step_id,
-       next_time_step_id,
-       time_step,
-       time_step_id.step_time().value(),
-       AdaptiveSteppingDiagnostics{},
-       quadrature,
-       evolved_vars,
-       dt_evolved_vars,
-       history,
-       var3,
-       mesh,
-       clone_unique_ptrs(functions_of_time),
-       grid_to_inertial_map->get_clone(),
-       element,
-       neighbor_mesh,
-       inertial_coords,
-       inv_jac,
-       mesh_velocity,
-       div_mesh_velocity,
-       ElementMap<Dim, Frame::Grid>{
-           self_id,
-           domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Grid>(
-               domain::CoordinateMaps::Identity<Dim>{})},
-       std::make_unique<TimeSteppers::AdamsBashforth>(5)});
+  // The initialization values match `component::simple_tags`. For the `HasAux`
+  // configuration the auxiliary storage `aux_vars` is inserted right after
+  // `var3` (matching the conditional entry in `simple_tags`).
+  const auto emplace_self = [&](auto... aux_storage) {
+    ActionTesting::emplace_component_and_initialize<component<metavars>>(
+        &runner, self_id,
+        {time_step_id,
+         next_time_step_id,
+         time_step,
+         time_step_id.step_time().value(),
+         AdaptiveSteppingDiagnostics{},
+         quadrature,
+         evolved_vars,
+         dt_evolved_vars,
+         history,
+         var3,
+         std::move(aux_storage)...,
+         mesh,
+         clone_unique_ptrs(functions_of_time),
+         grid_to_inertial_map->get_clone(),
+         element,
+         neighbor_mesh,
+         inertial_coords,
+         inv_jac,
+         mesh_velocity,
+         div_mesh_velocity,
+         ElementMap<Dim, Frame::Grid>{
+             self_id,
+             domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Grid>(
+                 domain::CoordinateMaps::Identity<Dim>{})},
+         std::make_unique<TimeSteppers::AdamsBashforth>(5)});
+  };
+  if constexpr (HasAux) {
+    emplace_self(aux_vars);
+  } else {
+    emplace_self();
+  }
+  const auto emplace_neighbor = [&](const ElementId<Dim>& neighbor_id,
+                                    auto... aux_storage) {
+    ActionTesting::emplace_component_and_initialize<component<metavars>>(
+        &runner, neighbor_id,
+        {time_step_id,
+         next_time_step_id,
+         time_step,
+         time_step_id.step_time().value(),
+         AdaptiveSteppingDiagnostics{},
+         quadrature,
+         evolved_vars,
+         dt_evolved_vars,
+         history,
+         var3,
+         std::move(aux_storage)...,
+         mesh,
+         clone_unique_ptrs(functions_of_time),
+         grid_to_inertial_map->get_clone(),
+         element,
+         neighbor_mesh,
+         inertial_coords,
+         inv_jac,
+         mesh_velocity,
+         div_mesh_velocity,
+         ElementMap<Dim, Frame::Grid>{
+             neighbor_id,
+             domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Grid>(
+                 domain::CoordinateMaps::Identity<Dim>{})},
+         std::make_unique<TimeSteppers::AdamsBashforth>(5)});
+  };
   for (const auto& [direction, neighbor_ids] : neighbors) {
     (void)direction;
     for (const auto& neighbor_id : neighbor_ids) {
-      ActionTesting::emplace_component_and_initialize<component<metavars>>(
-          &runner, neighbor_id,
-          {time_step_id,
-           next_time_step_id,
-           time_step,
-           time_step_id.step_time().value(),
-           AdaptiveSteppingDiagnostics{},
-           quadrature,
-           evolved_vars,
-           dt_evolved_vars,
-           history,
-           var3,
-           mesh,
-           clone_unique_ptrs(functions_of_time),
-           grid_to_inertial_map->get_clone(),
-           element,
-           neighbor_mesh,
-           inertial_coords,
-           inv_jac,
-           mesh_velocity,
-           div_mesh_velocity,
-           ElementMap<Dim, Frame::Grid>{
-               neighbor_id,
-               domain::make_coordinate_map_base<Frame::BlockLogical,
-                                                Frame::Grid>(
-                   domain::CoordinateMaps::Identity<Dim>{})},
-           std::make_unique<TimeSteppers::AdamsBashforth>(5)});
+      if constexpr (HasAux) {
+        emplace_neighbor(neighbor_id, aux_vars);
+      } else {
+        emplace_neighbor(neighbor_id);
+      }
     }
   }
 
@@ -1465,6 +1628,15 @@ void test_impl(const Spectral::Quadrature quadrature,
                     Tags::Flux<Var1, tmpl::size_t<Dim>, Frame::Inertial>>>(
                 weak_div_fluxes));
       }
+    }
+  }
+
+  if constexpr (HasAux) {
+    const auto d_var_aux =
+        get<::Tags::deriv<VarAux, tmpl::size_t<Dim>, Frame::Inertial>>(
+            partial_derivatives<tmpl::list<VarAux>>(aux_vars, mesh, inv_jac));
+    for (size_t d = 0; d < Dim; ++d) {
+      get(get<::Tags::dt<Var1>>(expected_dt_evolved_vars)) += d_var_aux.get(d);
     }
   }
   // Set dt<Var2<Dim>>
@@ -1971,6 +2143,40 @@ void test() {
           test_impl<true, std::decay_t<decltype(moving_mesh)>::value, Dim,
                     system_type, UsePrims, true, use_nodegroup_dg_elements>(
               quadrature, local_dg_formulation);
+        };
+        moving_mesh_helper(std::integral_constant<bool, false>{});
+        moving_mesh_helper(std::integral_constant<bool, true>{});
+      };
+  for (const auto dg_formulation :
+       {::dg::Formulation::StrongInertial, ::dg::Formulation::WeakInertial}) {
+    invoke_tests_with_quadrature_and_formulation(
+        Spectral::Quadrature::GaussLobatto, dg_formulation);
+    invoke_tests_with_quadrature_and_formulation(Spectral::Quadrature::Gauss,
+                                                 dg_formulation);
+  }
+}
+
+template <SystemType system_type, size_t Dim>
+void test_LDG() {
+  // `LocalTimeStepping` is not tested because LDG is global-time-stepping only
+  // for now. The auxiliary variable is not time-integrated, so it gets no
+  // moving-mesh term of its own; the moving-mesh cases check that it coexists
+  // with the mesh-velocity terms on the evolved variables.
+  constexpr bool use_nodegroup_dg_elements = false;
+
+  const auto invoke_tests_with_quadrature_and_formulation =
+      [](const Spectral::Quadrature quadrature,
+         const ::dg::Formulation local_dg_formulation) {
+        const auto moving_mesh_helper = [&local_dg_formulation,
+                                         &quadrature](auto moving_mesh) {
+          // PassVariables == false
+          test_impl<false, std::decay_t<decltype(moving_mesh)>::value, Dim,
+                    system_type, false, false, use_nodegroup_dg_elements,
+                    /*HasAux=*/true>(quadrature, local_dg_formulation);
+          // PassVariables == true
+          test_impl<false, std::decay_t<decltype(moving_mesh)>::value, Dim,
+                    system_type, false, true, use_nodegroup_dg_elements,
+                    /*HasAux=*/true>(quadrature, local_dg_formulation);
         };
         moving_mesh_helper(std::integral_constant<bool, false>{});
         moving_mesh_helper(std::integral_constant<bool, true>{});

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/InstantiateMixed1d.cpp
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/InstantiateMixed1d.cpp
@@ -7,4 +7,5 @@
 
 namespace TestHelpers::evolution::dg::Actions {
 template void test<SystemType::Mixed, false, 1>();
+template void test_LDG<SystemType::Mixed, 1>();
 }  // namespace TestHelpers::evolution::dg::Actions

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/InstantiateMixed2d.cpp
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/InstantiateMixed2d.cpp
@@ -7,4 +7,5 @@
 
 namespace TestHelpers::evolution::dg::Actions {
 template void test<SystemType::Mixed, false, 2>();
+template void test_LDG<SystemType::Mixed, 2>();
 }  // namespace TestHelpers::evolution::dg::Actions

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/InstantiateMixed3d.cpp
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/InstantiateMixed3d.cpp
@@ -7,4 +7,5 @@
 
 namespace TestHelpers::evolution::dg::Actions {
 template void test<SystemType::Mixed, false, 3>();
+template void test_LDG<SystemType::Mixed, 3>();
 }  // namespace TestHelpers::evolution::dg::Actions

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/InstantiateNoncons1d.cpp
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/InstantiateNoncons1d.cpp
@@ -7,4 +7,5 @@
 
 namespace TestHelpers::evolution::dg::Actions {
 template void test<SystemType::Nonconservative, false, 1>();
+template void test_LDG<SystemType::Nonconservative, 1>();
 }  // namespace TestHelpers::evolution::dg::Actions

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/InstantiateNoncons2d.cpp
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/InstantiateNoncons2d.cpp
@@ -7,4 +7,5 @@
 
 namespace TestHelpers::evolution::dg::Actions {
 template void test<SystemType::Nonconservative, false, 2>();
+template void test_LDG<SystemType::Nonconservative, 2>();
 }  // namespace TestHelpers::evolution::dg::Actions

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/InstantiateNoncons3d.cpp
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/InstantiateNoncons3d.cpp
@@ -7,4 +7,5 @@
 
 namespace TestHelpers::evolution::dg::Actions {
 template void test<SystemType::Nonconservative, false, 3>();
+template void test_LDG<SystemType::Nonconservative, 3>();
 }  // namespace TestHelpers::evolution::dg::Actions


### PR DESCRIPTION
## Proposed changes

Allow systems to optionally declare an `auxiliary_variables` tmpl list to indicate variables used as LDG auxiliary reduction variables.

Does not affect existing systems.

- ComputeTimeDerivativeHelpers: add `evolved_and_auxiliary_vars_tags`.
- VolumeTermsImpl: decouple the differentiation source (`SourceVarsTags`)
  from the evolved/time-derivative variables so it can be evolved plus
  auxiliary.
- ComputeTimeDerivative: build and differentiate the combined container
  when `auxiliary_variables` is non-empty.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
