### PR TITLE
Add method to force runtime-LTS off in metavars

### DIFF
--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -312,7 +312,7 @@ struct EvolutionMetavars {
   using initialization_actions = tmpl::list<
       Initialization::Actions::InitializeItems<
           Initialization::TimeStepping<EvolutionMetavars, TimeStepperBase,
-                                       false>,
+                                       false, local_time_stepping>,
           evolution::dg::Initialization::Domain<EvolutionMetavars>,
           Initialization::TimeStepperHistory<EvolutionMetavars>>,
       Initialization::Actions::ConservativeSystem<system>,

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
@@ -301,7 +301,7 @@ struct EvolutionMetavars {
   using initialization_actions = tmpl::list<
       Initialization::Actions::InitializeItems<
           Initialization::TimeStepping<EvolutionMetavars, TimeStepperBase,
-                                       false>,
+                                       false, local_time_stepping>,
           evolution::dg::Initialization::Domain<EvolutionMetavars>,
           Initialization::TimeStepperHistory<EvolutionMetavars>>,
       Initialization::Actions::NonconservativeSystem<system>,

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
@@ -289,7 +289,7 @@ struct EvolutionMetavars {
   using initialization_actions = tmpl::list<
       Initialization::Actions::InitializeItems<
           Initialization::TimeStepping<EvolutionMetavars, TimeStepperBase,
-                                       false>,
+                                       false, local_time_stepping>,
           evolution::dg::Initialization::Domain<EvolutionMetavars>,
           Initialization::TimeStepperHistory<EvolutionMetavars>>,
       Initialization::Actions::NonconservativeSystem<system>,

--- a/src/Evolution/Executables/ForceFree/EvolveForceFree.hpp
+++ b/src/Evolution/Executables/ForceFree/EvolveForceFree.hpp
@@ -232,7 +232,7 @@ struct EvolutionMetavars {
   using initialization_actions = tmpl::list<
       Initialization::Actions::InitializeItems<
           Initialization::TimeStepping<EvolutionMetavars, TimeStepperBase,
-                                       false>,
+                                       false, local_time_stepping>,
           evolution::dg::Initialization::Domain<EvolutionMetavars>,
           Initialization::TimeStepperHistory<EvolutionMetavars>>,
       Initialization::Actions::AddSimpleTags<

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -625,7 +625,8 @@ struct EvolutionMetavars {
   using initialization_actions = tmpl::list<
       Initialization::Actions::InitializeItems<
           Initialization::TimeStepping<EvolutionMetavars, TimeStepperBase,
-                                       use_control_systems>,
+                                       use_control_systems,
+                                       local_time_stepping>,
           evolution::dg::Initialization::Domain<EvolutionMetavars,
                                                 use_control_systems>,
           ::amr::Initialization::Initialize<volume_dim, EvolutionMetavars>,

--- a/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
@@ -425,7 +425,7 @@ struct GeneralizedHarmonicTemplateBase {
   using initialization_actions = tmpl::list<
       Initialization::Actions::InitializeItems<
           Initialization::TimeStepping<DerivedMetavars, TimeStepperBase,
-                                       UseControlSystems>,
+                                       UseControlSystems, local_time_stepping>,
           evolution::dg::Initialization::Domain<DerivedMetavars,
                                                 UseControlSystems>,
           ::amr::Initialization::Initialize<volume_dim, DerivedMetavars>,

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -877,7 +877,8 @@ struct GhValenciaDivCleanTemplateBase<
   using initialization_actions = tmpl::list<
       Initialization::Actions::InitializeItems<
           Initialization::TimeStepping<derived_metavars, TimeStepperBase,
-                                       use_control_systems>,
+                                       use_control_systems,
+                                       local_time_stepping>,
           evolution::dg::Initialization::Domain<derived_metavars,
                                                 use_control_systems>,
           Initialization::TimeStepperHistory<derived_metavars>>,

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -532,7 +532,7 @@ struct EvolutionMetavars<tmpl::list<InterpolationTargetTags...>,
   using initialization_actions = tmpl::flatten<tmpl::list<
       Initialization::Actions::InitializeItems<
           Initialization::TimeStepping<EvolutionMetavars, TimeStepperBase,
-                                       false>,
+                                       false, local_time_stepping>,
           evolution::dg::Initialization::Domain<EvolutionMetavars>,
           Initialization::TimeStepperHistory<EvolutionMetavars>>,
       Initialization::Actions::AddSimpleTags<

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -274,7 +274,7 @@ struct EvolutionMetavars {
   using initialization_actions = tmpl::flatten<tmpl::list<
       Initialization::Actions::InitializeItems<
           Initialization::TimeStepping<EvolutionMetavars, TimeStepperBase,
-                                       false>,
+                                       false, local_time_stepping>,
           evolution::dg::Initialization::Domain<EvolutionMetavars>,
           Initialization::TimeStepperHistory<EvolutionMetavars>>,
       Initialization::Actions::ConservativeSystem<system>,

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
@@ -243,7 +243,7 @@ struct EvolutionMetavars {
   using initialization_actions = tmpl::list<
       Initialization::Actions::InitializeItems<
           Initialization::TimeStepping<EvolutionMetavars, TimeStepperBase,
-                                       false>,
+                                       false, local_time_stepping>,
           evolution::dg::Initialization::Domain<EvolutionMetavars>,
           Initialization::TimeStepperHistory<EvolutionMetavars>>,
       Initialization::Actions::AddSimpleTags<

--- a/src/Evolution/Executables/RadiationTransport/MonteCarlo/EvolveMonteCarlo.hpp
+++ b/src/Evolution/Executables/RadiationTransport/MonteCarlo/EvolveMonteCarlo.hpp
@@ -199,7 +199,7 @@ struct EvolutionMetavars {
   using initialization_actions = tmpl::list<
       Initialization::Actions::InitializeItems<
           Initialization::TimeStepping<EvolutionMetavars, TimeStepperBase,
-                                       false>,
+                                       false, local_time_stepping>,
           evolution::dg::Initialization::Domain<EvolutionMetavars>>,
       Initialization::Actions::AddSimpleTags<
           evolution::dg::BackgroundGrVars<system, EvolutionMetavars>>,

--- a/src/Evolution/Executables/RadiationTransport/MonteCarlo/EvolveMonteCarlo.hpp
+++ b/src/Evolution/Executables/RadiationTransport/MonteCarlo/EvolveMonteCarlo.hpp
@@ -82,6 +82,7 @@
 #include "Time/ChangeSlabSize/Action.hpp"
 #include "Time/StepChoosers/Factory.hpp"
 #include "Time/StepChoosers/StepChooser.hpp"
+#include "Time/Tags/StepperErrorTolerancesCompute.hpp"
 #include "Time/Tags/Time.hpp"
 #include "Time/Tags/TimeStepId.hpp"
 #include "Time/TimeSequence.hpp"
@@ -116,6 +117,8 @@ struct EvolutionMetavars {
   using system = Particles::MonteCarlo::System;
   using temporal_id = Tags::TimeStepId;
   using TimeStepperBase = TimeStepper;
+  static constexpr bool local_time_stepping =
+      TimeStepperBase::local_time_stepping;
   static constexpr bool use_dg_subcell = true;
 
   using initial_data_list =
@@ -212,7 +215,8 @@ struct EvolutionMetavars {
           Particles::MonteCarlo::CellLightCrossingTimeCompute,
           Particles::MonteCarlo::InertialFrameEnergyDensityCompute,
           Particles::MonteCarlo::InverseJacobianInertialToFluidCompute,
-          domain::Tags::JacobianCompute<4, Frame::Inertial, Frame::Fluid>>>,
+          domain::Tags::JacobianCompute<4, Frame::Inertial, Frame::Fluid>,
+          ::Tags::StepperErrorEstimatesEnabledCompute<false>>>,
       evolution::Actions::InitializeRunEventsAndDenseTriggers,
       Parallel::Actions::TerminatePhase>;
 

--- a/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
+++ b/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
@@ -340,7 +340,7 @@ struct EvolutionMetavars {
   using initialization_actions = tmpl::list<
       Initialization::Actions::InitializeItems<
           Initialization::TimeStepping<EvolutionMetavars, TimeStepperBase,
-                                       false>,
+                                       false, local_time_stepping>,
           evolution::dg::Initialization::Domain<EvolutionMetavars>,
           Initialization::TimeStepperHistory<EvolutionMetavars>>,
       Initialization::Actions::ConservativeSystem<system>,

--- a/src/Evolution/Executables/ScalarTensor/ScalarTensorBase.hpp
+++ b/src/Evolution/Executables/ScalarTensor/ScalarTensorBase.hpp
@@ -473,7 +473,7 @@ struct ScalarTensorTemplateBase {
   using initialization_actions = tmpl::list<
       Initialization::Actions::InitializeItems<
           Initialization::TimeStepping<derived_metavars, TimeStepperBase,
-                                       UseControlSystems>,
+                                       UseControlSystems, local_time_stepping>,
           evolution::dg::Initialization::Domain<derived_metavars,
                                                 UseControlSystems>,
           Initialization::TimeStepperHistory<derived_metavars>>,

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -276,7 +276,7 @@ struct EvolutionMetavars {
   using initialization_actions = tmpl::list<
       Initialization::Actions::InitializeItems<
           Initialization::TimeStepping<EvolutionMetavars, TimeStepperBase,
-                                       false>,
+                                       false, local_time_stepping>,
           evolution::dg::Initialization::Domain<EvolutionMetavars>,
           ::amr::Initialization::Initialize<volume_dim, EvolutionMetavars>,
           Initialization::TimeStepperHistory<EvolutionMetavars>>,

--- a/src/Evolution/Initialization/Evolution.hpp
+++ b/src/Evolution/Initialization/Evolution.hpp
@@ -30,6 +30,7 @@
 #include "Time/ChangeSlabSize/Tags.hpp"
 #include "Time/ChooseLtsStepSize.hpp"
 #include "Time/History.hpp"
+#include "Time/LtsMode.hpp"
 #include "Time/Slab.hpp"
 #include "Time/StepChoosers/StepChooser.hpp"
 #include "Time/Tags/AdaptiveSteppingDiagnostics.hpp"
@@ -113,13 +114,14 @@ void set_next_time_step_id(const gsl::not_null<TimeStepId*> next_time_step_id,
 /// _before_ the initial time. So `Tags::TimeStepId` is undefined at this point,
 /// and `Tags::Next<Tags::TimeStepId>` is the initial time.
 template <typename Metavariables, typename TimeStepperBase,
-          bool WithControlSystems>
+          bool WithControlSystems, bool AllowLocalTimeStepping>
 struct TimeStepping {
   /// Tags for constant items added to the GlobalCache.  These items are
   /// initialized from input file options.
   using const_global_cache_tags = tmpl::list<
       ::Tags::ConcreteTimeStepper<TimeStepperBase, WithControlSystems>,
-      ::Tags::LtsMode>;
+      tmpl::conditional_t<AllowLocalTimeStepping, ::Tags::LtsMode,
+                          ::Tags::LtsModeForced<LtsMode::Off>>>;
 
   /// Tags for mutable items added to the GlobalCache.  These items are
   /// initialized from input file options.
@@ -128,13 +130,13 @@ struct TimeStepping {
   /// Tags for items fetched by the DataBox and passed to the apply function
   using argument_tags =
       tmpl::list<::Tags::Time, Tags::InitialTimeDelta,
-                 Tags::InitialSlabSize<TimeStepperBase::local_time_stepping>,
+                 Tags::InitialSlabSize<AllowLocalTimeStepping>,
                  ::Tags::TimeStepper<TimeStepperBase>>;
 
   /// Tags for simple DataBox items that are initialized from input file options
   using simple_tags_from_options =
       tmpl::list<::Tags::Time, Tags::InitialTimeDelta,
-                 Tags::InitialSlabSize<TimeStepperBase::local_time_stepping>>;
+                 Tags::InitialSlabSize<AllowLocalTimeStepping>>;
 
   /// Tags for simple DataBox items that are default initialized.
   using default_initialized_simple_tags =

--- a/src/Evolution/Systems/Cce/Actions/InitializeCharacteristicEvolutionTime.hpp
+++ b/src/Evolution/Systems/Cce/Actions/InitializeCharacteristicEvolutionTime.hpp
@@ -16,9 +16,11 @@
 #include "Parallel/AlgorithmExecution.hpp"
 #include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
 #include "Time/ChooseLtsStepSize.hpp"
+#include "Time/LtsMode.hpp"
 #include "Time/Slab.hpp"
 #include "Time/Tags/AdaptiveSteppingDiagnostics.hpp"
 #include "Time/Tags/HistoryEvolvedVariables.hpp"
+#include "Time/Tags/LtsMode.hpp"
 #include "Time/Tags/StepNumberWithinSlab.hpp"
 #include "Time/Tags/Time.hpp"
 #include "Time/Tags/TimeStep.hpp"
@@ -74,7 +76,8 @@ struct InitializeCharacteristicEvolutionTime {
                  ::Initialization::Tags::InitialTimeDelta>;
 
   using const_global_cache_tags = tmpl::list<
-      Tags::CceEvolutionPrefix<::Tags::ConcreteTimeStepper<LtsTimeStepper>>>;
+      Tags::CceEvolutionPrefix<::Tags::ConcreteTimeStepper<LtsTimeStepper>>,
+      Tags::CceEvolutionPrefix<::Tags::LtsModeForced<LtsMode::Conservative>>>;
 
   using evolved_swsh_variables_tag = ::Tags::Variables<EvolvedSwshTag>;
   using simple_tags = tmpl::list<

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonChare.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonChare.hpp
@@ -76,7 +76,8 @@ struct WorldtubeSingleton {
 
   using initialization_actions = tmpl::list<
       ::Initialization::Actions::InitializeItems<
-          ::Initialization::TimeStepping<Metavariables, TimeStepperBase, false>,
+          ::Initialization::TimeStepping<Metavariables, TimeStepperBase, false,
+                                         local_time_stepping>,
           Initialization::InitializeEvolvedVariables,
           Initialization::InitializeElementFacesGridCoordinates<Dim>>,
       ::Initialization::Actions::AddComputeTags<

--- a/src/Executables/ExportCoordinates/ExportCoordinates.hpp
+++ b/src/Executables/ExportCoordinates/ExportCoordinates.hpp
@@ -338,7 +338,8 @@ struct Metavariables {
               tmpl::list<
                   Initialization::Actions::InitializeItems<
                       Initialization::TimeStepping<Metavariables,
-                                                   TimeStepperBase, false>,
+                                                   TimeStepperBase, false,
+                                                   local_time_stepping>,
                       evolution::dg::Initialization::Domain<Metavariables>,
                       ::amr::Initialization::Initialize<volume_dim,
                                                         Metavariables>,

--- a/src/Time/Tags/LtsMode.hpp
+++ b/src/Time/Tags/LtsMode.hpp
@@ -5,6 +5,7 @@
 
 #include "DataStructures/DataBox/Tag.hpp"
 #include "Time/LtsMode.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace Tags {
@@ -23,6 +24,30 @@ struct LtsMode : db::SimpleTag {
   static type create_from_options() {
     return Metavars::local_time_stepping ? ::LtsMode::Conservative
                                          : ::LtsMode::Off;
+  }
+};
+
+/// \ingroup DataBoxTagsGroup
+/// \ingroup TimeGroup
+/// Version of LtsMode that forces a specific value, primarily for
+/// executables without LTS support.
+template <::LtsMode Mode>
+struct LtsModeForced : LtsMode {
+  using base = LtsMode;
+
+  template <typename Metavars>
+  static type create_from_options() {
+    // Check consistency rather than just returning the forced mode so
+    // that other tag creation functions can rely on the parsed value
+    // being correct.
+    const auto lts_mode = Metavars::local_time_stepping
+                              ? ::LtsMode::Conservative
+                              : ::LtsMode::Off;
+    if (lts_mode != Mode) {
+      ERROR_NO_TRACE(
+          "This executable only supports LocalTimeStepping: " << Mode);
+    }
+    return lts_mode;
   }
 };
 }  // namespace Tags

--- a/tests/Unit/Evolution/Initialization/Test_Evolution.cpp
+++ b/tests/Unit/Evolution/Initialization/Test_Evolution.cpp
@@ -129,7 +129,7 @@ void test_gts() {
       TimeDelta{}, std::numeric_limits<double>::signaling_NaN());
 
   db::mutate_apply<Initialization::TimeStepping<TestMetavariables<TimeStepper>,
-                                                TimeStepper, false>>(
+                                                TimeStepper, false, false>>(
       make_not_null(&box));
 
   CHECK(db::get<::Tags::Next<::Tags::TimeStepId>>(box) ==
@@ -175,7 +175,7 @@ void test_lts() {
       TimeDelta{}, std::numeric_limits<double>::signaling_NaN());
 
   db::mutate_apply<Initialization::TimeStepping<
-      TestMetavariables<LtsTimeStepper>, LtsTimeStepper, false>>(
+      TestMetavariables<LtsTimeStepper>, LtsTimeStepper, false, true>>(
       make_not_null(&box));
 
   CHECK(db::get<::Tags::Next<::Tags::TimeStepId>>(box) ==

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_AnalyticBoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_AnalyticBoundaryCommunication.cpp
@@ -32,6 +32,7 @@
 #include "ParallelAlgorithms/Actions/MutateApply.hpp"
 #include "ParallelAlgorithms/Actions/TerminatePhase.hpp"
 #include "Time/AdvanceTime.hpp"
+#include "Time/LtsMode.hpp"
 #include "Time/StepChoosers/StepChooser.hpp"
 #include "Time/Tags/StepperErrorEstimatesEnabled.hpp"
 #include "Time/TimeSteppers/AdamsBashforth.hpp"
@@ -192,7 +193,8 @@ SPECTRE_TEST_CASE(
           false, l_max, extraction_radius, end_time, start_time,
           number_of_radial_points,
           static_cast<std::unique_ptr<LtsTimeStepper>>(
-              std::make_unique<::TimeSteppers::AdamsBashforth>(3))}};
+              std::make_unique<::TimeSteppers::AdamsBashforth>(3)),
+          LtsMode::Conservative}};
 
   const AnalyticBoundaryDataManager analytic_manager{
       l_max, extraction_radius,

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_CharacteristicEvolutionBondiCalculations.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_CharacteristicEvolutionBondiCalculations.cpp
@@ -40,6 +40,7 @@
 #include "ParallelAlgorithms/Actions/TerminatePhase.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "Time/AdvanceTime.hpp"
+#include "Time/LtsMode.hpp"
 #include "Time/StepChoosers/StepChooser.hpp"
 #include "Time/Tags/StepperErrorEstimatesEnabled.hpp"
 #include "Time/TimeSteppers/AdamsBashforth.hpp"
@@ -243,7 +244,8 @@ SPECTRE_TEST_CASE(
       {start_time, std::make_unique<InitializeJ::InverseCubic<false>>(), false,
        l_max, number_of_radial_points,
        static_cast<std::unique_ptr<LtsTimeStepper>>(
-           std::make_unique<::TimeSteppers::AdamsBashforth>(3))}};
+           std::make_unique<::TimeSteppers::AdamsBashforth>(3)),
+       LtsMode::Conservative}};
 
   ActionTesting::set_phase(make_not_null(&runner),
                            Parallel::Phase::Initialization);

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_GhBoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_GhBoundaryCommunication.cpp
@@ -43,6 +43,7 @@
 #include "ParallelAlgorithms/Actions/MutateApply.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "Time/AdvanceTime.hpp"
+#include "Time/LtsMode.hpp"
 #include "Time/Slab.hpp"
 #include "Time/StepChoosers/StepChooser.hpp"
 #include "Time/Tags/StepperErrorEstimatesEnabled.hpp"
@@ -209,7 +210,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.GhBoundaryCommunication",
           false, l_max, extraction_radius, end_time, start_time,
           number_of_radial_points,
           static_cast<std::unique_ptr<LtsTimeStepper>>(
-              std::make_unique<::TimeSteppers::AdamsBashforth>(3))}};
+              std::make_unique<::TimeSteppers::AdamsBashforth>(3)),
+          LtsMode::Conservative}};
 
   // first prepare the input for the modal version
   const double mass = value_dist(gen);

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_H5BoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_H5BoundaryCommunication.cpp
@@ -41,6 +41,7 @@
 #include "ParallelAlgorithms/Actions/TerminatePhase.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "Time/AdvanceTime.hpp"
+#include "Time/LtsMode.hpp"
 #include "Time/StepChoosers/StepChooser.hpp"
 #include "Time/Tags/StepperErrorEstimatesEnabled.hpp"
 #include "Time/TimeSteppers/AdamsBashforth.hpp"
@@ -239,7 +240,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.H5BoundaryCommunication",
        Tags::EndTimeFromFile::create_from_options(end_time, filename, false),
        start_time, number_of_radial_points,
        static_cast<std::unique_ptr<LtsTimeStepper>>(
-           std::make_unique<::TimeSteppers::AdamsBashforth>(3))}};
+           std::make_unique<::TimeSteppers::AdamsBashforth>(3)),
+       LtsMode::Conservative}};
 
   // create the test file, because on initialization the manager will need
   // to get basic data out of the file

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeCharacteristicEvolution.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeCharacteristicEvolution.cpp
@@ -35,6 +35,7 @@
 #include "ParallelAlgorithms/Actions/TerminatePhase.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "Time/AdvanceTime.hpp"
+#include "Time/LtsMode.hpp"
 #include "Time/StepChoosers/StepChooser.hpp"
 #include "Time/Tags/StepperErrorEstimatesEnabled.hpp"
 #include "Time/TimeSteppers/AdamsBashforth.hpp"
@@ -190,7 +191,8 @@ SPECTRE_TEST_CASE(
   ActionTesting::MockRuntimeSystem<metavariables> runner{
       {start_time, false, l_max, number_of_radial_points,
        static_cast<std::unique_ptr<LtsTimeStepper>>(
-           std::make_unique<::TimeSteppers::AdamsBashforth>(3))}};
+           std::make_unique<::TimeSteppers::AdamsBashforth>(3)),
+       LtsMode::Conservative}};
 
   ActionTesting::set_phase(make_not_null(&runner),
                            Parallel::Phase::Initialization);

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeKleinGordonCharacteristicEvolution.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeKleinGordonCharacteristicEvolution.cpp
@@ -13,6 +13,7 @@
 #include "ParallelAlgorithms/Actions/MutateApply.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "Time/AdvanceTime.hpp"
+#include "Time/LtsMode.hpp"
 #include "Time/Tags/StepperErrorEstimatesEnabled.hpp"
 #include "Time/TimeSteppers/AdamsBashforth.hpp"
 #include "Time/TimeSteppers/LtsTimeStepper.hpp"
@@ -177,7 +178,8 @@ void test_klein_gordon_cce_initialization(const gsl::not_null<Generator*> gen) {
   ActionTesting::MockRuntimeSystem<metavariables> runner{
       {start_time, false, l_max, number_of_radial_points,
        static_cast<std::unique_ptr<LtsTimeStepper>>(
-           std::make_unique<::TimeSteppers::AdamsBashforth>(3))}};
+           std::make_unique<::TimeSteppers::AdamsBashforth>(3)),
+       LtsMode::Conservative}};
 
   ActionTesting::set_phase(make_not_null(&runner),
                            Parallel::Phase::Initialization);

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InsertInterpolationScriData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InsertInterpolationScriData.cpp
@@ -31,6 +31,7 @@
 #include "ParallelAlgorithms/Actions/TerminatePhase.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "Time/AdvanceTime.hpp"
+#include "Time/LtsMode.hpp"
 #include "Time/StepChoosers/StepChooser.hpp"
 #include "Time/Tags/StepperErrorEstimatesEnabled.hpp"
 #include "Time/TimeSteppers/AdamsBashforth.hpp"
@@ -282,7 +283,7 @@ SPECTRE_TEST_CASE(
       {start_time, false, l_max, l_max, number_of_radial_points,
        static_cast<std::unique_ptr<LtsTimeStepper>>(
            std::make_unique<::TimeSteppers::AdamsBashforth>(3)),
-       scri_output_density, true}};
+       LtsMode::Conservative, scri_output_density, true}};
   runner.set_phase(Parallel::Phase::Initialization);
   // Serialize and deserialize to get around the lack of implicit copy
   // constructor.

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_KleinGordonH5BoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_KleinGordonH5BoundaryCommunication.cpp
@@ -17,6 +17,7 @@
 #include "ParallelAlgorithms/Actions/MutateApply.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "Time/AdvanceTime.hpp"
+#include "Time/LtsMode.hpp"
 #include "Time/Tags/StepperErrorEstimatesEnabled.hpp"
 #include "Time/TimeSteppers/AdamsBashforth.hpp"
 #include "Utilities/FileSystem.hpp"
@@ -218,7 +219,8 @@ void test_klein_gordon_h5_boundary_communication(
                                                   false),
        start_time, number_of_radial_points,
        static_cast<std::unique_ptr<LtsTimeStepper>>(
-           std::make_unique<::TimeSteppers::AdamsBashforth>(3))}};
+           std::make_unique<::TimeSteppers::AdamsBashforth>(3)),
+       LtsMode::Conservative}};
 
   const size_t buffer_size = 5;
   ActionTesting::set_phase(make_not_null(&runner),

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestBoundaryData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestBoundaryData.cpp
@@ -29,6 +29,7 @@
 #include "ParallelAlgorithms/Actions/TerminatePhase.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "Time/AdvanceTime.hpp"
+#include "Time/LtsMode.hpp"
 #include "Time/StepChoosers/StepChooser.hpp"
 #include "Time/Tags/StepperErrorEstimatesEnabled.hpp"
 #include "Time/TimeStepId.hpp"
@@ -206,7 +207,8 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.RequestBoundaryData",
        Tags::EndTimeFromFile::create_from_options(end_time, filename, false),
        start_time, number_of_radial_points,
        static_cast<std::unique_ptr<LtsTimeStepper>>(
-           std::make_unique<::TimeSteppers::AdamsBashforth>(3))}};
+           std::make_unique<::TimeSteppers::AdamsBashforth>(3)),
+       LtsMode::Conservative}};
 
   ActionTesting::set_phase(make_not_null(&runner),
                            Parallel::Phase::Initialization);

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestKleinGordonBoundaryData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestKleinGordonBoundaryData.cpp
@@ -18,6 +18,7 @@
 #include "ParallelAlgorithms/Actions/MutateApply.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "Time/AdvanceTime.hpp"
