### PR TITLE
Support filled / hollow sphere mortar equality

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/Actions/ApplyBoundaryCorrections.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/ApplyBoundaryCorrections.hpp
@@ -267,7 +267,8 @@ bool receive_boundary_data(
       const auto& direction = received_mortar_id.direction();
       const auto& neighbor_mesh = received_mortar_data.volume_mesh;
       const size_t sliced_away_dim = direction.dimension();
-      const Mesh<face_dim> face_mesh = volume_mesh.slice_away(sliced_away_dim);
+      const Mesh<face_dim> face_mesh =
+          volume_mesh.on_interface(sliced_away_dim);
       // If there are multiple non-conforming neighbors, there is only a
       // single mortar labeled by the host ElementId.  This is done
       // because the data from all neighbors will be combined onto a
@@ -328,7 +329,7 @@ bool receive_boundary_data(
                 neighbor_meshes->insert_or_assign(received_mortar_id,
                                                   neighbor_mesh);
                 const Mesh<face_dim> neighbor_face_mesh =
-                    received_mortar_data.volume_mesh.slice_away(
+                    received_mortar_data.volume_mesh.on_interface(
                         sliced_away_dim);
                 const Mesh<face_dim> mortar_mesh =
                     ::dg::mortar_mesh(face_mesh, neighbor_face_mesh);
@@ -959,7 +960,7 @@ struct ApplyBoundaryCorrections {
             }
 
             const Mesh<volume_dim - 1> face_mesh =
-                volume_mesh.slice_away(direction.dimension());
+                volume_mesh.on_interface(direction.dimension());
 
             // Whether the mesh has a collocation point on this face. True for
             // GaussLobatto (points on both faces) and GaussRadauUpper (point

--- a/src/Evolution/DiscontinuousGalerkin/Actions/ApplyBoundaryCorrections.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/ApplyBoundaryCorrections.hpp
@@ -947,15 +947,17 @@ struct ApplyBoundaryCorrections {
                      "instead. You may have unintentionally added external "
                      "mortars in one of the initialization actions.");
             }
-            if (volume_mesh.basis(direction.dimension()) ==
-                    Spectral::Basis::ZernikeB2 and
-                volume_mesh.quadrature(direction.dimension()) ==
-                    Spectral::Quadrature::GaussRadauUpper and
-                direction.side() != Side::Upper) {
+            if (UNLIKELY((volume_mesh.basis(direction.dimension()) ==
+                              Spectral::Basis::ZernikeB2 or
+                          volume_mesh.basis(direction.dimension()) ==
+                              Spectral::Basis::ZernikeB3) and
+                         volume_mesh.quadrature(direction.dimension()) ==
+                             Spectral::Quadrature::GaussRadauUpper and
+                         direction.side() != Side::Upper)) {
               ERROR(
-                  "Trying to use ZernikeB2 basis with GaussRadauUpper "
-                  "quadrature on the lower side: there is not a boundary here. "
-                  "volume mesh: "
+                  "Trying to use ZernikeB2 or ZernikeB3 basis with "
+                  "GaussRadauUpper quadrature on the lower side: there is not "
+                  "a boundary here. volume mesh: "
                   << volume_mesh << ", element ID " << element.id());
             }
 

--- a/src/Evolution/DiscontinuousGalerkin/Actions/InternalMortarDataImpl.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/InternalMortarDataImpl.hpp
@@ -95,7 +95,7 @@ void internal_mortar_data_impl(
   std::optional<tnsr::I<DataVector, Dim>> face_mesh_velocity{};
   for (const auto& [direction, neighbors_in_direction] : element.neighbors()) {
     const Mesh<Dim - 1> face_mesh =
-        volume_mesh.slice_away(direction.dimension());
+        volume_mesh.on_interface(direction.dimension());
 
     // The face_temporaries buffer is guaranteed to be big enough because we
     // allocated it in ComputeTimeDerivative with the max number of grid points

--- a/src/Evolution/DiscontinuousGalerkin/Initialization/Mortars.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/Initialization/Mortars.cpp
@@ -141,8 +141,8 @@ template <size_t Dim>
                     {.interpolator =
                          ::dg::MortarInterpolator<Dim>{
                              element.id(), mortar_id, domain,
-                             volume_mesh.slice_away(direction.dimension()),
-                             neighbor_mesh.at(mortar_id).slice_away(
+                             volume_mesh.on_interface(direction.dimension()),
+                             neighbor_mesh.at(mortar_id).on_interface(
                                  neighbor_orientation(direction.dimension()))},
                      .interface_data_policy =
                          InterfaceDataPolicy::NonconformingSelfInterpolates,
@@ -191,7 +191,7 @@ mortars_apply_impl(const Element<Dim>& element,
   for (const auto& [direction, neighbors] : element.neighbors()) {
     normal_covector_quantities[direction] = std::nullopt;
     const Mesh<Dim - 1> face_mesh =
-        volume_mesh.slice_away(direction.dimension());
+        volume_mesh.on_interface(direction.dimension());
     const domain::FaceType face_type = element.face_types().at(direction);
     switch (face_type) {
       // NOLINTNEXTLINE(bugprone-branch-clone)
@@ -212,9 +212,10 @@ mortars_apply_impl(const Element<Dim>& element,
         for (const auto& neighbor : neighbors) {
           const DirectionalId<Dim> mortar_id{direction, neighbor};
           mortar_meshes.emplace(
-              mortar_id, ::dg::mortar_mesh(
-                             face_mesh, neighbor_mesh.at(mortar_id).slice_away(
-                                            direction.dimension())));
+              mortar_id,
+              ::dg::mortar_mesh(face_mesh,
+                                neighbor_mesh.at(mortar_id).on_interface(
+                                    direction.dimension())));
           // Since no communication needs to happen for boundary conditions
           // the temporal id is not advanced on the boundary, so we only need
           // to initialize it on internal boundaries
@@ -288,12 +289,12 @@ void h_refine_structure(
                domain::FaceType::MultipleNonconforming,
            "This code needs updating to handle nonconforming blocks");
     const auto sliced_away_dimension = direction.dimension();
-    const auto new_face_mesh = new_mesh.slice_away(sliced_away_dimension);
+    const auto new_face_mesh = new_mesh.on_interface(sliced_away_dimension);
     for (const auto& neighbor : neighbors) {
       const DirectionalId<Dim> mortar_id{direction, neighbor};
       const auto& new_neighbor_mesh = neighbor_mesh.at(mortar_id);
       const auto new_mortar_mesh = ::dg::mortar_mesh(
-          new_face_mesh, new_neighbor_mesh.slice_away(sliced_away_dimension));
+          new_face_mesh, new_neighbor_mesh.on_interface(sliced_away_dimension));
       mortar_mesh->emplace(mortar_id, new_mortar_mesh);
       // We only do h refinement at a slab boundary, so we know all
       // the neighbors are aligned with us temporally.
@@ -392,8 +393,8 @@ void ProjectMortars<Dim>::apply(
                domain::FaceType::MultipleNonconforming,
            "This code needs updating to handle nonconforming blocks");
     const auto sliced_away_dimension = direction.dimension();
-    const auto old_face_mesh = old_mesh.slice_away(sliced_away_dimension);
-    const auto new_face_mesh = new_mesh.slice_away(sliced_away_dimension);
+    const auto old_face_mesh = old_mesh.on_interface(sliced_away_dimension);
+    const auto new_face_mesh = new_mesh.on_interface(sliced_away_dimension);
     const bool face_mesh_changed = old_face_mesh != new_face_mesh;
     if (face_mesh_changed) {
       (*normal_covector_and_magnitude)[direction] = std::nullopt;
@@ -402,7 +403,7 @@ void ProjectMortars<Dim>::apply(
       const DirectionalId<Dim> mortar_id{direction, neighbor};
       const auto& new_neighbor_mesh = neighbor_mesh.at(mortar_id);
       const auto new_mortar_mesh = ::dg::mortar_mesh(
-          new_face_mesh, new_neighbor_mesh.slice_away(sliced_away_dimension));
+          new_face_mesh, new_neighbor_mesh.on_interface(sliced_away_dimension));
       if (mortar_mesh->contains(mortar_id)) {
         // Set the mortar mesh, but do not project any existing mesh
         // data.  The mesh needs to have a valid value in order to
@@ -514,8 +515,8 @@ void ProjectMortars<Dim>::apply(
 
   for (const auto& direction : new_element.external_boundaries()) {
     const auto sliced_away_dimension = direction.dimension();
-    const auto old_face_mesh = old_mesh.slice_away(sliced_away_dimension);
-    const auto new_face_mesh = new_mesh.slice_away(sliced_away_dimension);
+    const auto old_face_mesh = old_mesh.on_interface(sliced_away_dimension);
+    const auto new_face_mesh = new_mesh.on_interface(sliced_away_dimension);
     const bool face_mesh_changed = old_face_mesh != new_face_mesh;
     if (face_mesh_changed) {
       (*normal_covector_and_magnitude)[direction] = std::nullopt;

--- a/src/NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.cpp
+++ b/src/NumericalAlgorithms/DiscontinuousGalerkin/MortarHelpers.cpp
@@ -11,7 +11,6 @@
 #include "Domain/Structure/Side.hpp"
 #include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
-#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
 #include "NumericalAlgorithms/Spectral/SegmentSize.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
@@ -26,19 +25,11 @@ Mesh<Dim> mortar_mesh(const Mesh<Dim>& face_mesh1,
   } else {
     Index<Dim> mortar_extents{};
     for (size_t i = 0; i < Dim; ++i) {
-      // From the point of view of mortars, ZernikeB2 with Equiangular
-      // quadrature are identical to Fourier with Equiangular quadrature
-      ASSERT(
-          face_mesh1.basis(i) == face_mesh2.basis(i) or
-              (face_mesh1.quadrature(i) == Spectral::Quadrature::Equiangular and
-               ((face_mesh1.basis(i) == Spectral::Basis::ZernikeB2 and
-                 face_mesh2.basis(i) == Spectral::Basis::Fourier) or
-                (face_mesh1.basis(i) == Spectral::Basis::Fourier and
-                 face_mesh2.basis(i) == Spectral::Basis::ZernikeB2))),
-          "The basis on face_mesh1 and face_mesh2 must be equal in "
-          "direction "
-              << i << " but face_mesh1 is " << face_mesh1.basis(i)
-              << " while face_mesh2 is " << face_mesh2.basis(i));
+      ASSERT(face_mesh1.basis(i) == face_mesh2.basis(i),
+             "The basis on face_mesh1 and face_mesh2 must be equal in "
+             "direction "
+                 << i << " but face_mesh1 is " << face_mesh1.basis(i)
+                 << " while face_mesh2 is " << face_mesh2.basis(i));
       ASSERT(face_mesh1.quadrature(i) == face_mesh2.quadrature(i),
              "The quadrature on face_mesh1 and face_mesh2 must be equal in "
              "direction "

--- a/src/NumericalAlgorithms/Spectral/Mesh.cpp
+++ b/src/NumericalAlgorithms/Spectral/Mesh.cpp
@@ -227,6 +227,49 @@ Mesh<Dim - 1> Mesh<Dim>::slice_away(const size_t d) const {
 }
 
 template <size_t Dim>
+// clang-tidy: incorrectly reported redundancy in template expression
+template <size_t N, Requires<(N > 0 and N == Dim)>>  // NOLINT
+Mesh<Dim - 1> Mesh<Dim>::on_interface(const size_t d) const {
+  auto face = slice_away(d);
+  // The outer boundary of a B3 ball (B2 disk) is an S2 (S1): convert the
+  // remaining ZernikeB3 (ZernikeB2) angular bases to SphericalHarmonic
+  // (Fourier) so that the face mesh has the correct basis for the boundary.
+  if (basis(d) == Spectral::Basis::ZernikeB3) {
+    ASSERT(Dim == 3, "ZernikeB3 should only be used on 3D meshes, got " << Dim);
+    // Can't test interface direction is upper, but that is also an assumption
+    ASSERT(d == 0 and quadrature(d) == Spectral::Quadrature::GaussRadauUpper,
+           "A mesh using B3 only has an interface when sliced in the first "
+           "dimension (not in angular directions), got "
+               << d);
+    ASSERT(basis() == make_array<Dim>(Spectral::Basis::ZernikeB3),
+           "Mesh is using ZernikeB3 basis in a nonisotropic manner, got "
+               << basis());
+    return {face.extents().indices(),
+            make_array<Dim - 1>(Spectral::Basis::SphericalHarmonic),
+            face.quadrature()};
+  }
+  if (basis(d) == Spectral::Basis::ZernikeB2) {
+    ASSERT(Dim == 2 or Dim == 3,
+           "ZernikeB2 should only be used on 2D or 3D meshes, got " << Dim);
+    // Can't test interface direction is upper, but that is also an assumption
+    ASSERT(d == 0 and quadrature(d) == Spectral::Quadrature::GaussRadauUpper,
+           "A mesh using B2 only has an interface when sliced in the first "
+           "dimension (not in angular direction), got "
+               << d);
+    ASSERT(basis(0) == Spectral::Basis::ZernikeB2 and
+               basis(1) == Spectral::Basis::ZernikeB2,
+           "Mesh does not have ZernikeB2 for the first two bases, got "
+               << basis());
+    auto bases = face.basis();
+    if constexpr (Dim > 1) {
+      bases[0] = Spectral::Basis::Fourier;
+    }
+    return {face.extents().indices(), bases, face.quadrature()};
+  }
+  return face;
+}
+
+template <size_t Dim>
 template <size_t SliceDim, Requires<(SliceDim <= Dim)>>
 Mesh<SliceDim> Mesh<Dim>::slice_through(
     const std::array<size_t, SliceDim>& dims) const {
@@ -306,8 +349,11 @@ std::ostream& operator<<(std::ostream& os, const Mesh<Dim>& mesh) {
                                     const Mesh<DIM(data)>& mesh); \
   template bool is_isotropic(const Mesh<DIM(data)>& mesh);
 
-#define INSTANTIATE_SLICE_AWAY(_, data) \
-  template Mesh<DIM(data) - 1> Mesh<DIM(data)>::slice_away(const size_t) const;
+#define INSTANTIATE_SLICE_AWAY(_, data)                                    \
+  template Mesh<DIM(data) - 1> Mesh<DIM(data)>::slice_away(const size_t)   \
+      const;                                                               \
+  template Mesh<DIM(data) - 1> Mesh<DIM(data)>::on_interface(const size_t) \
+      const;
 template Mesh<0> Mesh<0>::slice_through(const std::array<size_t, 0>&) const;
 template Mesh<0> Mesh<1>::slice_through(const std::array<size_t, 0>&) const;
 template Mesh<1> Mesh<1>::slice_through(const std::array<size_t, 1>&) const;

--- a/src/NumericalAlgorithms/Spectral/Mesh.hpp
+++ b/src/NumericalAlgorithms/Spectral/Mesh.hpp
@@ -194,6 +194,21 @@ class Mesh {
   Mesh<Dim - 1> slice_away(size_t d) const;
 
   /*!
+   * \brief Returns the interface Mesh for a DG boundary in direction \p d.
+   *
+   * \details Unlike `slice_away`, this function converts ZernikeB3 (ZernikeB2)
+   * angular bases to SphericalHarmonic (Fourier) when slicing away the radial
+   * dimension of a B3 ball (B2 disk), reflecting the fact that the outer
+   * boundary of a B3 ball (B2 disk) is geometrically an S2 (S1) and shares its
+   * collocation points with SphericalHarmonic (Fourier).
+   *
+   * \see slice_away()
+   */
+  // clang-tidy: incorrectly reported redundancy in template expression
+  template <size_t N = Dim, Requires<(N > 0 and N == Dim)> = nullptr>  // NOLINT
+  Mesh<Dim - 1> on_interface(size_t d) const;
+
+  /*!
    * \brief Returns a Mesh with the dimensions \p d, ... present (zero-indexed).
    *
    * \details Generally you use this method to obtain a lower-dimensional Mesh

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_MortarHelpers.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_MortarHelpers.cpp
@@ -46,21 +46,6 @@ void test_mortar_mesh() {
         lgl_mesh<1>({{5}}));
   CHECK(dg::mortar_mesh(lgl_mesh<2>({{2, 5}}), lgl_mesh<2>({{3, 4}})) ==
         lgl_mesh<2>({{3, 5}}));
-  CHECK(
-      dg::mortar_mesh(Mesh<2>({{3, 4}},
-                              std::array{Spectral::Basis::Legendre,
-                                         Spectral::Basis::ZernikeB2},
-                              std::array{Spectral::Quadrature::GaussLobatto,
-                                         Spectral::Quadrature::Equiangular}),
-                      Mesh<2>({{5, 6}},
-                              std::array{Spectral::Basis::Legendre,
-                                         Spectral::Basis::Fourier},
-                              std::array{Spectral::Quadrature::GaussLobatto,
-                                         Spectral::Quadrature::Equiangular})) ==
-      Mesh<2>({{5, 6}},
-              std::array{Spectral::Basis::Legendre, Spectral::Basis::ZernikeB2},
-              std::array{Spectral::Quadrature::GaussLobatto,
-                         Spectral::Quadrature::Equiangular}));
 #ifdef SPECTRE_DEBUG
   CHECK_THROWS_WITH(
       dg::mortar_mesh(Mesh<2>({{3, 4}},

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_MortarHelpers.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_MortarHelpers.cpp
@@ -30,6 +30,7 @@
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
 #include "Utilities/StdArrayHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -46,6 +47,20 @@ void test_mortar_mesh() {
         lgl_mesh<1>({{5}}));
   CHECK(dg::mortar_mesh(lgl_mesh<2>({{2, 5}}), lgl_mesh<2>({{3, 4}})) ==
         lgl_mesh<2>({{3, 5}}));
+  // B3 ball / shell interface: the B3 face mesh (from on_interface()) uses
+  // SphericalHarmonic and must match the shell face mesh.
+  const Mesh<3> b3_volume_mesh{
+      {{3, 5, 9}},
+      make_array<3>(Spectral::Basis::ZernikeB3),
+      {{Spectral::Quadrature::GaussRadauUpper, Spectral::Quadrature::Gauss,
+        Spectral::Quadrature::Equiangular}}};
+  const Mesh<2> b3_face_mesh = b3_volume_mesh.on_interface(0);
+  const Mesh<2> shell_face_mesh{
+      {{5, 9}},
+      make_array<2>(Spectral::Basis::SphericalHarmonic),
+      {{Spectral::Quadrature::Gauss, Spectral::Quadrature::Equiangular}}};
+  CHECK(b3_face_mesh == shell_face_mesh);
+  CHECK(dg::mortar_mesh(b3_face_mesh, shell_face_mesh) == shell_face_mesh);
 #ifdef SPECTRE_DEBUG
   CHECK_THROWS_WITH(
       dg::mortar_mesh(Mesh<2>({{3, 4}},

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_Mesh.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_Mesh.cpp
@@ -20,6 +20,7 @@
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/GetOutput.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/MakeArray.hpp"
 #include "Utilities/StdHelpers.hpp"
 
 namespace {
@@ -164,6 +165,134 @@ void test_explicit_choices_per_dimension() {
                 {{Spectral::Quadrature::GaussLobatto,
                   Spectral::Quadrature::GaussLobatto,
                   Spectral::Quadrature::Gauss}}});
+}
+
+void test_interface_mesh() {
+  INFO("interface mesh");
+  // Non-Bn meshes: on_interface == slice_away
+  const Mesh<3> mesh3d{
+      {{2, 3, 4}},
+      {{Spectral::Basis::Legendre, Spectral::Basis::Legendre,
+        Spectral::Basis::Fourier}},
+      {{Spectral::Quadrature::GaussLobatto, Spectral::Quadrature::GaussLobatto,
+        Spectral::Quadrature::Equiangular}}};
+  CHECK(mesh3d.on_interface(0) == mesh3d.slice_away(0));
+  CHECK(mesh3d.on_interface(1) == mesh3d.slice_away(1));
+  CHECK(mesh3d.on_interface(2) == mesh3d.slice_away(2));
+
+  // B3 ball: slicing away the radial dimension converts ZernikeB3 angular bases
+  // to SphericalHarmonic.
+  const Mesh<3> b3_mesh{
+      {{4, 5, 9}},
+      make_array<3>(Spectral::Basis::ZernikeB3),
+      {{Spectral::Quadrature::GaussRadauUpper, Spectral::Quadrature::Gauss,
+        Spectral::Quadrature::Equiangular}}};
+  CHECK(b3_mesh.on_interface(0) ==
+        Mesh<2>({{5, 9}},
+                std::array{Spectral::Basis::SphericalHarmonic,
+                           Spectral::Basis::SphericalHarmonic},
+                std::array{Spectral::Quadrature::Gauss,
+                           Spectral::Quadrature::Equiangular}));
+
+  // B2 disk: slicing away the radial dimension converts ZernikeB2 to Fourier.
+  const Mesh<2> b2_mesh{{{3, 7}},
+                        make_array<2>(Spectral::Basis::ZernikeB2),
+                        {{Spectral::Quadrature::GaussRadauUpper,
+                          Spectral::Quadrature::Equiangular}}};
+  CHECK(b2_mesh.on_interface(0) == Mesh<1>{7, Spectral::Basis::Fourier,
+                                           Spectral::Quadrature::Equiangular});
+
+  // B2 cylinder (mixed bases): only ZernikeB2 dims are converted.
+  const Mesh<3> b2_cyl_mesh{
+      {{3, 7, 5}},
+      {{Spectral::Basis::ZernikeB2, Spectral::Basis::ZernikeB2,
+        Spectral::Basis::Legendre}},
+      {{Spectral::Quadrature::GaussRadauUpper,
+        Spectral::Quadrature::Equiangular,
+        Spectral::Quadrature::GaussLobatto}}};
+  CHECK(b2_cyl_mesh.on_interface(0) ==
+        Mesh<2>({{7, 5}},
+                std::array{Spectral::Basis::Fourier, Spectral::Basis::Legendre},
+                std::array{Spectral::Quadrature::Equiangular,
+                           Spectral::Quadrature::GaussLobatto}));
+
+#ifdef SPECTRE_DEBUG
+  // B3: wrong Dim
+  CHECK_THROWS_WITH((Mesh<2>{{{3, 7}},
+                             make_array<2>(Spectral::Basis::ZernikeB3),
+                             {{Spectral::Quadrature::GaussRadauUpper,
+                               Spectral::Quadrature::Gauss}}}
+                         .on_interface(0)),
+                    Catch::Matchers::ContainsSubstring(
+                        "ZernikeB3 should only be used on 3D meshes"));
+  // B3: slicing an angular direction
+  CHECK_THROWS_WITH(
+      (Mesh<3>{
+          {{4, 5, 9}},
+          make_array<3>(Spectral::Basis::ZernikeB3),
+          {{Spectral::Quadrature::GaussRadauUpper, Spectral::Quadrature::Gauss,
+            Spectral::Quadrature::Equiangular}}}
+           .on_interface(1)),
+      Catch::Matchers::ContainsSubstring(
+          "A mesh using B3 only has an interface when sliced in the first "
+          "dimension"));
+  // B3: radial dimension does not use GaussRadauUpper
+  CHECK_THROWS_WITH(
+      (Mesh<3>{{{4, 5, 9}},
+               make_array<3>(Spectral::Basis::ZernikeB3),
+               {{Spectral::Quadrature::Gauss, Spectral::Quadrature::Gauss,
+                 Spectral::Quadrature::Equiangular}}}
+           .on_interface(0)),
+      Catch::Matchers::ContainsSubstring(
+          "A mesh using B3 only has an interface when sliced in the first "
+          "dimension"));
+  // B3: non-isotropic bases
+  CHECK_THROWS_WITH(
+      (Mesh<3>{
+          {{4, 5, 9}},
+          {{Spectral::Basis::ZernikeB3, Spectral::Basis::Legendre,
+            Spectral::Basis::Legendre}},
+          {{Spectral::Quadrature::GaussRadauUpper, Spectral::Quadrature::Gauss,
+            Spectral::Quadrature::GaussLobatto}}}
+           .on_interface(0)),
+      Catch::Matchers::ContainsSubstring(
+          "Mesh is using ZernikeB3 basis in a nonisotropic manner"));
+  // B2: wrong Dim
+  CHECK_THROWS_WITH((Mesh<1>{3, Spectral::Basis::ZernikeB2,
+                             Spectral::Quadrature::GaussRadauUpper}
+                         .on_interface(0)),
+                    Catch::Matchers::ContainsSubstring(
+                        "ZernikeB2 should only be used on 2D or 3D meshes"));
+  // B2: slicing an angular direction
+  CHECK_THROWS_WITH(
+      (Mesh<2>{{{3, 7}},
+               make_array<2>(Spectral::Basis::ZernikeB2),
+               {{Spectral::Quadrature::GaussRadauUpper,
+                 Spectral::Quadrature::Equiangular}}}
+           .on_interface(1)),
+      Catch::Matchers::ContainsSubstring(
+          "A mesh using B2 only has an interface when sliced in the first "
+          "dimension"));
+  // B2: radial dimension does not use GaussRadauUpper
+  CHECK_THROWS_WITH(
+      (Mesh<2>{
+          {{3, 7}},
+          make_array<2>(Spectral::Basis::ZernikeB2),
+          {{Spectral::Quadrature::Gauss, Spectral::Quadrature::Equiangular}}}
+           .on_interface(0)),
+      Catch::Matchers::ContainsSubstring(
+          "A mesh using B2 only has an interface when sliced in the first "
+          "dimension"));
+  // B2: first two bases are not both ZernikeB2
+  CHECK_THROWS_WITH(
+      (Mesh<2>{{{3, 7}},
+               {{Spectral::Basis::ZernikeB2, Spectral::Basis::Legendre}},
+               {{Spectral::Quadrature::GaussRadauUpper,
+                 Spectral::Quadrature::Gauss}}}
+           .on_interface(0)),
+      Catch::Matchers::ContainsSubstring(
+          "Mesh does not have ZernikeB2 for the first two bases"));
+#endif  // SPECTRE_DEBUG
 }
 
 void test_equality() {
@@ -342,6 +471,7 @@ SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Spectral.Mesh",
                   "[NumericalAlgorithms][Spectral][Unit]") {
   test_uniform_lgl_mesh();
   test_explicit_choices_per_dimension();
+  test_interface_mesh();
   test_equality();
   test_serialization();
   test_option_parsing<1>();


### PR DESCRIPTION

## Proposed changes

Add `.on_interface()` member function to Mesh. It converts B3 $\to$ S2 and B2 $\to$ S1 on boundaries.

It is used for mortar and boundary code where the mesh should reflect this basis change (whereas some places only care about number of grid points, and some places should know the true basis)

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent was used, have a co-author trailer of the form
      "Co-Authored-By: <agent name> <agent email>" as the last line of the
      commit, e.g. "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>".

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
