### PR TITLE
Add UniformCardinalBSpline

### DIFF
--- a/src/NumericalAlgorithms/Interpolation/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Interpolation/CMakeLists.txt
@@ -20,6 +20,7 @@ spectre_target_sources(
   PredictedZeroCrossing.cpp
   RegularGridInterpolant.cpp
   SpanInterpolator.cpp
+  UniformCardinalBSpline.cpp
   ZeroCrossingPredictor.cpp
   )
 
@@ -41,6 +42,7 @@ spectre_target_headers(
   PredictedZeroCrossing.hpp
   RegularGridInterpolant.hpp
   SpanInterpolator.hpp
+  UniformCardinalBSpline.hpp
   ZeroCrossingPredictor.hpp
   )
 
@@ -48,6 +50,7 @@ target_link_libraries(
   ${LIBRARY}
   PUBLIC
   BLAS::BLAS
+  Boost::boost
   DataStructures
   ErrorHandling
   Options
@@ -56,7 +59,6 @@ target_link_libraries(
   SphericalHarmonics
   Utilities
   PRIVATE
-  Boost::boost
   GSL::gsl
   )
 

--- a/src/NumericalAlgorithms/Interpolation/UniformCardinalBSpline.cpp
+++ b/src/NumericalAlgorithms/Interpolation/UniformCardinalBSpline.cpp
@@ -1,0 +1,218 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/Interpolation/UniformCardinalBSpline.hpp"
+
+#include <algorithm>
+#include <boost/version.hpp>
+#include <cmath>
+#include <cstddef>
+#include <limits>
+#include <pup.h>
+#include <pup_stl.h>
+#include <utility>
+#include <vector>
+
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+
+namespace intrp {
+
+namespace {
+
+// NOLINTNEXTLINE(clang-diagnostic-missing-noreturn)
+void check_boost_version() {
+  // Read the version into a volatile so compilers can't prove that this
+  // function never returns when compiled with Boost older than 1.81, which
+  // would trigger noreturn warnings here and in callers
+  const volatile int boost_version = BOOST_VERSION;
+  if (boost_version < 108100) {
+    ERROR_NO_TRACE(
+        "UniformCardinalBSpline requires Boost 1.81 or newer because of a "
+        "bugfix in boost::math::interpolators::cardinal_cubic_b_spline, but "
+        "found version "
+        << BOOST_LIB_VERSION
+        << ". See https://github.com/boostorg/math/commit/"
+           "4809e714d4806c07da3a3def0c4550daa0529b8d");
+  }
+}
+
+}  // namespace
+
+UniformCardinalBSpline::UniformCardinalBSpline(std::vector<double> values,
+                                               const double start_time,
+                                               const double time_step)
+    : values_(std::move(values)),
+      start_time_(start_time),
+      time_step_(time_step) {
+  check_boost_version();
+  if (values_.size() < 5) {
+    ERROR_NO_TRACE(
+        "At least 5 samples are required to construct a cubic B-spline, but "
+        << values_.size() << " were given.");
+  }
+  if (not std::isfinite(start_time_)) {
+    ERROR_NO_TRACE("The start time must be finite, but is " << start_time_
+                                                            << ".");
+  }
+  if (not std::isfinite(time_step_) or time_step_ <= 0.0) {
+    ERROR_NO_TRACE("The time step must be finite and positive, but is "
+                   << time_step_ << ".");
+  }
+  if (const auto non_finite_it = std::find_if(
+          values_.begin(), values_.end(),
+          [](const double value) { return not std::isfinite(value); });
+      non_finite_it != values_.end()) {
+    ERROR_NO_TRACE("The sampled values must be finite, but the value at index "
+                   << std::distance(values_.begin(), non_finite_it) << " is "
+                   << *non_finite_it << ".");
+  }
+  initialize_interpolant();
+}
+
+void UniformCardinalBSpline::initialize_interpolant() {
+  if (values_.empty()) {
+    // Do nothing for default-initialized objects
+    return;
+  }
+  interpolant_.emplace(values_.begin(), values_.end(), start_time_, time_step_);
+}
+
+double UniformCardinalBSpline::operator()(const double time) const {
+  ASSERT(interpolant_.has_value(),
+         "The interpolant is empty. It was probably default-constructed.");
+  const double end_time =
+      start_time_ + time_step_ * static_cast<double>(values_.size() - 1);
+#ifdef SPECTRE_DEBUG
+  const double roundoff_slack =
+      100.0 * std::numeric_limits<double>::epsilon() *
+      std::max({1.0, std::abs(start_time_), std::abs(end_time)});
+  ASSERT(time >= start_time_ - roundoff_slack and
+             time <= end_time + roundoff_slack,
+         "The time " << time << " to interpolate to is outside the sampled "
+                     << "interval [" << start_time_ << ", " << end_time
+                     << "].");
+#endif
+  // Clamp to the sampled interval: the Boost implementation extrapolates the
+  // spline outside its knots, but times that fall outside the interval by
+  // roundoff should evaluate to the boundary values.
+  return interpolant_.value()(std::clamp(time, start_time_, end_time));
+}
+
+std::array<double, 2> UniformCardinalBSpline::bounds() const {
+  return {{start_time_,
+           start_time_ + time_step_ * static_cast<double>(values_.size() - 1)}};
+}
+
+void UniformCardinalBSpline::pup(PUP::er& p) {
+  p | values_;
+  p | start_time_;
+  p | time_step_;
+  if (p.isUnpacking()) {
+    initialize_interpolant();
+  }
+}
+
+bool operator==(const UniformCardinalBSpline& lhs,
+                const UniformCardinalBSpline& rhs) {
+  return lhs.values() == rhs.values() and
+         lhs.start_time() == rhs.start_time() and
+         lhs.time_step() == rhs.time_step();
+}
+
+bool operator!=(const UniformCardinalBSpline& lhs,
+                const UniformCardinalBSpline& rhs) {
+  return not(lhs == rhs);
+}
+
+double estimate_interpolation_error(const std::vector<double>& values,
+                                    const double start_time,
+                                    const double time_step) {
+  const size_t num_samples = values.size();
+  if (num_samples < 9) {
+    ERROR_NO_TRACE(
+        "At least 9 samples are required to estimate the interpolation "
+        "error, but "
+        << num_samples << " were given.");
+  }
+  const size_t num_coarse_samples = (num_samples + 1) / 2;
+  std::vector<double> coarse_values(num_coarse_samples);
+  for (size_t i = 0; i < num_coarse_samples; ++i) {
+    coarse_values[i] = values[2 * i];
+  }
+  const UniformCardinalBSpline coarse_interpolant{std::move(coarse_values),
+                                                  start_time, 2.0 * time_step};
+  // Measure the deviation of the coarse interpolant from the samples at the
+  // sample times. An interpolant through all samples would pass through the
+  // samples there, so this deviation is also the difference between the two
+  // interpolants. For an even number of samples the last sample lies beyond
+  // the coarse interpolant's bounds, so skip it.
+  const size_t num_compared_samples = 2 * num_coarse_samples - 1;
+  double max_deviation = 0.0;
+  for (size_t i = 0; i < num_compared_samples; ++i) {
+    const double time = start_time + static_cast<double>(i) * time_step;
+    max_deviation =
+        std::max(max_deviation, std::abs(coarse_interpolant(time) - values[i]));
+  }
+  // For smooth data the interpolation error of a cubic spline decreases by a
+  // factor of 16 when the step size is halved, so the error of an
+  // interpolant through all samples is about 1/16 of the coarse
+  // interpolant's deviation measured here. Divide by only 8 to obtain a
+  // conservative estimate, accounting for nonsmooth data that converges
+  // slower.
+  return max_deviation / 8.0;
+}
+
+std::pair<UniformCardinalBSpline, double> compress_to_tolerance(
+    const std::vector<double>& values, const double start_time,
+    const double time_step, const double absolute_tolerance) {
+  const size_t num_samples = values.size();
+  UniformCardinalBSpline reference_interpolant{values, start_time, time_step};
+  if (num_samples <= 6) {
+    return {std::move(reference_interpolant), 0.0};
+  }
+  const double time_interval = time_step * static_cast<double>(num_samples - 1);
+
+  const auto resampled_interpolant = [&reference_interpolant, &start_time,
+                                      &time_interval](const size_t num_points) {
+    const double resampled_time_step =
+        time_interval / static_cast<double>(num_points - 1);
+    std::vector<double> resampled_values(num_points);
+    for (size_t i = 0; i < num_points; ++i) {
+      resampled_values[i] = reference_interpolant(
+          start_time + static_cast<double>(i) * resampled_time_step);
+    }
+    return UniformCardinalBSpline{std::move(resampled_values), start_time,
+                                  resampled_time_step};
+  };
+  const auto max_error_at_samples =
+      [&values, &start_time, &time_step,
+       num_samples](const UniformCardinalBSpline& candidate) {
+        double max_error = 0.0;
+        for (size_t i = 0; i < num_samples; ++i) {
+          const double time = start_time + static_cast<double>(i) * time_step;
+          max_error =
+              std::max(max_error, std::abs(candidate(time) - values[i]));
+        }
+        return max_error;
+      };
+
+  size_t num_points = 6;
+  auto candidate = resampled_interpolant(num_points);
+  double max_error = max_error_at_samples(candidate);
+  while (max_error > absolute_tolerance and num_points < num_samples) {
+    num_points = std::min(2 * num_points, num_samples);
+    if (num_points == num_samples) {
+      // The tolerance could not be met with fewer points than the input, so
+      // return the original samples. Their deviation at the sample times
+      // vanishes by construction, so report the error of the last coarser
+      // candidate as a conservative estimate.
+      return {std::move(reference_interpolant), max_error};
+    }
+    candidate = resampled_interpolant(num_points);
+    max_error = max_error_at_samples(candidate);
+  }
+  return {std::move(candidate), max_error};
+}
+
+}  // namespace intrp

--- a/src/NumericalAlgorithms/Interpolation/UniformCardinalBSpline.hpp
+++ b/src/NumericalAlgorithms/Interpolation/UniformCardinalBSpline.hpp
@@ -1,0 +1,152 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <boost/math/interpolators/cardinal_cubic_b_spline.hpp>
+#include <cstddef>
+#include <optional>
+#include <utility>
+#include <vector>
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace intrp {
+
+/*!
+ * \ingroup NumericalAlgorithmsGroup
+ * \brief A cubic B-spline interpolant of uniformly spaced samples
+ *
+ * Interpolates samples \f$f_i = f(t_0 + i \Delta t)\f$, \f$i = 0, \ldots,
+ * N-1\f$, with a cubic B-spline. The interpolation error decreases as
+ * \f$\mathcal{O}(\Delta t^4)\f$ for smooth data. This class wraps
+ * `boost::math::interpolators::cardinal_cubic_b_spline` and adds:
+ *
+ * - Serialization: the samples, start time, and time step fully determine the
+ *   interpolant, so it can be sent in a `pup` and rebuilt on the receiving
+ *   side.
+ * - Clamped evaluation: evaluation is clamped to the bounds of the sampled
+ *   interval, so times that fall outside the interval by roundoff evaluate
+ *   to the boundary values instead of extrapolating the spline. Times
+ *   outside the bounds beyond roundoff trigger an `ASSERT` in debug builds.
+ *
+ * Here is an example how to use this class:
+ *
+ * \snippet Test_UniformCardinalBSpline.cpp uniform_cardinal_b_spline_example
+ *
+ * \note Requires Boost 1.81 or newer at runtime because of an accuracy fix
+ * for the estimate of the derivative at the right endpoint in the Boost
+ * implementation, see
+ * https://github.com/boostorg/math/commit/4809e714d4806c07da3a3def0c4550daa0529b8d.
+ * The constructor raises an error for older Boost versions.
+ */
+class UniformCardinalBSpline {
+ public:
+  /*!
+   * \brief Construct from uniformly spaced samples.
+   *
+   * \param values The sampled function values \f$f(t_0 + i \Delta t)\f$. At
+   *     least 5 samples are required.
+   * \param start_time The time \f$t_0\f$ of the first sample.
+   * \param time_step The (positive) spacing \f$\Delta t\f$ between samples.
+   */
+  UniformCardinalBSpline(std::vector<double> values, double start_time,
+                         double time_step);
+
+  UniformCardinalBSpline() = default;
+
+  /// Evaluate the interpolant at `time`, clamped to the `bounds()`
+  double operator()(double time) const;
+
+  /// The sampled function values
+  const std::vector<double>& values() const { return values_; }
+
+  /// The time of the first sample
+  double start_time() const { return start_time_; }
+
+  /// The spacing between samples
+  double time_step() const { return time_step_; }
+
+  /// The first and last sample time
+  std::array<double, 2> bounds() const;
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p);
+
+ private:
+  void initialize_interpolant();
+
+  std::vector<double> values_{};
+  double start_time_{};
+  double time_step_{};
+  std::optional<boost::math::interpolators::cardinal_cubic_b_spline<double>>
+      interpolant_{};
+};
+
+bool operator==(const UniformCardinalBSpline& lhs,
+                const UniformCardinalBSpline& rhs);
+
+bool operator!=(const UniformCardinalBSpline& lhs,
+                const UniformCardinalBSpline& rhs);
+
+/*!
+ * \ingroup NumericalAlgorithmsGroup
+ * \brief Estimate the maximum interpolation error of a
+ * `intrp::UniformCardinalBSpline` through the given samples.
+ *
+ * Measures the deviation of an interpolant through every other sample from
+ * the sampled values at the sample times, where the error of that coarser
+ * interpolant peaks. For smooth data the interpolation error of a cubic
+ * spline decreases by a factor of 16 when the step size is halved, so the
+ * error of the interpolant through all samples is about 1/16 of the measured
+ * deviation for smooth data in the convergent regime. The deviation is divided
+ * by only 8 to obtain a conservative estimate, accounting for nonsmooth data
+ * that converges slower.
+ *
+ * \param values The sampled function values. At least 9 samples are required
+ *     so the coarser interpolant has at least 5.
+ * \param start_time The time of the first sample.
+ * \param time_step The (positive) spacing between samples.
+ */
+double estimate_interpolation_error(const std::vector<double>& values,
+                                    double start_time, double time_step);
+
+/*!
+ * \ingroup NumericalAlgorithmsGroup
+ * \brief Compress uniformly spaced samples into a
+ * `intrp::UniformCardinalBSpline` with fewer points that reproduces the
+ * samples to the given tolerance.
+ *
+ * Builds a reference interpolant through all samples and resamples it on
+ * coarser uniform grids over the same time interval, starting with 6 points
+ * and doubling until the resampled interpolant reproduces the input samples
+ * to within `absolute_tolerance` at the sample times. This reduces memory
+ * for smooth, densely sampled data, e.g. time series of spectral modes in a
+ * simulation.
+ *
+ * \returns The compressed interpolant and its maximum absolute deviation
+ * from the input samples at the sample times.
+ *
+ * If the tolerance cannot be met with fewer points than the input, the
+ * returned interpolant holds the original samples. Its deviation from the
+ * samples at the sample times vanishes by construction, so the returned
+ * error is the error of the last (coarser) candidate in the doubling search
+ * as a conservative estimate, and may exceed the tolerance. Inputs with 6 or
+ * fewer samples are returned unchanged with zero error.
+ *
+ * \param values The sampled function values. At least 5 samples are required.
+ * \param start_time The time of the first sample.
+ * \param time_step The (positive) spacing between samples.
+ * \param absolute_tolerance Maximum allowed absolute deviation of the
+ *     compressed interpolant from the input samples.
+ */
+std::pair<UniformCardinalBSpline, double> compress_to_tolerance(
+    const std::vector<double>& values, double start_time, double time_step,
+    double absolute_tolerance);
+
+}  // namespace intrp

