### PR TITLE
Add half-fourier basis

### DIFF
--- a/src/NumericalAlgorithms/Spectral/Basis.cpp
+++ b/src/NumericalAlgorithms/Spectral/Basis.cpp
@@ -15,17 +15,12 @@
 
 namespace Spectral {
 
-std::array<Basis, 10> all_bases() {
-  return std::array{Basis::Uninitialized,
-                    Basis::Chebyshev,
-                    Basis::Legendre,
-                    Basis::FiniteDifference,
-                    Basis::SphericalHarmonic,
-                    Basis::Fourier,
-                    Basis::ZernikeB1,
-                    Basis::ZernikeB2,
-                    Basis::ZernikeB3,
-                    Basis::Cartoon};
+std::array<Basis, 11> all_bases() {
+  return std::array{
+      Basis::Uninitialized,    Basis::Chebyshev,         Basis::Legendre,
+      Basis::FiniteDifference, Basis::SphericalHarmonic, Basis::Fourier,
+      Basis::ZernikeB1,        Basis::ZernikeB2,         Basis::ZernikeB3,
+      Basis::Cartoon,          Basis::HalfFourier};
 }
 
 Basis to_basis(const std::string& basis) {
@@ -62,6 +57,8 @@ std::ostream& operator<<(std::ostream& os, const Basis& basis) {
       return os << "ZernikeB3";
     case Basis::Cartoon:
       return os << "Cartoon";
+    case Basis::HalfFourier:
+      return os << "HalfFourier";
     default:
       ERROR("Invalid basis");
   }

--- a/src/NumericalAlgorithms/Spectral/Basis.hpp
+++ b/src/NumericalAlgorithms/Spectral/Basis.hpp
@@ -45,6 +45,12 @@ constexpr uint8_t basis_shift = 4;
  * which the expected solution is smooth.  A Mesh with this Basis cannot be
  * split by h-refinement in this dimension.
  *
+ * \note Choose `HalfFourier` for a dimension that is spatially periodic and in
+ * which the expected solution is smooth and each tensor component has a
+ * definite parity, i.e. and be expanded purely in terms of either sines or
+ * cosines. A Mesh with this Basis cannot be split by h-refinement in this
+ * dimension.
+ *
  * \note Choose two consecutive dimensions to have `SphericalHarmonic` to choose
  * a spherical harmonic basis.  By convention, the first dimension represents
  * the polar/zenith angle (or colatitude), while the second dimension represents
@@ -83,11 +89,12 @@ enum class Basis : uint8_t {
   ZernikeB1 = 6 << basis_shift,
   ZernikeB2 = 7 << basis_shift,
   ZernikeB3 = 8 << basis_shift,
-  Cartoon = 9 << basis_shift
+  Cartoon = 9 << basis_shift,
+  HalfFourier = 10 << basis_shift
 };
 
 /// All possible values of Basis
-std::array<Basis, 10> all_bases();
+std::array<Basis, 11> all_bases();
 
 /// Convert a string to a Basis enum.
 Basis to_basis(const std::string& basis);

--- a/src/NumericalAlgorithms/Spectral/BasisFunctions/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Spectral/BasisFunctions/CMakeLists.txt
@@ -6,6 +6,7 @@ spectre_target_sources(
   PRIVATE
   Chebyshev.cpp
   Fourier.cpp
+  HalfFourier.cpp
   Jacobi.cpp
   Legendre.cpp
   Zernike.cpp
@@ -17,6 +18,7 @@ spectre_target_headers(
   HEADERS
   Chebyshev.hpp
   Fourier.hpp
+  HalfFourier.hpp
   Jacobi.hpp
   Zernike.hpp
   )

--- a/src/NumericalAlgorithms/Spectral/BasisFunctions/HalfFourier.cpp
+++ b/src/NumericalAlgorithms/Spectral/BasisFunctions/HalfFourier.cpp
@@ -1,0 +1,202 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/Spectral/BasisFunctions/HalfFourier.hpp"
+
+#include <cmath>
+#include <cstddef>
+#include <numbers>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Matrix.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/BasisFunctionNormalizationSquare.hpp"
+#include "NumericalAlgorithms/Spectral/BasisFunctionValue.hpp"
+#include "NumericalAlgorithms/Spectral/CollocationPointsAndWeights.hpp"
+#include "NumericalAlgorithms/Spectral/Parity.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+namespace Spectral {
+
+DataVector HalfFourier::collocation_points(const size_t num_points) {
+  const double pi_over_n = std::numbers::pi / static_cast<double>(num_points);
+  DataVector result(num_points);
+  for (size_t j = 0; j < num_points; ++j) {
+    result[j] = pi_over_n * (static_cast<double>(j) + 0.5);
+  }
+  return result;
+}
+
+DataVector HalfFourier::quadrature_weights(const size_t num_points) {
+  return DataVector{num_points,
+                    std::numbers::pi / static_cast<double>(num_points)};
+}
+
+Matrix HalfFourier::even_differentiation_matrix(const size_t num_points) {
+  const double pi_over_n = std::numbers::pi / static_cast<double>(num_points);
+  const double two_over_n = 2.0 / static_cast<double>(num_points);
+  Matrix result(num_points, num_points, 0.0);
+  for (size_t i = 0; i < num_points; ++i) {
+    const double phi_i = pi_over_n * (static_cast<double>(i) + 0.5);
+    for (size_t j = 0; j < num_points; ++j) {
+      const double phi_j = pi_over_n * (static_cast<double>(j) + 0.5);
+      double val = 0.0;
+      for (size_t n = 1; n < num_points; ++n) {
+        val += static_cast<double>(n) * sin(static_cast<double>(n) * phi_i) *
+               cos(static_cast<double>(n) * phi_j);
+      }
+      result(i, j) = -two_over_n * val;
+    }
+  }
+  return result;
+}
+
+Matrix HalfFourier::odd_differentiation_matrix(const size_t num_points) {
+  const double pi_over_n = std::numbers::pi / static_cast<double>(num_points);
+  const double two_over_n = 2.0 / static_cast<double>(num_points);
+  Matrix result(num_points, num_points, 0.0);
+  for (size_t i = 0; i < num_points; ++i) {
+    const double phi_i = pi_over_n * (static_cast<double>(i) + 0.5);
+    for (size_t j = 0; j < num_points; ++j) {
+      const double phi_j = pi_over_n * (static_cast<double>(j) + 0.5);
+      double val = 0.0;
+      // Note: the n=num_points term vanishes because cos(num_points * phi_i) =
+      // cos(pi*(i+0.5)) = 0, so only n=1,...,num_points-1 contribute.
+      for (size_t n = 1; n < num_points; ++n) {
+        val += static_cast<double>(n) * cos(static_cast<double>(n) * phi_i) *
+               sin(static_cast<double>(n) * phi_j);
+      }
+      result(i, j) = two_over_n * val;
+    }
+  }
+  return result;
+}
+
+template <typename T>
+Matrix HalfFourier::even_interpolation_matrix(const size_t num_points,
+                                              const T& target_points) {
+  const double pi_over_n = std::numbers::pi / static_cast<double>(num_points);
+  const double inv_n = 1.0 / static_cast<double>(num_points);
+  const size_t num_target_points = get_size(target_points);
+  Matrix result(num_target_points, num_points);
+  for (size_t i = 0; i < num_target_points; ++i) {
+    const double x = get_element(target_points, i);
+    for (size_t j = 0; j < num_points; ++j) {
+      const double phi_j = pi_over_n * (static_cast<double>(j) + 0.5);
+      double val = 1.0;
+      for (size_t n = 1; n < num_points; ++n) {
+        val += 2.0 * cos(static_cast<double>(n) * x) *
+               cos(static_cast<double>(n) * phi_j);
+      }
+      result(i, j) = inv_n * val;
+    }
+  }
+  return result;
+}
+
+template <typename T>
+Matrix HalfFourier::odd_interpolation_matrix(const size_t num_points,
+                                             const T& target_points) {
+  const double pi_over_n = std::numbers::pi / static_cast<double>(num_points);
+  const double two_over_n = 2.0 / static_cast<double>(num_points);
+  const double inv_n = 1.0 / static_cast<double>(num_points);
+  const size_t num_target_points = get_size(target_points);
+  Matrix result(num_target_points, num_points);
+  for (size_t i = 0; i < num_target_points; ++i) {
+    const double x = get_element(target_points, i);
+    for (size_t j = 0; j < num_points; ++j) {
+      const double phi_j = pi_over_n * (static_cast<double>(j) + 0.5);
+      double val = 0.0;
+      // Modes n=1,...,N-1 have discrete norm N/2 → coefficient 2/N.
+      // Mode n=N (Nyquist) has discrete norm N → coefficient 1/N.
+      for (size_t n = 1; n < num_points; ++n) {
+        val += sin(static_cast<double>(n) * x) *
+               sin(static_cast<double>(n) * phi_j);
+      }
+      result(i, j) =
+          two_over_n * val + inv_n * sin(static_cast<double>(num_points) * x) *
+                                 sin(static_cast<double>(num_points) * phi_j);
+    }
+  }
+  return result;
+}
+
+template <typename T>
+Matrix HalfFourier::interpolation_matrix(const size_t num_points,
+                                         const T& target_points,
+                                         const Parity parity) {
+  ASSERT(parity != Parity::Uninitialized,
+         "Parity must be set to either Even or Odd");
+  if (parity == Parity::Even) {
+    return even_interpolation_matrix(num_points, target_points);
+  } else {
+    return odd_interpolation_matrix(num_points, target_points);
+  }
+}
+
+// Specializations of function templates defined in the Spectral directory
+
+template <>
+std::pair<DataVector, DataVector> compute_collocation_points_and_weights<
+    Basis::HalfFourier, Quadrature::Equiangular>(const size_t num_points) {
+  return std::make_pair(HalfFourier::collocation_points(num_points),
+                        HalfFourier::quadrature_weights(num_points));
+}
+
+template <Basis BasisType>
+Matrix spectral_indefinite_integral_matrix(size_t num_points);
+
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsuggest-attribute=noreturn"
+#endif
+
+template <>
+Matrix spectral_indefinite_integral_matrix<Basis::HalfFourier>(
+    size_t /*num_points*/) {
+  ERROR("Indefinite integral matrix is not implemented for HalfFourier basis");
+}
+
+template <>
+DataVector compute_basis_function_value<Basis::HalfFourier>(
+    const size_t /*k*/, const DataVector& /*x*/) {
+  ERROR("HalfFourier basis function value requires a parity argument");
+}
+
+template <>
+double compute_basis_function_value<Basis::HalfFourier>(const size_t /*k*/,
+                                                        const double& /*x*/) {
+  ERROR("HalfFourier basis function value requires a parity argument");
+}
+
+template <>
+double compute_basis_function_normalization_square<Basis::HalfFourier>(
+    const size_t /*k*/) {
+  ERROR(
+      "HalfFourier normalization square requires a parity argument; "
+      "norms are pi (even k=0), pi/2 (even k>=1 or odd k=1,...,N).");
+}
+
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+
+#define GET_TYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE_INTERPOLATION(r, data)                \
+  template Matrix HalfFourier::even_interpolation_matrix( \
+      size_t num_points, const GET_TYPE(data)&);          \
+  template Matrix HalfFourier::odd_interpolation_matrix(  \
+      size_t num_points, const GET_TYPE(data)&);          \
+  template Matrix HalfFourier::interpolation_matrix(      \
+      size_t, const GET_TYPE(data)&, Parity);
+
+GENERATE_INSTANTIATIONS(INSTANTIATE_INTERPOLATION,
+                        (double, DataVector, std::vector<double>))
+
+#undef INSTANTIATE_INTERP
+#undef GET_TYPE
+}  // namespace Spectral

--- a/src/NumericalAlgorithms/Spectral/BasisFunctions/HalfFourier.hpp
+++ b/src/NumericalAlgorithms/Spectral/BasisFunctions/HalfFourier.hpp
@@ -1,0 +1,144 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+/// \cond
+class DataVector;
+class Matrix;
+namespace Spectral {
+enum class Parity : uint8_t;
+}  // namespace Spectral
+/// \endcond
+
+namespace Spectral {
+
+/*!
+ * \ingroup SpectralGroup
+ *
+ * \brief A collection of helper functions for the half-Fourier spectral basis
+ *
+ * \details The half-Fourier basis represents functions on the interval
+ * \f$\phi \in [0, \pi)\f$ using \f$N\f$ equispaced interior collocation
+ * points \f$\phi_j = (j + \tfrac{1}{2})\pi/N\f$ for \f$j = 0, \ldots, N-1\f$.
+ *
+ * Functions of even parity under \f$\phi \to -\phi\f$ (i.e. those satisfying
+ * \f$f(-\phi)=f(\phi)\f$) are expanded in cosines:
+ * \f[
+ * f(\phi) = \sum_{n=0}^{N-1} a_n \cos(n\phi)
+ * \f]
+ *
+ * Functions of odd parity under \f$\phi \to -\phi\f$ (i.e. those satisfying
+ * \f$f(-\phi)=-f(\phi)\f$) are expanded in sines:
+ * \f[
+ * f(\phi) = \sum_{n=1}^{N} b_n \sin(n\phi)
+ * \f]
+ *
+ * The derivative \f$\partial / \partial \phi\f$ maps even-parity functions to
+ * odd-parity functions and vice versa.
+ *
+ * This basis is intended for use in the Cartoon method for axisymmetric
+ * problems on a cylinder, where the azimuthal direction covers only half a
+ * circle due to the reflection symmetry, and the parity boundary conditions
+ * are internal to the spectral representation.
+ */
+class HalfFourier {
+ public:
+  /*!
+   * \brief Collocation points \f$\{\phi_j\}\f$
+   *
+   * \details The collocation points on the interval \f$(0, \pi)\f$ are given
+   * by
+   * \f[
+   * \phi_j = \frac{(j + \tfrac{1}{2})\pi}{N}
+   * \f]
+   */
+  static DataVector collocation_points(size_t num_points);
+
+  /*!
+   * \brief Quadrature weights \f$\{w_j\}\f$
+   *
+   * \details The quadrature weights are uniform:
+   * \f[
+   * w_j = \frac{\pi}{N}
+   * \f]
+   */
+  static DataVector quadrature_weights(size_t num_points);
+
+  /*!
+   * \brief Differentiation matrix \f$D^{\text{even}}_{ij}\f$ for even-parity
+   * functions
+   *
+   * \details Maps an even-parity function (expanded in cosines) to its
+   * derivative, which is an odd-parity function (expanded in sines).
+   * Explicitly:
+   * \f[
+   * D^{\text{even}}_{ij} = \frac{2}{N} \sum_{n=1}^{N-1}
+   * (-n) \sin(n\phi_i) \cos(n\phi_j)
+   * \f]
+   */
+  static Matrix even_differentiation_matrix(size_t num_points);
+
+  /*!
+   * \brief Differentiation matrix \f$D^{\text{odd}}_{ij}\f$ for odd-parity
+   * functions
+   *
+   * \details Maps an odd-parity function (expanded in sines) to its
+   * derivative, which is an even-parity function (expanded in cosines).
+   * Explicitly:
+   * \f[
+   * D^{\text{odd}}_{ij} = \frac{2}{N} \sum_{n=1}^{N-1}
+   * n \cos(n\phi_i) \sin(n\phi_j)
+   * \f]
+   *
+   * Note that \f$D^{\text{even}} = -(D^{\text{odd}})^T\f$.
+   */
+  static Matrix odd_differentiation_matrix(size_t num_points);
+
+  /*!
+   * \brief Interpolation matrix for even-parity functions to
+   * \p target_points.
+   *
+   * \details Using the discrete cosine transform (DCT-II) representation, the
+   * interpolation weights at a target point \f$x\f$ are:
+   * \f[
+   * I^{\text{even}}_j(x) = \frac{1}{N}\left[1 + 2\sum_{n=1}^{N-1}
+   * \cos(nx)\cos(n\phi_j)\right]
+   * \f]
+   */
+  template <typename T>
+  static Matrix even_interpolation_matrix(size_t num_points,
+                                          const T& target_points);
+
+  /*!
+   * \brief Interpolation matrix for odd-parity functions to
+   * \p target_points.
+   *
+   * \details Using the discrete sine transform (DST-II) representation, the
+   * interpolation weights at a target point \f$x\f$ are:
+   * \f[
+   * I^{\text{odd}}_j(x) = \frac{2}{N}\sum_{n=1}^{N-1}
+   * \sin(nx)\sin(n\phi_j) + \frac{1}{N}\sin(Nx)\sin(N\phi_j)
+   * \f]
+   * where the Nyquist mode \f$n=N\f$ carries half the weight of the other
+   * modes.
+   */
+  template <typename T>
+  static Matrix odd_interpolation_matrix(size_t num_points,
+                                         const T& target_points);
+
+  /*!
+   * \brief %Matrix used to interpolate to the \p target_points for a given
+   * \p parity.
+   *
+   * \details Dispatches to `even_interpolation_matrix` when \p parity is
+   * `Parity::Even` and to `odd_interpolation_matrix` when it is `Parity::Odd`.
+   * This mirrors the interface of `Zernike<1>::interpolation_matrix`.
+   */
+  template <typename T>
+  static Matrix interpolation_matrix(size_t num_points, const T& target_points,
+                                     Parity parity);
+};
+}  // namespace Spectral

--- a/src/NumericalAlgorithms/Spectral/CollocationPoints.cpp
+++ b/src/NumericalAlgorithms/Spectral/CollocationPoints.cpp
@@ -48,6 +48,8 @@ template const DataVector& collocation_points<Basis::FiniteDifference,
 template const DataVector&
     collocation_points<Basis::Fourier, Quadrature::Equiangular>(size_t);
 template const DataVector&
+    collocation_points<Basis::HalfFourier, Quadrature::Equiangular>(size_t);
+template const DataVector&
     collocation_points<Basis::ZernikeB1, Quadrature::GaussRadauUpper>(size_t);
 template const DataVector&
     collocation_points<Basis::ZernikeB2, Quadrature::GaussRadauUpper>(size_t);

--- a/src/NumericalAlgorithms/Spectral/CollocationPointsAndWeights.cpp
+++ b/src/NumericalAlgorithms/Spectral/CollocationPointsAndWeights.cpp
@@ -37,6 +37,8 @@ template struct CollocationPointsAndWeightsGenerator<Basis::FiniteDifference,
                                                      Quadrature::FaceCentered>;
 template struct CollocationPointsAndWeightsGenerator<Basis::Fourier,
                                                      Quadrature::Equiangular>;
+template struct CollocationPointsAndWeightsGenerator<Basis::HalfFourier,
+                                                     Quadrature::Equiangular>;
 template struct CollocationPointsAndWeightsGenerator<
     Basis::ZernikeB1, Quadrature::GaussRadauUpper>;
 template struct CollocationPointsAndWeightsGenerator<

--- a/src/NumericalAlgorithms/Spectral/DifferentiationMatrix.cpp
+++ b/src/NumericalAlgorithms/Spectral/DifferentiationMatrix.cpp
@@ -10,6 +10,7 @@
 #include "NumericalAlgorithms/Spectral/BarycentricWeights.hpp"
 #include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "NumericalAlgorithms/Spectral/BasisFunctions/Fourier.hpp"
+#include "NumericalAlgorithms/Spectral/BasisFunctions/HalfFourier.hpp"
 #include "NumericalAlgorithms/Spectral/BasisFunctions/Zernike.hpp"
 #include "NumericalAlgorithms/Spectral/CollocationPoints.hpp"
 #include "NumericalAlgorithms/Spectral/GetSpectralQuantityForMesh.hpp"
@@ -379,7 +380,13 @@ struct ParityBasedDifferentiationMatrixGenerator {
   Matrix operator()(const size_t num_points, const Parity parity) const {
     // We intentionally do not instantiate "normal" derivatives for Zernike
     // bases due to their large errors
-    if constexpr (BasisType == Spectral::Basis::ZernikeB1) {
+    if constexpr (BasisType == Spectral::Basis::HalfFourier) {
+      if (parity == Parity::Even) {
+        return HalfFourier::even_differentiation_matrix(num_points);
+      } else {
+        return HalfFourier::odd_differentiation_matrix(num_points);
+      }
+    } else if constexpr (BasisType == Spectral::Basis::ZernikeB1) {
       return Zernike<1>::differentiation_matrix(num_points, parity);
     } else if constexpr (BasisType == Spectral::Basis::ZernikeB2) {
       return Zernike<2>::differentiation_matrix(num_points, parity);
@@ -388,7 +395,7 @@ struct ParityBasedDifferentiationMatrixGenerator {
     } else {
       ERROR(
           "Calling ParityBasedDifferentiationMatrixGenerator with a "
-          "non-Zernike basis: call non-parity generator");
+          "non-Zernike, non-HalfFourier basis: call non-parity generator");
     }
   }
 };
@@ -455,6 +462,9 @@ template const Matrix&
 template const Matrix&
     differentiation_matrix<Basis::Legendre, Quadrature::GaussLobatto>(size_t);
 
+template const Matrix&
+    differentiation_matrix<Basis::HalfFourier, Quadrature::Equiangular>(size_t,
+                                                                        Parity);
 template const Matrix& differentiation_matrix<
     Basis::ZernikeB1, Quadrature::GaussRadauUpper>(size_t, Parity);
 template const Matrix& differentiation_matrix<

--- a/src/NumericalAlgorithms/Spectral/GetSpectralQuantityForMesh.hpp
+++ b/src/NumericalAlgorithms/Spectral/GetSpectralQuantityForMesh.hpp
@@ -8,6 +8,7 @@
 
 #include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Parity.hpp"
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 
@@ -186,4 +187,26 @@ decltype(auto) get_two_indexed_spectral_quantity_for_mesh(F&& f,
   }
 }
 
+template <typename F>
+decltype(auto) get_spectral_quantity_with_parity_for_mesh(
+    F&& f, const Mesh<1>& mesh, const Spectral::Parity parity) {
+  const auto num_points = mesh.extents(0);
+  switch (mesh.basis(0)) {
+    case Basis::HalfFourier:
+      switch (mesh.quadrature(0)) {
+        case Quadrature::Equiangular:
+          return std::forward<F>(f)(
+              std::integral_constant<Basis, Basis::HalfFourier>{},
+              std::integral_constant<Quadrature, Quadrature::Equiangular>{},
+              num_points, parity);
+        default:
+          ERROR("Missing quadrature case for two-indexed spectral quantity");
+      }
+    default:
+      ERROR(
+          "Missing basis case for parity-dependent spectral quantity. The "
+          "missing basis is: "
+          << mesh.basis(0));
+  }
+}
 }  // namespace Spectral::detail

--- a/src/NumericalAlgorithms/Spectral/InterpolationMatrix.cpp
+++ b/src/NumericalAlgorithms/Spectral/InterpolationMatrix.cpp
@@ -11,6 +11,7 @@
 #include "NumericalAlgorithms/Spectral/BarycentricWeights.hpp"
 #include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "NumericalAlgorithms/Spectral/BasisFunctions/Fourier.hpp"
+#include "NumericalAlgorithms/Spectral/BasisFunctions/HalfFourier.hpp"
 #include "NumericalAlgorithms/Spectral/BasisFunctions/Zernike.hpp"
 #include "NumericalAlgorithms/Spectral/CollocationPoints.hpp"
 #include "NumericalAlgorithms/Spectral/GetSpectralQuantityForMesh.hpp"
@@ -101,15 +102,24 @@ Matrix interpolation_matrix(const Mesh<1>& mesh, const T& target_points) {
 template <Basis BasisType, Quadrature QuadratureType, typename T>
 Matrix interpolation_matrix(size_t num_points, const T& target_points,
                             const Spectral::Parity parity) {
-  static_assert(BasisType == Basis::ZernikeB1,
-                "Only Basis::ZernikeB1 is supported by this overload; for "
-                "ZernikeB2/ZernikeB3 use Irregular or Cardinal interpolants.");
   static_assert(
-      QuadratureType == Quadrature::GaussRadauUpper,
-      "Zernike bases are only instantiated with GaussRadauUpper quadrature.");
+      BasisType == Basis::ZernikeB1 or BasisType == Basis::HalfFourier,
+      "Only Basis::ZernikeB1 and Basis::HalfFourier are supported by "
+      "this overload; for ZernikeB2/ZernikeB3 use Irregular or "
+      "Cardinal interpolants.");
   ASSERT(parity != Parity::Uninitialized,
          "Parity must be set to either Even or Odd");
-  return Zernike<1>::interpolation_matrix(num_points, target_points, parity);
+  if constexpr (BasisType == Basis::HalfFourier) {
+    static_assert(
+        QuadratureType == Quadrature::Equiangular,
+        "HalfFourier bases are only instantiated with Equiangularquadrature.");
+    return HalfFourier::interpolation_matrix(num_points, target_points, parity);
+  } else {
+    static_assert(
+        QuadratureType == Quadrature::GaussRadauUpper,
+        "Zernike bases are only instantiated with GaussRadauUpper quadrature.");
+    return Zernike<1>::interpolation_matrix(num_points, target_points, parity);
+  }
 }
 
 template Matrix interpolation_matrix<Basis::Chebyshev, Quadrature::Gauss>(
@@ -141,6 +151,17 @@ template Matrix Spectral::interpolation_matrix(const Mesh<1>&,
                                                const std::vector<double>&);
 template Matrix Spectral::interpolation_matrix(const Mesh<1>&, const double&);
 
+template Matrix
+interpolation_matrix<Basis::HalfFourier, Quadrature::Equiangular>(
+    size_t, const std::vector<double>&, Spectral::Parity);
+template Matrix interpolation_matrix<Basis::HalfFourier,
+                                     Quadrature::Equiangular>(size_t,
+                                                              const DataVector&,
+                                                              Spectral::Parity);
+template Matrix interpolation_matrix<Basis::HalfFourier,
+                                     Quadrature::Equiangular>(size_t,
+                                                              const double&,
+                                                              Spectral::Parity);
 template Matrix
 interpolation_matrix<Basis::ZernikeB1, Quadrature::GaussRadauUpper>(
     size_t, const std::vector<double>&, Spectral::Parity);

--- a/src/NumericalAlgorithms/Spectral/InterpolationMatrix.hpp
+++ b/src/NumericalAlgorithms/Spectral/InterpolationMatrix.hpp
@@ -42,8 +42,8 @@ template <typename T>
 Matrix interpolation_matrix(const Mesh<1>& mesh, const T& target_points);
 
 /*!
- * \brief  %Matrix used to interpolate to the \p target_points for bases with
- * a spectral space that depends on parity, i.e. ZernikeB1.
+ * \brief %Matrix used to interpolate to the \p target_points for bases with
+ * a spectral space that depends on parity, i.e. ZernikeB1 and HalfFourier.
  *
  * \see interpolation_matrix(size_t, const T&)
  */

--- a/src/NumericalAlgorithms/Spectral/ModalToNodalMatrix.cpp
+++ b/src/NumericalAlgorithms/Spectral/ModalToNodalMatrix.cpp
@@ -4,6 +4,8 @@
 #include "NumericalAlgorithms/Spectral/ModalToNodalMatrix.hpp"
 
 #include <cstddef>
+#include <cmath>
+#include <numbers>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Matrix.hpp"
@@ -12,6 +14,7 @@
 #include "NumericalAlgorithms/Spectral/CollocationPoints.hpp"
 #include "NumericalAlgorithms/Spectral/GetSpectralQuantityForMesh.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Parity.hpp"
 #include "NumericalAlgorithms/Spectral/PrecomputedSpectralQuantity.hpp"
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
 #include "NumericalAlgorithms/Spectral/SpectralQuantityForMesh.hpp"
@@ -71,6 +74,34 @@ struct TwoIndexedModalToNodalMatrixGenerator {
     return vandermonde_matrix;
   }
 };
+
+template <Basis BasisType, Quadrature QuadratureType>
+struct ModalToNodalMatrixWithParityGenerator {
+  Matrix operator()(const size_t num_points, const Parity parity) const {
+    static_assert(BasisType == Basis::HalfFourier);
+    ASSERT(parity != Parity::Uninitialized,
+           "Passed parity must be set to either Even or Odd");
+    const double pi_over_n = std::numbers::pi / static_cast<double>(num_points);
+    Matrix vandermonde_matrix(num_points, num_points);
+    if (parity == Parity::Even) {
+      for (size_t j = 0; j < num_points; ++j) {
+        const double phi_j = pi_over_n * (static_cast<double>(j) + 0.5);
+        vandermonde_matrix(j, 0) = 1.0;
+        for (size_t k = 1; k < num_points; ++k) {
+          vandermonde_matrix(j, k) = cos(static_cast<double>(k) * phi_j);
+        }
+      }
+    } else {
+      for (size_t j = 0; j < num_points; ++j) {
+        const double phi_j = pi_over_n * (static_cast<double>(j) + 0.5);
+        for (size_t k = 1; k <= num_points; ++k) {
+          vandermonde_matrix(j, k - 1) = sin(static_cast<double>(k) * phi_j);
+        }
+      }
+    }
+    return vandermonde_matrix;
+  }
+};
 }  // namespace
 
 PRECOMPUTED_SPECTRAL_QUANTITY(modal_to_nodal_matrix, Matrix,
@@ -90,6 +121,15 @@ PRECOMPUTED_TWO_INDEXED_SPECTRAL_QUANTITY(modal_to_nodal_matrix, Matrix,
 TWO_INDEXED_SPECTRAL_QUANTITY_FOR_MESH(modal_to_nodal_matrix, Matrix)
 
 #undef TWO_INDEXED_SPECTRAL_QUANTITY_FOR_MESH
+
+PRECOMPUTED_SPECTRAL_QUANTITY_WITH_PARITY(modal_to_nodal_matrix, Matrix,
+                                          ModalToNodalMatrixWithParityGenerator)
+
+#undef PRECOMPUTED_SPECTRAL_QUANTITY_WITH_PARITY
+
+SPECTRAL_QUANTITY_WITH_PARITY_FOR_MESH(modal_to_nodal_matrix, Matrix)
+
+#undef SPECTRAL_QUANTITY_WITH_PARITY_FOR_MESH
 
 template const Matrix&
     modal_to_nodal_matrix<Basis::Cartoon, Quadrature::AxialSymmetry>(size_t);
@@ -111,6 +151,9 @@ template const Matrix& modal_to_nodal_matrix<
     Basis::ZernikeB2, Quadrature::GaussRadauUpper>(size_t, size_t, size_t);
 template const Matrix& modal_to_nodal_matrix<
     Basis::ZernikeB3, Quadrature::GaussRadauUpper>(size_t, size_t, size_t);
+template const Matrix&
+    modal_to_nodal_matrix<Basis::HalfFourier, Quadrature::Equiangular>(size_t,
+                                                                       Parity);
 // Some compilers require these instantiations to exist
 template const Matrix& modal_to_nodal_matrix<Basis::FiniteDifference,
                                              Quadrature::CellCentered>(size_t);

--- a/src/NumericalAlgorithms/Spectral/ModalToNodalMatrix.hpp
+++ b/src/NumericalAlgorithms/Spectral/ModalToNodalMatrix.hpp
@@ -11,6 +11,7 @@ template <size_t>
 class Mesh;
 namespace Spectral {
 enum class Basis : uint8_t;
+enum class Parity : uint8_t;
 enum class Quadrature : uint8_t;
 }  // namespace Spectral
 /// \endcond
@@ -69,4 +70,26 @@ const Matrix& modal_to_nodal_matrix(const Mesh<1>& mesh);
  * \see modal_to_nodal_matrix(size_t, size_t, size_t)
  */
 const Matrix& modal_to_nodal_matrix(const Mesh<1>& mesh, size_t m, size_t N);
+
+/*!
+ * \brief %Matrix used to transform from the spectral coefficients (modes) of a
+ * function to its nodal coefficients, for a parity-dependent basis such as
+ * `Basis::HalfFourier`.
+ *
+ * \param num_points The number of collocation points
+ * \param parity The parity of the function (`Parity::Even` or `Parity::Odd`)
+ *
+ * \see modal_to_nodal_matrix(size_t)
+ */
+template <Basis BasisType, Quadrature QuadratureType>
+const Matrix& modal_to_nodal_matrix(size_t num_points, Parity parity);
+
+/*!
+ * \brief Transformation matrix from modal to nodal coefficients for a
+ * one-dimensional mesh with a parity-dependent basis such as
+ * `Basis::HalfFourier`.
+ *
+ * \see modal_to_nodal_matrix(size_t, Parity)
+ */
+const Matrix& modal_to_nodal_matrix(const Mesh<1>& mesh, Parity parity);
 }  // namespace Spectral

--- a/src/NumericalAlgorithms/Spectral/NodalToModalMatrix.cpp
+++ b/src/NumericalAlgorithms/Spectral/NodalToModalMatrix.cpp
@@ -4,6 +4,8 @@
 #include "NumericalAlgorithms/Spectral/NodalToModalMatrix.hpp"
 
 #include <cstddef>
+#include <cmath>
+#include <numbers>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Matrix.hpp"
@@ -15,6 +17,7 @@
 #include "NumericalAlgorithms/Spectral/GetSpectralQuantityForMesh.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/ModalToNodalMatrix.hpp"
+#include "NumericalAlgorithms/Spectral/Parity.hpp"
 #include "NumericalAlgorithms/Spectral/PrecomputedSpectralQuantity.hpp"
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
 #include "NumericalAlgorithms/Spectral/SpectralQuantityForMesh.hpp"
@@ -90,6 +93,41 @@ struct TwoIndexedNodalToModalMatrixGenerator {
     return inv_matrix;
   }
 };
+
+template <Basis BasisType, Quadrature QuadratureType>
+struct NodalToModalMatrixWithParityGenerator {
+  Matrix operator()(const size_t num_points, const Parity parity) const {
+    static_assert(BasisType == Basis::HalfFourier);
+    ASSERT(parity != Parity::Uninitialized,
+           "Passed parity must be set to either Even or Odd");
+    const double pi_over_n = std::numbers::pi / static_cast<double>(num_points);
+    const double one_over_n = 1.0 / static_cast<double>(num_points);
+    const double two_over_n = 2.0 / static_cast<double>(num_points);
+    Matrix inv_matrix(num_points, num_points);
+    if (parity == Parity::Even) {
+      for (size_t j = 0; j < num_points; ++j) {
+        const double phi_j = pi_over_n * (static_cast<double>(j) + 0.5);
+        inv_matrix(0, j) = one_over_n;
+        for (size_t k = 1; k < num_points; ++k) {
+          inv_matrix(k, j) = two_over_n * cos(static_cast<double>(k) * phi_j);
+        }
+      }
+      return inv_matrix;
+    } else {
+      for (size_t j = 0; j < num_points; ++j) {
+        const double phi_j = pi_over_n * (static_cast<double>(j) + 0.5);
+        for (size_t k = 1; k < num_points; ++k) {
+          inv_matrix(k - 1, j) =
+              two_over_n * sin(static_cast<double>(k) * phi_j);
+        }
+        // Nyquist mode k = N stored at row index N-1
+        inv_matrix(num_points - 1, j) =
+            one_over_n * sin(static_cast<double>(num_points) * phi_j);
+      }
+    }
+    return inv_matrix;
+  }
+};
 }  // namespace
 
 PRECOMPUTED_SPECTRAL_QUANTITY(nodal_to_modal_matrix, Matrix,
@@ -109,6 +147,15 @@ PRECOMPUTED_TWO_INDEXED_SPECTRAL_QUANTITY(nodal_to_modal_matrix, Matrix,
 TWO_INDEXED_SPECTRAL_QUANTITY_FOR_MESH(nodal_to_modal_matrix, Matrix)
 
 #undef TWO_INDEXED_SPECTRAL_QUANTITY_FOR_MESH
+
+PRECOMPUTED_SPECTRAL_QUANTITY_WITH_PARITY(nodal_to_modal_matrix, Matrix,
+                                          NodalToModalMatrixWithParityGenerator)
+
+#undef PRECOMPUTED_SPECTRAL_QUANTITY_WITH_PARITY
+
+SPECTRAL_QUANTITY_WITH_PARITY_FOR_MESH(nodal_to_modal_matrix, Matrix)
+
+#undef SPECTRAL_QUANTITY_WITH_PARITY_FOR_MESH
 
 template const Matrix&
     nodal_to_modal_matrix<Basis::Cartoon, Quadrature::AxialSymmetry>(size_t);
@@ -130,6 +177,9 @@ template const Matrix& nodal_to_modal_matrix<
     Basis::ZernikeB2, Quadrature::GaussRadauUpper>(size_t, size_t, size_t);
 template const Matrix& nodal_to_modal_matrix<
     Basis::ZernikeB3, Quadrature::GaussRadauUpper>(size_t, size_t, size_t);
+template const Matrix&
+    nodal_to_modal_matrix<Basis::HalfFourier, Quadrature::Equiangular>(size_t,
+                                                                       Parity);
 // Some compilers require these instantiations to exist
 template const Matrix& nodal_to_modal_matrix<Basis::FiniteDifference,
                                              Quadrature::CellCentered>(size_t);

--- a/src/NumericalAlgorithms/Spectral/NodalToModalMatrix.hpp
+++ b/src/NumericalAlgorithms/Spectral/NodalToModalMatrix.hpp
@@ -11,6 +11,7 @@ template <size_t>
 class Mesh;
 namespace Spectral {
 enum class Basis : uint8_t;
+enum class Parity : uint8_t;
 enum class Quadrature : uint8_t;
 }  // namespace Spectral
 /// \endcond
@@ -69,4 +70,26 @@ const Matrix& nodal_to_modal_matrix(const Mesh<1>& mesh);
  * \see nodal_to_modal_matrix(size_t, size_t, size_t)
  */
 const Matrix& nodal_to_modal_matrix(const Mesh<1>& mesh, size_t m, size_t N);
+
+/*!
+ * \brief %Matrix used to transform from the nodal coefficients of a function to
+ * its spectral coefficients (modes), for a parity-dependent basis such as
+ * `Basis::HalfFourier`.
+ *
+ * \param num_points The number of collocation points
+ * \param parity The parity of the function (`Parity::Even` or `Parity::Odd`)
+ *
+ * \see nodal_to_modal_matrix(size_t)
+ */
+template <Basis BasisType, Quadrature QuadratureType>
+const Matrix& nodal_to_modal_matrix(size_t num_points, Parity parity);
+
+/*!
+ * \brief Transformation matrix from nodal to modal coefficients for a
+ * one-dimensional mesh with a parity-dependent basis such as
+ * `Basis::HalfFourier`.
+ *
+ * \see nodal_to_modal_matrix(size_t, Parity)
+ */
+const Matrix& nodal_to_modal_matrix(const Mesh<1>& mesh, Parity parity);
 }  // namespace Spectral

--- a/src/NumericalAlgorithms/Spectral/QuadratureWeights.cpp
+++ b/src/NumericalAlgorithms/Spectral/QuadratureWeights.cpp
@@ -79,4 +79,6 @@ template const DataVector& quadrature_weights<Basis::FiniteDifference,
                                               Quadrature::FaceCentered>(size_t);
 template const DataVector&
     quadrature_weights<Basis::Fourier, Quadrature::Equiangular>(size_t);
+template const DataVector&
+    quadrature_weights<Basis::HalfFourier, Quadrature::Equiangular>(size_t);
 }  // namespace Spectral

