### PR TITLE
Some AMR topology fixes

### DIFF
--- a/src/Domain/Amr/Helpers.cpp
+++ b/src/Domain/Amr/Helpers.cpp
@@ -14,6 +14,7 @@
 #include "Domain/Structure/ElementId.hpp"
 #include "Domain/Structure/OrientationMap.hpp"
 #include "Domain/Structure/SegmentId.hpp"
+#include "Domain/Structure/Topology.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
@@ -203,6 +204,88 @@ bool prevent_element_from_joining_while_splitting(
   return flags_changed;
 }
 
+namespace {
+constexpr auto can_be_h_refined =
+    std::array{domain::Topology::I1, domain::Topology::B1Radial,
+               domain::Topology::B2Radial, domain::Topology::B3Radial};
+constexpr auto cannot_be_h_refined =
+    std::array{domain::Topology::S1,
+               domain::Topology::S2Colatitude,
+               domain::Topology::S2Longitude,
+               domain::Topology::B2Angular,
+               domain::Topology::B3Colatitude,
+               domain::Topology::B3Longitude,
+               domain::Topology::CartoonSphere,
+               domain::Topology::CartoonCylinder};
+}  // namespace
+
+template <size_t VolumeDim>
+void enforce_h_refinement_topology_restrictions(
+    gsl::not_null<std::array<Flag, VolumeDim>*> flags,
+    const std::array<domain::Topology, VolumeDim>& topologies) {
+  for (size_t d = 0; d < VolumeDim; ++d) {
+    auto& flag = gsl::at(*flags, d);
+    const auto topology = gsl::at(topologies, d);
+    if (flag != amr::Flag::DoNothing) {
+      ASSERT(flag == amr::Flag::Split or flag == amr::Flag::Join,
+             "Expected h-refinement flag, not " << flag);
+      if (alg::found(cannot_be_h_refined, topology)) {
+        flag = amr::Flag::DoNothing;
+      } else {
+        ASSERT(alg::found(can_be_h_refined, topology),
+               "Topology " << topology
+                           << " not found in either list can_be_h_refined or "
+                              "cannot_be_h_refined");
+      }
+    }
+  }
+}
+
+template <size_t VolumeDim>
+void enforce_p_refinement_topology_restrictions(
+    gsl::not_null<std::array<Flag, VolumeDim>*> flags,
+    const std::array<domain::Topology, VolumeDim>& topologies) {
+  if constexpr (VolumeDim == 2) {
+    auto& [first_flag, second_flag] = *flags;
+    if ((topologies == domain::topologies::disk or
+         topologies == domain::topologies::spherical_surface) and
+        first_flag != second_flag) {
+      const auto max_flag = std::max(first_flag, second_flag);
+      ASSERT(max_flag != amr::Flag::Split and max_flag != amr::Flag::Join,
+             "Expected p-refinement flag, not " << max_flag);
+      *flags = make_array<2>(max_flag);
+    }
+  } else if constexpr (VolumeDim == 3) {
+    auto& [first_flag, second_flag, third_flag] = *flags;
+    if (topologies == domain::topologies::spherical_shell and
+        second_flag != third_flag) {
+      const auto max_flag = std::max(second_flag, third_flag);
+      ASSERT(max_flag != amr::Flag::Split and max_flag != amr::Flag::Join,
+             "Expected p-refinement flag, not " << max_flag);
+      second_flag = max_flag;
+      third_flag = max_flag;
+    } else if (topologies == domain::topologies::full_cylinder and
+               first_flag != second_flag) {
+      const auto max_flag = std::max(first_flag, second_flag);
+      ASSERT(max_flag != amr::Flag::Split and max_flag != amr::Flag::Join,
+             "Expected p-refinement flag, not " << max_flag);
+      first_flag = max_flag;
+      second_flag = max_flag;
+    } else if (topologies == domain::topologies::full_sphere and
+               (first_flag != second_flag or second_flag != third_flag)) {
+      const auto max_flag = *(alg::max_element(*flags));
+      ASSERT(max_flag != amr::Flag::Split and max_flag != amr::Flag::Join,
+             "Expected p-refinement flag, not " << max_flag);
+      *flags = make_array<3>(max_flag);
+    } else if (topologies[2] == domain::Topology::CartoonSphere) {
+      second_flag = amr::Flag::DoNothing;
+      third_flag = amr::Flag::DoNothing;
+    } else if (topologies[2] == domain::Topology::CartoonCylinder) {
+      third_flag = amr::Flag::DoNothing;
+    }
+  }
+}
+
 #define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
 #define INSTANTIATE(_, data)                                                   \
@@ -230,7 +313,13 @@ bool prevent_element_from_joining_while_splitting(
       const ElementId<DIM(data)>& element_id,                                  \
       const std::array<Flag, DIM(data)>& flags);                               \
   template bool prevent_element_from_joining_while_splitting(                  \
-      const gsl::not_null<std::array<Flag, DIM(data)>*> flags);
+      const gsl::not_null<std::array<Flag, DIM(data)>*> flags);                \
+  template void enforce_h_refinement_topology_restrictions(                    \
+      const gsl::not_null<std::array<Flag, DIM(data)>*> flags,                 \
+      const std::array<domain::Topology, DIM(data)>& topologies);              \
+  template void enforce_p_refinement_topology_restrictions(                    \
+      const gsl::not_null<std::array<Flag, DIM(data)>*> flags,                 \
+      const std::array<domain::Topology, DIM(data)>& topologies);
 
 GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
 

