### PR TITLE
Add ModalTimeSeriesReader

### DIFF
--- a/src/IO/Exporter/CMakeLists.txt
+++ b/src/IO/Exporter/CMakeLists.txt
@@ -15,6 +15,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   Exporter.cpp
+  ModalTimeSeriesReader.cpp
   PointwiseInterpolator.cpp
   SelectObservation.cpp
   SpacetimeInterpolator.cpp
@@ -25,6 +26,7 @@ spectre_target_headers(
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
   Exporter.hpp
+  ModalTimeSeriesReader.hpp
   PointwiseInterpolator.hpp
   SelectObservation.hpp
   SpacetimeInterpolator.hpp
@@ -36,10 +38,13 @@ target_link_libraries(
   DataStructures
   Domain
   DomainCreators
+  DomainStructure
   FunctionsOfTime
   H5
   Interpolation
+  LinearOperators
   Serialization
+  Spectral
   Utilities
   )
 

--- a/src/IO/Exporter/ModalTimeSeriesReader.cpp
+++ b/src/IO/Exporter/ModalTimeSeriesReader.cpp
@@ -1,0 +1,445 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "IO/Exporter/ModalTimeSeriesReader.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <limits>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/ModalVector.hpp"
+#include "IO/H5/File.hpp"
+#include "IO/H5/TensorData.hpp"
+#include "IO/H5/VolumeData.hpp"
+#include "NumericalAlgorithms/LinearOperators/CoefficientTransforms.hpp"
+#include "Utilities/EqualWithinRoundoff.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/FileSystem.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/GetOutput.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Overloader.hpp"
+
+namespace spectre::Exporter {
+
+namespace {
+
+std::vector<std::string> resolve_filenames(
+    const std::variant<std::vector<std::string>, std::string>&
+        volume_files_or_glob) {
+  std::vector<std::string> filenames =
+      std::visit(Overloader{[](const std::vector<std::string>& volume_files) {
+                              return volume_files;
+                            },
+                            [](const std::string& volume_files_glob) {
+                              return file_system::glob(volume_files_glob);
+                            }},
+                 volume_files_or_glob);
+  if (filenames.empty()) {
+    ERROR_NO_TRACE("No volume files found. Specify at least one volume file.");
+  }
+  return filenames;
+}
+
+template <size_t Dim>
+void enforce_dimension(const h5::VolumeData& volfile,
+                       const std::string& filename) {
+  if (volfile.get_dimension() != Dim) {
+    ERROR_NO_TRACE("Mismatched dimensions: expected "
+                   << Dim << "D volume data, but got "
+                   << volfile.get_dimension() << "D in file '" << filename
+                   << "'.");
+  }
+}
+
+std::vector<std::pair<size_t, double>> observation_ids_and_times(
+    const h5::VolumeData& volfile, const std::optional<double> start_time,
+    const std::optional<double> end_time) {
+  const auto observation_ids = volfile.list_observation_ids();
+  std::vector<std::pair<size_t, double>> result{};
+  result.reserve(observation_ids.size());
+  for (const size_t observation_id : observation_ids) {
+    const double observation_time =
+        volfile.get_observation_value(observation_id);
+    if ((start_time.has_value() and observation_time < start_time.value()) or
+        (end_time.has_value() and observation_time > end_time.value())) {
+      continue;
+    }
+    result.emplace_back(observation_id, observation_time);
+  }
+  return result;
+}
+
+template <size_t Dim>
+void enforce_legendre_basis(const Mesh<Dim>& mesh, const std::string& context) {
+  for (size_t d = 0; d < Dim; ++d) {
+    if (gsl::at(mesh.basis(), d) != Spectral::Basis::Legendre) {
+      ERROR_NO_TRACE("Only the Legendre basis is supported, but found "
+                     << gsl::at(mesh.basis(), d) << " in dimension " << d
+                     << " for " << context << ".");
+    }
+  }
+}
+
+}  // namespace
+
+namespace ModalTimeSeriesReader_detail {
+
+// Data of one observation in one file that is needed to locate and interpret
+// each element's subset of the tensor component datasets
+struct ObservationCache {
+  size_t obs_id{};
+  std::unordered_map<std::string, size_t> grid_index_by_name{};
+  // Offset of each grid into the contiguous datasets, plus a total size at
+  // the end
+  std::vector<size_t> grid_offsets{};
+  std::vector<std::vector<size_t>> extents{};
+  std::vector<std::vector<Spectral::Basis>> bases{};
+  std::vector<std::vector<Spectral::Quadrature>> quadratures{};
+};
+
+}  // namespace ModalTimeSeriesReader_detail
+
+namespace {
+
+// The functions operating on the `ObservationCache` are only used in this
+// file. Only the struct itself needs external linkage because it is a member
+// of `FileCache` below (-Wsubobject-linkage).
+using ModalTimeSeriesReader_detail::ObservationCache;
+
+ObservationCache make_observation_cache(const h5::VolumeData& volfile,
+                                        const size_t obs_id,
+                                        const std::string& filename) {
+  ObservationCache cache{};
+  cache.obs_id = obs_id;
+  const auto grid_names = volfile.get_grid_names(obs_id);
+  cache.extents = volfile.get_extents(obs_id);
+  cache.bases = volfile.get_bases(obs_id);
+  cache.quadratures = volfile.get_quadratures(obs_id);
+  cache.grid_index_by_name.reserve(grid_names.size());
+  cache.grid_offsets.reserve(grid_names.size() + 1);
+  cache.grid_offsets.push_back(0);
+  for (size_t grid_index = 0; grid_index < grid_names.size(); ++grid_index) {
+    if (not cache.grid_index_by_name.emplace(grid_names[grid_index], grid_index)
+                .second) {
+      ERROR_NO_TRACE("Grid '" << grid_names[grid_index]
+                              << "' appears multiple times at observation ID "
+                              << obs_id << " in file '" << filename << "'.");
+    }
+    size_t num_points = 1;
+    for (const size_t extent : cache.extents[grid_index]) {
+      num_points *= extent;
+    }
+    cache.grid_offsets.push_back(cache.grid_offsets.back() + num_points);
+  }
+  return cache;
+}
+
+template <size_t Dim>
+Mesh<Dim> mesh_from_cache(const ObservationCache& cache,
+                          const size_t grid_index) {
+  std::array<size_t, Dim> extents{};
+  std::array<Spectral::Basis, Dim> bases{};
+  std::array<Spectral::Quadrature, Dim> quadratures{};
+  for (size_t d = 0; d < Dim; ++d) {
+    gsl::at(extents, d) = cache.extents[grid_index][d];
+    gsl::at(bases, d) = cache.bases[grid_index][d];
+    gsl::at(quadratures, d) = cache.quadratures[grid_index][d];
+  }
+  return Mesh<Dim>{extents, bases, quadratures};
+}
+
+}  // namespace
+
+// Metadata of one volume file, cached between `modal_time_series()` calls so
+// requesting elements grouped by file avoids re-reading the metadata
+template <size_t Dim>
+struct ModalTimeSeriesReader<Dim>::FileCache {
+  FileCache(const size_t in_file_index, const std::string& filename,
+            const std::string& subfile_name,
+            const std::vector<std::pair<size_t, double>>& obs_ids_and_times,
+            const size_t num_elements_in_file)
+      : file_index(in_file_index),
+        h5file(filename),
+        volfile(&h5file.get<h5::VolumeData>(subfile_name)) {
+    observations.reserve(obs_ids_and_times.size());
+    for (const auto& id_and_time : obs_ids_and_times) {
+      const size_t obs_id = id_and_time.first;
+      observations.push_back(
+          make_observation_cache(*volfile, obs_id, filename));
+      if (observations.back().grid_index_by_name.size() !=
+          num_elements_in_file) {
+        ERROR_NO_TRACE("File '"
+                       << filename << "' contains "
+                       << observations.back().grid_index_by_name.size()
+                       << " elements at observation ID " << obs_id << " but "
+                       << num_elements_in_file
+                       << " elements at the last observation. Adaptive mesh "
+                          "refinement and element migration between files "
+                          "(e.g. by load balancing) are not supported.");
+      }
+    }
+  }
+
+  size_t file_index;
+  h5::H5File<h5::AccessType::ReadOnly> h5file;
+  const h5::VolumeData* volfile;
+  std::vector<ModalTimeSeriesReader_detail::ObservationCache> observations{};
+};
+
+template <size_t Dim>
+ModalTimeSeriesReader<Dim>::ModalTimeSeriesReader(
+    const std::variant<std::vector<std::string>, std::string>&
+        volume_files_or_glob,
+    std::string subfile_name, std::vector<std::string> tensor_components,
+    const std::optional<double> start_time,
+    const std::optional<double> end_time)
+    : filenames_(resolve_filenames(volume_files_or_glob)),
+      subfile_name_(std::move(subfile_name)),
+      tensor_components_(std::move(tensor_components)) {
+  // Load the observation IDs and times from the first file, restrict them to
+  // the requested time interval, and check they are uniformly spaced
+  {
+    const h5::H5File<h5::AccessType::ReadOnly> first_h5file(filenames_.front());
+    const auto& volfile = first_h5file.get<h5::VolumeData>(subfile_name_);
+    enforce_dimension<Dim>(volfile, filenames_.front());
+    obs_ids_and_times_ =
+        observation_ids_and_times(volfile, start_time, end_time);
+  }
+  if (obs_ids_and_times_.size() < 2) {
+    ERROR_NO_TRACE("At least 2 observations are required, but found "
+                   << obs_ids_and_times_.size() << " in subfile '"
+                   << subfile_name_ << "'"
+                   << (start_time.has_value() or end_time.has_value()
+                           ? " after restricting to the requested time "
+                             "interval."
+                           : "."));
+  }
+  const double first_time = obs_ids_and_times_.front().second;
+  time_step_ = obs_ids_and_times_[1].second - first_time;
+  const double relative_epsilon =
+      100.0 * std::numeric_limits<double>::epsilon();
+  if (time_step_ <= 0.0) {
+    ERROR_NO_TRACE("Observation times in subfile '"
+                   << subfile_name_
+                   << "' must be strictly increasing, but the first time step "
+                      "is "
+                   << time_step_
+                   << ". Select a strictly increasing interval with "
+                      "start_time and end_time or preprocess the volume "
+                      "files.");
+  }
+  for (size_t i = 2; i < obs_ids_and_times_.size(); ++i) {
+    const double actual_time = obs_ids_and_times_[i].second;
+    const double expected_time =
+        first_time + static_cast<double>(i) * time_step_;
+    const double scale =
+        std::max({1.0, std::abs(expected_time), std::abs(actual_time)});
+    if (not equal_within_roundoff(actual_time, expected_time, relative_epsilon,
+                                  scale)) {
+      ERROR_NO_TRACE(
+          "Observation times in subfile '"
+          << subfile_name_
+          << "' must be uniformly spaced, but observation index " << i
+          << " has time " << actual_time << " where " << expected_time
+          << " was expected from the first time " << first_time
+          << " and the time step " << time_step_
+          << ". Select a uniformly spaced interval with start_time and "
+             "end_time or preprocess the volume files.");
+    }
+  }
+
+  // Check that all other files contain the same observations
+  for (size_t file_index = 1; file_index < filenames_.size(); ++file_index) {
+    const h5::H5File<h5::AccessType::ReadOnly> h5file(filenames_[file_index]);
+    const auto& volfile = h5file.get<h5::VolumeData>(subfile_name_);
+    enforce_dimension<Dim>(volfile, filenames_[file_index]);
+    const auto other_obs_ids_and_times =
+        observation_ids_and_times(volfile, start_time, end_time);
+    if (other_obs_ids_and_times.size() != obs_ids_and_times_.size()) {
+      ERROR_NO_TRACE("File '"
+                     << filenames_[file_index] << "' contains "
+                     << other_obs_ids_and_times.size()
+                     << " observations in the requested time interval, but "
+                     << "file '" << filenames_.front() << "' contains "
+                     << obs_ids_and_times_.size()
+                     << ". All volume files must contain the same "
+                        "observations in the requested time interval.");
+    }
+    for (size_t obs_index = 0; obs_index < obs_ids_and_times_.size();
+         ++obs_index) {
+      const auto& [obs_id, obs_time] = obs_ids_and_times_[obs_index];
+      const auto& [other_obs_id, other_time] =
+          other_obs_ids_and_times[obs_index];
+      if (other_obs_id != obs_id) {
+        ERROR_NO_TRACE("Mismatched observation ID at observation index "
+                       << obs_index << ": expected " << obs_id << " from file '"
+                       << filenames_.front() << "' but found " << other_obs_id
+                       << " in file '" << filenames_[file_index]
+                       << "'. All volume files must contain the same "
+                          "observations in the requested time interval.");
+      }
+      if (other_time != obs_time) {
+        ERROR_NO_TRACE("Mismatched observation value for observation ID "
+                       << obs_id << ": expected " << obs_time << " from file '"
+                       << filenames_.front() << "' but found " << other_time
+                       << " in file '" << filenames_[file_index] << "'.");
+      }
+    }
+  }
+
+  // Gather the elements and their meshes from all files at the last
+  // observation. Consistency with the other observations is checked when
+  // reading the data in `modal_time_series`.
+  const size_t reference_obs_id = obs_ids_and_times_.back().first;
+  for (size_t file_index = 0; file_index < filenames_.size(); ++file_index) {
+    const h5::H5File<h5::AccessType::ReadOnly> h5file(filenames_[file_index]);
+    const auto& volfile = h5file.get<h5::VolumeData>(subfile_name_);
+    const auto grid_names = volfile.get_grid_names(reference_obs_id);
+    const auto all_extents = volfile.get_extents(reference_obs_id);
+    const auto all_bases = volfile.get_bases(reference_obs_id);
+    const auto all_quadratures = volfile.get_quadratures(reference_obs_id);
+    for (const auto& grid_name : grid_names) {
+      const ElementId<Dim> element_id(grid_name);
+      const auto mesh = h5::mesh_for_grid<Dim>(
+          grid_name, grid_names, all_extents, all_bases, all_quadratures);
+      enforce_legendre_basis(mesh, "element " + grid_name + " in file '" +
+                                       filenames_[file_index] + "'");
+      if (const auto existing_it = element_info_.find(element_id);
+          existing_it != element_info_.end()) {
+        ERROR_NO_TRACE("Element "
+                       << grid_name << " in file '" << filenames_[file_index]
+                       << "' already exists in file '"
+                       << filenames_[existing_it->second.second]
+                       << "'. Each element must reside in exactly one volume "
+                          "file.");
+      }
+      element_info_.emplace(element_id, std::make_pair(mesh, file_index));
+      elements_.emplace_back(element_id, mesh);
+    }
+  }
+}
+
+template <size_t Dim>
+ModalTimeSeriesReader<Dim>::ModalTimeSeriesReader(ModalTimeSeriesReader&&) =
+    default;
+template <size_t Dim>
+ModalTimeSeriesReader<Dim>& ModalTimeSeriesReader<Dim>::operator=(
+    ModalTimeSeriesReader&&) = default;
+template <size_t Dim>
+ModalTimeSeriesReader<Dim>::~ModalTimeSeriesReader() = default;
+
+template <size_t Dim>
+typename ModalTimeSeriesReader<Dim>::Series
+ModalTimeSeriesReader<Dim>::modal_time_series(
+    const ElementId<Dim>& element_id) {
+  const auto info_it = element_info_.find(element_id);
+  if (info_it == element_info_.end()) {
+    ERROR_NO_TRACE("Element "
+                   << element_id
+                   << " does not exist in the volume files. The available "
+                      "elements are listed by `elements()`.");
+  }
+  const auto& [mesh, file_index] = info_it->second;
+  const std::string& filename = filenames_[file_index];
+  if (file_cache_ == nullptr or file_cache_->file_index != file_index) {
+    size_t num_elements_in_file = 0;
+    for (const auto& info : element_info_) {
+      if (info.second.second == file_index) {
+        ++num_elements_in_file;
+      }
+    }
+    file_cache_ =
+        std::make_unique<FileCache>(file_index, filename, subfile_name_,
+                                    obs_ids_and_times_, num_elements_in_file);
+  }
+  const auto& volfile = *file_cache_->volfile;
+  const size_t num_observations = obs_ids_and_times_.size();
+  const size_t num_components = tensor_components_.size();
+  const std::string element_name = get_output(element_id);
+  const size_t num_points = mesh.number_of_grid_points();
+  Series series(num_components,
+                std::vector<std::vector<double>>(
+                    num_points, std::vector<double>(num_observations)));
+  DataVector nodal_data(num_points);
+  ModalVector modal_data(num_points);
+  for (size_t obs_index = 0; obs_index < num_observations; ++obs_index) {
+    const auto& obs_cache = file_cache_->observations[obs_index];
+    const auto grid_index_it = obs_cache.grid_index_by_name.find(element_name);
+    if (grid_index_it == obs_cache.grid_index_by_name.end()) {
+      ERROR_NO_TRACE("Element "
+                     << element_name << " is missing in file '" << filename
+                     << "' at observation ID " << obs_cache.obs_id
+                     << ". Each element must reside in the same volume "
+                        "file for all observations, so element migration "
+                        "between files (e.g. by load balancing) is not "
+                        "supported.");
+    }
+    const size_t grid_index = grid_index_it->second;
+    const auto obs_mesh = mesh_from_cache<Dim>(obs_cache, grid_index);
+    if (obs_mesh != mesh) {
+      ERROR_NO_TRACE("Element "
+                     << element_name << " in file '" << filename
+                     << "' has mesh " << obs_mesh << " at observation ID "
+                     << obs_cache.obs_id << " but mesh " << mesh
+                     << " at the last observation. Mesh changes between "
+                        "observations (e.g. by adaptive mesh refinement) "
+                        "are not supported.");
+    }
+    const size_t offset = obs_cache.grid_offsets[grid_index];
+    for (size_t component_index = 0; component_index < num_components;
+         ++component_index) {
+      // This currently reads the data of all elements in the file and
+      // discards all but this element's subset. Reading only the subset is a
+      // possible optimization, see docs of `modal_time_series`.
+      const auto tensor_component = volfile.get_tensor_component(
+          obs_cache.obs_id, tensor_components_[component_index]);
+      std::visit(
+          Overloader{
+              [&nodal_data, &offset, &num_points](const DataVector& data) {
+                std::copy_n(data.begin() + static_cast<std::ptrdiff_t>(offset),
+                            static_cast<std::ptrdiff_t>(num_points),
+                            nodal_data.begin());
+              },
+              [&nodal_data, &offset,
+               &num_points](const std::vector<float>& data) {
+                std::transform(
+                    data.begin() + static_cast<std::ptrdiff_t>(offset),
+                    data.begin() +
+                        static_cast<std::ptrdiff_t>(offset + num_points),
+                    nodal_data.begin(), [](const float value) {
+                      return static_cast<double>(value);
+                    });
+              }},
+          tensor_component.data);
+      to_modal_coefficients(make_not_null(&modal_data), nodal_data, mesh);
+      auto& component_series = series[component_index];
+      for (size_t mode = 0; mode < num_points; ++mode) {
+        component_series[mode][obs_index] = modal_data[mode];
+      }
+    }
+  }
+  return series;
+}
+
+// Explicit instantiations
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data) template class ModalTimeSeriesReader<DIM(data)>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#undef INSTANTIATE
+#undef DIM
+
+}  // namespace spectre::Exporter