--- a/src/NumericalAlgorithms/Spectral/SpectralQuantityForMesh.hpp
+++ b/src/NumericalAlgorithms/Spectral/SpectralQuantityForMesh.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "NumericalAlgorithms/Spectral/Parity.hpp"
+
 /// \cond
 // clang-tidy: Macro arguments should be in parentheses, but we want to append
 // template parameters here.
@@ -15,7 +17,7 @@
                                decltype(quadrature)::value>(num_points); \
         },                                                               \
         mesh);                                                           \
-    }
+  }
 
 #define TWO_INDEXED_SPECTRAL_QUANTITY_FOR_MESH(function_name, return_type)   \
   const return_type& function_name(const Mesh<1>& mesh, const size_t m,      \
@@ -28,5 +30,18 @@
                                                             NN);             \
         },                                                                   \
         mesh, m, N);                                                         \
+  }
+
+#define SPECTRAL_QUANTITY_WITH_PARITY_FOR_MESH(function_name, return_type)   \
+  const return_type& function_name(const Mesh<1>& mesh,                      \
+                                   const Spectral::Parity parity) {          \
+    return Spectral::detail::get_spectral_quantity_with_parity_for_mesh(     \
+        [](const auto basis, const auto quadrature, const size_t num_points, \
+           const Spectral::Parity local_parity) -> const return_type& {      \
+          return function_name</* NOLINT */ decltype(basis)::value,          \
+                               decltype(quadrature)::value>(num_points,      \
+                                                            local_parity);   \
+        },                                                                   \
+        mesh, parity);                                                       \
   }
 /// \endcond

