### PR TITLE
Cache component name hash in ArrayComponentId

### DIFF
--- a/src/Parallel/ArrayComponentId.hpp
+++ b/src/Parallel/ArrayComponentId.hpp
@@ -48,9 +48,14 @@ class ArrayComponentId {
 template <typename ParallelComponent>
 ArrayComponentId::ArrayComponentId(const ParallelComponent* const /*meta*/,
                                    const CkArrayIndex& index)
-    : component_id_(
-          std::hash<std::string>{}(pretty_type::get_name<ParallelComponent>())),
-      array_index_(index) {}
+    : array_index_(index) {
+  // Hashing the pretty name demangles it, which is very expensive for the
+  // long template names of parallel components. Since the result is the same
+  // for every instance of `ParallelComponent`, compute it only once.
+  static const size_t cached_component_id =
+      std::hash<std::string>{}(pretty_type::get_name<ParallelComponent>());
+  component_id_ = cached_component_id;
+}
 
 bool operator==(const ArrayComponentId& lhs, const ArrayComponentId& rhs);
 


### PR DESCRIPTION
The constructor hashed pretty_type::get_name<ParallelComponent>() on every construction, demangling the component's very long template name each time. ArrayComponentId is constructed for every element at every time step, e.g. through make_array_component_id in CheckFunctionsOfTimeAreReady. In a profile of a worldtube scalar-wave evolution on 8 cores, boost::core::demangle from this call chain accounted for ~5% of total run time. Cache the hash in a function-local static, since it is a compile-time constant per ParallelComponent.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