--- a/src/IO/Exporter/ModalTimeSeriesReader.hpp
+++ b/src/IO/Exporter/ModalTimeSeriesReader.hpp
@@ -1,0 +1,146 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "Domain/Structure/ElementId.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+
+namespace spectre::Exporter {
+
+/*!
+ * \brief Reads time series of modal coefficients from volume data files.
+ *
+ * This class reads tensor components written by multiple observations of a
+ * volume data subfile, transforms the nodal data of each element to modal
+ * coefficients, and returns the time series of every modal coefficient one
+ * element at a time. Reading element-by-element keeps memory usage low: only
+ * a single element's time series is held in memory at once, so the volume
+ * data never has to be loaded into memory as a whole.
+ *
+ * Request the time series with `modal_time_series()`, e.g.:
+ *
+ * \snippet Test_ModalTimeSeriesReader.cpp modal_time_series_reader_example
+ *
+ * The observation times must be uniformly spaced. Multiple files can be used
+ * when the elements of each observation are distributed across files, such as
+ * files written by different nodes. All files must contain the same
+ * observations in the requested time interval, and each element must reside
+ * in the same file with the same mesh for all observations. Files from
+ * different simulation segments must be joined first, with overlapping
+ * observations removed. Adaptive mesh refinement and element migration
+ * between files (e.g. by load balancing) are not supported yet and raise
+ * errors.
+ *
+ * Only the Legendre basis is supported for now.
+ *
+ * \note When observing fields on a smaller mesh, use the `ProjectToMesh`
+ * option of the ObserveFields event to ensure the data is truncated cleanly
+ * in modal space. Do not use `InterpolateToMesh` as this creates a
+ * catastrophic aliasing error.
+ */
+template <size_t Dim>
+class ModalTimeSeriesReader {
+ public:
+  /// Modal coefficient time series of a single element, indexed as
+  /// `series[component][mode][observation]`. Modes are ordered by the
+  /// collapsed index of the element's mesh.
+  using Series = std::vector<std::vector<std::vector<double>>>;
+
+  /*!
+   * \brief Construct from one or more volume files.
+   *
+   * Reads and validates metadata from all files. The volume data itself is
+   * only read when calling `modal_time_series()`.
+   *
+   * \param volume_files_or_glob A list of volume H5 files, or a glob string
+   *     that resolves to volume files. The files can distribute elements of
+   *     the same observations across nodes, but files from different
+   *     simulation segments must be joined first.
+   * \param subfile_name The name of the volume data subfile in the H5 files.
+   * \param tensor_components Tensor component names to read. Each component
+   *     must exist in every file at every observation.
+   * \param start_time Optional lower bound to restrict observations.
+   * \param end_time Optional upper bound to restrict observations.
+   */
+  ModalTimeSeriesReader(const std::variant<std::vector<std::string>,
+                                           std::string>& volume_files_or_glob,
+                        std::string subfile_name,
+                        std::vector<std::string> tensor_components,
+                        std::optional<double> start_time = std::nullopt,
+                        std::optional<double> end_time = std::nullopt);
+
+  ModalTimeSeriesReader(ModalTimeSeriesReader&&);
+  ModalTimeSeriesReader& operator=(ModalTimeSeriesReader&&);
+  ModalTimeSeriesReader(const ModalTimeSeriesReader&) = delete;
+  ModalTimeSeriesReader& operator=(const ModalTimeSeriesReader&) = delete;
+  ~ModalTimeSeriesReader();
+
+  /// Time of the first observation (after filtering by `start_time` and
+  /// `end_time`)
+  double start_time() const { return obs_ids_and_times_.front().second; }
+
+  /// Uniform spacing between observation times
+  double time_step() const { return time_step_; }
+
+  /// Number of observations (after filtering by `start_time` and `end_time`)
+  size_t num_observations() const { return obs_ids_and_times_.size(); }
+
+  /// The tensor components that will be read
+  const std::vector<std::string>& tensor_components() const {
+    return tensor_components_;
+  }
+
+  /*!
+   * \brief All elements in the volume files and their meshes.
+   *
+   * The elements are grouped by the volume file they reside in. Requesting
+   * the `modal_time_series()` in this order avoids re-reading per-file
+   * metadata.
+   */
+  const std::vector<std::pair<ElementId<Dim>, Mesh<Dim>>>& elements() const {
+    return elements_;
+  }
+
+  /*!
+   * \brief The time series of all modal coefficients of all tensor
+   * components of the given element.
+   *
+   * Metadata of the file in which the element resides is cached between
+   * calls, so requesting elements in the order of `elements()` is most
+   * efficient (this is also why this function is not const).
+   *
+   * Reading the volume data is currently not optimized: every observation of
+   * a tensor component is read from disk once per element residing in the
+   * file. Reading only the element's subset of the data would avoid this
+   * amplification without changing this interface.
+   */
+  Series modal_time_series(const ElementId<Dim>& element_id);
+
+ private:
+  struct FileCache;
+
+  std::vector<std::string> filenames_;
+  std::string subfile_name_;
+  std::vector<std::string> tensor_components_;
+  std::vector<std::pair<size_t, double>> obs_ids_and_times_;
+  double time_step_{};
+  /// Elements grouped by file, in the order they appear in the files
+  std::vector<std::pair<ElementId<Dim>, Mesh<Dim>>> elements_;
+  /// Mesh and file index of each element for fast lookup
+  std::unordered_map<ElementId<Dim>, std::pair<Mesh<Dim>, size_t>>
+      element_info_;
+  /// Metadata of the most recently accessed file
+  std::unique_ptr<FileCache> file_cache_;
+};
+
+}  // namespace spectre::Exporter

