### PR TITLE
Fix Taylor series in ControlErrors/Size.hpp

### DIFF
--- a/src/ControlSystem/ControlErrors/Size.hpp
+++ b/src/ControlSystem/ControlErrors/Size.hpp
@@ -37,6 +37,7 @@
 #include "Parallel/Printf/Printf.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Surfaces/Tags.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
@@ -458,11 +459,15 @@ struct Size : tt::ConformsTo<protocols::ControlError> {
       const double d2t_horizon_00 =
           averaged_horizon_coef_at_average_time.value()[2][0];
 
-      // Must account for time offset of averaged time. Do a simple Taylor
-      // expansion
+      // Taylor expand from the averaged time t_avg to the current time t,
+      // where time_diff = t - t_avg:
+      // h(t) = h(t_avg) + time_diff * h'(t_avg)
+      //        + 0.5 * time_diff^2 * h''(t_avg),
+      // h'(t) = h'(t_avg) + time_diff * h''(t_avg).
       const double time_diff = time - averaged_time;
-      horizon_00 += time_diff * dt_horizon_00;
-      dt_horizon_00 += 0.5 * square(time_diff) * d2t_horizon_00;
+      horizon_00 +=
+          time_diff * dt_horizon_00 + 0.5 * square(time_diff) * d2t_horizon_00;
+      dt_horizon_00 += time_diff * d2t_horizon_00;
 
       // The "control error" for the averaged horizon coefficients is just the
       // averaged coefs minus the actual coef and time derivative from

--- a/tests/Unit/ControlSystem/ControlErrors/Test_SizeError.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_SizeError.cpp
@@ -45,6 +45,7 @@
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Solutions.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/TMPL.hpp"
@@ -376,11 +377,9 @@ void test_size_error_one_step(
     const auto control_error_history = error_class.control_error_history();
 
     // These should be identical because the control error class calls the
-    // control_error function. The horizon smoothing averager would normally
-    // make this slightly different, but it needs a few times before it can do
-    // anything. Therefore, the smoothing aspect of the control error from class
-    // is not tested yet. So in the meantime, the initial values for the horizon
-    // coef and its derivatives are the ones specified above
+    // control_error function. The horizon smoothing averager needs several
+    // measurements before it can act, so this first call uses the raw horizon
+    // coefficient and derivative specified above.
     CHECK(control_error_from_class == error.control_error);
 
     CHECK_FALSE(error_class.get_suggested_timescale().has_value());
@@ -429,6 +428,101 @@ void test_size_error_one_step(
     CHECK_FALSE(error_class.get_suggested_timescale().has_value());
     CHECK_FALSE(error_class.discontinuous_change_has_occurred());
     CHECK(control_error_history.empty());
+
+    // The DeltaR state's output is control_error_delta_r itself, which is used
+    // in the following test of the Taylor series used in computing size error
+    if constexpr (std::is_same_v<FinalState,
+                                 control_system::size::States::DeltaR>) {
+      // This instance holds its smoothing timescale fixed at 0.2, so
+      // its private averager can be reproduced independently below.
+      auto smoothing_error_class =
+          size_error{4,
+                     0.25,
+                     TimescaleTuner<true>{std::vector<double>{0.2}, 20.0,
+                                          1.0e-4, 2.5e-4, 1.0, 1.0e-3, 1.0},
+                     std::make_unique<control_system::size::States::Initial>(),
+                     std::nullopt,
+                     std::nullopt};
+      const auto smoother_timescale = DataVector{1, 0.2};
+      auto mirror_horizon_averager = Averager<2>{0.25, true};
+
+      // A quadratic horizon has the nonzero second derivative needed to
+      // test the Taylor series expansion of the horizon coefs used when
+      // computing size error. Three samples build enough history. The fourth
+      // sample produces the nonzero time offset needed to test the
+      // extrapolation.
+      constexpr double horizon_acceleration = 0.2;
+      constexpr size_t number_of_measurements = 4;
+      for (size_t step = 0; step < number_of_measurements; ++step) {
+        const double time_offset = 0.1 * static_cast<double>(step);
+        const double current_time = time + time_offset;
+        const auto current_horizon = ylm::Strahlkorper<Frame::Distorted>{
+            l_max,
+            distorted_horizon_radius +
+                distorted_horizon_velocity * time_offset +
+                0.5 * horizon_acceleration * square(time_offset),
+            center};
+        const auto current_time_deriv_horizon =
+            ylm::Strahlkorper<Frame::Distorted>{
+                l_max,
+                distorted_horizon_velocity + horizon_acceleration * time_offset,
+                center};
+
+        // Pass the analytic horizon and its time derivative to the
+        // production measurement tuple.
+        auto& horizon_measurements =
+            tuples::get<HorizonQuantities>(measurements);
+        tuples::get<ylm::Tags::Strahlkorper<Frame::Distorted>>(
+            horizon_measurements) = current_horizon;
+        tuples::get<::Tags::dt<ylm::Tags::Strahlkorper<Frame::Distorted>>>(
+            horizon_measurements) = current_time_deriv_horizon;
+
+        // Update Mirror Size's averager. Until there is enough history, both
+        // paths use the raw horizon coefficients at the measurement time.
+        mirror_horizon_averager.update(
+            current_time, DataVector{current_horizon.coefficients()[0]},
+            smoother_timescale);
+        const double smoothed_control_error = smoothing_error_class(
+            tuner, cache, current_time, "Size"s, measurements)[0];
+
+        // The first three measurements only build the history needed by the
+        // averagers. Check the result once the fourth measurement produces a
+        // retarded effective time.
+        if (step + 1 < number_of_measurements) {
+          continue;
+        }
+
+        CAPTURE(current_time);
+        const auto& averaged_horizon = mirror_horizon_averager(current_time);
+        REQUIRE(averaged_horizon.has_value());
+        const auto& averaged_horizon_values = averaged_horizon.value();
+        const double average_time =
+            mirror_horizon_averager.average_time(current_time);
+        const double time_from_average = current_time - average_time;
+        CHECK(time_from_average > 0.0);
+
+        // The averager returns the horizon and its derivatives at its effective
+        // time. Extrapolate them to the measurement time just as Size should
+        // before it evaluates the DeltaR control error.
+        const double horizon_00 =
+            averaged_horizon_values[0][0] +
+            time_from_average * averaged_horizon_values[1][0] +
+            0.5 * square(time_from_average) * averaged_horizon_values[2][0];
+        const double dt_horizon_00 =
+            averaged_horizon_values[1][0] +
+            time_from_average * averaged_horizon_values[2][0];
+
+        const auto current_lambda_dt_lambda =
+            function_of_time->func_and_deriv(current_time);
+        // In the DeltaR state this is the class's expected output
+        const double expected_control_error_delta_r =
+            control_system::size::control_error_delta_r(
+                horizon_00, dt_horizon_00, current_lambda_dt_lambda[0][0],
+                current_lambda_dt_lambda[1][0], grid_excision_boundary_radius);
+
+        CHECK(smoothed_control_error == approx(expected_control_error_delta_r));
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Proposed changes

It looks to me like the Taylor series expansion in `ControlErrors/Size.hpp` is incorrect. 

Call `horizon_00` $h(t)$. Then I would have thought the Taylor series would be $h(t) = h_(t_{\rm avg}) + h^\prime(t_{\rm avg}) (t - t_{\rm avg}) + \frac{1}{2} h^{\prime \prime}(t_{\rm avg}) (t - t_{\rm avg})^2$ and $h^\prime(t) = h^\prime(t_{\rm avg}) + h^{\prime \prime}(t_{\rm avg}) (t-t_{\rm avg})$. 

But the existing implementation has $h(t) = h_(t_{\rm avg}) + h^\prime(t_{\rm avg}) (t - t_{\rm avg})$ and $h^\prime(t) = h^\prime(t_{\rm avg}) + \frac{1}{2} h^{\prime \prime}(t_{\rm avg}) (t - t_{\rm avg})^2$.

Codex first pointed me to this code, but when I looked at it, it looks incorrect to me, too, unless I'm missing something?

I'm not sure what affect, if any, this would have, if it is in fact a bug.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [x] If a coding agent was used, have a co-author trailer of the form
      "Co-Authored-By: <agent name> <agent email>" as the last line of the
      commit, e.g. "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>".

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