+#include "Time/LtsMode.hpp"
 #include "Time/Tags/StepperErrorEstimatesEnabled.hpp"
 #include "Time/TimeSteppers/AdamsBashforth.hpp"
 #include "Utilities/Gsl.hpp"
@@ -185,7 +186,8 @@ void test_klein_gordon_boundary_data(const gsl::not_null<Generator*> gen) {
        Tags::EndTimeFromFile::create_from_options(end_time, filename, false),
        start_time, number_of_radial_points,
        static_cast<std::unique_ptr<LtsTimeStepper>>(
-           std::make_unique<::TimeSteppers::AdamsBashforth>(3))}};
+           std::make_unique<::TimeSteppers::AdamsBashforth>(3)),
+       LtsMode::Conservative}};
 
   ActionTesting::set_phase(make_not_null(&runner),
                            Parallel::Phase::Initialization);

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_ScriObserveInterpolated.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_ScriObserveInterpolated.cpp
@@ -43,6 +43,7 @@
 #include "ParallelAlgorithms/Actions/MutateApply.hpp"
 #include "ParallelAlgorithms/Actions/TerminatePhase.hpp"
 #include "Time/AdvanceTime.hpp"
+#include "Time/LtsMode.hpp"
 #include "Time/StepChoosers/StepChooser.hpp"
 #include "Time/Tags/StepperErrorEstimatesEnabled.hpp"
 #include "Time/TimeSteppers/AdamsBashforth.hpp"
@@ -280,7 +281,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.Actions.ScriObserveInterpolated",
        number_of_radial_points,
        static_cast<std::unique_ptr<LtsTimeStepper>>(
            std::make_unique<::TimeSteppers::AdamsBashforth>(3)),
-       scri_output_density, false}};
+       LtsMode::Conservative, scri_output_density, false}};
 
   runner.set_phase(Parallel::Phase::Initialization);
   // Serialize and deserialize to get around the lack of implicit copy

--- a/tests/Unit/Time/Tags/Test_LtsMode.cpp
+++ b/tests/Unit/Time/Tags/Test_LtsMode.cpp
@@ -6,8 +6,11 @@
 #include <string>
 
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "Time/LtsMode.hpp"
 #include "Time/Tags/LtsMode.hpp"
 
 SPECTRE_TEST_CASE("Unit.Time.Tags.LtsMode", "[Unit][Time]") {
   TestHelpers::db::test_simple_tag<Tags::LtsMode>("LtsMode");
+  TestHelpers::db::test_simple_tag<Tags::LtsModeForced<LtsMode::Off>>(
+      "LtsMode");
 }


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