--- a/tests/Unit/NumericalAlgorithms/Spectral/BasisFunctions/Test_HalfFourier.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/BasisFunctions/Test_HalfFourier.cpp
@@ -1,0 +1,300 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <numbers>
+#include <random>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Matrix.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/ApplyMatrix.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/CollocationPoints.hpp"
+#include "NumericalAlgorithms/Spectral/DifferentiationMatrix.hpp"
+#include "NumericalAlgorithms/Spectral/InterpolationMatrix.hpp"
+#include "NumericalAlgorithms/Spectral/ModalToNodalMatrix.hpp"
+#include "NumericalAlgorithms/Spectral/NodalToModalMatrix.hpp"
+#include "NumericalAlgorithms/Spectral/Parity.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "NumericalAlgorithms/Spectral/QuadratureWeights.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace Spectral {
+namespace {
+
+void test_collocation_points_and_weights() {
+  // phi_j = (j + 1/2) * pi / N, w_j = pi / N for all j
+  const Approx custom_approx = Approx::custom().epsilon(1.0e-14).scale(1.0);
+  for (size_t n = 1; n <= 10; ++n) {
+    CAPTURE(n);
+    const DataVector& phi =
+        collocation_points<Basis::HalfFourier, Quadrature::Equiangular>(n);
+    const DataVector& weights =
+        quadrature_weights<Basis::HalfFourier, Quadrature::Equiangular>(n);
+    REQUIRE(phi.size() == n);
+    REQUIRE(weights.size() == n);
+    const double pi_over_n = std::numbers::pi / static_cast<double>(n);
+    for (size_t j = 0; j < n; ++j) {
+      CHECK(phi[j] ==
+            custom_approx(pi_over_n * (static_cast<double>(j) + 0.5)));
+      CHECK(weights[j] == custom_approx(pi_over_n));
+    }
+  }
+}
+
+void test_differentiation_matrices() {
+  const Approx custom_approx = Approx::custom().epsilon(1.0e-12).scale(1.0);
+  for (size_t n = 1; n <= 8; ++n) {
+    CAPTURE(n);
+    const DataVector& phi =
+        collocation_points<Basis::HalfFourier, Quadrature::Equiangular>(n);
+    const Matrix& D_even =
+        differentiation_matrix<Basis::HalfFourier, Quadrature::Equiangular>(
+            n, Parity::Even);
+    const Matrix& D_odd =
+        differentiation_matrix<Basis::HalfFourier, Quadrature::Equiangular>(
+            n, Parity::Odd);
+
+    REQUIRE(D_even.rows() == n);
+    REQUIRE(D_even.columns() == n);
+    REQUIRE(D_odd.rows() == n);
+    REQUIRE(D_odd.columns() == n);
+
+    {
+      INFO("D_even applied to constant (k=0): should give zero");
+      const DataVector one(n, 1.0);
+      const DataVector result = apply_matrix(D_even, one);
+      const DataVector expected(n, 0.0);
+      CHECK_ITERABLE_CUSTOM_APPROX(result, expected, custom_approx);
+    }
+
+    {
+      INFO("D_even * cos(k*phi) = -k * sin(k*phi) for k = 1, ..., n-1");
+      for (size_t k = 1; k < n; ++k) {
+        CAPTURE(k);
+        const DataVector cos_k = cos(static_cast<double>(k) * phi);
+        const DataVector expected =
+            -static_cast<double>(k) * sin(static_cast<double>(k) * phi);
+        const DataVector result = apply_matrix(D_even, cos_k);
+        CHECK_ITERABLE_CUSTOM_APPROX(result, expected, custom_approx);
+      }
+    }
+
+    {
+      INFO("D_odd * sin(k*phi) = k * cos(k*phi) for k = 1, ..., n");
+      for (size_t k = 1; k <= n; ++k) {
+        CAPTURE(k);
+        const DataVector sin_k = sin(static_cast<double>(k) * phi);
+        const DataVector expected =
+            static_cast<double>(k) * cos(static_cast<double>(k) * phi);
+        const DataVector result = apply_matrix(D_odd, sin_k);
+        CHECK_ITERABLE_CUSTOM_APPROX(result, expected, custom_approx);
+      }
+    }
+
+    {
+      INFO("Antisymmetry relation: D_even[i,j] = -D_odd[j,i]");
+      for (size_t i = 0; i < n; ++i) {
+        for (size_t j = 0; j < n; ++j) {
+          CAPTURE(i);
+          CAPTURE(j);
+          CHECK(D_even(i, j) == custom_approx(-D_odd(j, i)));
+        }
+      }
+    }
+  }
+}
+
+void test_interpolation_matrices() {
+  const Approx custom_approx = Approx::custom().epsilon(1.0e-12).scale(1.0);
+  MAKE_GENERATOR(gen);
+  std::uniform_real_distribution<> phi_dist(0.0, std::numbers::pi);
+  const auto target_pts = make_with_random_values<DataVector>(
+      make_not_null(&gen), make_not_null(&phi_dist), 5_st);
+
+  for (size_t n = 1; n <= 8; ++n) {
+    CAPTURE(n);
+    const DataVector& phi =
+        collocation_points<Basis::HalfFourier, Quadrature::Equiangular>(n);
+
+    {
+      INFO("Identity at source points");
+      const Matrix I_even =
+          interpolation_matrix<Basis::HalfFourier, Quadrature::Equiangular>(
+              n, phi, Parity::Even);
+      const Matrix I_odd =
+          interpolation_matrix<Basis::HalfFourier, Quadrature::Equiangular>(
+              n, phi, Parity::Odd);
+      REQUIRE(I_even.rows() == n);
+      REQUIRE(I_even.columns() == n);
+      REQUIRE(I_odd.rows() == n);
+      REQUIRE(I_odd.columns() == n);
+      for (size_t i = 0; i < n; ++i) {
+        for (size_t j = 0; j < n; ++j) {
+          CHECK(I_even(i, j) == custom_approx(i == j ? 1.0 : 0.0));
+          CHECK(I_odd(i, j) == custom_approx(i == j ? 1.0 : 0.0));
+        }
+      }
+    }
+
+    {
+      INFO("Even interpolation");
+      const Matrix I_even =
+          interpolation_matrix<Basis::HalfFourier, Quadrature::Equiangular>(
+              n, target_pts, Parity::Even);
+      REQUIRE(I_even.rows() == 5);
+      REQUIRE(I_even.columns() == n);
+      for (size_t k = 0; k < n; ++k) {
+        CAPTURE(k);
+        const DataVector u = cos(static_cast<double>(k) * phi);
+        const DataVector expected = cos(static_cast<double>(k) * target_pts);
+        const DataVector result = apply_matrix(I_even, u);
+        CHECK_ITERABLE_CUSTOM_APPROX(result, expected, custom_approx);
+      }
+    }
+
+    {
+      INFO("Odd interpolation");
+      const Matrix I_odd =
+          interpolation_matrix<Basis::HalfFourier, Quadrature::Equiangular>(
+              n, target_pts, Parity::Odd);
+      REQUIRE(I_odd.rows() == 5);
+      REQUIRE(I_odd.columns() == n);
+      for (size_t k = 1; k <= n; ++k) {
+        CAPTURE(k);
+        const DataVector u = sin(static_cast<double>(k) * phi);
+        const DataVector expected = sin(static_cast<double>(k) * target_pts);
+        const DataVector result = apply_matrix(I_odd, u);
+        CHECK_ITERABLE_CUSTOM_APPROX(result, expected, custom_approx);
+      }
+    }
+  }
+}
+
+void test_modal_to_nodal_matrices() {
+  const Approx custom_approx = Approx::custom().epsilon(1.0e-12).scale(1.0);
+  for (size_t n = 1; n <= 8; ++n) {
+    CAPTURE(n);
+    const DataVector& phi =
+        collocation_points<Basis::HalfFourier, Quadrature::Equiangular>(n);
+
+    {
+      INFO("Even parity");
+      const Matrix& mtn =
+          modal_to_nodal_matrix<Basis::HalfFourier, Quadrature::Equiangular>(
+              n, Parity::Even);
+      const Matrix& ntm =
+          nodal_to_modal_matrix<Basis::HalfFourier, Quadrature::Equiangular>(
+              n, Parity::Even);
+      REQUIRE(mtn.rows() == n);
+      REQUIRE(mtn.columns() == n);
+      REQUIRE(ntm.rows() == n);
+      REQUIRE(ntm.columns() == n);
+
+      // Applying NTM to cos(k*phi) should give the k-th unit vector
+      for (size_t k = 0; k < n; ++k) {
+        CAPTURE(k);
+        const DataVector u = cos(static_cast<double>(k) * phi);
+        const DataVector coeffs = apply_matrix(ntm, u);
+        for (size_t i = 0; i < n; ++i) {
+          CHECK(coeffs[i] == custom_approx(i == k ? 1.0 : 0.0));
+        }
+      }
+
+      // Applying MTN to a unit vector should reconstruct cos(k*phi)
+      for (size_t k = 0; k < n; ++k) {
+        CAPTURE(k);
+        DataVector e_k(n, 0.0);
+        e_k[k] = 1.0;
+        const DataVector nodal = apply_matrix(mtn, e_k);
+        const DataVector expected = cos(static_cast<double>(k) * phi);
+        CHECK_ITERABLE_CUSTOM_APPROX(nodal, expected, custom_approx);
+      }
+
+      // Round-trip: NTM * MTN = I
+      const Matrix round_trip_ntm_mtm = ntm * mtn;
+      for (size_t i = 0; i < n; ++i) {
+        for (size_t j = 0; j < n; ++j) {
+          CHECK(round_trip_ntm_mtm(i, j) == custom_approx(i == j ? 1.0 : 0.0));
+        }
+      }
+    }
+
+    {
+      INFO("Odd parity");
+      const Matrix& mtn =
+          modal_to_nodal_matrix<Basis::HalfFourier, Quadrature::Equiangular>(
+              n, Parity::Odd);
+      const Matrix& ntm =
+          nodal_to_modal_matrix<Basis::HalfFourier, Quadrature::Equiangular>(
+              n, Parity::Odd);
+      REQUIRE(mtn.rows() == n);
+      REQUIRE(mtn.columns() == n);
+      REQUIRE(ntm.rows() == n);
+      REQUIRE(ntm.columns() == n);
+
+      // Applying NTM to sin(k*phi) for k=1,...,N should give the (k-1)-th unit
+      // vector
+      for (size_t k = 1; k <= n; ++k) {
+        CAPTURE(k);
+        const DataVector u = sin(static_cast<double>(k) * phi);
+        const DataVector coeffs = apply_matrix(ntm, u);
+        for (size_t i = 0; i < n; ++i) {
+          CHECK(coeffs[i] == custom_approx(i == k - 1 ? 1.0 : 0.0));
+        }
+      }
+
+      // Applying MTN to a unit vector should reconstruct sin(k*phi)
+      for (size_t k = 1; k <= n; ++k) {
+        CAPTURE(k);
+        DataVector e_k(n, 0.0);
+        e_k[k - 1] = 1.0;
+        const DataVector nodal = apply_matrix(mtn, e_k);
+        const DataVector expected = sin(static_cast<double>(k) * phi);
+        CHECK_ITERABLE_CUSTOM_APPROX(nodal, expected, custom_approx);
+      }
+
+      // Round-trip: NTM * MTN = I
+      const Matrix round_trip_ntm_mtm = ntm * mtn;
+      for (size_t i = 0; i < n; ++i) {
+        for (size_t j = 0; j < n; ++j) {
+          CHECK(round_trip_ntm_mtm(i, j) == custom_approx(i == j ? 1.0 : 0.0));
+        }
+      }
+    }
+  }
+#ifdef SPECTRE_DEBUG
+  const DataVector& phi =
+      collocation_points<Basis::HalfFourier, Quadrature::Equiangular>(4);
+  CHECK_THROWS_WITH(
+      (modal_to_nodal_matrix<Basis::HalfFourier, Quadrature::Equiangular>(
+          4, Parity::Uninitialized)),
+      Catch::Matchers::ContainsSubstring(
+          "Tried to use a parity-based function without a definite parity"));
+  CHECK_THROWS_WITH(
+      (nodal_to_modal_matrix<Basis::HalfFourier, Quadrature::Equiangular>(
+          4, Parity::Uninitialized)),
+      Catch::Matchers::ContainsSubstring(
+          "Tried to use a parity-based function without a definite parity"));
+  CHECK_THROWS_WITH(
+      (interpolation_matrix<Basis::HalfFourier, Quadrature::Equiangular>(
+          4, phi, Parity::Uninitialized)),
+      Catch::Matchers::ContainsSubstring(
+          "Parity must be set to either Even or Odd"));
+#endif
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Numerical.Spectral.BasisFunctions.HalfFourier",
+                  "[NumericalAlgorithms][Spectral][Unit]") {
+  test_collocation_points_and_weights();
+  test_differentiation_matrices();
+  test_interpolation_matrices();
+  test_modal_to_nodal_matrices();
+}
+}  // namespace Spectral