--- a/tests/Unit/NumericalAlgorithms/Interpolation/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/CMakeLists.txt
@@ -21,6 +21,10 @@ set(LIBRARY_SOURCES
   Test_ZeroCrossingPredictor.cpp
   )
 
+if(Boost_VERSION VERSION_GREATER_EQUAL 1.81.0)
+  list(APPEND LIBRARY_SOURCES Test_UniformCardinalBSpline.cpp)
+endif()
+
 add_test_library(${LIBRARY} "${LIBRARY_SOURCES}")
 
 target_link_libraries(

--- a/tests/Unit/NumericalAlgorithms/Interpolation/Test_UniformCardinalBSpline.cpp
+++ b/tests/Unit/NumericalAlgorithms/Interpolation/Test_UniformCardinalBSpline.cpp
@@ -1,0 +1,245 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <limits>
+#include <vector>
+
+#include "Framework/TestHelpers.hpp"
+#include "NumericalAlgorithms/Interpolation/UniformCardinalBSpline.hpp"
+
+namespace {
+
+template <typename F>
+std::vector<double> sample_function(const F& function, const double start_time,
+                                    const double time_step,
+                                    const size_t num_samples) {
+  std::vector<double> values(num_samples);
+  for (size_t i = 0; i < num_samples; ++i) {
+    values[i] = function(start_time + static_cast<double>(i) * time_step);
+  }
+  return values;
+}
+
+// Maximum absolute deviation of the interpolant from the function over a
+// dense sampling of the interpolant's bounds
+template <typename F>
+double max_error_against_function(
+    const intrp::UniformCardinalBSpline& interpolant, const F& function) {
+  const auto bounds = interpolant.bounds();
+  const size_t num_test_points = 500;
+  double max_error = 0.0;
+  for (size_t i = 0; i <= num_test_points; ++i) {
+    const double time = bounds[0] + (bounds[1] - bounds[0]) *
+                                        static_cast<double>(i) /
+                                        static_cast<double>(num_test_points);
+    max_error =
+        std::max(max_error, std::abs(interpolant(time) - function(time)));
+  }
+  return max_error;
+}
+
+void test_interpolation_and_convergence() {
+  const auto function = [](const double time) { return std::sin(time); };
+  const double start_time = 0.0;
+  const double end_time = 2.0 * M_PI;
+
+  const auto interpolant_error = [&function, &start_time,
+                                  &end_time](const size_t num_samples) {
+    const double time_step =
+        (end_time - start_time) / static_cast<double>(num_samples - 1);
+    // [uniform_cardinal_b_spline_example]
+    const intrp::UniformCardinalBSpline interpolant{
+        sample_function(function, start_time, time_step, num_samples),
+        start_time, time_step};
+    const double interpolated_value =
+        interpolant(0.5 * (start_time + end_time));
+    // [uniform_cardinal_b_spline_example]
+    CHECK(interpolated_value ==
+          approx(function(0.5 * (start_time + end_time))));
+    return max_error_against_function(interpolant, function);
+  };
+
+  // The interpolation error should decrease with 4th order when the time step
+  // is halved. Expect a factor of 16, check for at least 8.
+  const double error_coarse = interpolant_error(17);
+  const double error_fine = interpolant_error(33);
+  CHECK(error_fine < error_coarse / 8.0);
+
+  // The interpolant passes through the samples
+  const size_t num_samples = 17;
+  const double time_step =
+      (end_time - start_time) / static_cast<double>(num_samples - 1);
+  const auto values =
+      sample_function(function, start_time, time_step, num_samples);
+  const intrp::UniformCardinalBSpline interpolant{values, start_time,
+                                                  time_step};
+  for (size_t i = 0; i < num_samples; ++i) {
+    CHECK(interpolant(start_time + static_cast<double>(i) * time_step) ==
+          approx(values[i]));
+  }
+
+  // Accessors
+  CHECK(interpolant.values() == values);
+  CHECK(interpolant.start_time() == start_time);
+  CHECK(interpolant.time_step() == time_step);
+  CHECK(interpolant.bounds()[0] == approx(start_time));
+  CHECK(interpolant.bounds()[1] == approx(end_time));
+
+  // Evaluation at the exact bounds is clamped and does not throw
+  CHECK(interpolant(interpolant.bounds()[0]) == approx(values.front()));
+  CHECK(interpolant(interpolant.bounds()[1]) == approx(values.back()));
+
+#ifdef SPECTRE_DEBUG
+  CHECK_THROWS_WITH(
+      interpolant(end_time + 1.0),
+      Catch::Matchers::ContainsSubstring("is outside the sampled interval"));
+#endif
+}
+
+void test_serialization() {
+  const auto function = [](const double time) { return std::cos(time); };
+  const intrp::UniformCardinalBSpline interpolant{
+      sample_function(function, 1.2, 0.3, 20), 1.2, 0.3};
+  const auto deserialized = serialize_and_deserialize(interpolant);
+  CHECK(deserialized == interpolant);
+  CHECK(deserialized(2.5) == interpolant(2.5));
+  intrp::UniformCardinalBSpline copy{};
+  copy = interpolant;
+  CHECK(copy == interpolant);
+  CHECK(copy(2.5) == interpolant(2.5));
+
+  // Default-constructed (empty) interpolants can be serialized too
+  const intrp::UniformCardinalBSpline default_constructed{};
+  CHECK(default_constructed != interpolant);
+  CHECK(serialize_and_deserialize(default_constructed) == default_constructed);
+}
+
+void test_estimate_interpolation_error() {
+  const auto function = [](const double time) { return std::sin(time); };
+  const double start_time = 0.0;
+  const double end_time = 2.0 * M_PI;
+  // Check both an odd and an even number of samples. For an even number the
+  // coarser interpolant ends one time step early.
+  for (const size_t num_samples : std::array<size_t, 2>{{33, 32}}) {
+    CAPTURE(num_samples);
+    const double time_step =
+        (end_time - start_time) / static_cast<double>(num_samples - 1);
+    const auto values =
+        sample_function(function, start_time, time_step, num_samples);
+    const double estimated_error =
+        intrp::estimate_interpolation_error(values, start_time, time_step);
+    const double actual_error = max_error_against_function(
+        intrp::UniformCardinalBSpline{values, start_time, time_step}, function);
+    // The estimate is conservative for smooth data, but not wildly so
+    CHECK(estimated_error >= actual_error);
+    CHECK(estimated_error <= 100.0 * actual_error);
+  }
+
+  CHECK_THROWS_WITH(
+      intrp::estimate_interpolation_error({1.0, 2.0, 3.0, 4.0, 5.0}, 0.0, 1.0),
+      Catch::Matchers::ContainsSubstring("At least 9 samples are required"));
+}
+
+void test_compress_to_tolerance() {
+  const double start_time = 0.0;
+  const double time_step = 4.0e-3;
+  const size_t num_samples = 1001;
+
+  {
+    // Slowly varying data compresses to few points and stays within tolerance
+    const auto function = [](const double time) {
+      return std::sin(0.1 * time);
+    };
+    const auto values =
+        sample_function(function, start_time, time_step, num_samples);
+    const double tolerance = 1.0e-8;
+    const auto [interpolant, max_error] =
+        intrp::compress_to_tolerance(values, start_time, time_step, tolerance);
+    CHECK(interpolant.values().size() < 100);
+    CHECK(max_error <= tolerance);
+    double max_deviation = 0.0;
+    for (size_t i = 0; i < num_samples; ++i) {
+      max_deviation =
+          std::max(max_deviation,
+                   std::abs(interpolant(start_time +
+                                        static_cast<double>(i) * time_step) -
+                            values[i]));
+    }
+    CHECK(max_deviation <= tolerance);
+  }
+
+  {
+    // Linear data is reproduced exactly by the minimal number of points
+    const auto function = [](const double time) { return 2.0 * time + 1.0; };
+    const auto values =
+        sample_function(function, start_time, time_step, num_samples);
+    const auto [interpolant, max_error] =
+        intrp::compress_to_tolerance(values, start_time, time_step, 1.0e-10);
+    CHECK(interpolant.values().size() == 6);
+    CHECK(max_error <= 1.0e-10);
+  }
+
+  {
+    // Data that cannot be compressed is returned at full resolution with the
+    // error of the last coarser candidate
+    const auto function = [](const double time) {
+      return std::sin(1.0e3 * time);
+    };
+    const auto values =
+        sample_function(function, start_time, time_step, num_samples);
+    const auto [interpolant, max_error] =
+        intrp::compress_to_tolerance(values, start_time, time_step, 1.0e-300);
+    CHECK(interpolant.values() == values);
+    CHECK(max_error > 0.0);
+  }
+
+  {
+    // Inputs with 6 or fewer samples are returned unchanged
+    const std::vector<double> values{1.0, 2.0, 4.0, 8.0, 16.0};
+    const auto [interpolant, max_error] =
+        intrp::compress_to_tolerance(values, start_time, time_step, 1.0e-16);
+    CHECK(interpolant.values() == values);
+    CHECK(max_error == 0.0);
+  }
+}
+
+void test_construction_errors() {
+  CHECK_THROWS_WITH(
+      (intrp::UniformCardinalBSpline{{1.0, 2.0, 3.0, 4.0}, 0.0, 1.0}),
+      Catch::Matchers::ContainsSubstring("At least 5 samples are required"));
+  CHECK_THROWS_WITH(
+      (intrp::UniformCardinalBSpline{{1.0, 2.0, 3.0, 4.0, 5.0}, 0.0, 0.0}),
+      Catch::Matchers::ContainsSubstring(
+          "The time step must be finite and positive"));
+  CHECK_THROWS_WITH(
+      (intrp::UniformCardinalBSpline{{1.0, 2.0, 3.0, 4.0, 5.0}, 0.0, -1.0}),
+      Catch::Matchers::ContainsSubstring(
+          "The time step must be finite and positive"));
+  CHECK_THROWS_WITH(
+      (intrp::UniformCardinalBSpline{{1.0, 2.0, 3.0, 4.0, 5.0},
+                                     std::numeric_limits<double>::infinity(),
+                                     1.0}),
+      Catch::Matchers::ContainsSubstring("The start time must be finite"));
+  CHECK_THROWS_WITH(
+      (intrp::UniformCardinalBSpline{
+          {1.0, 2.0, std::numeric_limits<double>::quiet_NaN(), 4.0, 5.0},
+          0.0,
+          1.0}),
+      Catch::Matchers::ContainsSubstring("The sampled values must be finite"));
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Numerical.Interpolation.UniformCardinalBSpline",
+                  "[Unit][NumericalAlgorithms]") {
+  test_interpolation_and_convergence();
+  test_serialization();
+  test_estimate_interpolation_error();
+  test_compress_to_tolerance();
+  test_construction_errors();
+}


### PR DESCRIPTION
Serializable cubic B-spline interpolant of uniformly spaced samples, wrapping boost::math::interpolators::cardinal_cubic_b_spline with clamped evaluation at the bounds. Also adds free functions to estimate the interpolation error of sampled data and to compress samples into a coarser interpolant that meets an error tolerance.

First piece of the ModalSpacetimeInterpolator (#7053), where these compress time series of spectral modes.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
