### PR TITLE
brigand: Prevent invalid instantiations in erase

### DIFF
--- a/external/brigand/include/brigand/brigand.hpp
+++ b/external/brigand/include/brigand/brigand.hpp
@@ -267,7 +267,7 @@ namespace detail
         {
         };
         template <typename C, typename P>
-        static auto test(P * p) -> decltype(C::at(*p), brigand::true_type());
+        static auto test(P * p) -> decltype((void)C::at(*p), brigand::true_type());
         template <typename, typename>
         static brigand::false_type test(...);
         static const bool value =
@@ -2616,7 +2616,7 @@ namespace detail
         {
         };
         template <typename C, typename P>
-        static auto test(P * p) -> decltype(C::erase(type_<P>{}), brigand::true_type());
+        static auto test(P * p) -> decltype((void)C::erase(type_<P>{}), brigand::true_type());
         template <typename, typename>
         static brigand::false_type test(...);
         static const bool value =


### PR DESCRIPTION
Upstream PR: https://github.com/edouarda/brigand/pull/280

Both gcc and clang attempt to recursively instantiate template arguments to classes passed to the comma operator.  If the types are incomplete that seems to be ignored, but definitions that cause substitution failures are errors.  I'm not convinced this is actually allowed by the standard, but we have to live with it, and a void cast is a simple workaround.

The code for at was changed for consistency, although it was not required since it always tests with a non-present type and so returns type_<no_such_type_>.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent was used, have a co-author trailer of the form
      "Co-Authored-By: <agent name> <agent email>" as the last line of the
      commit, e.g. "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>".

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