--- a/tests/Unit/NumericalAlgorithms/Spectral/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Spectral/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY "Test_Spectral")
 set(LIBRARY_SOURCES
   BasisFunctions/Test_Chebyshev.cpp
   BasisFunctions/Test_Fourier.cpp
+  BasisFunctions/Test_HalfFourier.cpp
   BasisFunctions/Test_Jacobi.cpp
   BasisFunctions/Test_Legendre.cpp
   BasisFunctions/Test_Zernike.cpp

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_Basis.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_Basis.cpp
@@ -21,6 +21,7 @@ SPECTRE_TEST_CASE("Unit.Spectral.Basis", "[NumericalAlgorithms][Unit]") {
   CHECK(get_output(Spectral::Basis::ZernikeB2) == "ZernikeB2");
   CHECK(get_output(Spectral::Basis::ZernikeB3) == "ZernikeB3");
   CHECK(get_output(Spectral::Basis::Cartoon) == "Cartoon");
+  CHECK(get_output(Spectral::Basis::HalfFourier) == "HalfFourier");
 
   for (const auto basis : Spectral::all_bases()) {
     CHECK(basis ==


### PR DESCRIPTION
## Proposed changes

This packages the discrete sin/cos transformations (II) into one basis, which when needed will take a parity parameter (similar to ZernikeB1)

One motivation for this basis is for axially symmetric cartoon simulations, where having an angular basis for an outer boundary could be beneficial for GH constraint-preserving BC (though as of now, I have not seen improvements in my recent runs)

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