--- a/tests/Unit/IO/Exporter/CMakeLists.txt
+++ b/tests/Unit/IO/Exporter/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY "Test_Exporter")
 
 set(LIBRARY_SOURCES
   Test_Exporter.cpp
+  Test_ModalTimeSeriesReader.cpp
   Test_SpacetimeInterpolator.cpp
   )
 
@@ -15,9 +16,11 @@ target_link_libraries(
   PRIVATE
   DataStructures
   DomainCreators
+  DomainStructure
   Exporter
   H5
   Informer
+  LinearOperators
   Serialization
   Spectral
   Utilities

--- a/tests/Unit/IO/Exporter/Test_ModalTimeSeriesReader.cpp
+++ b/tests/Unit/IO/Exporter/Test_ModalTimeSeriesReader.cpp
@@ -1,0 +1,397 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/ModalVector.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "IO/Exporter/ModalTimeSeriesReader.hpp"
+#include "IO/H5/File.hpp"
+#include "IO/H5/TensorData.hpp"
+#include "IO/H5/VolumeData.hpp"
+#include "NumericalAlgorithms/LinearOperators/CoefficientTransforms.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Utilities/FileSystem.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace spectre::Exporter {
+
+namespace {
+
+// Deterministic nodal data so the streamed modal coefficients can be compared
+// against a direct transform of the same data
+double nodal_value(const size_t element_index, const size_t point_index,
+                   const double time) {
+  return std::sin(0.3 * static_cast<double>(point_index) +
+                  static_cast<double>(element_index)) *
+             (1.0 + 0.1 * time) +
+         time;
+}
+
+DataVector nodal_data(const size_t element_index, const size_t num_points,
+                      const double time) {
+  DataVector result(num_points);
+  for (size_t i = 0; i < num_points; ++i) {
+    result[i] = nodal_value(element_index, i, time);
+  }
+  return result;
+}
+
+void write_3d_test_file(const std::string& filename,
+                        const std::string& subfile_name,
+                        const std::vector<std::pair<size_t, double>>& obs,
+                        const std::vector<std::string>& grid_names,
+                        const std::vector<size_t>& element_indices,
+                        const Mesh<3>& mesh) {
+  const size_t num_points = mesh.number_of_grid_points();
+  h5::H5File<h5::AccessType::ReadWrite> h5file{filename, true};
+  auto& volfile = h5file.insert<h5::VolumeData>(subfile_name, 0);
+  for (const auto& [obs_id, time] : obs) {
+    std::vector<ElementVolumeData> elements{};
+    elements.reserve(grid_names.size());
+    for (size_t i = 0; i < grid_names.size(); ++i) {
+      const auto psi = nodal_data(element_indices[i], num_points, time);
+      // Store the second component in single precision to test the
+      // float codepath
+      std::vector<float> phi(num_points);
+      for (size_t p = 0; p < num_points; ++p) {
+        phi[p] = static_cast<float>(2.0 * psi[p] + 1.0);
+      }
+      elements.push_back(ElementVolumeData{
+          ElementId<3>(grid_names[i]),
+          {TensorComponent{"Psi", psi}, TensorComponent{"Phi", std::move(phi)}},
+          mesh});
+    }
+    volfile.write_volume_data(obs_id, time, elements);
+  }
+}
+
+// Writes a 1D volume file where each observation can hold a different set of
+// grids, to construct the various unsupported scenarios
+void write_1d_test_file(
+    const std::string& filename, const std::string& subfile_name,
+    const std::vector<std::pair<size_t, double>>& obs,
+    const std::vector<std::vector<std::pair<std::string, size_t>>>&
+        grids_per_obs,
+    const Spectral::Basis basis = Spectral::Basis::Legendre) {
+  h5::H5File<h5::AccessType::ReadWrite> h5file{filename, true};
+  auto& volfile = h5file.insert<h5::VolumeData>(subfile_name, 0);
+  for (size_t obs_index = 0; obs_index < obs.size(); ++obs_index) {
+    const auto& [obs_id, time] = obs[obs_index];
+    std::vector<ElementVolumeData> elements{};
+    for (const auto& [grid_name, num_points] : grids_per_obs[obs_index]) {
+      const Mesh<1> mesh{num_points, basis, Spectral::Quadrature::GaussLobatto};
+      elements.push_back(ElementVolumeData{
+          ElementId<1>(grid_name),
+          {TensorComponent{"Psi", DataVector{num_points, time}}},
+          mesh});
+    }
+    volfile.write_volume_data(obs_id, time, elements);
+  }
+}
+
+void test_streaming() {
+  const std::string filename_1{"TestModalTimeSeriesReader3D_1.h5"};
+  const std::string filename_2{"TestModalTimeSeriesReader3D_2.h5"};
+  file_system::rm(filename_1, true);
+  file_system::rm(filename_2, true);
+  const std::string subfile_name{"/VolumeData"};
+
+  const Mesh<3> mesh{3, Spectral::Basis::Legendre,
+                     Spectral::Quadrature::GaussLobatto};
+  const size_t num_points = mesh.number_of_grid_points();
+  // Elements split across two files
+  const std::vector<std::string> grid_names_1{"[B0,(L1I0,L0I0,L0I0)]",
+                                              "[B0,(L1I1,L0I0,L0I0)]"};
+  const std::vector<std::string> grid_names_2{"[B1,(L1I0,L0I0,L0I0)]",
+                                              "[B1,(L1I1,L0I0,L0I0)]"};
+  std::vector<std::pair<size_t, double>> obs{};
+  const double start_time = 0.25;
+  const double time_step = 0.5;
+  const size_t num_observations = 10;
+  for (size_t i = 0; i < num_observations; ++i) {
+    obs.emplace_back(i, start_time + static_cast<double>(i) * time_step);
+  }
+  write_3d_test_file(filename_1, subfile_name, obs, grid_names_1, {0, 1}, mesh);
+  write_3d_test_file(filename_2, subfile_name, obs, grid_names_2, {2, 3}, mesh);
+
+  // Construct from a glob to test glob resolution
+  ModalTimeSeriesReader<3> reader{
+      std::string{"TestModalTimeSeriesReader3D_*.h5"},
+      subfile_name,
+      {"Psi", "Phi"}};
+  CHECK(reader.num_observations() == num_observations);
+  CHECK(reader.start_time() == approx(start_time));
+  CHECK(reader.time_step() == approx(time_step));
+  CHECK(reader.tensor_components() == std::vector<std::string>{"Psi", "Phi"});
+  REQUIRE(reader.elements().size() == 4);
+  // Elements are grouped by file, in the order they appear in the files
+  for (size_t i = 0; i < 2; ++i) {
+    CHECK(reader.elements()[i].first == ElementId<3>(grid_names_1[i]));
+    CHECK(reader.elements()[i + 2].first == ElementId<3>(grid_names_2[i]));
+    CHECK(reader.elements()[i].second == mesh);
+    CHECK(reader.elements()[i + 2].second == mesh);
+  }
+
+  const auto element_index_for = [&grid_names_1,
+                                  &grid_names_2](const ElementId<3>& id) {
+    for (size_t i = 0; i < grid_names_1.size(); ++i) {
+      if (ElementId<3>(grid_names_1[i]) == id) {
+        return i;
+      }
+    }
+    for (size_t i = 0; i < grid_names_2.size(); ++i) {
+      if (ElementId<3>(grid_names_2[i]) == id) {
+        return i + grid_names_1.size();
+      }
+    }
+    ERROR("Unexpected element ID: " << id);
+  };
+
+  const auto check_series =
+      [&mesh, &num_points, &obs, &element_index_for](
+          const ElementId<3>& element_id,
+          const ModalTimeSeriesReader<3>::Series& series) {
+        const size_t element_index = element_index_for(element_id);
+        REQUIRE(series.size() == 2);
+        REQUIRE(series[0].size() == num_points);
+        REQUIRE(series[0][0].size() == obs.size());
+        // Compute the expected modal coefficients directly and compare
+        ModalVector expected_modes(num_points);
+        DataVector nodal(num_points);
+        double max_deviation = 0.0;
+        for (size_t obs_index = 0; obs_index < obs.size(); ++obs_index) {
+          const double time = obs[obs_index].second;
+          // Psi (written in double precision)
+          nodal = nodal_data(element_index, num_points, time);
+          to_modal_coefficients(make_not_null(&expected_modes), nodal, mesh);
+          for (size_t mode = 0; mode < num_points; ++mode) {
+            max_deviation = std::max(
+                max_deviation,
+                std::abs(series[0][mode][obs_index] - expected_modes[mode]));
+          }
+          // Phi (written in single precision)
+          for (size_t p = 0; p < num_points; ++p) {
+            nodal[p] =
+                static_cast<double>(static_cast<float>(2.0 * nodal[p] + 1.0));
+          }
+          to_modal_coefficients(make_not_null(&expected_modes), nodal, mesh);
+          for (size_t mode = 0; mode < num_points; ++mode) {
+            max_deviation = std::max(
+                max_deviation,
+                std::abs(series[1][mode][obs_index] - expected_modes[mode]));
+          }
+        }
+        CHECK(max_deviation == approx(0.0));
+      };
+
+  // [modal_time_series_reader_example]
+  for (const auto& [element_id, element_mesh] : reader.elements()) {
+    const auto series = reader.modal_time_series(element_id);
+    // ... process the time series of this element ...
+    // [modal_time_series_reader_example]
+    CHECK(element_mesh == mesh);
+    check_series(element_id, series);
+  }
+
+  // Out-of-order access across files re-reads the file metadata but returns
+  // the same data
+  const auto& last_element_id = reader.elements().back().first;
+  check_series(last_element_id, reader.modal_time_series(last_element_id));
+  const auto& first_element_id = reader.elements().front().first;
+  check_series(first_element_id, reader.modal_time_series(first_element_id));
+
+  // Unknown element
+  CHECK_THROWS_WITH(
+      reader.modal_time_series(ElementId<3>("[B5,(L0I0,L0I0,L0I0)]")),
+      Catch::Matchers::ContainsSubstring("does not exist in the volume"));
+
+  // Restrict the time interval
+  const ModalTimeSeriesReader<3> restricted_reader{
+      std::vector<std::string>{filename_1, filename_2},
+      subfile_name,
+      {"Psi"},
+      1.0,
+      3.9};
+  // Times are 0.25, 0.75, ..., 4.75, so [1.0, 3.9] keeps 1.25, ..., 3.75
+  CHECK(restricted_reader.num_observations() == 6);
+  CHECK(restricted_reader.start_time() == approx(1.25));
+  CHECK(restricted_reader.time_step() == approx(time_step));
+
+  file_system::rm(filename_1, true);
+  file_system::rm(filename_2, true);
+}
+
+void test_errors() {
+  const std::string filename_1{"TestModalTimeSeriesReader1D_1.h5"};
+  const std::string filename_2{"TestModalTimeSeriesReader1D_2.h5"};
+  file_system::rm(filename_1, true);
+  file_system::rm(filename_2, true);
+  // All error scenarios share the same two H5 files, with one subfile per
+  // scenario, because creating H5 files is slow enough to hit the test
+  // timeout on slow file systems.
+  const std::vector<std::string> psi{"Psi"};
+  const auto make_reader =
+      [&filename_1,
+       &psi](const std::string& subfile_name) -> ModalTimeSeriesReader<1> {
+    return {std::vector<std::string>{filename_1}, subfile_name, psi};
+  };
+
+  {
+    // Non-uniform observation times
+    write_1d_test_file(
+        filename_1, "/NonUniformTimes", {{0, 0.0}, {1, 1.0}, {2, 2.5}},
+        {{{"[B0,(L0I0)]", 4}}, {{"[B0,(L0I0)]", 4}}, {{"[B0,(L0I0)]", 4}}});
+    CHECK_THROWS_WITH(
+        make_reader("/NonUniformTimes"),
+        Catch::Matchers::ContainsSubstring("must be uniformly spaced"));
+  }
+  {
+    // Too few observations
+    write_1d_test_file(filename_1, "/TooFewObservations", {{0, 0.0}},
+                       {{{"[B0,(L0I0)]", 4}}});
+    CHECK_THROWS_WITH(
+        make_reader("/TooFewObservations"),
+        Catch::Matchers::ContainsSubstring("At least 2 observations"));
+  }
+  {
+    // Wrong dimension
+    write_1d_test_file(filename_1, "/WrongDim", {{0, 0.0}, {1, 1.0}},
+                       {{{"[B0,(L0I0)]", 4}}, {{"[B0,(L0I0)]", 4}}});
+    CHECK_THROWS_WITH(
+        (ModalTimeSeriesReader<2>{std::vector<std::string>{filename_1},
+                                  "/WrongDim", psi}),
+        Catch::Matchers::ContainsSubstring("Mismatched dimensions"));
+  }
+  {
+    // Mismatched observation values between files
+    write_1d_test_file(filename_1, "/MismatchedObs", {{0, 0.0}, {1, 1.0}},
+                       {{{"[B0,(L0I0)]", 4}}, {{"[B0,(L0I0)]", 4}}});
+    write_1d_test_file(filename_2, "/MismatchedObs",
+                       {{0, 0.0}, {1, std::nextafter(1.0, 2.0)}},
+                       {{{"[B1,(L0I0)]", 4}}, {{"[B1,(L0I0)]", 4}}});
+    CHECK_THROWS_WITH(
+        (ModalTimeSeriesReader<1>{
+            std::vector<std::string>{filename_1, filename_2}, "/MismatchedObs",
+            psi}),
+        Catch::Matchers::ContainsSubstring("Mismatched observation value"));
+  }
+  {
+    // Different numbers of observations across files
+    write_1d_test_file(filename_1, "/MissingObs", {{0, 0.0}, {1, 1.0}},
+                       {{{"[B0,(L0I0)]", 4}}, {{"[B0,(L0I0)]", 4}}});
+    write_1d_test_file(filename_2, "/MissingObs", {{0, 0.0}},
+                       {{{"[B1,(L0I0)]", 4}}});
+    CHECK_THROWS_WITH((ModalTimeSeriesReader<1>{
+                          std::vector<std::string>{filename_1, filename_2},
+                          "/MissingObs", psi}),
+                      Catch::Matchers::ContainsSubstring(
+                          "must contain the same observations"));
+    write_1d_test_file(filename_1, "/ExtraObs", {{0, 0.0}, {1, 1.0}},
+                       {{{"[B0,(L0I0)]", 4}}, {{"[B0,(L0I0)]", 4}}});
+    write_1d_test_file(
+        filename_2, "/ExtraObs", {{0, 0.0}, {1, 1.0}, {2, 2.0}},
+        {{{"[B1,(L0I0)]", 4}}, {{"[B1,(L0I0)]", 4}}, {{"[B1,(L0I0)]", 4}}});
+    CHECK_THROWS_WITH((ModalTimeSeriesReader<1>{
+                          std::vector<std::string>{filename_1, filename_2},
+                          "/ExtraObs", psi}),
+                      Catch::Matchers::ContainsSubstring(
+                          "must contain the same observations"));
+  }
+  {
+    // Mismatched dimension in second file
+    write_1d_test_file(filename_1, "/MismatchedFileDim", {{0, 0.0}, {1, 1.0}},
+                       {{{"[B0,(L0I0)]", 4}}, {{"[B0,(L0I0)]", 4}}});
+    write_3d_test_file(filename_2, "/MismatchedFileDim", {{0, 0.0}, {1, 1.0}},
+                       {"[B1,(L0I0,L0I0,L0I0)]"}, {0},
+                       Mesh<3>{2, Spectral::Basis::Legendre,
+                               Spectral::Quadrature::GaussLobatto});
+    CHECK_THROWS_WITH(
+        (ModalTimeSeriesReader<1>{
+            std::vector<std::string>{filename_1, filename_2},
+            "/MismatchedFileDim", psi}),
+        Catch::Matchers::ContainsSubstring("Mismatched dimensions"));
+  }
+  {
+    // Duplicate element across files
+    write_1d_test_file(filename_1, "/DuplicateElement", {{0, 0.0}, {1, 1.0}},
+                       {{{"[B0,(L0I0)]", 4}}, {{"[B0,(L0I0)]", 4}}});
+    write_1d_test_file(filename_2, "/DuplicateElement", {{0, 0.0}, {1, 1.0}},
+                       {{{"[B0,(L0I0)]", 4}}, {{"[B0,(L0I0)]", 4}}});
+    CHECK_THROWS_WITH((ModalTimeSeriesReader<1>{
+                          std::vector<std::string>{filename_1, filename_2},
+                          "/DuplicateElement", psi}),
+                      Catch::Matchers::ContainsSubstring(
+                          "must reside in exactly one volume file"));
+  }
+  {
+    // Non-Legendre basis
+    write_1d_test_file(filename_1, "/NonLegendre", {{0, 0.0}, {1, 1.0}},
+                       {{{"[B0,(L0I0)]", 4}}, {{"[B0,(L0I0)]", 4}}},
+                       Spectral::Basis::Chebyshev);
+    CHECK_THROWS_WITH(
+        make_reader("/NonLegendre"),
+        Catch::Matchers::ContainsSubstring("Only the Legendre basis"));
+  }
+  {
+    // Different number of elements per observation (h-refinement or
+    // migration)
+    write_1d_test_file(
+        filename_1, "/ChangingNumElements", {{0, 0.0}, {1, 1.0}},
+        {{{"[B0,(L0I0)]", 4}}, {{"[B0,(L1I0)]", 4}, {"[B0,(L1I1)]", 4}}});
+    CHECK_THROWS_WITH(make_reader("/ChangingNumElements")
+                          .modal_time_series(ElementId<1>("[B0,(L1I0)]")),
+                      Catch::Matchers::ContainsSubstring("are not supported"));
+  }
+  {
+    // Same number of elements but an element is missing at an earlier
+    // observation (migration between files)
+    write_1d_test_file(filename_1, "/MigratedElement", {{0, 0.0}, {1, 1.0}},
+                       {{{"[B0,(L1I0)]", 4}, {"[B1,(L0I0)]", 4}},
+                        {{"[B0,(L1I0)]", 4}, {"[B0,(L1I1)]", 4}}});
+    CHECK_THROWS_WITH(make_reader("/MigratedElement")
+                          .modal_time_series(ElementId<1>("[B0,(L1I1)]")),
+                      Catch::Matchers::ContainsSubstring("is missing in file"));
+  }
+  {
+    // Mesh changes between observations (p-refinement)
+    write_1d_test_file(filename_1, "/ChangingMesh", {{0, 0.0}, {1, 1.0}},
+                       {{{"[B0,(L0I0)]", 5}}, {{"[B0,(L0I0)]", 4}}});
+    CHECK_THROWS_WITH(
+        make_reader("/ChangingMesh")
+            .modal_time_series(ElementId<1>("[B0,(L0I0)]")),
+        Catch::Matchers::ContainsSubstring("Mesh changes between"));
+  }
+  {
+    // No files found
+    CHECK_THROWS_WITH(
+        (ModalTimeSeriesReader<1>{std::vector<std::string>{}, "/VolumeData",
+                                  psi}),
+        Catch::Matchers::ContainsSubstring("No volume files found"));
+    // A glob that matches nothing already raises in file_system::glob
+    CHECK_THROWS_WITH(
+        (ModalTimeSeriesReader<1>{std::string{"NonexistentGlob_*.h5"},
+                                  "/VolumeData", psi}),
+        Catch::Matchers::ContainsSubstring("Unable to resolve glob"));
+  }
+  file_system::rm(filename_1, true);
+  file_system::rm(filename_2, true);
+}
+
+}  // namespace
+
+// [[TimeOut, 15]]
+SPECTRE_TEST_CASE("Unit.IO.Exporter.ModalTimeSeriesReader", "[Unit]") {
+  test_streaming();
+  test_errors();
+}
+
+}  // namespace spectre::Exporter


### PR DESCRIPTION
Streams time series of modal coefficients from volume data files, one element at a time, so the volume data never has to be loaded into memory as a whole. Validates that observations are uniformly spaced and consistent across files, and raises errors for unsupported scenarios: mesh changes between observations (AMR), element migration between files (load balancing), and overlapping observations (restarts).

Second piece of the ModalSpacetimeInterpolator (#7053), which will use this to build time interpolants for every modal coefficient.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