--- a/src/Domain/Amr/Helpers.hpp
+++ b/src/Domain/Amr/Helpers.hpp
@@ -28,10 +28,14 @@ class ElementId;
 template <size_t VolumeDim>
 class OrientationMap;
 
+namespace domain {
+enum class Topology : uint8_t;
+}  // namespace domain
+
 namespace gsl {
 template <typename>
 class not_null;
-}
+}  // namespace gsl
 /// \endcond
 
 namespace amr {
@@ -135,4 +139,27 @@ bool is_child_that_creates_parent(const ElementId<VolumeDim>& element_id,
 template <size_t VolumeDim>
 bool prevent_element_from_joining_while_splitting(
     gsl::not_null<std::array<Flag, VolumeDim>*> flags);
+
+/// \ingroup AmrGroup
+/// \brief Enforce restrictions on AMR decisions for h-refinement based on the
+/// topologies of the Element.
+///
+/// \details Angular topologies (e.g. S1 or S2) and cartoon topologies (e.g.
+/// (CartoonSphere)  cannot be h-refined.
+template <size_t VolumeDim>
+void enforce_h_refinement_topology_restrictions(
+    gsl::not_null<std::array<Flag, VolumeDim>*> flags,
+    const std::array<domain::Topology, VolumeDim>& topologies);
+
+/// \ingroup AmrGroup
+/// \brief Enforce restrictions on AMR decisions for p-refinement based on the
+/// topologies of the Element.
+///
+/// \details Multi-dimensional topologies (e.g. S2, B2, B3) have relationships
+/// between their extents that must be enforced so that the highest modes
+/// are correctly represented. Cartoon topologies cannot be p-refined.
+template <size_t VolumeDim>
+void enforce_p_refinement_topology_restrictions(
+    [[maybe_unused]] gsl::not_null<std::array<Flag, VolumeDim>*> flags,
+    [[maybe_unused]] const std::array<domain::Topology, VolumeDim>& topologies);
 }  // namespace amr

--- a/src/Domain/Structure/Topology.hpp
+++ b/src/Domain/Structure/Topology.hpp
@@ -69,6 +69,9 @@ static constexpr auto hypertorus = make_array<VolumeDim>(Topology::S1);
 
 static constexpr auto annulus = std::array{Topology::I1, Topology::S1};
 
+static constexpr auto spherical_surface =
+    std::array{Topology::S2Colatitude, Topology::S2Longitude};
+
 static constexpr auto disk =
     std::array{Topology::B2Radial, Topology::B2Angular};
 

--- a/src/NumericalAlgorithms/Spectral/Basis.hpp
+++ b/src/NumericalAlgorithms/Spectral/Basis.hpp
@@ -8,6 +8,8 @@
 #include <iosfwd>
 #include <string>
 
+#include "Utilities/MakeArray.hpp"
+
 /// \cond
 namespace Options {
 class Option;
@@ -92,6 +94,53 @@ Basis to_basis(const std::string& basis);
 
 /// Output operator for a Basis.
 std::ostream& operator<<(std::ostream& os, const Basis& basis);
+
+/// Shortcuts for common Basis products where the default for I1Basis is
+/// Basis::Legendre
+namespace bases {
+template <size_t VolumeDim, Basis I1Basis = Basis::Legendre>
+static constexpr auto hypercube = make_array<VolumeDim>(Basis::Legendre);
+
+template <size_t VolumeDim>
+static constexpr auto hypertorus = make_array<VolumeDim>(Basis::Fourier);
+
+template <Basis I1Basis = Basis::Legendre>
+static constexpr auto annulus = std::array{I1Basis, Basis::Fourier};
+
+static constexpr auto spherical_surface =
+    make_array<2>(Basis::SphericalHarmonic);
+
+static constexpr auto disk = make_array<2>(Basis::ZernikeB2);
+
+template <Basis I1Basis = Basis::Legendre>
+static constexpr auto spherical_shell =
+    std::array{I1Basis, Basis::SphericalHarmonic, Basis::SphericalHarmonic};
+
+template <Basis I1Basis = Basis::Legendre>
+static constexpr auto cylindrical_shell =
+    std::array{I1Basis, Basis::Fourier, I1Basis};
+
+template <Basis I1Basis = Basis::Legendre>
+static constexpr auto full_cylinder =
+    std::array{Basis::ZernikeB2, Basis::ZernikeB2, I1Basis};
+
+static constexpr auto full_sphere = make_array<3>(Basis::ZernikeB3);
+
+template <Basis I1Basis = Basis::Legendre>
+static constexpr auto cartoon_sphere =
+    std::array{I1Basis, Basis::Cartoon, Basis::Cartoon};
+
+static constexpr auto cartoon_sphere_inner =
+    std::array{Basis::ZernikeB1, Basis::Cartoon, Basis::Cartoon};
+
+template <Basis I1Basis = Basis::Legendre>
+static constexpr auto cartoon_cylinder =
+    std::array{I1Basis, I1Basis, Basis::Cartoon};
+
+template <Basis I1Basis = Basis::Legendre>
+static constexpr auto cartoon_cylinder_inner =
+    std::array{Basis::ZernikeB1, I1Basis, Basis::Cartoon};
+}  // namespace bases
 }  // namespace Spectral
 
 template <>

--- a/src/NumericalAlgorithms/Spectral/Quadrature.hpp
+++ b/src/NumericalAlgorithms/Spectral/Quadrature.hpp
@@ -8,6 +8,8 @@
 #include <iosfwd>
 #include <string>
 
+#include "Utilities/MakeArray.hpp"
+
 /// \cond
 namespace Options {
 class Option;
@@ -80,6 +82,58 @@ Quadrature to_quadrature(const std::string& quadrature);
 
 /// Output operator for a Quadrature.
 std::ostream& operator<<(std::ostream& os, const Quadrature& quadrature);
+
+/// Shortcuts for common Quadrature products where the default value of
+/// I1Quadrature is Quadrature::GaussLobatto
+namespace quadratures {
+template <size_t VolumeDim, Quadrature I1Quadrature = Quadrature::GaussLobatto>
+static constexpr auto hypercube = make_array<VolumeDim>(I1Quadrature);
+
+template <size_t VolumeDim>
+static constexpr auto hypertorus =
+    make_array<VolumeDim>(Quadrature::Equiangular);
+
+template <Quadrature I1Quadrature = Quadrature::GaussLobatto>
+static constexpr auto annulus =
+    std::array{I1Quadrature, Quadrature::Equiangular};
+
+static constexpr auto spherical_surface =
+    std::array{Quadrature::Gauss, Quadrature::Equiangular};
+
+static constexpr auto disk =
+    std::array{Quadrature::GaussRadauUpper, Quadrature::Equiangular};
+
+template <Quadrature I1Quadrature = Quadrature::GaussLobatto>
+static constexpr auto spherical_shell =
+    std::array{I1Quadrature, Quadrature::Gauss, Quadrature::Equiangular};
+
+template <Quadrature I1Quadrature = Quadrature::GaussLobatto>
+static constexpr auto cylindrical_shell =
+    std::array{I1Quadrature, Quadrature::Equiangular, I1Quadrature};
+
+template <Quadrature I1Quadrature = Quadrature::GaussLobatto>
+static constexpr auto full_cylinder = std::array{
+    Quadrature::GaussRadauUpper, Quadrature::Equiangular, I1Quadrature};
+
+static constexpr auto full_sphere = std::array{
+    Quadrature::GaussRadauUpper, Quadrature::Gauss, Quadrature::Equiangular};
+
+template <Quadrature I1Quadrature = Quadrature::GaussLobatto>
+static constexpr auto cartoon_sphere = std::array{
+    I1Quadrature, Quadrature::SphericalSymmetry, Quadrature::SphericalSymmetry};
+
+static constexpr auto cartoon_sphere_inner =
+    std::array{Quadrature::GaussRadauUpper, Quadrature::SphericalSymmetry,
+               Quadrature::SphericalSymmetry};
+
+template <Quadrature I1Quadrature = Quadrature::GaussLobatto>
+static constexpr auto cartoon_cylinder =
+    std::array{I1Quadrature, I1Quadrature, Quadrature::AxialSymmetry};
+
+template <Quadrature I1Quadrature = Quadrature::GaussLobatto>
+static constexpr auto cartoon_cylinder_inner = std::array{
+    Quadrature::GaussRadauUpper, I1Quadrature, Quadrature::AxialSymmetry};
+}  // namespace quadratures
 }  // namespace Spectral
 
 template <>

--- a/src/ParallelAlgorithms/Amr/Actions/AdjustDomain.hpp
+++ b/src/ParallelAlgorithms/Amr/Actions/AdjustDomain.hpp
@@ -220,18 +220,19 @@ struct AdjustDomain {
           std::make_pair(db::get<::domain::Tags::Mesh<volume_dim>>(box),
                          db::get<::domain::Tags::Element<volume_dim>>(box));
       const auto& old_mesh = old_mesh_and_element.first;
+      const auto& old_element = old_mesh_and_element.second;
 
       // Determine new neighbors and update the Element
       const auto& amr_info_of_neighbors =
           db::get<amr::Tags::NeighborInfo<volume_dim>>(box);
-      auto [new_neighbors, new_neighbor_meshes] =
-          neighbors_of_child(old_mesh_and_element.second, my_amr_info,
-                             amr_info_of_neighbors, element_id);
+      auto [new_neighbors, new_neighbor_meshes] = neighbors_of_child(
+          old_element, my_amr_info, amr_info_of_neighbors, element_id);
       ::Initialization::mutate_assign<
           tmpl::list<::domain::Tags::Element<volume_dim>,
                      ::domain::Tags::NeighborMesh<volume_dim>>>(
           make_not_null(&box),
-          Element<volume_dim>(element_id, std::move(new_neighbors)),
+          Element<volume_dim>(element_id, std::move(new_neighbors),
+                              old_element.topologies()),
           std::move(new_neighbor_meshes));
 
       // Check for p-refinement

--- a/src/ParallelAlgorithms/Amr/Actions/EvaluateRefinementCriteria.hpp
+++ b/src/ParallelAlgorithms/Amr/Actions/EvaluateRefinementCriteria.hpp
@@ -127,8 +127,9 @@ struct EvaluateRefinementCriteria {
       const auto& refinement_criteria =
           db::get<amr::Criteria::Tags::Criteria>(box);
       for (const auto& criterion : refinement_criteria) {
+        const auto refinement_type = criterion->type();
         if (Metavariables::amr::p_refine_only_in_event and
-            criterion->type() == amr::Criteria::Type::p) {
+            refinement_type == amr::Criteria::Type::p) {
           continue;
         }
         auto decision = criterion->evaluate(observation_box, cache, element_id);
@@ -142,6 +143,19 @@ struct EvaluateRefinementCriteria {
                      << typeid(*criterion).name()
                      << "' requested p-refinement, but claims to be "
                         "for h-refinement.");
+        }
+
+        // Enforce restrictions from the topologies of the Element
+        const auto& topologies =
+            db::get<domain::Tags::Element<Dim>>(box).topologies();
+        if (refinement_type == amr::Criteria::Type::p) {
+          enforce_p_refinement_topology_restrictions(make_not_null(&decision),
+                                                     topologies);
+        } else if (refinement_type == amr::Criteria::Type::h) {
+          enforce_h_refinement_topology_restrictions(make_not_null(&decision),
+                                                     topologies);
+        } else {
+          ERROR("Bad refinement type " << refinement_type);
         }
         for (size_t d = 0; d < volume_dim; ++d) {
           overall_decision[d] = std::max(overall_decision[d], decision[d]);

--- a/src/ParallelAlgorithms/Amr/Projectors/Mesh.cpp
+++ b/src/ParallelAlgorithms/Amr/Projectors/Mesh.cpp
@@ -18,6 +18,7 @@
 #include "Domain/Structure/Element.hpp"
 #include "Domain/Structure/ElementId.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
 #include "Utilities/Algorithm.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
@@ -31,8 +32,14 @@ Mesh<Dim> mesh(const Mesh<Dim>& old_mesh,
   for (size_t d = 0; d < Dim; ++d) {
     if (gsl::at(flags, d) == amr::Flag::IncreaseResolution) {
       ++gsl::at(new_extents, d);
+      if (old_mesh.quadrature(d) == Spectral::Quadrature::Equiangular) {
+        ++gsl::at(new_extents, d);
+      }
     } else if (gsl::at(flags, d) == amr::Flag::DecreaseResolution) {
       --gsl::at(new_extents, d);
+      if (old_mesh.quadrature(d) == Spectral::Quadrature::Equiangular) {
+        --gsl::at(new_extents, d);
+      }
     }
   }
   return {new_extents, old_mesh.basis(), old_mesh.quadrature()};

--- a/tests/Unit/Domain/Amr/Test_Helpers.cpp
+++ b/tests/Unit/Domain/Amr/Test_Helpers.cpp
@@ -595,6 +595,112 @@ void test_prevent_element_from_joining_while_splitting() {
   check(stay_stay_stay, stay_stay_stay);
 }
 
+template <size_t Dim>
+void check_h(std::array<amr::Flag, Dim> flags,
+             const std::array<amr::Flag, Dim>& expected_flags,
+             const std::array<domain::Topology, Dim>& topologies) {
+  amr::enforce_h_refinement_topology_restrictions(make_not_null(&flags),
+                                                  topologies);
+  CHECK(flags == expected_flags);
+}
+
+void test_enforce_h_refinement_topology_restrictions() {
+  const auto join = amr::Flag::Join;
+  const auto split = amr::Flag::Split;
+  const auto stay = amr::Flag::DoNothing;
+  const auto h_flags = std::vector{join, stay, split};
+
+  for (const auto first_flag : h_flags) {
+    const auto flags_1d = std::array{first_flag};
+    check_h(flags_1d, flags_1d, domain::topologies::hypercube<1>);
+    check_h(flags_1d, std::array{stay}, domain::topologies::hypertorus<1>);
+    for (const auto second_flag : h_flags) {
+      const auto flags_2d = std::array{first_flag, second_flag};
+      check_h(flags_2d, flags_2d, domain::topologies::hypercube<2>);
+      check_h(flags_2d, std::array{stay, stay},
+              domain::topologies::hypertorus<2>);
+      check_h(flags_2d, std::array{first_flag, stay},
+              domain::topologies::annulus);
+      check_h(flags_2d, std::array{first_flag, stay}, domain::topologies::disk);
+      for (const auto third_flag : h_flags) {
+        const auto flags_3d = std::array{first_flag, second_flag, third_flag};
+        check_h(flags_3d, flags_3d, domain::topologies::hypercube<3>);
+        check_h(flags_3d, std::array{stay, stay, stay},
+                domain::topologies::hypertorus<3>);
+        check_h(flags_3d, std::array{first_flag, stay, stay},
+                domain::topologies::spherical_shell);
+        check_h(flags_3d, std::array{first_flag, stay, third_flag},
+                domain::topologies::cylindrical_shell);
+        check_h(flags_3d, std::array{first_flag, stay, third_flag},
+                domain::topologies::full_cylinder);
+        check_h(flags_3d, std::array{first_flag, stay, stay},
+                domain::topologies::full_sphere);
+        check_h(flags_3d, std::array{first_flag, stay, stay},
+                domain::topologies::cartoon_sphere);
+        check_h(flags_3d, std::array{first_flag, stay, stay},
+                domain::topologies::cartoon_sphere_inner);
+        check_h(flags_3d, std::array{first_flag, second_flag, stay},
+                domain::topologies::cartoon_cylinder);
+        check_h(flags_3d, std::array{first_flag, second_flag, stay},
+                domain::topologies::cartoon_cylinder_inner);
+      }
+    }
+  }
+}
+
+template <size_t Dim>
+void check_p(std::array<amr::Flag, Dim> flags,
+             const std::array<amr::Flag, Dim>& expected_flags,
+             const std::array<domain::Topology, Dim>& topologies) {
+  CAPTURE(topologies);
+  amr::enforce_p_refinement_topology_restrictions(make_not_null(&flags),
+                                                  topologies);
+  CHECK(flags == expected_flags);
+}
+
+void test_enforce_p_refinement_topology_restrictions() {
+  const auto decrease = amr::Flag::DecreaseResolution;
+  const auto increase = amr::Flag::IncreaseResolution;
+  const auto stay = amr::Flag::DoNothing;
+  const auto p_flags = std::vector{decrease, stay, increase};
+
+  for (const auto first_flag : p_flags) {
+    const auto flags_1d = std::array{first_flag};
+    check_p(flags_1d, flags_1d, domain::topologies::hypercube<1>);
+    check_p(flags_1d, flags_1d, domain::topologies::hypertorus<1>);
+    for (const auto second_flag : p_flags) {
+      const auto flags_2d = std::array{first_flag, second_flag};
+      const auto max_flag_12 = std::max(first_flag, second_flag);
+      check_p(flags_2d, flags_2d, domain::topologies::hypercube<2>);
+      check_p(flags_2d, flags_2d, domain::topologies::hypertorus<2>);
+      check_p(flags_2d, flags_2d, domain::topologies::annulus);
+      check_p(flags_2d, make_array<2>(max_flag_12), domain::topologies::disk);
+      for (const auto third_flag : p_flags) {
+        const auto flags_3d = std::array{first_flag, second_flag, third_flag};
+        const auto max_flag_23 = std::max(second_flag, third_flag);
+        const auto max_flag = *(alg::max_element(flags_3d));
+        check_p(flags_3d, flags_3d, domain::topologies::hypercube<3>);
+        check_p(flags_3d, flags_3d, domain::topologies::hypertorus<3>);
+        check_p(flags_3d, std::array{first_flag, max_flag_23, max_flag_23},
+                domain::topologies::spherical_shell);
+        check_p(flags_3d, flags_3d, domain::topologies::cylindrical_shell);
+        check_p(flags_3d, std::array{max_flag_12, max_flag_12, third_flag},
+                domain::topologies::full_cylinder);
+        check_p(flags_3d, make_array<3>(max_flag),
+                domain::topologies::full_sphere);
+        check_p(flags_3d, std::array{first_flag, stay, stay},
+                domain::topologies::cartoon_sphere);
+        check_p(flags_3d, std::array{first_flag, stay, stay},
+                domain::topologies::cartoon_sphere_inner);
+        check_p(flags_3d, std::array{first_flag, second_flag, stay},
+                domain::topologies::cartoon_cylinder);
+        check_p(flags_3d, std::array{first_flag, second_flag, stay},
+                domain::topologies::cartoon_cylinder_inner);
+      }
+    }
+  }
+}
+
 void test_assertions() {
 #ifdef SPECTRE_DEBUG
   const ElementId<1> element_id_1d{0, {{SegmentId(2, 3)}}};
@@ -642,6 +748,43 @@ void test_assertions() {
       amr::is_child_that_creates_parent(element_id_3d, flags_3d_split_join),
       Catch::Matchers::ContainsSubstring(
           "Splitting and joining an Element is not supported"));
+  auto increase_1d = make_array<1>(amr::Flag::IncreaseResolution);
+  auto increase_2d = make_array<2>(amr::Flag::IncreaseResolution);
+  auto increase_3d = make_array<3>(amr::Flag::IncreaseResolution);
+  CHECK_THROWS_WITH(
+      amr::enforce_h_refinement_topology_restrictions(
+          make_not_null(&increase_1d), domain::topologies::hypertorus<1>),
+      Catch::Matchers::ContainsSubstring("Expected h-refinement flag, not"));
+  CHECK_THROWS_WITH(
+      amr::enforce_h_refinement_topology_restrictions(
+          make_not_null(&increase_2d), domain::topologies::hypertorus<2>),
+      Catch::Matchers::ContainsSubstring("Expected h-refinement flag, not"));
+  CHECK_THROWS_WITH(
+      amr::enforce_h_refinement_topology_restrictions(
+          make_not_null(&increase_3d), domain::topologies::hypertorus<3>),
+      Catch::Matchers::ContainsSubstring("Expected h-refinement flag, not"));
+  auto bad_p_2d = std::array{amr::Flag::Split, amr::Flag::Join};
+  auto bad_p_3d = flags_3d_split_join;
+  CHECK_THROWS_WITH(
+      amr::enforce_p_refinement_topology_restrictions(make_not_null(&bad_p_2d),
+                                                      domain::topologies::disk),
+      Catch::Matchers::ContainsSubstring("Expected p-refinement flag, not"));
+  CHECK_THROWS_WITH(
+      amr::enforce_p_refinement_topology_restrictions(
+          make_not_null(&bad_p_2d), domain::topologies::spherical_surface),
+      Catch::Matchers::ContainsSubstring("Expected p-refinement flag, not"));
+  CHECK_THROWS_WITH(
+      amr::enforce_p_refinement_topology_restrictions(
+          make_not_null(&bad_p_3d), domain::topologies::spherical_shell),
+      Catch::Matchers::ContainsSubstring("Expected p-refinement flag, not"));
+  CHECK_THROWS_WITH(
+      amr::enforce_p_refinement_topology_restrictions(
+          make_not_null(&bad_p_3d), domain::topologies::full_sphere),
+      Catch::Matchers::ContainsSubstring("Expected p-refinement flag, not"));
+  CHECK_THROWS_WITH(
+      amr::enforce_p_refinement_topology_restrictions(
+          make_not_null(&bad_p_3d), domain::topologies::full_cylinder),
+      Catch::Matchers::ContainsSubstring("Expected p-refinement flag, not"));
 #endif
 }
 }  // namespace
@@ -656,5 +799,7 @@ SPECTRE_TEST_CASE("Unit.Domain.Amr.Helpers", "[Domain][Unit]") {
   test_ids_of_joining_neighbors();
   test_is_child_that_creates_parent();
   test_prevent_element_from_joining_while_splitting();
+  test_enforce_h_refinement_topology_restrictions();
+  test_enforce_p_refinement_topology_restrictions();
   test_assertions();
 }

--- a/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_AdjustDomain.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_AdjustDomain.cpp
@@ -376,10 +376,44 @@ void test() {
         {std::array{amr::Flag::Undefined}, element_3_mesh_post_refinement}, {});
   }
 }
+
+void test_s1() {
+  using metavariables = Metavariables<false>;
+  using array_component = ArrayComponent<metavariables>;
+  using singleton_component = SingletonComponent<metavariables>;
+  const ElementId<1> element_id{0};
+  const Element<1> element{element_id, {}, domain::topologies::hypertorus<1>};
+  const Mesh<1> mesh{std::array{3_st}, Spectral::bases::hypertorus<1>,
+                     Spectral::quadratures::hypertorus<1>};
+  const Mesh<1> refined_mesh{std::array{5_st}, Spectral::bases::hypertorus<1>,
+                             Spectral::quadratures::hypertorus<1>};
+  amr::Info<1> element_info{{amr::Flag::IncreaseResolution}, refined_mesh};
+  std::unordered_map<ElementId<1>, amr::Info<1>> neighbor_info{};
+  using NeighborMeshes = DirectionalIdMap<1, Mesh<1>>;
+
+  ActionTesting::MockRuntimeSystem<metavariables> runner{{::Verbosity::Debug}};
+  ActionTesting::emplace_component_and_initialize<array_component>(
+      &runner, element_id,
+      {element, mesh, NeighborMeshes{}, element_info, neighbor_info});
+  ActionTesting::emplace_component<singleton_component>(&runner, 0);
+  CHECK(ActionTesting::is_simple_action_queue_empty<array_component>(
+      runner, element_id));
+  CHECK(ActionTesting::number_of_queued_simple_actions<singleton_component>(
+            runner, 0) == 0);
+  ActionTesting::simple_action<array_component, amr::Actions::AdjustDomain>(
+      make_not_null(&runner), element_id);
+  CHECK(ActionTesting::is_simple_action_queue_empty<array_component>(
+      runner, element_id));
+  CHECK(ActionTesting::number_of_queued_simple_actions<singleton_component>(
+            runner, 0) == 0);
+  check_box(runner, element_id, element, refined_mesh, NeighborMeshes{},
+            {std::array{amr::Flag::Undefined}, refined_mesh}, {});
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Amr.Actions.AdjustDomain",
                   "[Unit][ParallelAlgorithms]") {
   test<false>();
   test<true>();
+  test_s1();
 }

--- a/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_EvaluateRefinementCriteria.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Actions/Test_EvaluateRefinementCriteria.cpp
@@ -82,9 +82,12 @@ class BadCriterion : public amr::Criterion {
       const ElementId<Metavariables::volume_dim>& /*element_id*/) const {
     if constexpr (Dim == 1) {
       return std::array{amr::Flag::DecreaseResolution};
-    } else {
+    } else if constexpr (Dim == 2) {
       return std::array{amr::Flag::DecreaseResolution,
                         amr::Flag::IncreaseResolution};
+    } else {
+      return std::array{amr::Flag::DecreaseResolution,
+                        amr::Flag::IncreaseResolution, amr::Flag::DoNothing};
     }
   }
 
@@ -120,12 +123,13 @@ struct Metavariables {
   using component_list = tmpl::list<Component<Metavariables>>;
   struct factory_creation
       : tt::ConformsTo<Options::protocols::FactoryCreation> {
-    using factory_classes = tmpl::map<
-        tmpl::pair<amr::Criterion,
-                   tmpl::list<BadCriterion<volume_dim>,
-                              amr::Criteria::IncreaseResolution<volume_dim>,
-                              amr::Criteria::DriveToTarget<
-                                  volume_dim, amr::Criteria::Type::h>>>>;
+    using factory_classes = tmpl::map<tmpl::pair<
+        amr::Criterion,
+        tmpl::list<
+            BadCriterion<volume_dim>,
+            amr::Criteria::IncreaseResolution<volume_dim>,
+            amr::Criteria::DriveToTarget<volume_dim, amr::Criteria::Type::h>,
+            amr::Criteria::DriveToTarget<volume_dim, amr::Criteria::Type::p>>>>;
   };
 
   struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
@@ -353,7 +357,8 @@ void check_split_while_join_is_avoided() {
 
   Parallel::GlobalCache<metavariables> empty_cache{};
   auto databox = db::create<tmpl::list<::domain::Tags::Mesh<2>>>(mesh);
-  ObservationBox<tmpl::list<>, db::DataBox<tmpl::list<::domain::Tags::Mesh<2>>>>
+  const ObservationBox<tmpl::list<>,
+                       db::DataBox<tmpl::list<::domain::Tags::Mesh<2>>>>
       box{make_not_null(&databox)};
   auto flags_from_criterion =
       criteria.front()->evaluate(box, empty_cache, self_id);
@@ -394,10 +399,99 @@ void check_split_while_join_is_avoided() {
   CHECK(ActionTesting::number_of_queued_simple_actions<my_component>(
             runner, self_id) == 0);
 }
+
+template <bool IgnoreP>
+void check_topology_restrictions_enforced() {
+  CAPTURE(IgnoreP);
+  using metavariables = Metavariables<3, IgnoreP>;
+  using my_component = Component<metavariables>;
+
+  // The part of action we are testing does not depend upon information
+  // from neighbors, so we just use a single Element setup on the root
+  // refinement level
+  const ElementId<3> self_id(0);
+  const Mesh<3> mesh{std::array{2_st, 4_st, 7_st},
+                     Spectral::bases::spherical_shell<>,
+                     Spectral::quadratures::spherical_shell<>};
+  const amr::Info<3> initial_info{make_array<3>(amr::Flag::Undefined),
+                                  Mesh<3>{}};
+  const std::unordered_map<ElementId<3>, amr::Info<3>> initial_neighbor_info{};
+
+  // the refinement criteria wants to drive self to levels (2, 2, 2) so
+  // it will return flags (Split, Split, Split).
+  std::vector<std::unique_ptr<amr::Criterion>> criteria;
+  criteria.emplace_back(
+      std::make_unique<amr::Criteria::DriveToTarget<3, amr::Criteria::Type::h>>(
+          make_array<3>(2_st), make_array<3>(amr::Flag::DoNothing)));
+  // If IgnoreP is false, this criteria will want to drive resolution to
+  // (3, 4, 9)
+  criteria.emplace_back(
+      std::make_unique<amr::Criteria::DriveToTarget<3, amr::Criteria::Type::p>>(
+          std::array{3_st, 4_st, 9_st}, make_array<3>(amr::Flag::DoNothing)));
+
+  Parallel::GlobalCache<metavariables> empty_cache{};
+  auto databox = db::create<tmpl::list<::domain::Tags::Mesh<3>>>(mesh);
+  const ObservationBox<tmpl::list<>,
+                       db::DataBox<tmpl::list<::domain::Tags::Mesh<3>>>>
+      box{make_not_null(&databox)};
+  // Check the raw criteria produce unwanted values
+  const auto flags_from_h_criterion =
+      criteria.front()->evaluate(box, empty_cache, self_id);
+  CHECK(flags_from_h_criterion == make_array<3>(amr::Flag::Split));
+  const auto flags_from_p_criterion =
+      criteria.back()->evaluate(box, empty_cache, self_id);
+  CHECK(flags_from_p_criterion == std::array{amr::Flag::IncreaseResolution,
+                                             amr::Flag::DoNothing,
+                                             amr::Flag::IncreaseResolution});
+
+  ActionTesting::MockRuntimeSystem<metavariables> runner{
+      {std::move(criteria), std::nullopt,
+       amr::Policies{amr::Isotropy::Anisotropic, amr::Limits{}, true, true}}};
+
+  const Element<3> self(self_id, {}, domain::topologies::spherical_shell);
+  ActionTesting::emplace_component_and_initialize<my_component>(
+      &runner, self_id, {self, mesh, initial_info, initial_neighbor_info});
+
+  runner.set_phase(Parallel::Phase::Testing);
+
+  CHECK(ActionTesting::get_databox_tag<my_component, amr::Tags::Info<3>>(
+            runner, self_id) == initial_info);
+  CHECK(
+      ActionTesting::get_databox_tag<my_component, amr::Tags::NeighborInfo<3>>(
+          runner, self_id) == initial_neighbor_info);
+  CHECK(ActionTesting::is_simple_action_queue_empty<my_component>(runner,
+                                                                  self_id));
+
+  // self runs EvaluateAmrCriteria
+  ActionTesting::simple_action<my_component,
+                               amr::Actions::EvaluateRefinementCriteria>(
+      make_not_null(&runner), self_id);
+
+  // check the action correctly resets flags based on topology
+  // If IgonreP is false, IncreaseResolution has higher priority than DoNothing
+  const amr::Info<3> expected_info{
+      std::array{
+          amr::Flag::Split,
+          IgnoreP ? amr::Flag::DoNothing : amr::Flag::IncreaseResolution,
+          IgnoreP ? amr::Flag::DoNothing : amr::Flag::IncreaseResolution},
+      IgnoreP ? mesh
+              : Mesh<3>{std::array{2_st, 5_st, 9_st},
+                        Spectral::bases::spherical_shell<>,
+                        Spectral::quadratures::spherical_shell<>}};
+  CHECK(ActionTesting::get_databox_tag<my_component, amr::Tags::Info<3>>(
+            runner, self_id) == expected_info);
+  CHECK(
+      ActionTesting::get_databox_tag<my_component, amr::Tags::NeighborInfo<3>>(
+          runner, self_id) == initial_neighbor_info);
+  CHECK(ActionTesting::number_of_queued_simple_actions<my_component>(
+            runner, self_id) == 0);
+}
 }  //  namespace
 
 SPECTRE_TEST_CASE("Unit.Amr.Actions.EvaluateRefinementCriteria",
                   "[Unit][ParallelAlgorithms]") {
+  register_factory_classes_with_charm<Metavariables<3, true>>();
+  register_factory_classes_with_charm<Metavariables<3, false>>();
   register_factory_classes_with_charm<Metavariables<2, true>>();
   register_factory_classes_with_charm<Metavariables<1, true>>();
   register_factory_classes_with_charm<Metavariables<1, false>>();
@@ -464,4 +558,6 @@ SPECTRE_TEST_CASE("Unit.Amr.Actions.EvaluateRefinementCriteria",
   }
 #endif
   check_split_while_join_is_avoided();
+  check_topology_restrictions_enforced<true>();
+  check_topology_restrictions_enforced<false>();
 }

--- a/tests/Unit/ParallelAlgorithms/Amr/Projectors/Test_Mesh.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Projectors/Test_Mesh.cpp
@@ -169,10 +169,28 @@ void test_mesh_3d() {
 #endif
 }
 
+template <size_t Dim>
+void test_equiangular_mesh() {
+  const auto refine = make_array<Dim>(amr::Flag::IncreaseResolution);
+  const auto coarsen = make_array<Dim>(amr::Flag::DecreaseResolution);
+  const auto stay = make_array<Dim>(amr::Flag::DoNothing);
+  Mesh<Dim> mesh_3{make_array<Dim>(3_st), Spectral::bases::hypertorus<Dim>,
+                   Spectral::quadratures::hypertorus<Dim>};
+  Mesh<Dim> mesh_5{make_array<Dim>(5_st), Spectral::bases::hypertorus<Dim>,
+                   Spectral::quadratures::hypertorus<Dim>};
+  Mesh<Dim> mesh_7{make_array<Dim>(7_st), Spectral::bases::hypertorus<Dim>,
+                   Spectral::quadratures::hypertorus<Dim>};
+  CHECK(amr::projectors::mesh(mesh_5, refine) == mesh_7);
+  CHECK(amr::projectors::mesh(mesh_5, coarsen) == mesh_3);
+  CHECK(amr::projectors::mesh(mesh_5, stay) == mesh_5);
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Amr.Projectors.Mesh", "[ParallelAlgorithms][Unit]") {
   test_mesh_1d();
   test_mesh_2d();
   test_mesh_3d();
+  test_equiangular_mesh<1>();
+  test_equiangular_mesh<2>();
+  test_equiangular_mesh<3>();
 }


### PR DESCRIPTION
## Proposed changes

- Add functions to enforce AMR restrictions from topologies by changing the decision made by a AMR criterion, notably:
  - Prevent angular topologies (e.g. S1, S2) from h-refining
  - Prevent cartoon topologies from h- or p-refining
  - Keep multi-dimensional topologies (e.g. S2, B2, B3) in sync in their coupled dimensions when p-refining
- Update amr::projectors::mesh to changes the extents for Spectral::Quadrature::Equiangular by two rather than one when p-refining
- Fix a bug in AdjustElement that caused a p-refined Element to change its topology 

There are more changes coming to handle h-refinement for the new topologies, but these changes may be sufficient for the mechanics of p-refinement to work on the new topologies.


### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
