### PR TITLE
Allow any coding agent in PR template co-author checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,11 +24,11 @@ lines below.
   [code review guide](https://spectre-code.org/code_review_guide.html).
 - [ ] The PR lists upgrade instructions and is labeled `bugfix` or
   `new feature` if appropriate.
-- [ ] If a coding agent is used, have one of
-      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
+- [ ] If a coding agent was used, have a co-author trailer of the form
+      "Co-Authored-By: <agent name> <agent email>" as the last line of the
+      commit, e.g. "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
       "Co-Authored-by: Codex <noreply@openai.com>", or
-      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
-      as the last line of the commit, depending on the agent.
+      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>".
 
 ### Further comments
 


### PR DESCRIPTION
Fable keeps being sad that only Sonnet is allowed in the PR text, so I thought I would try and make it happy.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
