### PR TITLE
Support LDG infrastructure part five

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/Actions/BoundaryConditionsImpl.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/BoundaryConditionsImpl.hpp
@@ -19,6 +19,7 @@
 #include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
+#include "DataStructures/VariablesTag.hpp"
 #include "Domain/Block.hpp"
 #include "Domain/BoundaryConditions/Cartoon.hpp"
 #include "Domain/BoundaryConditions/None.hpp"
@@ -71,12 +72,14 @@ std::optional<std::string> apply_boundary_condition_impl(
       get<TagsFromFace>(fields_on_interior_face)..., volume_args...);
 }
 
-template <typename System, size_t Dim, typename DbTagsList,
-          typename BoundaryCorrection, typename BoundaryCondition,
-          typename... EvolvedVariablesTags, typename... PackageDataVolumeTags,
+template <typename System, size_t Dim, bool ComputeAuxiliary = false,
+          typename DbTagsList, typename BoundaryCorrection,
+          typename BoundaryCondition, typename... EvolvedVariablesTags,
+          typename... PackageDataVolumeTags,
           typename... BoundaryConditionVolumeTags, typename... PackageFieldTags,
           typename... BoundaryTermsVolumeTags,
-          typename... BoundaryCorrectionPackagedDataInputTags>
+          typename... BoundaryCorrectionPackagedDataInputTags,
+          typename... AuxiliaryCorrectionTags>
 void apply_boundary_condition_on_face(
     const gsl::not_null<db::DataBox<DbTagsList>*> box,
     [[maybe_unused]] const BoundaryCorrection& boundary_correction,
@@ -84,6 +87,12 @@ void apply_boundary_condition_on_face(
     const Direction<Dim>& direction,
     [[maybe_unused]] const Variables<tmpl::list<EvolvedVariablesTags...>>&
         volume_evolved_vars,
+    // The auxiliary variables are projected to the face in both passes
+    // because dg_ghost is called in the auxiliary pass and may declare
+    // auxiliary variables in dg_interior_evolved_variables_tags.
+    [[maybe_unused]] const Variables<
+        get_auxiliary_variables_or_default_t<System, tmpl::list<>>>* const
+        volume_auxiliary_variables,
     [[maybe_unused]] const Variables<
         db::wrap_tags_in<::Tags::Flux, typename System::flux_variables,
                          tmpl::size_t<Dim>, Frame::Inertial>>& volume_fluxes,
@@ -113,12 +122,21 @@ void apply_boundary_condition_on_face(
     tmpl::list<PackageFieldTags...> /*meta*/,
     tmpl::list<BoundaryTermsVolumeTags...> /*meta*/,
     tmpl::list<BoundaryCorrectionPackagedDataInputTags...> /*meta*/,
-    tmpl::list<BoundaryConditionVolumeTags...> /*meta*/) {
+    tmpl::list<BoundaryConditionVolumeTags...> /*meta*/,
+    tmpl::list<AuxiliaryCorrectionTags...> /*meta*/) {
   using variables_tag = typename System::variables_tag;
   using variables_tags = typename variables_tag::tags_list;
   using flux_variables = typename System::flux_variables;
   using dt_variables_tags = db::wrap_tags_in<::Tags::dt, variables_tags>;
   using dt_variables_tag = db::add_tag_prefix<::Tags::dt, variables_tag>;
+  using auxiliary_variables =
+      get_auxiliary_variables_or_default_t<System, tmpl::list<>>;
+  using auxiliary_variables_tag = ::Tags::Variables<auxiliary_variables>;
+  using tag_to_update =
+      tmpl::conditional_t<ComputeAuxiliary, auxiliary_variables_tag,
+                          dt_variables_tag>;
+  using projected_auxiliary_vars_tags =
+      tmpl::conditional_t<ComputeAuxiliary, tmpl::list<>, auxiliary_variables>;
 
   const Mesh<Dim - 1> face_mesh = volume_mesh.slice_away(direction.dimension());
   const size_t number_of_points_on_face = face_mesh.number_of_grid_points();
@@ -183,10 +201,11 @@ void apply_boundary_condition_on_face(
       detail::boundary_correction_primitive_tags<
           System::has_primitive_and_conservative_vars, BoundaryCorrection>,
       tmpl::list<>>;
-  using correction_evolved_vars_tags =
-      tmpl::conditional_t<uses_ghost_condition,
-                          typename System::variables_tag::tags_list,
-                          tmpl::list<>>;
+  using correction_evolved_and_auxiliary_vars_tags = tmpl::conditional_t<
+      uses_ghost_condition,
+      tmpl::append<typename System::variables_tag::tags_list,
+                   auxiliary_variables>,
+      tmpl::list<>>;
 
   // Now combine the tags lists for each type of tag. These are all the tags
   // we need to project from the interior, excluding the inverse spatial
@@ -196,8 +215,9 @@ void apply_boundary_condition_on_face(
       tmpl::append<bcondition_interior_temp_tags, correction_temp_tags>>;
   using interior_prim_tags = tmpl::remove_duplicates<
       tmpl::append<bcondition_interior_prim_tags, correction_prim_tags>>;
-  using interior_evolved_vars_tags = tmpl::remove_duplicates<tmpl::append<
-      correction_evolved_vars_tags, bcondition_interior_evolved_vars_tags>>;
+  using interior_vars_tags = tmpl::remove_duplicates<
+      tmpl::append<correction_evolved_and_auxiliary_vars_tags,
+                   bcondition_interior_evolved_vars_tags>>;
 
   // List tags on the interior of the face. We list the exterior side
   // separately in the `else` branch of the if-constexpr where we actually use
@@ -208,8 +228,8 @@ void apply_boundary_condition_on_face(
                                            tmpl::size_t<Dim>, Frame::Inertial>,
                           tmpl::list<>>;
   using tags_on_interior_face = tmpl::remove_duplicates<tmpl::append<
-      fluxes_tags, interior_temp_tags, interior_prim_tags,
-      interior_evolved_vars_tags, bcondition_interior_dt_evolved_vars_tags,
+      fluxes_tags, interior_temp_tags, interior_prim_tags, interior_vars_tags,
+      bcondition_interior_dt_evolved_vars_tags,
       bcondition_interior_deriv_evolved_vars_tags, inverse_spatial_metric_list,
       tmpl::list<detail::OneOverNormalVectorMagnitude,
                  detail::NormalVector<Dim>>>>;
@@ -232,8 +252,16 @@ void apply_boundary_condition_on_face(
     ::dg::project_contiguous_data_to_boundary(
         make_not_null(&interior_face_fields), volume_evolved_vars, volume_mesh,
         direction);
+    if constexpr (tmpl::size<auxiliary_variables>::value != 0) {
+      ASSERT(volume_auxiliary_variables != nullptr,
+             "The auxiliary variables must be provided when the system has "
+             "auxiliary variables.");
+      ::dg::project_tensors_to_boundary<auxiliary_variables>(
+          make_not_null(&interior_face_fields), *volume_auxiliary_variables,
+          volume_mesh, direction);
+    }
   } else {
-    ::dg::project_tensors_to_boundary<interior_evolved_vars_tags>(
+    ::dg::project_tensors_to_boundary<interior_vars_tags>(
         make_not_null(&interior_face_fields), volume_evolved_vars, volume_mesh,
         direction);
   }
@@ -391,7 +419,7 @@ void apply_boundary_condition_on_face(
   // time derivatives in the volume projected on to the face.
 
   Variables<dt_variables_tags> dt_time_derivative_correction{};
-  if constexpr (uses_time_derivative_condition) {
+  if constexpr (uses_time_derivative_condition and not ComputeAuxiliary) {
     dt_time_derivative_correction.initialize(number_of_points_on_face);
     auto apply_bc = [&boundary_condition, &dt_time_derivative_correction,
                      &face_mesh_velocity, &interior_normal_covector](
@@ -416,12 +444,15 @@ void apply_boundary_condition_on_face(
 
   // Now we populate the fields on the exterior side of the face using the
   // boundary condition.
-  using tags_on_exterior_face = tmpl::remove_duplicates<
-      tmpl::append<variables_tags, fluxes_tags, correction_temp_tags,
-                   correction_prim_tags, inverse_spatial_metric_list,
-                   tmpl::list<detail::OneOverNormalVectorMagnitude,
-                              detail::NormalVector<Dim>,
-                              evolution::dg::Tags::NormalCovector<Dim>>>>;
+  // `auxiliary_variables` is included unconditionally: `dg_ghost` supplies the
+  // exterior values of every field it declares in both the physical and the
+  // auxiliary pass.
+  using tags_on_exterior_face = tmpl::remove_duplicates<tmpl::append<
+      variables_tags, auxiliary_variables, fluxes_tags, correction_temp_tags,
+      correction_prim_tags, inverse_spatial_metric_list,
+      tmpl::list<detail::OneOverNormalVectorMagnitude,
+                 detail::NormalVector<Dim>,
+                 evolution::dg::Tags::NormalCovector<Dim>>>>;
   Variables<tags_on_exterior_face> exterior_face_fields{
       number_of_points_on_face};
 
@@ -435,17 +466,27 @@ void apply_boundary_condition_on_face(
   if constexpr (uses_ghost_condition) {
     using mortar_tags_list = tmpl::list<PackageFieldTags...>;
     using dg_package_data_projected_tags =
-        tmpl::append<variables_tags, fluxes_tags, correction_temp_tags,
-                     correction_prim_tags>;
+        tmpl::append<variables_tags, projected_auxiliary_vars_tags, fluxes_tags,
+                     correction_temp_tags, correction_prim_tags>;
 
     Variables<mortar_tags_list> internal_packaged_data{
         number_of_points_on_face};
-    const double max_abs_char_speed_on_face = detail::dg_package_data<System>(
-        make_not_null(&internal_packaged_data), boundary_correction,
-        interior_face_fields, interior_normal_covector, face_mesh_velocity,
-        dg_package_data_projected_tags{},
-        db::get<PackageDataVolumeTags>(*box)...);
-    (void)max_abs_char_speed_on_face;
+    if constexpr (ComputeAuxiliary) {
+      const double max_abs_char_speed_on_face =
+          detail::dg_auxiliary_package_data<System>(
+              make_not_null(&internal_packaged_data), boundary_correction,
+              interior_face_fields, interior_normal_covector,
+              face_mesh_velocity, dg_package_data_projected_tags{},
+              db::get<PackageDataVolumeTags>(*box)...);
+      (void)max_abs_char_speed_on_face;
+    } else {
+      const double max_abs_char_speed_on_face = detail::dg_package_data<System>(
+          make_not_null(&internal_packaged_data), boundary_correction,
+          interior_face_fields, interior_normal_covector, face_mesh_velocity,
+          dg_package_data_projected_tags{},
+          db::get<PackageDataVolumeTags>(*box)...);
+      (void)max_abs_char_speed_on_face;
+    }
 
     // Notes:
     // - we pass the outward directed normal vector normalized using the
@@ -569,23 +610,43 @@ void apply_boundary_condition_on_face(
     // Package the external-side data for the boundary correction
     Variables<mortar_tags_list> external_packaged_data{
         number_of_points_on_face};
-    detail::dg_package_data<System>(
-        make_not_null(&external_packaged_data), boundary_correction,
-        exterior_face_fields,
-        get<evolution::dg::Tags::NormalCovector<Dim>>(exterior_face_fields),
-        face_mesh_velocity, dg_package_data_projected_tags{},
-        db::get<PackageDataVolumeTags>(*box)...);
+    if constexpr (ComputeAuxiliary) {
+      detail::dg_auxiliary_package_data<System>(
+          make_not_null(&external_packaged_data), boundary_correction,
+          exterior_face_fields,
+          get<evolution::dg::Tags::NormalCovector<Dim>>(exterior_face_fields),
+          face_mesh_velocity, dg_package_data_projected_tags{},
+          db::get<PackageDataVolumeTags>(*box)...);
+    } else {
+      detail::dg_package_data<System>(
+          make_not_null(&external_packaged_data), boundary_correction,
+          exterior_face_fields,
+          get<evolution::dg::Tags::NormalCovector<Dim>>(exterior_face_fields),
+          face_mesh_velocity, dg_package_data_projected_tags{},
+          db::get<PackageDataVolumeTags>(*box)...);
+    }
 
-    Variables<dt_variables_tags> boundary_corrections_on_face{
+    typename tag_to_update::type boundary_corrections_on_face{
         number_of_points_on_face};
 
     // Compute boundary correction
-    boundary_correction.dg_boundary_terms(
-        make_not_null(&get<::Tags::dt<EvolvedVariablesTags>>(
-            boundary_corrections_on_face))...,
-        get<PackageFieldTags>(internal_packaged_data)...,
-        get<PackageFieldTags>(external_packaged_data)..., dg_formulation,
-        get<BoundaryTermsVolumeTags>(*box)...);
+    if constexpr (ComputeAuxiliary) {
+      // The auxiliary boundary terms write one correction per auxiliary
+      // variable (the buffer's own tags), not per evolved variable.
+      boundary_correction.dg_auxiliary_boundary_terms(
+          make_not_null(
+              &get<AuxiliaryCorrectionTags>(boundary_corrections_on_face))...,
+          get<PackageFieldTags>(internal_packaged_data)...,
+          get<PackageFieldTags>(external_packaged_data)..., dg_formulation,
+          get<BoundaryTermsVolumeTags>(*box)...);
+    } else {
+      boundary_correction.dg_boundary_terms(
+          make_not_null(&get<::Tags::dt<EvolvedVariablesTags>>(
+              boundary_corrections_on_face))...,
+          get<PackageFieldTags>(internal_packaged_data)...,
+          get<PackageFieldTags>(external_packaged_data)..., dg_formulation,
+          get<BoundaryTermsVolumeTags>(*box)...);
+    }
 
     // Lift the boundary correction
     const auto& magnitude_of_interior_face_normal =
@@ -601,12 +662,12 @@ void apply_boundary_condition_on_face(
                       volume_mesh.basis(direction.dimension()));
 
       // Add the flux contribution to the volume data
-      db::mutate<dt_variables_tag>(
+      db::mutate<tag_to_update>(
           [&direction, &boundary_corrections_on_face,
-           &volume_mesh](const auto dt_variables_ptr) {
+           &volume_mesh](const auto vars_ptr) {
             add_slice_to_data(
-                dt_variables_ptr, boundary_corrections_on_face,
-                volume_mesh.extents(), direction.dimension(),
+                vars_ptr, boundary_corrections_on_face, volume_mesh.extents(),
+                direction.dimension(),
                 index_to_slice_at(volume_mesh.extents(), direction));
           },
           box);
@@ -632,20 +693,20 @@ void apply_boundary_condition_on_face(
                      interpolation_matrices, volume_det_jacobian,
                      volume_mesh.extents());
 
-      db::mutate<dt_variables_tag>(
+      db::mutate<tag_to_update>(
           [&direction, &boundary_corrections_on_face, &face_det_jacobian,
            &magnitude_of_interior_face_normal, &volume_det_inv_jacobian,
-           &volume_mesh](const auto dt_variables_ptr) {
+           &volume_mesh](const auto vars_ptr) {
             ::dg::lift_boundary_terms_gauss_points(
-                dt_variables_ptr, volume_det_inv_jacobian, volume_mesh,
-                direction, boundary_corrections_on_face,
-                magnitude_of_interior_face_normal, face_det_jacobian);
+                vars_ptr, volume_det_inv_jacobian, volume_mesh, direction,
+                boundary_corrections_on_face, magnitude_of_interior_face_normal,
+                face_det_jacobian);
           },
           box);
     }
   }
   // Add TimeDerivative correction to volume time derivatives.
-  if constexpr (uses_time_derivative_condition) {
+  if constexpr (uses_time_derivative_condition and not ComputeAuxiliary) {
     if (has_collocation_points_on_side) {
       db::mutate<dt_variables_tag>(
           [&direction, &dt_time_derivative_correction,
@@ -677,9 +738,16 @@ void apply_boundary_condition_on_face(
  * known boundary conditions is being used. Since each direction can have a
  * different boundary condition, we must check each boundary condition in
  * each external direction.
+ *
+ * When `ComputeAuxiliary` is `true` the LDG auxiliary pass is applied instead
+ * of the physical pass: ghost faces package data with the boundary
+ * correction's `dg_auxiliary_*` interface and lift the resulting correction
+ * into the auxiliary-variable storage `::Tags::Variables<auxiliary_variables>`
+ * rather than into the time derivatives, and time-derivative boundary
+ * conditions are skipped.
  */
-template <typename System, size_t Dim, typename DbTagsList,
-          typename BoundaryCorrection>
+template <typename System, size_t Dim, bool ComputeAuxiliary = false,
+          typename DbTagsList, typename BoundaryCorrection>
 void apply_boundary_conditions_on_all_external_faces(
     const gsl::not_null<db::DataBox<DbTagsList>*> box,
     const BoundaryCorrection& boundary_correction,
@@ -710,12 +778,20 @@ void apply_boundary_conditions_on_all_external_faces(
   using flux_variables = typename System::flux_variables;
   using fluxes_tags = db::wrap_tags_in<::Tags::Flux, flux_variables,
                                        tmpl::size_t<Dim>, Frame::Inertial>;
+  using auxiliary_variables =
+      get_auxiliary_variables_or_default_t<System, tmpl::list<>>;
 
   const Element<Dim>& element = db::get<domain::Tags::Element<Dim>>(*box);
   size_t number_of_boundaries_left = element.external_boundaries().size();
 
   if (number_of_boundaries_left == 0) {
     return;
+  }
+
+  const Variables<auxiliary_variables>* volume_auxiliary_variables = nullptr;
+  if constexpr (tmpl::size<auxiliary_variables>::value != 0) {
+    volume_auxiliary_variables =
+        &db::get<::Tags::Variables<auxiliary_variables>>(*box);
   }
 
   const auto& external_boundary_conditions =
@@ -743,56 +819,79 @@ void apply_boundary_conditions_on_all_external_faces(
     }
   }
 
-  tmpl::for_each<derived_boundary_conditions>(
-      [&boundary_correction, &box, &element, &external_boundary_conditions,
-       &number_of_boundaries_left, &partial_derivs, &primitive_vars,
-       &temporaries, &volume_fluxes](auto derived_boundary_condition_v) {
-        using DerivedBoundaryCondition =
-            tmpl::type_from<decltype(derived_boundary_condition_v)>;
+  tmpl::for_each<
+      derived_boundary_conditions>([&boundary_correction, &box, &element,
+                                    &external_boundary_conditions,
+                                    &number_of_boundaries_left, &partial_derivs,
+                                    &primitive_vars, &temporaries,
+                                    &volume_fluxes, volume_auxiliary_variables](
+                                       auto derived_boundary_condition_v) {
+    using DerivedBoundaryCondition =
+        tmpl::type_from<decltype(derived_boundary_condition_v)>;
 
-        if (number_of_boundaries_left == 0) {
-          return;
-        }
+    if (number_of_boundaries_left == 0) {
+      return;
+    }
 
-        for (const Direction<Dim>& direction : element.external_boundaries()) {
-          const auto& boundary_condition =
-              *external_boundary_conditions.at(direction);
-          if (typeid(boundary_condition) == typeid(DerivedBoundaryCondition)) {
-            detail::apply_boundary_condition_on_face<System>(
-                box, boundary_correction,
-                dynamic_cast<const DerivedBoundaryCondition&>(
-                    boundary_condition),
-                direction, db::get<variables_tag>(*box), volume_fluxes,
-                partial_derivs, temporaries, primitive_vars,
-                db::get<::dg::Tags::Formulation>(*box),
-                db::get<::domain::Tags::Mesh<Dim>>(*box),
-                db::get<::domain::Tags::Element<Dim>>(*box),
-                db::get<::domain::Tags::ElementMap<Dim, Frame::Grid>>(*box),
-                db::get<::domain::CoordinateMaps::Tags::CoordinateMap<
-                    Dim, Frame::Grid, Frame::Inertial>>(*box),
-                db::get<::Tags::Time>(*box),
-                db::get<::domain::Tags::FunctionsOfTime>(*box),
-                db::get<::domain::Tags::MeshVelocity<Dim>>(*box),
-                db::get<::domain::Tags::InverseJacobian<
-                    Dim, Frame::ElementLogical, Frame::Inertial>>(*box),
-                db::get<::domain::Tags::DetInvJacobian<Frame::ElementLogical,
-                                                       Frame::Inertial>>(*box),
-                typename BoundaryCorrection::dg_package_data_volume_tags{},
-                typename BoundaryCorrection::dg_package_field_tags{},
-                typename BoundaryCorrection::dg_boundary_terms_volume_tags{},
-                tmpl::remove_duplicates<tmpl::append<
-                    typename variables_tag::tags_list, fluxes_tags,
-                    typename BoundaryCorrection::dg_package_data_temporary_tags,
-                    typename detail::get_primitive_vars<
-                        System::has_primitive_and_conservative_vars>::
-                        template f<BoundaryCorrection>>>{},
-                typename DerivedBoundaryCondition::dg_gridless_tags{});
-            --number_of_boundaries_left;
-          }
-          if (number_of_boundaries_left == 0) {
-            return;
-          }
-        }
-      });
+    for (const Direction<Dim>& direction : element.external_boundaries()) {
+      const auto& boundary_condition =
+          *external_boundary_conditions.at(direction);
+      if (typeid(boundary_condition) == typeid(DerivedBoundaryCondition)) {
+        // Select auxiliary or physical tags based on ComputeAuxiliary
+        using package_data_volume_tags = tmpl::conditional_t<
+            ComputeAuxiliary,
+            get_dg_auxiliary_package_data_volume_tags_or_default_t<
+                BoundaryCorrection, tmpl::list<>>,
+            typename BoundaryCorrection::dg_package_data_volume_tags>;
+        using package_field_tags = tmpl::conditional_t<
+            ComputeAuxiliary,
+            get_dg_auxiliary_package_field_tags_or_default_t<BoundaryCorrection,
+                                                             tmpl::list<>>,
+            typename BoundaryCorrection::dg_package_field_tags>;
+        using boundary_terms_volume_tags = tmpl::conditional_t<
+            ComputeAuxiliary,
+            get_dg_auxiliary_boundary_terms_volume_tags_or_default_t<
+                BoundaryCorrection, tmpl::list<>>,
+            typename BoundaryCorrection::dg_boundary_terms_volume_tags>;
+        using package_data_temp_tags = tmpl::conditional_t<
+            ComputeAuxiliary,
+            get_dg_auxiliary_package_data_temporary_tags_or_default_t<
+                BoundaryCorrection, tmpl::list<>>,
+            typename BoundaryCorrection::dg_package_data_temporary_tags>;
+        detail::apply_boundary_condition_on_face<System, Dim, ComputeAuxiliary>(
+            box, boundary_correction,
+            dynamic_cast<const DerivedBoundaryCondition&>(boundary_condition),
+            direction, db::get<variables_tag>(*box), volume_auxiliary_variables,
+            volume_fluxes, partial_derivs, temporaries, primitive_vars,
+            db::get<::dg::Tags::Formulation>(*box),
+            db::get<::domain::Tags::Mesh<Dim>>(*box),
+            db::get<::domain::Tags::Element<Dim>>(*box),
+            db::get<::domain::Tags::ElementMap<Dim, Frame::Grid>>(*box),
+            db::get<::domain::CoordinateMaps::Tags::CoordinateMap<
+                Dim, Frame::Grid, Frame::Inertial>>(*box),
+            db::get<::Tags::Time>(*box),
+            db::get<::domain::Tags::FunctionsOfTime>(*box),
+            db::get<::domain::Tags::MeshVelocity<Dim>>(*box),
+            db::get<::domain::Tags::InverseJacobian<Dim, Frame::ElementLogical,
+                                                    Frame::Inertial>>(*box),
+            db::get<::domain::Tags::DetInvJacobian<Frame::ElementLogical,
+                                                   Frame::Inertial>>(*box),
+            package_data_volume_tags{}, package_field_tags{},
+            boundary_terms_volume_tags{},
+            tmpl::remove_duplicates<tmpl::append<
+                typename variables_tag::tags_list, auxiliary_variables,
+                fluxes_tags, package_data_temp_tags,
+                typename detail::get_primitive_vars<
+                    System::has_primitive_and_conservative_vars>::
+                    template f<BoundaryCorrection>>>{},
+            typename DerivedBoundaryCondition::dg_gridless_tags{},
+            auxiliary_variables{});
+        --number_of_boundaries_left;
+      }
+      if (number_of_boundaries_left == 0) {
+        return;
+      }
+    }
+  });
 }
 }  // namespace evolution::dg::Actions::detail

--- a/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeHelpers.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeHelpers.hpp
@@ -33,8 +33,10 @@ using inverse_spatial_metric_tag = typename inverse_spatial_metric_tag_impl<
     has_inverse_spatial_metric_tag_v<System>>::template f<System>;
 
 CREATE_GET_TYPE_ALIAS_OR_DEFAULT(auxiliary_variables)
-CREATE_GET_TYPE_ALIAS_OR_DEFAULT(dg_auxiliary_package_field_tags)
 CREATE_GET_TYPE_ALIAS_OR_DEFAULT(dg_auxiliary_boundary_terms_volume_tags)
+CREATE_GET_TYPE_ALIAS_OR_DEFAULT(dg_auxiliary_package_data_temporary_tags)
+CREATE_GET_TYPE_ALIAS_OR_DEFAULT(dg_auxiliary_package_data_volume_tags)
+CREATE_GET_TYPE_ALIAS_OR_DEFAULT(dg_auxiliary_package_field_tags)
 
 // `gradient_variables` is prepended since `partial_derivatives` requires the
 // differentiated tags to be the *leading* tags of the source `Variables`.

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_BoundaryConditions.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_BoundaryConditions.cpp
@@ -71,6 +71,10 @@ struct BoundaryCorrectionVolumeTag : db::SimpleTag {
   using type = double;
 };
 
+struct BoundaryCorrectionAuxiliaryVolumeTag : db::SimpleTag {
+  using type = double;
+};
+
 struct BoundaryConditionVolumeTag : db::SimpleTag {
   using type = double;
 };
@@ -84,8 +88,14 @@ struct Var2 : db::SimpleTag {
   using type = tnsr::I<DataVector, Dim, Frame::Inertial>;
 };
 
-struct Var3Squared : db::SimpleTag {
+struct TempVar : db::SimpleTag {
   using type = Scalar<DataVector>;
+};
+
+// Auxiliary variable tag
+template <size_t Dim>
+struct Var3 : db::SimpleTag {
+  using type = tnsr::I<DataVector, Dim, Frame::Inertial>;
 };
 
 struct PrimVar1 : db::SimpleTag {
@@ -140,14 +150,25 @@ struct BoundaryTerms final : public evolution::BoundaryCorrection {
   using dg_package_field_tags = tmpl::push_back<
       tmpl::append<db::wrap_tags_in<::Tags::NormalDotFlux, variables_tags>,
                    variables_tags>,
-      MaxAbsCharSpeed>;
-  using dg_package_data_temporary_tags = tmpl::list<Tags::Var3Squared>;
+      MaxAbsCharSpeed, Tags::Var3<Dim>>;
+  using dg_package_data_temporary_tags = tmpl::list<Tags::TempVar>;
   using dg_package_data_primitive_tags =
       tmpl::conditional_t<HasPrims, tmpl::list<Tags::PrimVar1>, tmpl::list<>>;
   using dg_package_data_volume_tags = tmpl::conditional_t<
       HasPrims, tmpl::list<Tags::BoundaryCorrectionVolumeTag>, tmpl::list<>>;
   using dg_boundary_terms_volume_tags = tmpl::conditional_t<
       HasPrims, tmpl::list<Tags::BoundaryCorrectionVolumeTag>, tmpl::list<>>;
+
+  // Auxiliary variable is not used for auxiliary boundary correction
+  using dg_auxiliary_package_field_tags = tmpl::push_back<
+      tmpl::append<db::wrap_tags_in<::Tags::NormalDotFlux, variables_tags>,
+                   variables_tags>,
+      MaxAbsCharSpeed>;
+  using dg_auxiliary_package_data_temporary_tags = tmpl::list<Tags::TempVar>;
+  using dg_auxiliary_package_data_volume_tags =
+      tmpl::list<Tags::BoundaryCorrectionAuxiliaryVolumeTag>;
+  using dg_auxiliary_boundary_terms_volume_tags =
+      tmpl::list<Tags::BoundaryCorrectionAuxiliaryVolumeTag>;
 
   // Conservative system, flat background
   double dg_package_data(
@@ -157,14 +178,16 @@ struct BoundaryTerms final : public evolution::BoundaryCorrection {
       const gsl::not_null<Scalar<DataVector>*> out_var1,
       const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> out_var2,
       const gsl::not_null<Scalar<DataVector>*> max_abs_char_speed,
+      const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> out_var3,
 
       const Scalar<DataVector>& var1,
       const tnsr::I<DataVector, Dim, Frame::Inertial>& var2,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& var3,
 
       const tnsr::I<DataVector, Dim, Frame::Inertial>& flux_var1,
       const tnsr::IJ<DataVector, Dim, Frame::Inertial>& flux_var2,
 
-      const Scalar<DataVector>& var3_squared,
+      const Scalar<DataVector>& temp_var,
 
       const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_covector,
       const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
@@ -199,8 +222,9 @@ struct BoundaryTerms final : public evolution::BoundaryCorrection {
     }
     *out_var1 = var1;
     *out_var2 = var2;
+    *out_var3 = var3;
 
-    get(*max_abs_char_speed) = 2.0 * max(get(var3_squared));
+    get(*max_abs_char_speed) = 2.0 * max(get(temp_var));
 
     if (normal_dot_mesh_velocity.has_value()) {
       get(*max_abs_char_speed) += get(*normal_dot_mesh_velocity);
@@ -216,14 +240,16 @@ struct BoundaryTerms final : public evolution::BoundaryCorrection {
       const gsl::not_null<Scalar<DataVector>*> out_var1,
       const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> out_var2,
       const gsl::not_null<Scalar<DataVector>*> max_abs_char_speed,
+      const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> out_var3,
 
       const Scalar<DataVector>& var1,
       const tnsr::I<DataVector, Dim, Frame::Inertial>& var2,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& var3,
 
       const tnsr::I<DataVector, Dim, Frame::Inertial>& flux_var1,
       const tnsr::IJ<DataVector, Dim, Frame::Inertial>& flux_var2,
 
-      const Scalar<DataVector>& var3_squared,
+      const Scalar<DataVector>& temp_var,
 
       const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_covector,
       const tnsr::I<DataVector, Dim, Frame::Inertial>& normal_vector,
@@ -232,10 +258,10 @@ struct BoundaryTerms final : public evolution::BoundaryCorrection {
       const std::optional<Scalar<DataVector>>& normal_dot_mesh_velocity) const {
     CHECK_ITERABLE_APPROX(get(dot_product(normal_covector, normal_vector)),
                           DataVector(get(var1).size(), 1.0));
-    return dg_package_data(out_normal_dot_flux_var1, out_normal_dot_flux_var2,
-                           out_var1, out_var2, max_abs_char_speed, var1, var2,
-                           flux_var1, flux_var2, var3_squared, normal_covector,
-                           mesh_velocity, normal_dot_mesh_velocity);
+    return dg_package_data(
+        out_normal_dot_flux_var1, out_normal_dot_flux_var2, out_var1, out_var2,
+        max_abs_char_speed, out_var3, var1, var2, var3, flux_var1, flux_var2,
+        temp_var, normal_covector, mesh_velocity, normal_dot_mesh_velocity);
   }
 
   // Conservative system with prim vars, flat background
@@ -246,15 +272,16 @@ struct BoundaryTerms final : public evolution::BoundaryCorrection {
       const gsl::not_null<Scalar<DataVector>*> out_var1,
       const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> out_var2,
       const gsl::not_null<Scalar<DataVector>*> max_abs_char_speed,
+      const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> out_var3,
 
       const Scalar<DataVector>& var1,
       const tnsr::I<DataVector, Dim, Frame::Inertial>& var2,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& var3,
 
       const tnsr::I<DataVector, Dim, Frame::Inertial>& flux_var1,
       const tnsr::IJ<DataVector, Dim, Frame::Inertial>& flux_var2,
 
-      const Scalar<DataVector>& var3_squared,
-      const Scalar<DataVector>& prim_var1,
+      const Scalar<DataVector>& temp_var, const Scalar<DataVector>& prim_var1,
 
       const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_covector,
       const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
@@ -263,8 +290,8 @@ struct BoundaryTerms final : public evolution::BoundaryCorrection {
 
       const double volume_number) const {
     dg_package_data(out_normal_dot_flux_var1, out_normal_dot_flux_var2,
-                    out_var1, out_var2, max_abs_char_speed, var1, var2,
-                    flux_var1, flux_var2, var3_squared, normal_covector,
+                    out_var1, out_var2, max_abs_char_speed, out_var3, var1,
+                    var2, var3, flux_var1, flux_var2, temp_var, normal_covector,
                     mesh_velocity, normal_dot_mesh_velocity);
     get(*out_var1) += get(prim_var1) + volume_number;
     if (mesh_velocity.has_value()) {
@@ -283,15 +310,16 @@ struct BoundaryTerms final : public evolution::BoundaryCorrection {
       const gsl::not_null<Scalar<DataVector>*> out_var1,
       const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> out_var2,
       const gsl::not_null<Scalar<DataVector>*> max_abs_char_speed,
+      const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> out_var3,
 
       const Scalar<DataVector>& var1,
       const tnsr::I<DataVector, Dim, Frame::Inertial>& var2,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& var3,
 
       const tnsr::I<DataVector, Dim, Frame::Inertial>& flux_var1,
       const tnsr::IJ<DataVector, Dim, Frame::Inertial>& flux_var2,
 
-      const Scalar<DataVector>& var3_squared,
-      const Scalar<DataVector>& prim_var1,
+      const Scalar<DataVector>& temp_var, const Scalar<DataVector>& prim_var1,
 
       const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_covector,
       const tnsr::I<DataVector, Dim, Frame::Inertial>& normal_vector,
@@ -303,9 +331,9 @@ struct BoundaryTerms final : public evolution::BoundaryCorrection {
     CHECK_ITERABLE_APPROX(get(dot_product(normal_covector, normal_vector)),
                           DataVector(get(var1).size(), 1.0));
     return dg_package_data(out_normal_dot_flux_var1, out_normal_dot_flux_var2,
-                           out_var1, out_var2, max_abs_char_speed, var1, var2,
-                           flux_var1, flux_var2, var3_squared, prim_var1,
-                           normal_covector, mesh_velocity,
+                           out_var1, out_var2, max_abs_char_speed, out_var3,
+                           var1, var2, var3, flux_var1, flux_var2, temp_var,
+                           prim_var1, normal_covector, mesh_velocity,
                            normal_dot_mesh_velocity, volume_number);
   }
 
@@ -317,11 +345,13 @@ struct BoundaryTerms final : public evolution::BoundaryCorrection {
       const gsl::not_null<Scalar<DataVector>*> out_var1,
       const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> out_var2,
       const gsl::not_null<Scalar<DataVector>*> max_abs_char_speed,
+      const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> out_var3,
 
       const Scalar<DataVector>& var1,
       const tnsr::I<DataVector, Dim, Frame::Inertial>& var2,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& var3,
 
-      const Scalar<DataVector>& var3_squared,
+      const Scalar<DataVector>& temp_var,
 
       const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_covector,
       const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
@@ -357,8 +387,9 @@ struct BoundaryTerms final : public evolution::BoundaryCorrection {
     }
     *out_var1 = var1;
     *out_var2 = var2;
+    *out_var3 = var3;
 
-    get(*max_abs_char_speed) = 2.0 * max(get(var3_squared));
+    get(*max_abs_char_speed) = 2.0 * max(get(temp_var));
 
     if (normal_dot_mesh_velocity.has_value()) {
       get(*max_abs_char_speed) += get(*normal_dot_mesh_velocity);
@@ -374,11 +405,13 @@ struct BoundaryTerms final : public evolution::BoundaryCorrection {
       const gsl::not_null<Scalar<DataVector>*> out_var1,
       const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> out_var2,
       const gsl::not_null<Scalar<DataVector>*> max_abs_char_speed,
+      const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> out_var3,
 
       const Scalar<DataVector>& var1,
       const tnsr::I<DataVector, Dim, Frame::Inertial>& var2,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& var3,
 
-      const Scalar<DataVector>& var3_squared,
+      const Scalar<DataVector>& temp_var,
 
       const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_covector,
       const tnsr::I<DataVector, Dim, Frame::Inertial>& normal_vector,
@@ -388,9 +421,9 @@ struct BoundaryTerms final : public evolution::BoundaryCorrection {
     CHECK_ITERABLE_APPROX(get(dot_product(normal_covector, normal_vector)),
                           DataVector(get(var1).size(), 1.0));
     return dg_package_data(out_normal_dot_flux_var1, out_normal_dot_flux_var2,
-                           out_var1, out_var2, max_abs_char_speed, var1, var2,
-                           var3_squared, normal_covector, mesh_velocity,
-                           normal_dot_mesh_velocity);
+                           out_var1, out_var2, max_abs_char_speed, out_var3,
+                           var1, var2, var3, temp_var, normal_covector,
+                           mesh_velocity, normal_dot_mesh_velocity);
   }
 
   // Mixed system, no prims, flat background
@@ -401,13 +434,15 @@ struct BoundaryTerms final : public evolution::BoundaryCorrection {
       const gsl::not_null<Scalar<DataVector>*> out_var1,
       const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> out_var2,
       const gsl::not_null<Scalar<DataVector>*> max_abs_char_speed,
+      const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> out_var3,
 
       const Scalar<DataVector>& var1,
       const tnsr::I<DataVector, Dim, Frame::Inertial>& var2,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& var3,
 
       const tnsr::IJ<DataVector, Dim, Frame::Inertial>& flux_var2,
 
-      const Scalar<DataVector>& var3_squared,
+      const Scalar<DataVector>& temp_var,
 
       const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_covector,
       const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
@@ -443,8 +478,9 @@ struct BoundaryTerms final : public evolution::BoundaryCorrection {
     }
     *out_var1 = var1;
     *out_var2 = var2;
+    *out_var3 = var3;
 
-    get(*max_abs_char_speed) = 2.0 * max(get(var3_squared));
+    get(*max_abs_char_speed) = 2.0 * max(get(temp_var));
 
     if (normal_dot_mesh_velocity.has_value()) {
       get(*max_abs_char_speed) += get(*normal_dot_mesh_velocity);
@@ -460,13 +496,15 @@ struct BoundaryTerms final : public evolution::BoundaryCorrection {
       const gsl::not_null<Scalar<DataVector>*> out_var1,
       const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> out_var2,
       const gsl::not_null<Scalar<DataVector>*> max_abs_char_speed,
+      const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> out_var3,
 
       const Scalar<DataVector>& var1,
       const tnsr::I<DataVector, Dim, Frame::Inertial>& var2,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& var3,
 
       const tnsr::IJ<DataVector, Dim, Frame::Inertial>& flux_var2,
 
-      const Scalar<DataVector>& var3_squared,
+      const Scalar<DataVector>& temp_var,
 
       const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_covector,
       const tnsr::I<DataVector, Dim, Frame::Inertial>& normal_vector,
@@ -475,10 +513,10 @@ struct BoundaryTerms final : public evolution::BoundaryCorrection {
       const std::optional<Scalar<DataVector>>& normal_dot_mesh_velocity) const {
     CHECK_ITERABLE_APPROX(get(dot_product(normal_covector, normal_vector)),
                           DataVector(get(var1).size(), 1.0));
-    return dg_package_data(out_normal_dot_flux_var1, out_normal_dot_flux_var2,
-                           out_var1, out_var2, max_abs_char_speed, var1, var2,
-                           flux_var2, var3_squared, normal_covector,
-                           mesh_velocity, normal_dot_mesh_velocity);
+    return dg_package_data(
+        out_normal_dot_flux_var1, out_normal_dot_flux_var2, out_var1, out_var2,
+        max_abs_char_speed, out_var3, var1, var2, var3, flux_var2, temp_var,
+        normal_covector, mesh_velocity, normal_dot_mesh_velocity);
   }
 
   // Mixed system with prims, flat background
@@ -489,13 +527,15 @@ struct BoundaryTerms final : public evolution::BoundaryCorrection {
       const gsl::not_null<Scalar<DataVector>*> out_var1,
       const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> out_var2,
       const gsl::not_null<Scalar<DataVector>*> max_abs_char_speed,
+      const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> out_var3,
 
       const Scalar<DataVector>& var1,
       const tnsr::I<DataVector, Dim, Frame::Inertial>& var2,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& var3,
 
       const tnsr::IJ<DataVector, Dim, Frame::Inertial>& flux_var2,
 
-      const Scalar<DataVector>& var3_squared,
+      const Scalar<DataVector>& temp_var,
 
       const Scalar<DataVector>& prim_var1,
 
@@ -506,9 +546,9 @@ struct BoundaryTerms final : public evolution::BoundaryCorrection {
 
       const double volume_number) const {
     dg_package_data(out_normal_dot_flux_var1, out_normal_dot_flux_var2,
-                    out_var1, out_var2, max_abs_char_speed, var1, var2,
-                    flux_var2, var3_squared, normal_covector, mesh_velocity,
-                    normal_dot_mesh_velocity);
+                    out_var1, out_var2, max_abs_char_speed, out_var3, var1,
+                    var2, var3, flux_var2, temp_var, normal_covector,
+                    mesh_velocity, normal_dot_mesh_velocity);
     get(*out_var1) += get(prim_var1) + volume_number;
     return max(get(*max_abs_char_speed));
   }
@@ -521,13 +561,15 @@ struct BoundaryTerms final : public evolution::BoundaryCorrection {
       const gsl::not_null<Scalar<DataVector>*> out_var1,
       const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> out_var2,
       const gsl::not_null<Scalar<DataVector>*> max_abs_char_speed,
+      const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> out_var3,
 
       const Scalar<DataVector>& var1,
       const tnsr::I<DataVector, Dim, Frame::Inertial>& var2,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& var3,
 
       const tnsr::IJ<DataVector, Dim, Frame::Inertial>& flux_var2,
 
-      const Scalar<DataVector>& var3_squared,
+      const Scalar<DataVector>& temp_var,
 
       const Scalar<DataVector>& prim_var1,
 
@@ -541,10 +583,10 @@ struct BoundaryTerms final : public evolution::BoundaryCorrection {
     CHECK_ITERABLE_APPROX(get(dot_product(normal_covector, normal_vector)),
                           DataVector(get(var1).size(), 1.0));
     return dg_package_data(out_normal_dot_flux_var1, out_normal_dot_flux_var2,
-                           out_var1, out_var2, max_abs_char_speed, var1, var2,
-                           flux_var2, var3_squared, prim_var1, normal_covector,
-                           mesh_velocity, normal_dot_mesh_velocity,
-                           volume_number);
+                           out_var1, out_var2, max_abs_char_speed, out_var3,
+                           var1, var2, var3, flux_var2, temp_var, prim_var1,
+                           normal_covector, mesh_velocity,
+                           normal_dot_mesh_velocity, volume_number);
   }
 
   void dg_boundary_terms(
@@ -556,11 +598,13 @@ struct BoundaryTerms final : public evolution::BoundaryCorrection {
       const Scalar<DataVector>& int_var1,
       const tnsr::I<DataVector, Dim, Frame::Inertial>& int_var2,
       const Scalar<DataVector>& int_max_abs_char_speed,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& int_var3,
       const Scalar<DataVector>& ext_normal_dot_flux_var1,
       const tnsr::I<DataVector, Dim, Frame::Inertial>& ext_normal_dot_flux_var2,
       const Scalar<DataVector>& ext_var1,
       const tnsr::I<DataVector, Dim, Frame::Inertial>& ext_var2,
       const Scalar<DataVector>& ext_max_abs_char_speed,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& ext_var3,
       const dg::Formulation formulation) const {
     static_assert(Dim == 1,
                   "Flux dot normal assumes 1d, mostly because normal vector is "
@@ -634,6 +678,13 @@ struct BoundaryTerms final : public evolution::BoundaryCorrection {
                    2.0 * offset_temporaries +
                        sign_of_normal_ / normalization_factor * mesh_velocity));
 
+    // Check var3 is delivered correctly
+    for (size_t i = 0; i < Dim; ++i) {
+      CHECK_ITERABLE_APPROX(
+          int_var3.get(i),
+          DataVector(num_pts, offset_evolved_vars + static_cast<double>(i)));
+    }
+
     if (SysType == SystemType::Conservative) {
       // The two comes from the dg_package_data also subtracting off the mesh
       // velocity.
@@ -685,6 +736,13 @@ struct BoundaryTerms final : public evolution::BoundaryCorrection {
         DataVector(num_pts,
                    2.0 * (offset_boundary_condition + 2.0 + 2 * Dim) -
                        sign_of_normal_ / normalization_factor * mesh_velocity));
+
+    // Check var3 is delivered correctly
+    for (size_t i = 0; i < Dim; ++i) {
+      CHECK_ITERABLE_APPROX(
+          ext_var3.get(i), DataVector(num_pts, offset_boundary_condition + 2.0 +
+                                                   static_cast<double>(i)));
+    }
   }
 
   void dg_boundary_terms(
@@ -696,18 +754,417 @@ struct BoundaryTerms final : public evolution::BoundaryCorrection {
       const Scalar<DataVector>& int_var1,
       const tnsr::I<DataVector, Dim, Frame::Inertial>& int_var2,
       const Scalar<DataVector>& int_max_abs_char_speed,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& int_var3,
       const Scalar<DataVector>& ext_normal_dot_flux_var1,
       const tnsr::I<DataVector, Dim, Frame::Inertial>& ext_normal_dot_flux_var2,
       const Scalar<DataVector>& ext_var1,
       const tnsr::I<DataVector, Dim, Frame::Inertial>& ext_var2,
       const Scalar<DataVector>& ext_max_abs_char_speed,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& ext_var3,
       const dg::Formulation formulation, const double& volume_number) const {
     CHECK(volume_number == 3.5);
     dg_boundary_terms(boundary_correction_var1, boundary_correction_var2,
                       int_normal_dot_flux_var1, int_normal_dot_flux_var2,
-                      int_var1, int_var2, int_max_abs_char_speed,
+                      int_var1, int_var2, int_max_abs_char_speed, int_var3,
                       ext_normal_dot_flux_var1, ext_normal_dot_flux_var2,
-                      ext_var1, ext_var2, ext_max_abs_char_speed, formulation);
+                      ext_var1, ext_var2, ext_max_abs_char_speed, ext_var3,
+                      formulation);
+  }
+
+  // The auxiliary packaged fields are exactly the physical ones without Var3,
+  // so each auxiliary overload forwards to the corresponding physical
+  // `dg_package_data` overload with a scratch Var3 that is written and
+  // discarded.
+
+  // Conservative system, flat background
+  double dg_auxiliary_package_data(
+      const gsl::not_null<Scalar<DataVector>*> out_normal_dot_flux_var1,
+      const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*>
+          out_normal_dot_flux_var2,
+      const gsl::not_null<Scalar<DataVector>*> out_var1,
+      const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> out_var2,
+      const gsl::not_null<Scalar<DataVector>*> max_abs_char_speed,
+
+      const Scalar<DataVector>& var1,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& var2,
+
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& flux_var1,
+      const tnsr::IJ<DataVector, Dim, Frame::Inertial>& flux_var2,
+
+      const Scalar<DataVector>& temp_var,
+
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_covector,
+      const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
+          mesh_velocity,
+      const std::optional<Scalar<DataVector>>& normal_dot_mesh_velocity,
+
+      const double volume_number) const {
+    CHECK(volume_number == 4.5);
+    tnsr::I<DataVector, Dim, Frame::Inertial> var3_buffer{get(var1).size(),
+                                                          0.0};
+    return dg_package_data(out_normal_dot_flux_var1, out_normal_dot_flux_var2,
+                           out_var1, out_var2, max_abs_char_speed,
+                           make_not_null(&var3_buffer), var1, var2, var3_buffer,
+                           flux_var1, flux_var2, temp_var, normal_covector,
+                           mesh_velocity, normal_dot_mesh_velocity);
+  }
+
+  // Conservative system, curved background
+  double dg_auxiliary_package_data(
+      const gsl::not_null<Scalar<DataVector>*> out_normal_dot_flux_var1,
+      const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*>
+          out_normal_dot_flux_var2,
+      const gsl::not_null<Scalar<DataVector>*> out_var1,
+      const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> out_var2,
+      const gsl::not_null<Scalar<DataVector>*> max_abs_char_speed,
+
+      const Scalar<DataVector>& var1,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& var2,
+
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& flux_var1,
+      const tnsr::IJ<DataVector, Dim, Frame::Inertial>& flux_var2,
+
+      const Scalar<DataVector>& temp_var,
+
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_covector,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& normal_vector,
+      const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
+          mesh_velocity,
+      const std::optional<Scalar<DataVector>>& normal_dot_mesh_velocity,
+
+      const double volume_number) const {
+    CHECK(volume_number == 4.5);
+    tnsr::I<DataVector, Dim, Frame::Inertial> var3_buffer{get(var1).size(),
+                                                          0.0};
+    return dg_package_data(
+        out_normal_dot_flux_var1, out_normal_dot_flux_var2, out_var1, out_var2,
+        max_abs_char_speed, make_not_null(&var3_buffer), var1, var2,
+        var3_buffer, flux_var1, flux_var2, temp_var, normal_covector,
+        normal_vector, mesh_velocity, normal_dot_mesh_velocity);
+  }
+
+  // Conservative system with prim vars, flat background
+  double dg_auxiliary_package_data(
+      const gsl::not_null<Scalar<DataVector>*> out_normal_dot_flux_var1,
+      const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*>
+          out_normal_dot_flux_var2,
+      const gsl::not_null<Scalar<DataVector>*> out_var1,
+      const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> out_var2,
+      const gsl::not_null<Scalar<DataVector>*> max_abs_char_speed,
+
+      const Scalar<DataVector>& var1,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& var2,
+
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& flux_var1,
+      const tnsr::IJ<DataVector, Dim, Frame::Inertial>& flux_var2,
+
+      const Scalar<DataVector>& temp_var, const Scalar<DataVector>& prim_var1,
+
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_covector,
+      const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
+          mesh_velocity,
+      const std::optional<Scalar<DataVector>>& normal_dot_mesh_velocity,
+
+      const double volume_number) const {
+    CHECK(volume_number == 4.5);
+    tnsr::I<DataVector, Dim, Frame::Inertial> var3_buffer{get(var1).size(),
+                                                          0.0};
+    // The physical overload folds its own volume-tag value
+    // (`BoundaryCorrectionVolumeTag`, 3.5) into the packaged data, which is
+    // what the shared `dg_boundary_terms` checks expect; the auxiliary volume
+    // tag (4.5) is checked above and dropped.
+    return dg_package_data(
+        out_normal_dot_flux_var1, out_normal_dot_flux_var2, out_var1, out_var2,
+        max_abs_char_speed, make_not_null(&var3_buffer), var1, var2,
+        var3_buffer, flux_var1, flux_var2, temp_var, prim_var1, normal_covector,
+        mesh_velocity, normal_dot_mesh_velocity, 3.5);
+  }
+
+  // Conservative system with prim vars, curved background
+  double dg_auxiliary_package_data(
+      const gsl::not_null<Scalar<DataVector>*> out_normal_dot_flux_var1,
+      const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*>
+          out_normal_dot_flux_var2,
+      const gsl::not_null<Scalar<DataVector>*> out_var1,
+      const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> out_var2,
+      const gsl::not_null<Scalar<DataVector>*> max_abs_char_speed,
+
+      const Scalar<DataVector>& var1,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& var2,
+
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& flux_var1,
+      const tnsr::IJ<DataVector, Dim, Frame::Inertial>& flux_var2,
+
+      const Scalar<DataVector>& temp_var, const Scalar<DataVector>& prim_var1,
+
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_covector,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& normal_vector,
+      const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
+          mesh_velocity,
+      const std::optional<Scalar<DataVector>>& normal_dot_mesh_velocity,
+
+      const double volume_number) const {
+    CHECK(volume_number == 4.5);
+    tnsr::I<DataVector, Dim, Frame::Inertial> var3_buffer{get(var1).size(),
+                                                          0.0};
+    // The physical overload folds its own volume-tag value
+    // (`BoundaryCorrectionVolumeTag`, 3.5) into the packaged data, which is
+    // what the shared `dg_boundary_terms` checks expect; the auxiliary volume
+    // tag (4.5) is checked above and dropped.
+    return dg_package_data(
+        out_normal_dot_flux_var1, out_normal_dot_flux_var2, out_var1, out_var2,
+        max_abs_char_speed, make_not_null(&var3_buffer), var1, var2,
+        var3_buffer, flux_var1, flux_var2, temp_var, prim_var1, normal_covector,
+        normal_vector, mesh_velocity, normal_dot_mesh_velocity, 3.5);
+  }
+
+  // Nonconservative system, flat background
+  double dg_auxiliary_package_data(
+      const gsl::not_null<Scalar<DataVector>*> out_normal_dot_flux_var1,
+      const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*>
+          out_normal_dot_flux_var2,
+      const gsl::not_null<Scalar<DataVector>*> out_var1,
+      const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> out_var2,
+      const gsl::not_null<Scalar<DataVector>*> max_abs_char_speed,
+
+      const Scalar<DataVector>& var1,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& var2,
+
+      const Scalar<DataVector>& temp_var,
+
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_covector,
+      const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
+          mesh_velocity,
+      const std::optional<Scalar<DataVector>>& normal_dot_mesh_velocity,
+
+      const double volume_number) const {
+    CHECK(volume_number == 4.5);
+    tnsr::I<DataVector, Dim, Frame::Inertial> var3_buffer{get(var1).size(),
+                                                          0.0};
+    return dg_package_data(out_normal_dot_flux_var1, out_normal_dot_flux_var2,
+                           out_var1, out_var2, max_abs_char_speed,
+                           make_not_null(&var3_buffer), var1, var2, var3_buffer,
+                           temp_var, normal_covector, mesh_velocity,
+                           normal_dot_mesh_velocity);
+  }
+
+  // Nonconservative system, curved background
+  double dg_auxiliary_package_data(
+      const gsl::not_null<Scalar<DataVector>*> out_normal_dot_flux_var1,
+      const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*>
+          out_normal_dot_flux_var2,
+      const gsl::not_null<Scalar<DataVector>*> out_var1,
+      const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> out_var2,
+      const gsl::not_null<Scalar<DataVector>*> max_abs_char_speed,
+
+      const Scalar<DataVector>& var1,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& var2,
+
+      const Scalar<DataVector>& temp_var,
+
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_covector,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& normal_vector,
+      const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
+          mesh_velocity,
+      const std::optional<Scalar<DataVector>>& normal_dot_mesh_velocity,
+
+      const double volume_number) const {
+    CHECK(volume_number == 4.5);
+    tnsr::I<DataVector, Dim, Frame::Inertial> var3_buffer{get(var1).size(),
+                                                          0.0};
+    return dg_package_data(out_normal_dot_flux_var1, out_normal_dot_flux_var2,
+                           out_var1, out_var2, max_abs_char_speed,
+                           make_not_null(&var3_buffer), var1, var2, var3_buffer,
+                           temp_var, normal_covector, normal_vector,
+                           mesh_velocity, normal_dot_mesh_velocity);
+  }
+
+  // Mixed system, no prims, flat background
+  double dg_auxiliary_package_data(
+      const gsl::not_null<Scalar<DataVector>*> out_normal_dot_flux_var1,
+      const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*>
+          out_normal_dot_flux_var2,
+      const gsl::not_null<Scalar<DataVector>*> out_var1,
+      const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> out_var2,
+      const gsl::not_null<Scalar<DataVector>*> max_abs_char_speed,
+
+      const Scalar<DataVector>& var1,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& var2,
+
+      const tnsr::IJ<DataVector, Dim, Frame::Inertial>& flux_var2,
+
+      const Scalar<DataVector>& temp_var,
+
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_covector,
+      const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
+          mesh_velocity,
+      const std::optional<Scalar<DataVector>>& normal_dot_mesh_velocity,
+
+      const double volume_number) const {
+    CHECK(volume_number == 4.5);
+    tnsr::I<DataVector, Dim, Frame::Inertial> var3_buffer{get(var1).size(),
+                                                          0.0};
+    return dg_package_data(out_normal_dot_flux_var1, out_normal_dot_flux_var2,
+                           out_var1, out_var2, max_abs_char_speed,
+                           make_not_null(&var3_buffer), var1, var2, var3_buffer,
+                           flux_var2, temp_var, normal_covector, mesh_velocity,
+                           normal_dot_mesh_velocity);
+  }
+
+  // Mixed system, no prims, curved background
+  double dg_auxiliary_package_data(
+      const gsl::not_null<Scalar<DataVector>*> out_normal_dot_flux_var1,
+      const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*>
+          out_normal_dot_flux_var2,
+      const gsl::not_null<Scalar<DataVector>*> out_var1,
+      const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> out_var2,
+      const gsl::not_null<Scalar<DataVector>*> max_abs_char_speed,
+
+      const Scalar<DataVector>& var1,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& var2,
+
+      const tnsr::IJ<DataVector, Dim, Frame::Inertial>& flux_var2,
+
+      const Scalar<DataVector>& temp_var,
+
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_covector,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& normal_vector,
+      const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
+          mesh_velocity,
+      const std::optional<Scalar<DataVector>>& normal_dot_mesh_velocity,
+
+      const double volume_number) const {
+    CHECK(volume_number == 4.5);
+    tnsr::I<DataVector, Dim, Frame::Inertial> var3_buffer{get(var1).size(),
+                                                          0.0};
+    return dg_package_data(out_normal_dot_flux_var1, out_normal_dot_flux_var2,
+                           out_var1, out_var2, max_abs_char_speed,
+                           make_not_null(&var3_buffer), var1, var2, var3_buffer,
+                           flux_var2, temp_var, normal_covector, normal_vector,
+                           mesh_velocity, normal_dot_mesh_velocity);
+  }
+
+  // Mixed system with prims, flat background
+  double dg_auxiliary_package_data(
+      const gsl::not_null<Scalar<DataVector>*> out_normal_dot_flux_var1,
+      const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*>
+          out_normal_dot_flux_var2,
+      const gsl::not_null<Scalar<DataVector>*> out_var1,
+      const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> out_var2,
+      const gsl::not_null<Scalar<DataVector>*> max_abs_char_speed,
+
+      const Scalar<DataVector>& var1,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& var2,
+
+      const tnsr::IJ<DataVector, Dim, Frame::Inertial>& flux_var2,
+
+      const Scalar<DataVector>& temp_var,
+
+      const Scalar<DataVector>& prim_var1,
+
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_covector,
+      const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
+          mesh_velocity,
+      const std::optional<Scalar<DataVector>>& normal_dot_mesh_velocity,
+
+      const double volume_number) const {
+    CHECK(volume_number == 4.5);
+    tnsr::I<DataVector, Dim, Frame::Inertial> var3_buffer{get(var1).size(),
+                                                          0.0};
+    // The physical overload folds its own volume-tag value
+    // (`BoundaryCorrectionVolumeTag`, 3.5) into the packaged data, which is
+    // what the shared `dg_boundary_terms` checks expect; the auxiliary volume
+    // tag (4.5) is checked above and dropped.
+    return dg_package_data(out_normal_dot_flux_var1, out_normal_dot_flux_var2,
+                           out_var1, out_var2, max_abs_char_speed,
+                           make_not_null(&var3_buffer), var1, var2, var3_buffer,
+                           flux_var2, temp_var, prim_var1, normal_covector,
+                           mesh_velocity, normal_dot_mesh_velocity, 3.5);
+  }
+
+  // Mixed system with prims, curved background
+  double dg_auxiliary_package_data(
+      const gsl::not_null<Scalar<DataVector>*> out_normal_dot_flux_var1,
+      const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*>
+          out_normal_dot_flux_var2,
+      const gsl::not_null<Scalar<DataVector>*> out_var1,
+      const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> out_var2,
+      const gsl::not_null<Scalar<DataVector>*> max_abs_char_speed,
+
+      const Scalar<DataVector>& var1,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& var2,
+
+      const tnsr::IJ<DataVector, Dim, Frame::Inertial>& flux_var2,
+
+      const Scalar<DataVector>& temp_var,
+
+      const Scalar<DataVector>& prim_var1,
+
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_covector,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& normal_vector,
+      const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
+          mesh_velocity,
+      const std::optional<Scalar<DataVector>>& normal_dot_mesh_velocity,
+
+      const double volume_number) const {
+    CHECK(volume_number == 4.5);
+    tnsr::I<DataVector, Dim, Frame::Inertial> var3_buffer{get(var1).size(),
+                                                          0.0};
+    // The physical overload folds its own volume-tag value
+    // (`BoundaryCorrectionVolumeTag`, 3.5) into the packaged data, which is
+    // what the shared `dg_boundary_terms` checks expect; the auxiliary volume
+    // tag (4.5) is checked above and dropped.
+    return dg_package_data(
+        out_normal_dot_flux_var1, out_normal_dot_flux_var2, out_var1, out_var2,
+        max_abs_char_speed, make_not_null(&var3_buffer), var1, var2,
+        var3_buffer, flux_var2, temp_var, prim_var1, normal_covector,
+        normal_vector, mesh_velocity, normal_dot_mesh_velocity, 3.5);
+  }
+
+  // LDG auxiliary boundary terms.
+  // Verify the framework delivered the correct interior/exterior packaged
+  // data by reusing the physical `dg_boundary_terms` checks.
+  // Its evolved-variable corrections are written to scratch buffers and
+  // discarded. The Var3 passthrough fields it also checks are absent from
+  // the auxiliary packaged fields, so they are supplied here with the values
+  // expected, making those two checks vacuous in the auxiliary pass.
+  void dg_auxiliary_boundary_terms(
+      const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*>
+          boundary_correction_var3,
+      const Scalar<DataVector>& int_normal_dot_flux_var1,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& int_normal_dot_flux_var2,
+      const Scalar<DataVector>& int_var1,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& int_var2,
+      const Scalar<DataVector>& int_max_abs_char_speed,
+      const Scalar<DataVector>& ext_normal_dot_flux_var1,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& ext_normal_dot_flux_var2,
+      const Scalar<DataVector>& ext_var1,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& ext_var2,
+      const Scalar<DataVector>& ext_max_abs_char_speed,
+      const dg::Formulation formulation, const double volume_number) const {
+    CHECK(volume_number == 4.5);
+
+    for (size_t i = 0; i < Dim; ++i) {
+      boundary_correction_var3->get(i) =
+          0.5 * (int_var2.get(i) + ext_var2.get(i));
+    }
+
+    const size_t num_pts = get(int_var1).size();
+    Scalar<DataVector> correction_var1_buffer{num_pts};
+    tnsr::I<DataVector, Dim, Frame::Inertial> correction_var2_buffer{num_pts};
+    tnsr::I<DataVector, Dim, Frame::Inertial> int_var3{num_pts};
+    tnsr::I<DataVector, Dim, Frame::Inertial> ext_var3{num_pts};
+    for (size_t i = 0; i < Dim; ++i) {
+      int_var3.get(i) = offset_evolved_vars + static_cast<double>(i);
+      ext_var3.get(i) =
+          offset_boundary_condition + 2.0 + static_cast<double>(i);
+    }
+    dg_boundary_terms(
+        make_not_null(&correction_var1_buffer),
+        make_not_null(&correction_var2_buffer), int_normal_dot_flux_var1,
+        int_normal_dot_flux_var2, int_var1, int_var2, int_max_abs_char_speed,
+        int_var3, ext_normal_dot_flux_var1, ext_normal_dot_flux_var2, ext_var1,
+        ext_var2, ext_max_abs_char_speed, ext_var3, formulation);
   }
 
  private:
@@ -789,7 +1246,7 @@ class DemandOutgoingCharSpeeds : public BoundaryCondition<System> {
       tmpl::list<Tags::Var1, Tags::Var2<System::volume_dim>>;
   using dg_interior_primitive_variables_tags =
       tmpl::list<Tags::PrimVar1, Tags::PrimVar2<System::volume_dim>>;
-  using dg_interior_temporary_tags = tmpl::list<Tags::Var3Squared>;
+  using dg_interior_temporary_tags = tmpl::list<Tags::TempVar>;
   using dg_interior_dt_vars_tags = tmpl::list<::Tags::dt<Tags::Var1>>;
   using dg_gridless_tags = tmpl::list<Tags::BoundaryConditionVolumeTag>;
 
@@ -800,11 +1257,11 @@ class DemandOutgoingCharSpeeds : public BoundaryCondition<System> {
           outward_directed_normal_covector,
       const Scalar<DataVector>& var1,
       const tnsr::I<DataVector, System::volume_dim, Frame::Inertial>& var2,
-      const Scalar<DataVector>& var3_squared, const Scalar<DataVector>& dt_var1,
+      const Scalar<DataVector>& temp_var, const Scalar<DataVector>& dt_var1,
       const double volume_number) const {
     CHECK(volume_number == 2.5);
     const size_t num_pts = get(var1).size();
-    CHECK_ITERABLE_APPROX(get(var3_squared),
+    CHECK_ITERABLE_APPROX(get(temp_var),
                           DataVector(num_pts, offset_temporaries));
     CHECK_ITERABLE_APPROX(get(var1), DataVector(num_pts, offset_evolved_vars));
     for (size_t i = 0; i < System::volume_dim; ++i) {
@@ -851,11 +1308,11 @@ class DemandOutgoingCharSpeeds : public BoundaryCondition<System> {
           outward_directed_normal_vector,
       const Scalar<DataVector>& var1,
       const tnsr::I<DataVector, System::volume_dim, Frame::Inertial>& var2,
-      const Scalar<DataVector>& var3_squared, const Scalar<DataVector>& dt_var1,
+      const Scalar<DataVector>& temp_var, const Scalar<DataVector>& dt_var1,
       const double volume_number) const {
     dg_demand_outgoing_char_speeds(face_mesh_velocity,
                                    outward_directed_normal_covector, var1, var2,
-                                   var3_squared, dt_var1, volume_number);
+                                   temp_var, dt_var1, volume_number);
     CHECK_ITERABLE_APPROX(get(dot_product(outward_directed_normal_covector,
                                           outward_directed_normal_vector)),
                           DataVector(get(var1).size(), 1.0));
@@ -871,11 +1328,11 @@ class DemandOutgoingCharSpeeds : public BoundaryCondition<System> {
       const tnsr::I<DataVector, System::volume_dim, Frame::Inertial>& var2,
       const Scalar<DataVector>& prim_var1,
       const tnsr::i<DataVector, System::volume_dim, Frame::Inertial>& prim_var2,
-      const Scalar<DataVector>& var3_squared, const Scalar<DataVector>& dt_var1,
+      const Scalar<DataVector>& temp_var, const Scalar<DataVector>& dt_var1,
       const double volume_number) const {
     dg_demand_outgoing_char_speeds(face_mesh_velocity,
                                    outward_directed_normal_covector, var1, var2,
-                                   var3_squared, dt_var1, volume_number);
+                                   temp_var, dt_var1, volume_number);
     const size_t num_pts = get(var1).size();
     CHECK_ITERABLE_APPROX(get(prim_var1),
                           DataVector(num_pts, offset_primitive_vars));
@@ -897,11 +1354,11 @@ class DemandOutgoingCharSpeeds : public BoundaryCondition<System> {
       const tnsr::I<DataVector, System::volume_dim, Frame::Inertial>& var2,
       const Scalar<DataVector>& prim_var1,
       const tnsr::i<DataVector, System::volume_dim, Frame::Inertial>& prim_var2,
-      const Scalar<DataVector>& var3_squared, const Scalar<DataVector>& dt_var1,
+      const Scalar<DataVector>& temp_var, const Scalar<DataVector>& dt_var1,
       const double volume_number) const {
     dg_demand_outgoing_char_speeds(
         face_mesh_velocity, outward_directed_normal_covector, var1, var2,
-        prim_var1, prim_var2, var3_squared, dt_var1, volume_number);
+        prim_var1, prim_var2, temp_var, dt_var1, volume_number);
     CHECK_ITERABLE_APPROX(get(dot_product(outward_directed_normal_covector,
                                           outward_directed_normal_vector)),
                           DataVector(get(var1).size(), 1.0));
@@ -950,7 +1407,7 @@ class Ghost : public BoundaryCondition<System> {
       tmpl::list<Tags::Var1, Tags::Var2<System::volume_dim>>;
   using dg_interior_primitive_variables_tags =
       tmpl::list<Tags::PrimVar1, Tags::PrimVar2<System::volume_dim>>;
-  using dg_interior_temporary_tags = tmpl::list<Tags::Var3Squared>;
+  using dg_interior_temporary_tags = tmpl::list<Tags::TempVar>;
   using dg_interior_dt_vars_tags = tmpl::list<::Tags::dt<Tags::Var1>>;
   using dg_gridless_tags = tmpl::list<Tags::BoundaryConditionVolumeTag>;
 
@@ -960,26 +1417,33 @@ class Ghost : public BoundaryCondition<System> {
       const gsl::not_null<
           tnsr::I<DataVector, System::volume_dim, Frame::Inertial>*>
           out_var2,
-      const gsl::not_null<Scalar<DataVector>*> out_var3_squared,
+      const gsl::not_null<
+          tnsr::I<DataVector, System::volume_dim, Frame::Inertial>*>
+          out_var3,
+      const gsl::not_null<Scalar<DataVector>*> out_temp_var,
       const std::optional<tnsr::I<DataVector, System::volume_dim,
                                   Frame::Inertial>>& face_mesh_velocity,
       const tnsr::i<DataVector, System::volume_dim, Frame::Inertial>&
           outward_directed_normal_covector,
       const Scalar<DataVector>& var1,
       const tnsr::I<DataVector, System::volume_dim, Frame::Inertial>& var2,
-      const Scalar<DataVector>& var3_squared, const Scalar<DataVector>& dt_var1,
+      const Scalar<DataVector>& temp_var, const Scalar<DataVector>& dt_var1,
       const double volume_number) const {
     get(*out_var1) = offset_boundary_condition;
     for (size_t i = 0; i < System::volume_dim; ++i) {
       out_var2->get(i) =
           offset_boundary_condition + 1.0 + static_cast<double>(i);
     }
-    get(*out_var3_squared) = offset_boundary_condition + 1.0 +
-                             (2 + System::volume_dim) * System::volume_dim;
+    for (size_t i = 0; i < System::volume_dim; ++i) {
+      out_var3->get(i) =
+          offset_boundary_condition + 2.0 + static_cast<double>(i);
+    }
+    get(*out_temp_var) = offset_boundary_condition + 1.0 +
+                         (2 + System::volume_dim) * System::volume_dim;
 
     CHECK(volume_number == 2.5);
     const size_t num_pts = get(var1).size();
-    CHECK_ITERABLE_APPROX(get(var3_squared),
+    CHECK_ITERABLE_APPROX(get(temp_var),
                           DataVector(num_pts, offset_temporaries));
     CHECK_ITERABLE_APPROX(get(var1), DataVector(num_pts, offset_evolved_vars));
     for (size_t i = 0; i < System::volume_dim; ++i) {
@@ -1023,7 +1487,10 @@ class Ghost : public BoundaryCondition<System> {
       const gsl::not_null<
           tnsr::I<DataVector, System::volume_dim, Frame::Inertial>*>
           out_var2,
-      const gsl::not_null<Scalar<DataVector>*> out_var3_squared,
+      const gsl::not_null<
+          tnsr::I<DataVector, System::volume_dim, Frame::Inertial>*>
+          out_var3,
+      const gsl::not_null<Scalar<DataVector>*> out_temp_var,
       const gsl::not_null<
           tnsr::II<DataVector, System::volume_dim, Frame::Inertial>*>
           inv_spatial_metric,
@@ -1036,14 +1503,14 @@ class Ghost : public BoundaryCondition<System> {
           outward_directed_normal_vector,
       const Scalar<DataVector>& var1,
       const tnsr::I<DataVector, System::volume_dim, Frame::Inertial>& var2,
-      const Scalar<DataVector>& var3_squared, const Scalar<DataVector>& dt_var1,
+      const Scalar<DataVector>& temp_var, const Scalar<DataVector>& dt_var1,
       const double volume_number) const {
     check_normal_vector_set_inverse_spatial_metric(
         inv_spatial_metric, outward_directed_normal_covector,
         outward_directed_normal_vector);
-    return dg_ghost(out_var1, out_var2, out_var3_squared, face_mesh_velocity,
-                    outward_directed_normal_covector, var1, var2, var3_squared,
-                    dt_var1, volume_number);
+    return dg_ghost(out_var1, out_var2, out_var3, out_temp_var,
+                    face_mesh_velocity, outward_directed_normal_covector, var1,
+                    var2, temp_var, dt_var1, volume_number);
   }
 
   // Mixed conservative non-conservative system, no prims, flat background
@@ -1053,20 +1520,23 @@ class Ghost : public BoundaryCondition<System> {
           tnsr::I<DataVector, System::volume_dim, Frame::Inertial>*>
           out_var2,
       const gsl::not_null<
+          tnsr::I<DataVector, System::volume_dim, Frame::Inertial>*>
+          out_var3,
+      const gsl::not_null<
           tnsr::IJ<DataVector, System::volume_dim, Frame::Inertial>*>
           flux_var2,
-      const gsl::not_null<Scalar<DataVector>*> out_var3_squared,
+      const gsl::not_null<Scalar<DataVector>*> out_temp_var,
       const std::optional<tnsr::I<DataVector, System::volume_dim,
                                   Frame::Inertial>>& face_mesh_velocity,
       const tnsr::i<DataVector, System::volume_dim, Frame::Inertial>&
           outward_directed_normal_covector,
       const Scalar<DataVector>& var1,
       const tnsr::I<DataVector, System::volume_dim, Frame::Inertial>& var2,
-      const Scalar<DataVector>& var3_squared, const Scalar<DataVector>& dt_var1,
+      const Scalar<DataVector>& temp_var, const Scalar<DataVector>& dt_var1,
       const double volume_number) const {
-    dg_ghost(out_var1, out_var2, out_var3_squared, face_mesh_velocity,
-             outward_directed_normal_covector, var1, var2, var3_squared,
-             dt_var1, volume_number);
+    dg_ghost(out_var1, out_var2, out_var3, out_temp_var, face_mesh_velocity,
+             outward_directed_normal_covector, var1, var2, temp_var, dt_var1,
+             volume_number);
     for (size_t i = 0; i < System::volume_dim; ++i) {
       for (size_t j = 0; j < System::volume_dim; ++j) {
         flux_var2->get(i, j) = offset_boundary_condition + 1.0 +
@@ -1083,9 +1553,12 @@ class Ghost : public BoundaryCondition<System> {
           tnsr::I<DataVector, System::volume_dim, Frame::Inertial>*>
           out_var2,
       const gsl::not_null<
+          tnsr::I<DataVector, System::volume_dim, Frame::Inertial>*>
+          out_var3,
+      const gsl::not_null<
           tnsr::IJ<DataVector, System::volume_dim, Frame::Inertial>*>
           flux_var2,
-      const gsl::not_null<Scalar<DataVector>*> out_var3_squared,
+      const gsl::not_null<Scalar<DataVector>*> out_temp_var,
       const gsl::not_null<
           tnsr::II<DataVector, System::volume_dim, Frame::Inertial>*>
           inv_spatial_metric,
@@ -1098,14 +1571,14 @@ class Ghost : public BoundaryCondition<System> {
           outward_directed_normal_vector,
       const Scalar<DataVector>& var1,
       const tnsr::I<DataVector, System::volume_dim, Frame::Inertial>& var2,
-      const Scalar<DataVector>& var3_squared, const Scalar<DataVector>& dt_var1,
+      const Scalar<DataVector>& temp_var, const Scalar<DataVector>& dt_var1,
       const double volume_number) const {
     check_normal_vector_set_inverse_spatial_metric(
         inv_spatial_metric, outward_directed_normal_covector,
         outward_directed_normal_vector);
-    return dg_ghost(out_var1, out_var2, flux_var2, out_var3_squared,
+    return dg_ghost(out_var1, out_var2, out_var3, flux_var2, out_temp_var,
                     face_mesh_velocity, outward_directed_normal_covector, var1,
-                    var2, var3_squared, dt_var1, volume_number);
+                    var2, temp_var, dt_var1, volume_number);
   }
 
   // Mixed conservative non-conservative system, with prims, flat background
@@ -1115,9 +1588,12 @@ class Ghost : public BoundaryCondition<System> {
           tnsr::I<DataVector, System::volume_dim, Frame::Inertial>*>
           out_var2,
       const gsl::not_null<
+          tnsr::I<DataVector, System::volume_dim, Frame::Inertial>*>
+          out_var3,
+      const gsl::not_null<
           tnsr::IJ<DataVector, System::volume_dim, Frame::Inertial>*>
           flux_var2,
-      const gsl::not_null<Scalar<DataVector>*> out_var3_squared,
+      const gsl::not_null<Scalar<DataVector>*> out_temp_var,
       const gsl::not_null<Scalar<DataVector>*> out_prim_var1,
 
       const std::optional<tnsr::I<DataVector, System::volume_dim,
@@ -1128,12 +1604,12 @@ class Ghost : public BoundaryCondition<System> {
       const tnsr::I<DataVector, System::volume_dim, Frame::Inertial>& var2,
       const Scalar<DataVector>& prim_var1,
       const tnsr::i<DataVector, System::volume_dim, Frame::Inertial>& prim_var2,
-      const Scalar<DataVector>& var3_squared, const Scalar<DataVector>& dt_var1,
+      const Scalar<DataVector>& temp_var, const Scalar<DataVector>& dt_var1,
       const double volume_number) const {
-    dg_ghost(out_var1, out_var2, flux_var2, out_var3_squared,
+    dg_ghost(out_var1, out_var2, out_var3, flux_var2, out_temp_var,
              face_mesh_velocity, outward_directed_normal_covector, var1, var2,
-             var3_squared, dt_var1, volume_number);
-    get(*out_prim_var1) = get(*out_var3_squared) + 1.0;
+             temp_var, dt_var1, volume_number);
+    get(*out_prim_var1) = get(*out_temp_var) + 1.0;
     const size_t num_pts = get(var1).size();
     CHECK_ITERABLE_APPROX(get(prim_var1),
                           DataVector(num_pts, offset_primitive_vars));
@@ -1151,9 +1627,12 @@ class Ghost : public BoundaryCondition<System> {
           tnsr::I<DataVector, System::volume_dim, Frame::Inertial>*>
           out_var2,
       const gsl::not_null<
+          tnsr::I<DataVector, System::volume_dim, Frame::Inertial>*>
+          out_var3,
+      const gsl::not_null<
           tnsr::IJ<DataVector, System::volume_dim, Frame::Inertial>*>
           flux_var2,
-      const gsl::not_null<Scalar<DataVector>*> out_var3_squared,
+      const gsl::not_null<Scalar<DataVector>*> out_temp_var,
       const gsl::not_null<Scalar<DataVector>*> out_prim_var1,
       const gsl::not_null<
           tnsr::II<DataVector, System::volume_dim, Frame::Inertial>*>
@@ -1169,15 +1648,15 @@ class Ghost : public BoundaryCondition<System> {
       const tnsr::I<DataVector, System::volume_dim, Frame::Inertial>& var2,
       const Scalar<DataVector>& prim_var1,
       const tnsr::i<DataVector, System::volume_dim, Frame::Inertial>& prim_var2,
-      const Scalar<DataVector>& var3_squared, const Scalar<DataVector>& dt_var1,
+      const Scalar<DataVector>& temp_var, const Scalar<DataVector>& dt_var1,
       const double volume_number) const {
     check_normal_vector_set_inverse_spatial_metric(
         inv_spatial_metric, outward_directed_normal_covector,
         outward_directed_normal_vector);
-    return dg_ghost(out_var1, out_var2, flux_var2, out_var3_squared,
+    return dg_ghost(out_var1, out_var2, out_var3, flux_var2, out_temp_var,
                     out_prim_var1, face_mesh_velocity,
                     outward_directed_normal_covector, var1, var2, prim_var1,
-                    prim_var2, var3_squared, dt_var1, volume_number);
+                    prim_var2, temp_var, dt_var1, volume_number);
   }
 
   // Conservative system, no prims, flat background
@@ -1188,22 +1667,25 @@ class Ghost : public BoundaryCondition<System> {
           out_var2,
       const gsl::not_null<
           tnsr::I<DataVector, System::volume_dim, Frame::Inertial>*>
+          out_var3,
+      const gsl::not_null<
+          tnsr::I<DataVector, System::volume_dim, Frame::Inertial>*>
           flux_var1,
       const gsl::not_null<
           tnsr::IJ<DataVector, System::volume_dim, Frame::Inertial>*>
           flux_var2,
-      const gsl::not_null<Scalar<DataVector>*> out_var3_squared,
+      const gsl::not_null<Scalar<DataVector>*> out_temp_var,
       const std::optional<tnsr::I<DataVector, System::volume_dim,
                                   Frame::Inertial>>& face_mesh_velocity,
       const tnsr::i<DataVector, System::volume_dim, Frame::Inertial>&
           outward_directed_normal_covector,
       const Scalar<DataVector>& var1,
       const tnsr::I<DataVector, System::volume_dim, Frame::Inertial>& var2,
-      const Scalar<DataVector>& var3_squared, const Scalar<DataVector>& dt_var1,
+      const Scalar<DataVector>& temp_var, const Scalar<DataVector>& dt_var1,
       const double volume_number) const {
-    dg_ghost(out_var1, out_var2, flux_var2, out_var3_squared,
+    dg_ghost(out_var1, out_var2, out_var3, flux_var2, out_temp_var,
              face_mesh_velocity, outward_directed_normal_covector, var1, var2,
-             var3_squared, dt_var1, volume_number);
+             temp_var, dt_var1, volume_number);
     for (size_t i = 0; i < System::volume_dim; ++i) {
       flux_var1->get(i) = offset_boundary_condition + 1.0 +
                           static_cast<double>(i + System::volume_dim);
@@ -1219,11 +1701,14 @@ class Ghost : public BoundaryCondition<System> {
           out_var2,
       const gsl::not_null<
           tnsr::I<DataVector, System::volume_dim, Frame::Inertial>*>
+          out_var3,
+      const gsl::not_null<
+          tnsr::I<DataVector, System::volume_dim, Frame::Inertial>*>
           flux_var1,
       const gsl::not_null<
           tnsr::IJ<DataVector, System::volume_dim, Frame::Inertial>*>
           flux_var2,
-      const gsl::not_null<Scalar<DataVector>*> out_var3_squared,
+      const gsl::not_null<Scalar<DataVector>*> out_temp_var,
       const gsl::not_null<
           tnsr::II<DataVector, System::volume_dim, Frame::Inertial>*>
           inv_spatial_metric,
@@ -1235,14 +1720,14 @@ class Ghost : public BoundaryCondition<System> {
           outward_directed_normal_vector,
       const Scalar<DataVector>& var1,
       const tnsr::I<DataVector, System::volume_dim, Frame::Inertial>& var2,
-      const Scalar<DataVector>& var3_squared, const Scalar<DataVector>& dt_var1,
+      const Scalar<DataVector>& temp_var, const Scalar<DataVector>& dt_var1,
       const double volume_number) const {
     check_normal_vector_set_inverse_spatial_metric(
         inv_spatial_metric, outward_directed_normal_covector,
         outward_directed_normal_vector);
-    dg_ghost(out_var1, out_var2, flux_var1, flux_var2, out_var3_squared,
+    dg_ghost(out_var1, out_var2, out_var3, flux_var1, flux_var2, out_temp_var,
              face_mesh_velocity, outward_directed_normal_covector, var1, var2,
-             var3_squared, dt_var1, volume_number);
+             temp_var, dt_var1, volume_number);
     return std::nullopt;
   }
 
@@ -1254,11 +1739,14 @@ class Ghost : public BoundaryCondition<System> {
           out_var2,
       const gsl::not_null<
           tnsr::I<DataVector, System::volume_dim, Frame::Inertial>*>
+          out_var3,
+      const gsl::not_null<
+          tnsr::I<DataVector, System::volume_dim, Frame::Inertial>*>
           flux_var1,
       const gsl::not_null<
           tnsr::IJ<DataVector, System::volume_dim, Frame::Inertial>*>
           flux_var2,
-      const gsl::not_null<Scalar<DataVector>*> out_var3_squared,
+      const gsl::not_null<Scalar<DataVector>*> out_temp_var,
       const gsl::not_null<Scalar<DataVector>*> out_prim_var1,
 
       const std::optional<tnsr::I<DataVector, System::volume_dim,
@@ -1269,12 +1757,12 @@ class Ghost : public BoundaryCondition<System> {
       const tnsr::I<DataVector, System::volume_dim, Frame::Inertial>& var2,
       const Scalar<DataVector>& prim_var1,
       const tnsr::i<DataVector, System::volume_dim, Frame::Inertial>& prim_var2,
-      const Scalar<DataVector>& var3_squared, const Scalar<DataVector>& dt_var1,
+      const Scalar<DataVector>& temp_var, const Scalar<DataVector>& dt_var1,
       const double volume_number) const {
-    dg_ghost(out_var1, out_var2, flux_var1, flux_var2, out_var3_squared,
+    dg_ghost(out_var1, out_var2, out_var3, flux_var1, flux_var2, out_temp_var,
              face_mesh_velocity, outward_directed_normal_covector, var1, var2,
-             var3_squared, dt_var1, volume_number);
-    get(*out_prim_var1) = get(*out_var3_squared) + 1.0;
+             temp_var, dt_var1, volume_number);
+    get(*out_prim_var1) = get(*out_temp_var) + 1.0;
     const size_t num_pts = get(var1).size();
     CHECK_ITERABLE_APPROX(get(prim_var1),
                           DataVector(num_pts, offset_primitive_vars));
@@ -1293,11 +1781,14 @@ class Ghost : public BoundaryCondition<System> {
           out_var2,
       const gsl::not_null<
           tnsr::I<DataVector, System::volume_dim, Frame::Inertial>*>
+          out_var3,
+      const gsl::not_null<
+          tnsr::I<DataVector, System::volume_dim, Frame::Inertial>*>
           flux_var1,
       const gsl::not_null<
           tnsr::IJ<DataVector, System::volume_dim, Frame::Inertial>*>
           flux_var2,
-      const gsl::not_null<Scalar<DataVector>*> out_var3_squared,
+      const gsl::not_null<Scalar<DataVector>*> out_temp_var,
       const gsl::not_null<Scalar<DataVector>*> out_prim_var1,
       const gsl::not_null<
           tnsr::II<DataVector, System::volume_dim, Frame::Inertial>*>
@@ -1313,15 +1804,15 @@ class Ghost : public BoundaryCondition<System> {
       const tnsr::I<DataVector, System::volume_dim, Frame::Inertial>& var2,
       const Scalar<DataVector>& prim_var1,
       const tnsr::i<DataVector, System::volume_dim, Frame::Inertial>& prim_var2,
-      const Scalar<DataVector>& var3_squared, const Scalar<DataVector>& dt_var1,
+      const Scalar<DataVector>& temp_var, const Scalar<DataVector>& dt_var1,
       const double volume_number) const {
     check_normal_vector_set_inverse_spatial_metric(
         inv_spatial_metric, outward_directed_normal_covector,
         outward_directed_normal_vector);
-    return dg_ghost(out_var1, out_var2, flux_var1, flux_var2, out_var3_squared,
-                    out_prim_var1, face_mesh_velocity,
+    return dg_ghost(out_var1, out_var2, out_var3, flux_var1, flux_var2,
+                    out_temp_var, out_prim_var1, face_mesh_velocity,
                     outward_directed_normal_covector, var1, var2, prim_var1,
-                    prim_var2, var3_squared, dt_var1, volume_number);
+                    prim_var2, temp_var, dt_var1, volume_number);
   }
 
   // public so that GhostAndTimeDerivative can call into this
@@ -1389,7 +1880,7 @@ class TimeDerivative : public BoundaryCondition<System> {
       tmpl::list<Tags::Var1, Tags::Var2<System::volume_dim>>;
   using dg_interior_primitive_variables_tags =
       tmpl::list<Tags::PrimVar1, Tags::PrimVar2<System::volume_dim>>;
-  using dg_interior_temporary_tags = tmpl::list<Tags::Var3Squared>;
+  using dg_interior_temporary_tags = tmpl::list<Tags::TempVar>;
   using dg_interior_dt_vars_tags = tmpl::list<::Tags::dt<Tags::Var1>>;
   using dg_interior_deriv_vars_tags = tmpl::conditional_t<
       System::system_type == SystemType::Conservative, tmpl::list<>,
@@ -1409,11 +1900,11 @@ class TimeDerivative : public BoundaryCondition<System> {
           outward_directed_normal_covector,
       const Scalar<DataVector>& var1,
       const tnsr::I<DataVector, System::volume_dim, Frame::Inertial>& var2,
-      const Scalar<DataVector>& var3_squared, const Scalar<DataVector>& dt_var1,
+      const Scalar<DataVector>& temp_var, const Scalar<DataVector>& dt_var1,
       const double volume_number) const {
     CHECK(volume_number == 2.5);
     const size_t num_pts = get(var1).size();
-    CHECK_ITERABLE_APPROX(get(var3_squared),
+    CHECK_ITERABLE_APPROX(get(temp_var),
                           DataVector(num_pts, offset_temporaries));
     CHECK_ITERABLE_APPROX(get(var1), DataVector(num_pts, offset_evolved_vars));
     for (size_t i = 0; i < System::volume_dim; ++i) {
@@ -1469,14 +1960,14 @@ class TimeDerivative : public BoundaryCondition<System> {
           outward_directed_normal_vector,
       const Scalar<DataVector>& var1,
       const tnsr::I<DataVector, System::volume_dim, Frame::Inertial>& var2,
-      const Scalar<DataVector>& var3_squared, const Scalar<DataVector>& dt_var1,
+      const Scalar<DataVector>& temp_var, const Scalar<DataVector>& dt_var1,
       const double volume_number) const {
     check_normal_vector(outward_directed_normal_covector,
                         outward_directed_normal_vector);
     return dg_time_derivative(dt_correction_var1, dt_correction_var2,
                               face_mesh_velocity,
                               outward_directed_normal_covector, var1, var2,
-                              var3_squared, dt_var1, volume_number);
+                              temp_var, dt_var1, volume_number);
   }
 
   // Mixed and non-conservative system, flat background
@@ -1491,12 +1982,12 @@ class TimeDerivative : public BoundaryCondition<System> {
           outward_directed_normal_covector,
       const Scalar<DataVector>& var1,
       const tnsr::I<DataVector, System::volume_dim, Frame::Inertial>& var2,
-      const Scalar<DataVector>& var3_squared, const Scalar<DataVector>& dt_var1,
+      const Scalar<DataVector>& temp_var, const Scalar<DataVector>& dt_var1,
       const tnsr::i<DataVector, System::volume_dim, Frame::Inertial>& d_var1,
       const double volume_number) const {
     dg_time_derivative(dt_correction_var1, dt_correction_var2,
                        face_mesh_velocity, outward_directed_normal_covector,
-                       var1, var2, var3_squared, dt_var1, volume_number);
+                       var1, var2, temp_var, dt_var1, volume_number);
     const size_t num_pts = get(var1).size();
     for (size_t i = 0; i < System::volume_dim; ++i) {
       CHECK_ITERABLE_APPROX(d_var1.get(i),
@@ -1519,7 +2010,7 @@ class TimeDerivative : public BoundaryCondition<System> {
           outward_directed_normal_vector,
       const Scalar<DataVector>& var1,
       const tnsr::I<DataVector, System::volume_dim, Frame::Inertial>& var2,
-      const Scalar<DataVector>& var3_squared, const Scalar<DataVector>& dt_var1,
+      const Scalar<DataVector>& temp_var, const Scalar<DataVector>& dt_var1,
       const tnsr::i<DataVector, System::volume_dim, Frame::Inertial>& d_var1,
       const double volume_number) const {
     check_normal_vector(outward_directed_normal_covector,
@@ -1527,7 +2018,7 @@ class TimeDerivative : public BoundaryCondition<System> {
     return dg_time_derivative(dt_correction_var1, dt_correction_var2,
                               face_mesh_velocity,
                               outward_directed_normal_covector, var1, var2,
-                              var3_squared, dt_var1, d_var1, volume_number);
+                              temp_var, dt_var1, d_var1, volume_number);
   }
 
   // Mixed system with primitive vars, flat background
@@ -1544,18 +2035,17 @@ class TimeDerivative : public BoundaryCondition<System> {
       const tnsr::I<DataVector, System::volume_dim, Frame::Inertial>& var2,
       const Scalar<DataVector>& prim_var1,
       const tnsr::i<DataVector, System::volume_dim, Frame::Inertial>& prim_var2,
-      const Scalar<DataVector>& var3_squared, const Scalar<DataVector>& dt_var1,
+      const Scalar<DataVector>& temp_var, const Scalar<DataVector>& dt_var1,
       const tnsr::i<DataVector, System::volume_dim, Frame::Inertial>& d_var1,
       const double volume_number) const {
     dg_time_derivative(dt_correction_var1, dt_correction_var2,
                        face_mesh_velocity, outward_directed_normal_covector,
-                       var1, var2, prim_var1, prim_var2, var3_squared, dt_var1,
+                       var1, var2, prim_var1, prim_var2, temp_var, dt_var1,
                        volume_number);
     // Sets the dt_correction again, but that's fine, values stay the same.
     dg_time_derivative(dt_correction_var1, dt_correction_var2,
                        face_mesh_velocity, outward_directed_normal_covector,
-                       var1, var2, var3_squared, dt_var1, d_var1,
-                       volume_number);
+                       var1, var2, temp_var, dt_var1, d_var1, volume_number);
     return std::nullopt;
   }
 
@@ -1575,7 +2065,7 @@ class TimeDerivative : public BoundaryCondition<System> {
       const tnsr::I<DataVector, System::volume_dim, Frame::Inertial>& var2,
       const Scalar<DataVector>& prim_var1,
       const tnsr::i<DataVector, System::volume_dim, Frame::Inertial>& prim_var2,
-      const Scalar<DataVector>& var3_squared, const Scalar<DataVector>& dt_var1,
+      const Scalar<DataVector>& temp_var, const Scalar<DataVector>& dt_var1,
       const tnsr::i<DataVector, System::volume_dim, Frame::Inertial>& d_var1,
       const double volume_number) const {
     check_normal_vector(outward_directed_normal_covector,
@@ -1583,7 +2073,7 @@ class TimeDerivative : public BoundaryCondition<System> {
     return dg_time_derivative(
         dt_correction_var1, dt_correction_var2, face_mesh_velocity,
         outward_directed_normal_covector, var1, var2, prim_var1, prim_var2,
-        var3_squared, dt_var1, d_var1, volume_number);
+        temp_var, dt_var1, d_var1, volume_number);
   }
 
   // Conservative system with primitive vars
@@ -1600,11 +2090,11 @@ class TimeDerivative : public BoundaryCondition<System> {
       const tnsr::I<DataVector, System::volume_dim, Frame::Inertial>& var2,
       const Scalar<DataVector>& prim_var1,
       const tnsr::i<DataVector, System::volume_dim, Frame::Inertial>& prim_var2,
-      const Scalar<DataVector>& var3_squared, const Scalar<DataVector>& dt_var1,
+      const Scalar<DataVector>& temp_var, const Scalar<DataVector>& dt_var1,
       const double volume_number) const {
     dg_time_derivative(dt_correction_var1, dt_correction_var2,
                        face_mesh_velocity, outward_directed_normal_covector,
-                       var1, var2, var3_squared, dt_var1, volume_number);
+                       var1, var2, temp_var, dt_var1, volume_number);
     const size_t num_pts = get(var1).size();
     CHECK_ITERABLE_APPROX(get(prim_var1),
                           DataVector(num_pts, offset_primitive_vars));
@@ -1631,13 +2121,13 @@ class TimeDerivative : public BoundaryCondition<System> {
       const tnsr::I<DataVector, System::volume_dim, Frame::Inertial>& var2,
       const Scalar<DataVector>& prim_var1,
       const tnsr::i<DataVector, System::volume_dim, Frame::Inertial>& prim_var2,
-      const Scalar<DataVector>& var3_squared, const Scalar<DataVector>& dt_var1,
+      const Scalar<DataVector>& temp_var, const Scalar<DataVector>& dt_var1,
       const double volume_number) const {
     check_normal_vector(outward_directed_normal_covector,
                         outward_directed_normal_vector);
     dg_time_derivative(dt_correction_var1, dt_correction_var2,
                        face_mesh_velocity, outward_directed_normal_covector,
-                       var1, var2, prim_var1, prim_var2, var3_squared, dt_var1,
+                       var1, var2, prim_var1, prim_var2, temp_var, dt_var1,
                        volume_number);
     return std::nullopt;
   }
@@ -1714,19 +2204,22 @@ class GhostAndTimeDerivative : public BoundaryCondition<System> {
       const gsl::not_null<
           tnsr::I<DataVector, System::volume_dim, Frame::Inertial>*>
           out_var2,
-      const gsl::not_null<Scalar<DataVector>*> out_var3_squared,
+      const gsl::not_null<
+          tnsr::I<DataVector, System::volume_dim, Frame::Inertial>*>
+          out_var3,
+      const gsl::not_null<Scalar<DataVector>*> out_temp_var,
       const std::optional<tnsr::I<DataVector, System::volume_dim,
                                   Frame::Inertial>>& face_mesh_velocity,
       const tnsr::i<DataVector, System::volume_dim, Frame::Inertial>&
           outward_directed_normal_covector,
       const Scalar<DataVector>& var1,
       const tnsr::I<DataVector, System::volume_dim, Frame::Inertial>& var2,
-      const Scalar<DataVector>& var3_squared, const Scalar<DataVector>& dt_var1,
+      const Scalar<DataVector>& temp_var, const Scalar<DataVector>& dt_var1,
       const tnsr::i<DataVector, System::volume_dim, Frame::Inertial>& d_var1,
       const double volume_number) const {
-    ghost_.dg_ghost(out_var1, out_var2, out_var3_squared, face_mesh_velocity,
-                    outward_directed_normal_covector, var1, var2, var3_squared,
-                    dt_var1, volume_number);
+    ghost_.dg_ghost(out_var1, out_var2, out_var3, out_temp_var,
+                    face_mesh_velocity, outward_directed_normal_covector, var1,
+                    var2, temp_var, dt_var1, volume_number);
     const size_t num_pts = get(var1).size();
     for (size_t i = 0; i < System::volume_dim; ++i) {
       CHECK_ITERABLE_APPROX(d_var1.get(i),
@@ -1741,7 +2234,10 @@ class GhostAndTimeDerivative : public BoundaryCondition<System> {
       const gsl::not_null<
           tnsr::I<DataVector, System::volume_dim, Frame::Inertial>*>
           out_var2,
-      const gsl::not_null<Scalar<DataVector>*> out_var3_squared,
+      const gsl::not_null<
+          tnsr::I<DataVector, System::volume_dim, Frame::Inertial>*>
+          out_var3,
+      const gsl::not_null<Scalar<DataVector>*> out_temp_var,
       const gsl::not_null<
           tnsr::II<DataVector, System::volume_dim, Frame::Inertial>*>
           inv_spatial_metric,
@@ -1754,15 +2250,15 @@ class GhostAndTimeDerivative : public BoundaryCondition<System> {
           outward_directed_normal_vector,
       const Scalar<DataVector>& var1,
       const tnsr::I<DataVector, System::volume_dim, Frame::Inertial>& var2,
-      const Scalar<DataVector>& var3_squared, const Scalar<DataVector>& dt_var1,
+      const Scalar<DataVector>& temp_var, const Scalar<DataVector>& dt_var1,
       const tnsr::i<DataVector, System::volume_dim, Frame::Inertial>& d_var1,
       const double volume_number) const {
     ghost_.check_normal_vector_set_inverse_spatial_metric(
         inv_spatial_metric, outward_directed_normal_covector,
         outward_directed_normal_vector);
-    return dg_ghost(out_var1, out_var2, out_var3_squared, face_mesh_velocity,
-                    outward_directed_normal_covector, var1, var2, var3_squared,
-                    dt_var1, d_var1, volume_number);
+    return dg_ghost(out_var1, out_var2, out_var3, out_temp_var,
+                    face_mesh_velocity, outward_directed_normal_covector, var1,
+                    var2, temp_var, dt_var1, d_var1, volume_number);
   }
 
   // Mixed conservative non-conservative system, no prims, flat background
@@ -1772,21 +2268,24 @@ class GhostAndTimeDerivative : public BoundaryCondition<System> {
           tnsr::I<DataVector, System::volume_dim, Frame::Inertial>*>
           out_var2,
       const gsl::not_null<
+          tnsr::I<DataVector, System::volume_dim, Frame::Inertial>*>
+          out_var3,
+      const gsl::not_null<
           tnsr::IJ<DataVector, System::volume_dim, Frame::Inertial>*>
           flux_var2,
-      const gsl::not_null<Scalar<DataVector>*> out_var3_squared,
+      const gsl::not_null<Scalar<DataVector>*> out_temp_var,
       const std::optional<tnsr::I<DataVector, System::volume_dim,
                                   Frame::Inertial>>& face_mesh_velocity,
       const tnsr::i<DataVector, System::volume_dim, Frame::Inertial>&
           outward_directed_normal_covector,
       const Scalar<DataVector>& var1,
       const tnsr::I<DataVector, System::volume_dim, Frame::Inertial>& var2,
-      const Scalar<DataVector>& var3_squared, const Scalar<DataVector>& dt_var1,
+      const Scalar<DataVector>& temp_var, const Scalar<DataVector>& dt_var1,
       const tnsr::i<DataVector, System::volume_dim, Frame::Inertial>& d_var1,
       const double volume_number) const {
-    ghost_.dg_ghost(out_var1, out_var2, flux_var2, out_var3_squared,
+    ghost_.dg_ghost(out_var1, out_var2, out_var3, flux_var2, out_temp_var,
                     face_mesh_velocity, outward_directed_normal_covector, var1,
-                    var2, var3_squared, dt_var1, volume_number);
+                    var2, temp_var, dt_var1, volume_number);
     const size_t num_pts = get(var1).size();
     for (size_t i = 0; i < System::volume_dim; ++i) {
       CHECK_ITERABLE_APPROX(d_var1.get(i),
@@ -1802,9 +2301,12 @@ class GhostAndTimeDerivative : public BoundaryCondition<System> {
           tnsr::I<DataVector, System::volume_dim, Frame::Inertial>*>
           out_var2,
       const gsl::not_null<
+          tnsr::I<DataVector, System::volume_dim, Frame::Inertial>*>
+          out_var3,
+      const gsl::not_null<
           tnsr::IJ<DataVector, System::volume_dim, Frame::Inertial>*>
           flux_var2,
-      const gsl::not_null<Scalar<DataVector>*> out_var3_squared,
+      const gsl::not_null<Scalar<DataVector>*> out_temp_var,
       const gsl::not_null<
           tnsr::II<DataVector, System::volume_dim, Frame::Inertial>*>
           inv_spatial_metric,
@@ -1817,15 +2319,15 @@ class GhostAndTimeDerivative : public BoundaryCondition<System> {
           outward_directed_normal_vector,
       const Scalar<DataVector>& var1,
       const tnsr::I<DataVector, System::volume_dim, Frame::Inertial>& var2,
-      const Scalar<DataVector>& var3_squared, const Scalar<DataVector>& dt_var1,
+      const Scalar<DataVector>& temp_var, const Scalar<DataVector>& dt_var1,
       const tnsr::i<DataVector, System::volume_dim, Frame::Inertial>& d_var1,
       const double volume_number) const {
     ghost_.check_normal_vector_set_inverse_spatial_metric(
         inv_spatial_metric, outward_directed_normal_covector,
         outward_directed_normal_vector);
-    return dg_ghost(out_var1, out_var2, flux_var2, out_var3_squared,
+    return dg_ghost(out_var1, out_var2, out_var3, flux_var2, out_temp_var,
                     face_mesh_velocity, outward_directed_normal_covector, var1,
-                    var2, var3_squared, dt_var1, d_var1, volume_number);
+                    var2, temp_var, dt_var1, d_var1, volume_number);
   }
 
   // Mixed conservative non-conservative system, prims, flat background
@@ -1835,9 +2337,12 @@ class GhostAndTimeDerivative : public BoundaryCondition<System> {
           tnsr::I<DataVector, System::volume_dim, Frame::Inertial>*>
           out_var2,
       const gsl::not_null<
+          tnsr::I<DataVector, System::volume_dim, Frame::Inertial>*>
+          out_var3,
+      const gsl::not_null<
           tnsr::IJ<DataVector, System::volume_dim, Frame::Inertial>*>
           flux_var2,
-      const gsl::not_null<Scalar<DataVector>*> out_var3_squared,
+      const gsl::not_null<Scalar<DataVector>*> out_temp_var,
       const gsl::not_null<Scalar<DataVector>*> out_prim_var1,
       const std::optional<tnsr::I<DataVector, System::volume_dim,
                                   Frame::Inertial>>& face_mesh_velocity,
@@ -1847,13 +2352,13 @@ class GhostAndTimeDerivative : public BoundaryCondition<System> {
       const tnsr::I<DataVector, System::volume_dim, Frame::Inertial>& var2,
       const Scalar<DataVector>& prim_var1,
       const tnsr::i<DataVector, System::volume_dim, Frame::Inertial>& prim_var2,
-      const Scalar<DataVector>& var3_squared, const Scalar<DataVector>& dt_var1,
+      const Scalar<DataVector>& temp_var, const Scalar<DataVector>& dt_var1,
       const tnsr::i<DataVector, System::volume_dim, Frame::Inertial>& d_var1,
       const double volume_number) const {
-    ghost_.dg_ghost(out_var1, out_var2, flux_var2, out_var3_squared,
+    ghost_.dg_ghost(out_var1, out_var2, out_var3, flux_var2, out_temp_var,
                     out_prim_var1, face_mesh_velocity,
                     outward_directed_normal_covector, var1, var2, prim_var1,
-                    prim_var2, var3_squared, dt_var1, volume_number);
+                    prim_var2, temp_var, dt_var1, volume_number);
     const size_t num_pts = get(var1).size();
     for (size_t i = 0; i < System::volume_dim; ++i) {
       CHECK_ITERABLE_APPROX(d_var1.get(i),
@@ -1869,9 +2374,12 @@ class GhostAndTimeDerivative : public BoundaryCondition<System> {
           tnsr::I<DataVector, System::volume_dim, Frame::Inertial>*>
           out_var2,
       const gsl::not_null<
+          tnsr::I<DataVector, System::volume_dim, Frame::Inertial>*>
+          out_var3,
+      const gsl::not_null<
           tnsr::IJ<DataVector, System::volume_dim, Frame::Inertial>*>
           flux_var2,
-      const gsl::not_null<Scalar<DataVector>*> out_var3_squared,
+      const gsl::not_null<Scalar<DataVector>*> out_temp_var,
       const gsl::not_null<Scalar<DataVector>*> out_prim_var1,
       const gsl::not_null<
           tnsr::II<DataVector, System::volume_dim, Frame::Inertial>*>
@@ -1887,16 +2395,16 @@ class GhostAndTimeDerivative : public BoundaryCondition<System> {
       const tnsr::I<DataVector, System::volume_dim, Frame::Inertial>& var2,
       const Scalar<DataVector>& prim_var1,
       const tnsr::i<DataVector, System::volume_dim, Frame::Inertial>& prim_var2,
-      const Scalar<DataVector>& var3_squared, const Scalar<DataVector>& dt_var1,
+      const Scalar<DataVector>& temp_var, const Scalar<DataVector>& dt_var1,
       const tnsr::i<DataVector, System::volume_dim, Frame::Inertial>& d_var1,
       const double volume_number) const {
     ghost_.check_normal_vector_set_inverse_spatial_metric(
         inv_spatial_metric, outward_directed_normal_covector,
         outward_directed_normal_vector);
-    return dg_ghost(out_var1, out_var2, flux_var2, out_var3_squared,
+    return dg_ghost(out_var1, out_var2, out_var3, flux_var2, out_temp_var,
                     out_prim_var1, face_mesh_velocity,
                     outward_directed_normal_covector, var1, var2, prim_var1,
-                    prim_var2, var3_squared, dt_var1, d_var1, volume_number);
+                    prim_var2, temp_var, dt_var1, d_var1, volume_number);
   }
 
   // Conservative system, no prims
@@ -1907,22 +2415,26 @@ class GhostAndTimeDerivative : public BoundaryCondition<System> {
           out_var2,
       const gsl::not_null<
           tnsr::I<DataVector, System::volume_dim, Frame::Inertial>*>
+          out_var3,
+      const gsl::not_null<
+          tnsr::I<DataVector, System::volume_dim, Frame::Inertial>*>
           flux_var1,
       const gsl::not_null<
           tnsr::IJ<DataVector, System::volume_dim, Frame::Inertial>*>
           flux_var2,
-      const gsl::not_null<Scalar<DataVector>*> out_var3_squared,
+      const gsl::not_null<Scalar<DataVector>*> out_temp_var,
       const std::optional<tnsr::I<DataVector, System::volume_dim,
                                   Frame::Inertial>>& face_mesh_velocity,
       const tnsr::i<DataVector, System::volume_dim, Frame::Inertial>&
           outward_directed_normal_covector,
       const Scalar<DataVector>& var1,
       const tnsr::I<DataVector, System::volume_dim, Frame::Inertial>& var2,
-      const Scalar<DataVector>& var3_squared, const Scalar<DataVector>& dt_var1,
+      const Scalar<DataVector>& temp_var, const Scalar<DataVector>& dt_var1,
       const double volume_number) const {
-    ghost_.dg_ghost(out_var1, out_var2, flux_var1, flux_var2, out_var3_squared,
-                    face_mesh_velocity, outward_directed_normal_covector, var1,
-                    var2, var3_squared, dt_var1, volume_number);
+    ghost_.dg_ghost(out_var1, out_var2, out_var3, flux_var1, flux_var2,
+                    out_temp_var, face_mesh_velocity,
+                    outward_directed_normal_covector, var1, var2, temp_var,
+                    dt_var1, volume_number);
     return std::nullopt;
   }
 
@@ -1934,11 +2446,14 @@ class GhostAndTimeDerivative : public BoundaryCondition<System> {
           out_var2,
       const gsl::not_null<
           tnsr::I<DataVector, System::volume_dim, Frame::Inertial>*>
+          out_var3,
+      const gsl::not_null<
+          tnsr::I<DataVector, System::volume_dim, Frame::Inertial>*>
           flux_var1,
       const gsl::not_null<
           tnsr::IJ<DataVector, System::volume_dim, Frame::Inertial>*>
           flux_var2,
-      const gsl::not_null<Scalar<DataVector>*> out_var3_squared,
+      const gsl::not_null<Scalar<DataVector>*> out_temp_var,
       const gsl::not_null<
           tnsr::II<DataVector, System::volume_dim, Frame::Inertial>*>
           inv_spatial_metric,
@@ -1950,14 +2465,14 @@ class GhostAndTimeDerivative : public BoundaryCondition<System> {
           outward_directed_normal_vector,
       const Scalar<DataVector>& var1,
       const tnsr::I<DataVector, System::volume_dim, Frame::Inertial>& var2,
-      const Scalar<DataVector>& var3_squared, const Scalar<DataVector>& dt_var1,
+      const Scalar<DataVector>& temp_var, const Scalar<DataVector>& dt_var1,
       const double volume_number) const {
     ghost_.check_normal_vector_set_inverse_spatial_metric(
         inv_spatial_metric, outward_directed_normal_covector,
         outward_directed_normal_vector);
-    dg_ghost(out_var1, out_var2, flux_var1, flux_var2, out_var3_squared,
+    dg_ghost(out_var1, out_var2, out_var3, flux_var1, flux_var2, out_temp_var,
              face_mesh_velocity, outward_directed_normal_covector, var1, var2,
-             var3_squared, dt_var1, volume_number);
+             temp_var, dt_var1, volume_number);
     return std::nullopt;
   }
 
@@ -1969,11 +2484,14 @@ class GhostAndTimeDerivative : public BoundaryCondition<System> {
           out_var2,
       const gsl::not_null<
           tnsr::I<DataVector, System::volume_dim, Frame::Inertial>*>
+          out_var3,
+      const gsl::not_null<
+          tnsr::I<DataVector, System::volume_dim, Frame::Inertial>*>
           flux_var1,
       const gsl::not_null<
           tnsr::IJ<DataVector, System::volume_dim, Frame::Inertial>*>
           flux_var2,
-      const gsl::not_null<Scalar<DataVector>*> out_var3_squared,
+      const gsl::not_null<Scalar<DataVector>*> out_temp_var,
       const gsl::not_null<Scalar<DataVector>*> out_prim_var1,
 
       const std::optional<tnsr::I<DataVector, System::volume_dim,
@@ -1984,12 +2502,12 @@ class GhostAndTimeDerivative : public BoundaryCondition<System> {
       const tnsr::I<DataVector, System::volume_dim, Frame::Inertial>& var2,
       const Scalar<DataVector>& prim_var1,
       const tnsr::i<DataVector, System::volume_dim, Frame::Inertial>& prim_var2,
-      const Scalar<DataVector>& var3_squared, const Scalar<DataVector>& dt_var1,
+      const Scalar<DataVector>& temp_var, const Scalar<DataVector>& dt_var1,
       const double volume_number) const {
-    ghost_.dg_ghost(out_var1, out_var2, flux_var1, flux_var2, out_var3_squared,
-                    out_prim_var1, face_mesh_velocity,
+    ghost_.dg_ghost(out_var1, out_var2, out_var3, flux_var1, flux_var2,
+                    out_temp_var, out_prim_var1, face_mesh_velocity,
                     outward_directed_normal_covector, var1, var2, prim_var1,
-                    prim_var2, var3_squared, dt_var1, volume_number);
+                    prim_var2, temp_var, dt_var1, volume_number);
     return std::nullopt;
   }
 
@@ -2001,11 +2519,14 @@ class GhostAndTimeDerivative : public BoundaryCondition<System> {
           out_var2,
       const gsl::not_null<
           tnsr::I<DataVector, System::volume_dim, Frame::Inertial>*>
+          out_var3,
+      const gsl::not_null<
+          tnsr::I<DataVector, System::volume_dim, Frame::Inertial>*>
           flux_var1,
       const gsl::not_null<
           tnsr::IJ<DataVector, System::volume_dim, Frame::Inertial>*>
           flux_var2,
-      const gsl::not_null<Scalar<DataVector>*> out_var3_squared,
+      const gsl::not_null<Scalar<DataVector>*> out_temp_var,
       const gsl::not_null<Scalar<DataVector>*> out_prim_var1,
       const gsl::not_null<
           tnsr::II<DataVector, System::volume_dim, Frame::Inertial>*>
@@ -2021,15 +2542,15 @@ class GhostAndTimeDerivative : public BoundaryCondition<System> {
       const tnsr::I<DataVector, System::volume_dim, Frame::Inertial>& var2,
       const Scalar<DataVector>& prim_var1,
       const tnsr::i<DataVector, System::volume_dim, Frame::Inertial>& prim_var2,
-      const Scalar<DataVector>& var3_squared, const Scalar<DataVector>& dt_var1,
+      const Scalar<DataVector>& temp_var, const Scalar<DataVector>& dt_var1,
       const double volume_number) const {
     ghost_.check_normal_vector_set_inverse_spatial_metric(
         inv_spatial_metric, outward_directed_normal_covector,
         outward_directed_normal_vector);
-    ghost_.dg_ghost(out_var1, out_var2, flux_var1, flux_var2, out_var3_squared,
-                    out_prim_var1, face_mesh_velocity,
+    ghost_.dg_ghost(out_var1, out_var2, out_var3, flux_var1, flux_var2,
+                    out_temp_var, out_prim_var1, face_mesh_velocity,
                     outward_directed_normal_covector, var1, var2, prim_var1,
-                    prim_var2, var3_squared, dt_var1, volume_number);
+                    prim_var2, temp_var, dt_var1, volume_number);
     return std::nullopt;
   }
 
@@ -2069,6 +2590,7 @@ struct System
 
   using variables_tag =
       ::Tags::Variables<tmpl::list<Tags::Var1, Tags::Var2<Dim>>>;
+  using auxiliary_variables = tmpl::list<Tags::Var3<Dim>>;
   using flux_variables = tmpl::conditional_t<
       system_type == SystemType::Conservative,
       tmpl::list<Tags::Var1, Tags::Var2<Dim>>,
@@ -2084,7 +2606,7 @@ struct System
 
   struct compute_volume_time_derivative_terms {
     using temporary_tags = tmpl::append<
-        tmpl::list<Tags::Var3Squared>,
+        tmpl::list<Tags::TempVar>,
         tmpl::conditional_t<HasInverseSpatialMetric,
                             tmpl::list<Tags::InverseSpatialMetric<Dim>>,
                             tmpl::list<>>>;
@@ -2146,7 +2668,13 @@ void fill_variables(const gsl::not_null<Variables<TagsList>*> variables,
 // Note: clang-8 wants us to capture Dim in the closures if we do `constexpr
 // size_t Dim =...`, but then GCC-7 fails to build. Assigning `Dim` as a
 // template parameter gets around that.
-template <typename System, size_t Dim = System::volume_dim>
+// When `IsAuxiliary` is true this exercises the LDG auxiliary communication
+// pass (`ComputeAuxiliary=true`) instead of the physical pass. The two passes
+// share almost all of their setup and structure; the auxiliary-specific
+// deviations are folded in via `if constexpr (IsAuxiliary)` branches at the
+// points where the passes genuinely differ.
+template <typename System, bool IsAuxiliary = false,
+          size_t Dim = System::volume_dim>
 void test_1d(const bool moving_mesh, const dg::Formulation formulation,
              const Spectral::Quadrature quadrature) {
   CAPTURE(moving_mesh);
@@ -2206,6 +2734,7 @@ void test_1d(const bool moving_mesh, const dg::Formulation formulation,
   normal_covector_and_magnitude[Direction<Dim>::upper_xi()] = std::nullopt;
   const double boundary_condition_volume_tag_number{2.5};
   const double boundary_correction_volume_tag_number{3.5};
+  const double boundary_correction_auxiliary_volume_tag_number{4.5};
 
   Variables<
       db::wrap_tags_in<::Tags::dt, typename System::variables_tag::tags_list>>
@@ -2214,6 +2743,13 @@ void test_1d(const bool moving_mesh, const dg::Formulation formulation,
   Variables<typename System::variables_tag::tags_list> evolved_vars{
       mesh.number_of_grid_points()};
   fill_variables(make_not_null(&evolved_vars), offset_evolved_vars);
+  // Storage for the auxiliary variables. In the physical pass they are
+  // projected to the face and passed (unused) to `dg_package_data`; in the
+  // auxiliary pass this is the variable that receives the lifted
+  // auxiliary correction.
+  Variables<typename System::auxiliary_variables> auxiliary_vars{
+      mesh.number_of_grid_points()};
+  fill_variables(make_not_null(&auxiliary_vars), offset_evolved_vars);
   Variables<
       typename System::compute_volume_time_derivative_terms::temporary_tags>
       temporaries{mesh.number_of_grid_points()};
@@ -2275,9 +2811,10 @@ void test_1d(const bool moving_mesh, const dg::Formulation formulation,
                                     Frame::Inertial>,
       domain::Tags::DetInvJacobian<Frame::ElementLogical, Frame::Inertial>,
       evolution::dg::Tags::NormalCovectorAndMagnitude<Dim>,
-      typename System::variables_tag, dt_variables_tag,
+      typename System::variables_tag,
+      ::Tags::Variables<typename System::auxiliary_variables>, dt_variables_tag,
       Tags::BoundaryConditionVolumeTag, Tags::BoundaryCorrectionVolumeTag,
-      ::dg::Tags::Formulation>;
+      Tags::BoundaryCorrectionAuxiliaryVolumeTag, ::dg::Tags::Formulation>;
   using compute_tags = tmpl::list<>;
 
   auto box = db::create<simple_tags, compute_tags>(
@@ -2286,16 +2823,36 @@ void test_1d(const bool moving_mesh, const dg::Formulation formulation,
       std::move(element_map), grid_to_inertial_map->get_clone(), time,
       clone_unique_ptrs(functions_of_time), mesh_velocity, inv_jacobian,
       det_inv_jacobian, normal_covector_and_magnitude, evolved_vars,
-      dt_evolved_vars, boundary_condition_volume_tag_number,
-      boundary_correction_volume_tag_number, formulation);
+      auxiliary_vars, dt_evolved_vars, boundary_condition_volume_tag_number,
+      boundary_correction_volume_tag_number,
+      boundary_correction_auxiliary_volume_tag_number, formulation);
 
   {
     INFO("DemandOutgoingCharSpeeds only");
-    // DemandOutgoingCharSpeeds both sides, dt in volume shouldn't change.
+    // DemandOutgoingCharSpeeds both sides: neither side uses a ghost
+    // condition, so nothing is packaged or lifted in either pass. The evolved
+    // variables, the auxiliary variables (Var3), and the time derivatives
+    // are all unchanged.
     evolution::dg::Actions::detail::
-        apply_boundary_conditions_on_all_external_faces<System, Dim>(
+        apply_boundary_conditions_on_all_external_faces<System, Dim,
+                                                        IsAuxiliary>(
             make_not_null(&box), BndryTerms{moving_mesh, 0.0}, temporaries,
             volume_fluxes, partial_derivs, primitive_vars_ptr);
+    CHECK_ITERABLE_APPROX(
+        get(get<Tags::Var1>(box)),
+        DataVector(mesh.number_of_grid_points(), offset_evolved_vars));
+    for (size_t i = 0; i < Dim; ++i) {
+      CHECK_ITERABLE_APPROX(
+          get<Tags::Var2<Dim>>(box).get(i),
+          DataVector(mesh.number_of_grid_points(),
+                     offset_evolved_vars + 1.0 + static_cast<double>(i)));
+    }
+    for (size_t i = 0; i < Dim; ++i) {
+      CHECK_ITERABLE_APPROX(
+          get<Tags::Var3<Dim>>(box).get(i),
+          DataVector(mesh.number_of_grid_points(),
+                     offset_evolved_vars + static_cast<double>(i)));
+    }
     CHECK_ITERABLE_APPROX(
         get(get<::Tags::dt<Tags::Var1>>(box)),
         DataVector(mesh.number_of_grid_points(), offset_dt_evolved_vars));
@@ -2316,7 +2873,7 @@ void test_1d(const bool moving_mesh, const dg::Formulation formulation,
         (formulation == dg::Formulation::WeakInertial ? 2.0 : 1.0);
     for (size_t i = 0; i < Dim; ++i) {
       get<::Tags::dt<Tags::Var2<Dim>>>(expected_on_boundary).get(i) =
-          offset_boundary_correction + 1.0 + i;
+          offset_boundary_correction + 1.0 + static_cast<double>(i);
     }
     // lift into volume and add to volume time derivative
     Variables<tmpl::list<::Tags::dt<Tags::Var1>, ::Tags::dt<Tags::Var2<Dim>>>>
@@ -2343,7 +2900,8 @@ void test_1d(const bool moving_mesh, const dg::Formulation formulation,
       apply_matrices(make_not_null(&get(face_det_inv_jacobian)),
                      interpolation_matrices, get(volume_det_inv_jacobian),
                      mesh.extents());
-      Scalar<DataVector> face_det_jacobian{1.0 / get(face_det_inv_jacobian)};
+      const Scalar<DataVector> face_det_jacobian{1.0 /
+                                                 get(face_det_inv_jacobian)};
 
       ::dg::lift_boundary_terms_gauss_points(
           make_not_null(&expected_dt_volume_correction),
@@ -2362,18 +2920,91 @@ void test_1d(const bool moving_mesh, const dg::Formulation formulation,
     return expected_dt_volume_correction;
   };
 
-  const auto check_outgoing_and_ghost = [&box, &dt_evolved_vars,
-                                         &expected_ghost_dt_correction,
-                                         &moving_mesh, &partial_derivs,
-                                         &primitive_vars_ptr, &temporaries,
-                                         &volume_fluxes](
-                                            const Direction<Dim>&
+  // Auxiliary-pass analogue of `expected_ghost_dt_correction`. Expected lifted
+  // auxiliary (Var3) correction added to the
+  // ::Tags::Variables<auxiliary_variables> container by the auxiliary pass on a
+  // ghost face. The correction on the face is the mock's
+  // `dg_auxiliary_boundary_terms` output, `0.5 * (int_var2 + ext_var2)`. From
+  // the packaged data, `int_var2.get(i) == offset_evolved_vars + 1 + i`
+  // (projected volume Var2) and `ext_var2.get(i) == offset_boundary_condition +
+  // 1 + i` (the Var2 the Ghost boundary condition supplies), so the face value
+  // is
+  //   Var3.get(i) = 0.5 * ((offset_evolved_vars + 1 + i) +
+  //                        (offset_boundary_condition + 1 + i)).
+  // The mock's toy auxiliary correction ignores its `formulation` argument, so
+  // this expected value is formulation-independent. This is not a test gap
+  // as we currently intend to support only the strong formulation with LDG.
+  // This lambda mirrors the physical `expected_ghost_dt_correction` lift logic
+  // (GaussLobatto: lift_flux + add_slice_to_data; Gauss:
+  // lift_boundary_terms_gauss_points) but for a Var3-shaped `tnsr::I`
+  // correction.
+  const auto expected_ghost_var3_correction = [&box, &mesh](
+                                                  const auto& ghost_direction) {
+    Variables<tmpl::list<Tags::Var3<Dim>>> expected_on_boundary{
+        mesh.slice_away(ghost_direction.dimension()).number_of_grid_points()};
+    for (size_t i = 0; i < Dim; ++i) {
+      get<Tags::Var3<Dim>>(expected_on_boundary).get(i) =
+          0.5 * ((offset_evolved_vars + 1.0 + static_cast<double>(i)) +
+                 (offset_boundary_condition + 1.0 + static_cast<double>(i)));
+    }
+    // lift into volume and add to volume auxiliary variables
+    Variables<tmpl::list<Tags::Var3<Dim>>> expected_volume_correction{
+        mesh.number_of_grid_points(), 0.0};
+    const Scalar<DataVector>& volume_det_inv_jacobian = db::get<
+        domain::Tags::DetInvJacobian<Frame::ElementLogical, Frame::Inertial>>(
+        box);
+    const Scalar<DataVector>& magnitude_of_interior_face_normal =
+        get<evolution::dg::Tags::MagnitudeOfNormal>(
+            *db::get<evolution::dg::Tags::NormalCovectorAndMagnitude<Dim>>(box)
+                 .at(ghost_direction));
+    if (mesh.quadrature(ghost_direction.dimension()) ==
+        Spectral::Quadrature::Gauss) {
+      Scalar<DataVector> face_det_inv_jacobian{
+          mesh.slice_away(ghost_direction.dimension()).number_of_grid_points()};
+      const Matrix identity{};
+      auto interpolation_matrices = make_array<Dim>(std::cref(identity));
+      const std::pair<Matrix, Matrix>& matrices =
+          Spectral::boundary_interpolation_matrices(
+              mesh.slice_through(ghost_direction.dimension()));
+      gsl::at(interpolation_matrices, ghost_direction.dimension()) =
+          ghost_direction.side() == Side::Upper ? matrices.second
+                                                : matrices.first;
+      apply_matrices(make_not_null(&get(face_det_inv_jacobian)),
+                     interpolation_matrices, get(volume_det_inv_jacobian),
+                     mesh.extents());
+      const Scalar<DataVector> face_det_jacobian{1.0 /
+                                                 get(face_det_inv_jacobian)};
+
+      ::dg::lift_boundary_terms_gauss_points(
+          make_not_null(&expected_volume_correction), volume_det_inv_jacobian,
+          mesh, ghost_direction, expected_on_boundary,
+          magnitude_of_interior_face_normal, face_det_jacobian);
+    } else {
+      ::dg::lift_flux(make_not_null(&expected_on_boundary),
+                      mesh.extents(ghost_direction.dimension()),
+                      magnitude_of_interior_face_normal,
+                      mesh.basis(ghost_direction.dimension()));
+      add_slice_to_data(make_not_null(&expected_volume_correction),
+                        expected_on_boundary, mesh.extents(),
+                        ghost_direction.dimension(),
+                        index_to_slice_at(mesh.extents(), ghost_direction));
+    }
+    return expected_volume_correction;
+  };
+
+  const auto check_outgoing_and_ghost = [&](const Direction<Dim>&
                                                 outgoing_direction) {
     INFO("Ghost");
     CAPTURE(outgoing_direction);
-    db::mutate<domain::Tags::ExternalBoundaryConditions<Dim>, dt_variables_tag>(
-        [&moving_mesh, &outgoing_direction](const auto all_boundary_conditions,
-                                            const auto dt_vars_ptr) {
+    // Reset the evolved, auxiliary, and time-derivative variables to their
+    // baseline values.
+    db::mutate<domain::Tags::ExternalBoundaryConditions<Dim>,
+               typename System::variables_tag,
+               ::Tags::Variables<typename System::auxiliary_variables>,
+               dt_variables_tag>(
+        [&moving_mesh, &outgoing_direction](
+            const auto all_boundary_conditions, const auto vars_ptr,
+            const auto aux_vars_ptr, const auto dt_vars_ptr) {
           DirectionMap<Dim, std::unique_ptr<
                                 domain::BoundaryConditions::BoundaryCondition>>
               boundary_conditions{};
@@ -2383,18 +3014,25 @@ void test_1d(const bool moving_mesh, const dg::Formulation formulation,
               std::make_unique<DemandOutgoingCharSpeeds<System>>(moving_mesh);
           (*all_boundary_conditions)[0] = std::move(boundary_conditions);
 
+          fill_variables(vars_ptr, offset_evolved_vars);
+          fill_variables(aux_vars_ptr, offset_evolved_vars);
           fill_variables(dt_vars_ptr, offset_dt_evolved_vars);
         },
         make_not_null(&box));
     evolution::dg::Actions::detail::
-        apply_boundary_conditions_on_all_external_faces<System, Dim>(
+        apply_boundary_conditions_on_all_external_faces<System, Dim,
+                                                        IsAuxiliary>(
             make_not_null(&box),
             BndryTerms{moving_mesh, outgoing_direction.opposite().sign()},
             temporaries, volume_fluxes, partial_derivs, primitive_vars_ptr);
 
+    // The physical pass lifts the ghost correction into the time derivatives;
+    // the auxiliary pass leaves them untouched.
     auto expected_dt_evolved_vars = dt_evolved_vars;
-    expected_dt_evolved_vars +=
-        expected_ghost_dt_correction(outgoing_direction.opposite());
+    if constexpr (not IsAuxiliary) {
+      expected_dt_evolved_vars +=
+          expected_ghost_dt_correction(outgoing_direction.opposite());
+    }
     CHECK_ITERABLE_APPROX(
         get(get<::Tags::dt<Tags::Var1>>(box)),
         get(get<::Tags::dt<Tags::Var1>>(expected_dt_evolved_vars)));
@@ -2402,6 +3040,25 @@ void test_1d(const bool moving_mesh, const dg::Formulation formulation,
       CHECK_ITERABLE_APPROX(
           get<::Tags::dt<Tags::Var2<Dim>>>(box).get(i),
           get<::Tags::dt<Tags::Var2<Dim>>>(expected_dt_evolved_vars).get(i));
+    }
+    // The auxiliary pass lifts the ghost correction into the auxiliary
+    // variables (Var3); the physical pass leaves them untouched.
+    auto expected_auxiliary_vars = auxiliary_vars;
+    if constexpr (IsAuxiliary) {
+      expected_auxiliary_vars +=
+          expected_ghost_var3_correction(outgoing_direction.opposite());
+    }
+    for (size_t i = 0; i < Dim; ++i) {
+      CHECK_ITERABLE_APPROX(
+          get<Tags::Var3<Dim>>(box).get(i),
+          get<Tags::Var3<Dim>>(expected_auxiliary_vars).get(i));
+    }
+    // The evolved variables are untouched by both passes.
+    CHECK_ITERABLE_APPROX(get(get<Tags::Var1>(box)),
+                          get(get<Tags::Var1>(evolved_vars)));
+    for (size_t i = 0; i < Dim; ++i) {
+      CHECK_ITERABLE_APPROX(get<Tags::Var2<Dim>>(box).get(i),
+                            get<Tags::Var2<Dim>>(evolved_vars).get(i));
     }
   };
   // DemandOutgoingCharSpeeds +xi, Ghost -xi
@@ -2440,17 +3097,24 @@ void test_1d(const bool moving_mesh, const dg::Formulation formulation,
     return expected_dt_volume_correction;
   };
 
-  const auto check_outgoing_and_dt = [&box, &dt_evolved_vars,
-                                      &expected_time_derivative_dt_correction,
-                                      &moving_mesh, &partial_derivs,
-                                      &primitive_vars_ptr, &temporaries,
-                                      &volume_fluxes](const Direction<Dim>&
-                                                          outgoing_direction) {
+  // TimeDerivative on one side, DemandOutgoingCharSpeeds on the other.
+  // Neither boundary condition `uses_ghost_condition`, so no correction is
+  // packaged or lifted in either pass; the physical pass adds only the
+  // dg_time_derivative correction to the time derivatives, while the auxiliary
+  // pass skips that path and is a complete no-op.
+  const auto check_outgoing_and_dt = [&](const Direction<Dim>&
+                                             outgoing_direction) {
     INFO("TimeDerivative");
     CAPTURE(outgoing_direction);
-    db::mutate<domain::Tags::ExternalBoundaryConditions<Dim>, dt_variables_tag>(
-        [&moving_mesh, &outgoing_direction](const auto all_boundary_conditions,
-                                            const auto dt_vars_ptr) {
+    // Reset the evolved, auxiliary, and time-derivative variables to their
+    // baseline values.
+    db::mutate<domain::Tags::ExternalBoundaryConditions<Dim>,
+               typename System::variables_tag,
+               ::Tags::Variables<typename System::auxiliary_variables>,
+               dt_variables_tag>(
+        [&moving_mesh, &outgoing_direction](
+            const auto all_boundary_conditions, const auto vars_ptr,
+            const auto aux_vars_ptr, const auto dt_vars_ptr) {
           DirectionMap<Dim, std::unique_ptr<
                                 domain::BoundaryConditions::BoundaryCondition>>
               boundary_conditions{};
@@ -2461,18 +3125,23 @@ void test_1d(const bool moving_mesh, const dg::Formulation formulation,
               std::make_unique<DemandOutgoingCharSpeeds<System>>(moving_mesh);
           (*all_boundary_conditions)[0] = std::move(boundary_conditions);
 
+          fill_variables(vars_ptr, offset_evolved_vars);
+          fill_variables(aux_vars_ptr, offset_evolved_vars);
           fill_variables(dt_vars_ptr, offset_dt_evolved_vars);
         },
         make_not_null(&box));
     evolution::dg::Actions::detail::
-        apply_boundary_conditions_on_all_external_faces<System, Dim>(
+        apply_boundary_conditions_on_all_external_faces<System, Dim,
+                                                        IsAuxiliary>(
             make_not_null(&box),
             BndryTerms{moving_mesh, outgoing_direction.opposite().sign()},
             temporaries, volume_fluxes, partial_derivs, primitive_vars_ptr);
 
     auto expected_dt_evolved_vars = dt_evolved_vars;
-    expected_dt_evolved_vars +=
-        expected_time_derivative_dt_correction(outgoing_direction.opposite());
+    if constexpr (not IsAuxiliary) {
+      expected_dt_evolved_vars +=
+          expected_time_derivative_dt_correction(outgoing_direction.opposite());
+    }
     CHECK_ITERABLE_APPROX(
         get(get<::Tags::dt<Tags::Var1>>(box)),
         get(get<::Tags::dt<Tags::Var1>>(expected_dt_evolved_vars)));
@@ -2481,131 +3150,195 @@ void test_1d(const bool moving_mesh, const dg::Formulation formulation,
           get<::Tags::dt<Tags::Var2<Dim>>>(box).get(i),
           get<::Tags::dt<Tags::Var2<Dim>>>(expected_dt_evolved_vars).get(i));
     }
+    // No ghost condition on either side: the auxiliary variables (Var3) are
+    // untouched in both passes.
+    for (size_t i = 0; i < Dim; ++i) {
+      CHECK_ITERABLE_APPROX(get<Tags::Var3<Dim>>(box).get(i),
+                            get<Tags::Var3<Dim>>(auxiliary_vars).get(i));
+    }
+    // The evolved variables are untouched by both passes.
+    CHECK_ITERABLE_APPROX(get(get<Tags::Var1>(box)),
+                          get(get<Tags::Var1>(evolved_vars)));
+    for (size_t i = 0; i < Dim; ++i) {
+      CHECK_ITERABLE_APPROX(get<Tags::Var2<Dim>>(box).get(i),
+                            get<Tags::Var2<Dim>>(evolved_vars).get(i));
+    }
   };
   // DemandOutgoingCharSpeeds +xi, TimeDerivative -xi
   check_outgoing_and_dt(Direction<Dim>::upper_xi());
   // DemandOutgoingCharSpeeds -xi, TimeDerivative +xi
   check_outgoing_and_dt(Direction<Dim>::lower_xi());
 
-  const auto check_ghost_and_dt_opposite =
-      [&box, &dt_evolved_vars, &expected_ghost_dt_correction,
-       &expected_time_derivative_dt_correction, &mesh, &moving_mesh,
-       &partial_derivs, &primitive_vars_ptr, &temporaries,
-       &volume_fluxes](const Direction<Dim>& ghost_direction) {
-        INFO("Ghost and TimeDerivative on opposite sides");
-        CAPTURE(ghost_direction);
-        auto expected_dt_evolved_vars = dt_evolved_vars;
-        expected_dt_evolved_vars +=
-            expected_ghost_dt_correction(ghost_direction);
+  // Ghost on one side, TimeDerivative on the opposite side. The ghost side
+  // lifts its correction into the time derivatives (physical pass) or into the
+  // auxiliary variables (auxiliary pass); the TimeDerivative side adds its
+  // dg_time_derivative correction in the physical pass only.
+  const auto check_ghost_and_dt_opposite = [&](const Direction<Dim>&
+                                                   ghost_direction) {
+    INFO("Ghost and TimeDerivative on opposite sides");
+    CAPTURE(ghost_direction);
+    auto expected_dt_evolved_vars = dt_evolved_vars;
+    if constexpr (not IsAuxiliary) {
+      expected_dt_evolved_vars += expected_ghost_dt_correction(ghost_direction);
+    }
 
-        // Project to the boundary to figure out what will be the projected
-        // dt_var1 passed into the time derivative boundary condition. This is
-        // necessary because we apply _and lift_ the Ghost boundary correction
-        // before the TimeDerivative correction. This order is determined in the
-        // BoundaryCondition base class's `creatable_classes` typelist.
-        Variables<
-            tmpl::list<::Tags::dt<Tags::Var1>, ::Tags::dt<Tags::Var2<Dim>>>>
-            expected_dt_on_boundary{mesh.slice_away(ghost_direction.dimension())
-                                        .number_of_grid_points()};
-        ::dg::project_contiguous_data_to_boundary(
-            make_not_null(&expected_dt_on_boundary), expected_dt_evolved_vars,
-            mesh, ghost_direction.opposite());
+    // Project to the boundary to figure out what will be the projected
+    // dt_var1 passed into the time derivative boundary condition. This is
+    // necessary because we apply _and lift_ the Ghost boundary correction
+    // before the TimeDerivative correction. This order is determined in the
+    // BoundaryCondition base class's `creatable_classes` typelist. In the
+    // auxiliary pass no dt correction is lifted.
+    Variables<tmpl::list<::Tags::dt<Tags::Var1>, ::Tags::dt<Tags::Var2<Dim>>>>
+        expected_dt_on_boundary{mesh.slice_away(ghost_direction.dimension())
+                                    .number_of_grid_points()};
+    ::dg::project_contiguous_data_to_boundary(
+        make_not_null(&expected_dt_on_boundary), expected_dt_evolved_vars, mesh,
+        ghost_direction.opposite());
 
-        db::mutate<domain::Tags::ExternalBoundaryConditions<Dim>,
-                   dt_variables_tag>(
-            [&expected_dt_var1 =
-                 get<::Tags::dt<Tags::Var1>>(expected_dt_on_boundary),
-             &moving_mesh, &ghost_direction](const auto all_boundary_conditions,
-                                             const auto dt_vars_ptr) {
-              DirectionMap<Dim,
-                           std::unique_ptr<
-                               domain::BoundaryConditions::BoundaryCondition>>
-                  boundary_conditions{};
-              boundary_conditions[ghost_direction.opposite()] =
-                  std::make_unique<TimeDerivative<System>>(
-                      moving_mesh, get(expected_dt_var1)[0]);
-              boundary_conditions[ghost_direction] =
-                  std::make_unique<Ghost<System>>(moving_mesh);
-              (*all_boundary_conditions)[0] = std::move(boundary_conditions);
+    // Reset the evolved, auxiliary, and time-derivative variables to their
+    // baseline values.
+    db::mutate<domain::Tags::ExternalBoundaryConditions<Dim>,
+               typename System::variables_tag,
+               ::Tags::Variables<typename System::auxiliary_variables>,
+               dt_variables_tag>(
+        [&expected_dt_var1 =
+             get<::Tags::dt<Tags::Var1>>(expected_dt_on_boundary),
+         &moving_mesh, &ghost_direction](
+            const auto all_boundary_conditions, const auto vars_ptr,
+            const auto aux_vars_ptr, const auto dt_vars_ptr) {
+          DirectionMap<Dim, std::unique_ptr<
+                                domain::BoundaryConditions::BoundaryCondition>>
+              boundary_conditions{};
+          boundary_conditions[ghost_direction.opposite()] =
+              std::make_unique<TimeDerivative<System>>(
+                  moving_mesh, get(expected_dt_var1)[0]);
+          boundary_conditions[ghost_direction] =
+              std::make_unique<Ghost<System>>(moving_mesh);
+          (*all_boundary_conditions)[0] = std::move(boundary_conditions);
 
-              fill_variables(dt_vars_ptr, offset_dt_evolved_vars);
-            },
-            make_not_null(&box));
-        evolution::dg::Actions::detail::
-            apply_boundary_conditions_on_all_external_faces<System, Dim>(
-                make_not_null(&box),
-                BndryTerms{moving_mesh, ghost_direction.sign()}, temporaries,
-                volume_fluxes, partial_derivs, primitive_vars_ptr);
+          fill_variables(vars_ptr, offset_evolved_vars);
+          fill_variables(aux_vars_ptr, offset_evolved_vars);
+          fill_variables(dt_vars_ptr, offset_dt_evolved_vars);
+        },
+        make_not_null(&box));
+    evolution::dg::Actions::detail::
+        apply_boundary_conditions_on_all_external_faces<System, Dim,
+                                                        IsAuxiliary>(
+            make_not_null(&box),
+            BndryTerms{moving_mesh, ghost_direction.sign()}, temporaries,
+            volume_fluxes, partial_derivs, primitive_vars_ptr);
 
-        expected_dt_evolved_vars +=
-            expected_time_derivative_dt_correction(ghost_direction.opposite());
-
-        CHECK_ITERABLE_APPROX(
-            get(get<::Tags::dt<Tags::Var1>>(box)),
-            get(get<::Tags::dt<Tags::Var1>>(expected_dt_evolved_vars)));
-        for (size_t i = 0; i < Dim; ++i) {
-          CHECK_ITERABLE_APPROX(
-              get<::Tags::dt<Tags::Var2<Dim>>>(box).get(i),
-              get<::Tags::dt<Tags::Var2<Dim>>>(expected_dt_evolved_vars)
-                  .get(i));
-        }
-      };
+    if constexpr (not IsAuxiliary) {
+      expected_dt_evolved_vars +=
+          expected_time_derivative_dt_correction(ghost_direction.opposite());
+    }
+    CHECK_ITERABLE_APPROX(
+        get(get<::Tags::dt<Tags::Var1>>(box)),
+        get(get<::Tags::dt<Tags::Var1>>(expected_dt_evolved_vars)));
+    for (size_t i = 0; i < Dim; ++i) {
+      CHECK_ITERABLE_APPROX(
+          get<::Tags::dt<Tags::Var2<Dim>>>(box).get(i),
+          get<::Tags::dt<Tags::Var2<Dim>>>(expected_dt_evolved_vars).get(i));
+    }
+    auto expected_auxiliary_vars = auxiliary_vars;
+    if constexpr (IsAuxiliary) {
+      expected_auxiliary_vars +=
+          expected_ghost_var3_correction(ghost_direction);
+    }
+    for (size_t i = 0; i < Dim; ++i) {
+      CHECK_ITERABLE_APPROX(
+          get<Tags::Var3<Dim>>(box).get(i),
+          get<Tags::Var3<Dim>>(expected_auxiliary_vars).get(i));
+    }
+    // The evolved variables are untouched by both passes.
+    CHECK_ITERABLE_APPROX(get(get<Tags::Var1>(box)),
+                          get(get<Tags::Var1>(evolved_vars)));
+    for (size_t i = 0; i < Dim; ++i) {
+      CHECK_ITERABLE_APPROX(get<Tags::Var2<Dim>>(box).get(i),
+                            get<Tags::Var2<Dim>>(evolved_vars).get(i));
+    }
+  };
   // Ghost +xi, TimeDerivative -xi
   check_ghost_and_dt_opposite(Direction<Dim>::upper_xi());
   // Ghost -xi, TimeDerivative +xi
   check_ghost_and_dt_opposite(Direction<Dim>::lower_xi());
 
-  const auto check_ghost_and_dt_combined_bc =
-      [&box, &dt_evolved_vars, &expected_ghost_dt_correction,
-       &expected_time_derivative_dt_correction, &moving_mesh, &partial_derivs,
-       &primitive_vars_ptr, &temporaries,
-       &volume_fluxes](const Direction<Dim>& outgoing_direction) {
-        INFO("GhostAndTimeDerivative combined on one side");
-        CAPTURE(outgoing_direction);
-        // Since the Ghost and TimeDerivative are applied in the same direction
-        // they both receive the dt_vars _without_ either boundary condition
-        // applied, which is different from way Ghost and TimeDerivative are
-        // applied in different directions.
-        db::mutate<domain::Tags::ExternalBoundaryConditions<Dim>,
-                   dt_variables_tag>(
-            [&moving_mesh, &outgoing_direction](
-                const auto all_boundary_conditions, const auto dt_vars_ptr) {
-              DirectionMap<Dim,
-                           std::unique_ptr<
-                               domain::BoundaryConditions::BoundaryCondition>>
-                  boundary_conditions{};
-              boundary_conditions[outgoing_direction.opposite()] =
-                  std::make_unique<GhostAndTimeDerivative<System>>(moving_mesh);
-              boundary_conditions[outgoing_direction] =
-                  std::make_unique<DemandOutgoingCharSpeeds<System>>(
-                      moving_mesh);
-              (*all_boundary_conditions)[0] = std::move(boundary_conditions);
+  // GhostAndTimeDerivative supplies BOTH ghost data and a dg_time_derivative
+  // condition on one face. The physical pass lifts the ghost correction AND
+  // adds the dt correction to the time derivatives; the auxiliary pass lifts
+  // only the ghost part's auxiliary correction into the auxiliary variables
+  // (Var3) while the dg_time_derivative path is skipped.
+  const auto check_ghost_and_dt_combined_bc = [&](const Direction<Dim>&
+                                                      outgoing_direction) {
+    INFO("GhostAndTimeDerivative combined on one side");
+    CAPTURE(outgoing_direction);
+    // Since the Ghost and TimeDerivative are applied in the same direction
+    // they both receive the dt_vars _without_ either boundary condition
+    // applied, which is different from way Ghost and TimeDerivative are
+    // applied in different directions.
+    // Reset the evolved, auxiliary, and time-derivative variables to their
+    // baseline values.
+    db::mutate<domain::Tags::ExternalBoundaryConditions<Dim>,
+               typename System::variables_tag,
+               ::Tags::Variables<typename System::auxiliary_variables>,
+               dt_variables_tag>(
+        [&moving_mesh, &outgoing_direction](
+            const auto all_boundary_conditions, const auto vars_ptr,
+            const auto aux_vars_ptr, const auto dt_vars_ptr) {
+          DirectionMap<Dim, std::unique_ptr<
+                                domain::BoundaryConditions::BoundaryCondition>>
+              boundary_conditions{};
+          boundary_conditions[outgoing_direction.opposite()] =
+              std::make_unique<GhostAndTimeDerivative<System>>(moving_mesh);
+          boundary_conditions[outgoing_direction] =
+              std::make_unique<DemandOutgoingCharSpeeds<System>>(moving_mesh);
+          (*all_boundary_conditions)[0] = std::move(boundary_conditions);
 
-              fill_variables(dt_vars_ptr, offset_dt_evolved_vars);
-            },
-            make_not_null(&box));
-        evolution::dg::Actions::detail::
-            apply_boundary_conditions_on_all_external_faces<System, Dim>(
-                make_not_null(&box),
-                BndryTerms{moving_mesh, outgoing_direction.opposite().sign()},
-                temporaries, volume_fluxes, partial_derivs, primitive_vars_ptr);
+          fill_variables(vars_ptr, offset_evolved_vars);
+          fill_variables(aux_vars_ptr, offset_evolved_vars);
+          fill_variables(dt_vars_ptr, offset_dt_evolved_vars);
+        },
+        make_not_null(&box));
+    evolution::dg::Actions::detail::
+        apply_boundary_conditions_on_all_external_faces<System, Dim,
+                                                        IsAuxiliary>(
+            make_not_null(&box),
+            BndryTerms{moving_mesh, outgoing_direction.opposite().sign()},
+            temporaries, volume_fluxes, partial_derivs, primitive_vars_ptr);
 
-        auto expected_dt_evolved_vars = dt_evolved_vars;
-        expected_dt_evolved_vars += expected_time_derivative_dt_correction(
-            outgoing_direction.opposite());
-        expected_dt_evolved_vars +=
-            expected_ghost_dt_correction(outgoing_direction.opposite());
-
-        CHECK_ITERABLE_APPROX(
-            get(get<::Tags::dt<Tags::Var1>>(box)),
-            get(get<::Tags::dt<Tags::Var1>>(expected_dt_evolved_vars)));
-        for (size_t i = 0; i < Dim; ++i) {
-          CHECK_ITERABLE_APPROX(
-              get<::Tags::dt<Tags::Var2<Dim>>>(box).get(i),
-              get<::Tags::dt<Tags::Var2<Dim>>>(expected_dt_evolved_vars)
-                  .get(i));
-        }
-      };
+    auto expected_dt_evolved_vars = dt_evolved_vars;
+    if constexpr (not IsAuxiliary) {
+      expected_dt_evolved_vars +=
+          expected_time_derivative_dt_correction(outgoing_direction.opposite());
+      expected_dt_evolved_vars +=
+          expected_ghost_dt_correction(outgoing_direction.opposite());
+    }
+    CHECK_ITERABLE_APPROX(
+        get(get<::Tags::dt<Tags::Var1>>(box)),
+        get(get<::Tags::dt<Tags::Var1>>(expected_dt_evolved_vars)));
+    for (size_t i = 0; i < Dim; ++i) {
+      CHECK_ITERABLE_APPROX(
+          get<::Tags::dt<Tags::Var2<Dim>>>(box).get(i),
+          get<::Tags::dt<Tags::Var2<Dim>>>(expected_dt_evolved_vars).get(i));
+    }
+    auto expected_auxiliary_vars = auxiliary_vars;
+    if constexpr (IsAuxiliary) {
+      expected_auxiliary_vars +=
+          expected_ghost_var3_correction(outgoing_direction.opposite());
+    }
+    for (size_t i = 0; i < Dim; ++i) {
+      CHECK_ITERABLE_APPROX(
+          get<Tags::Var3<Dim>>(box).get(i),
+          get<Tags::Var3<Dim>>(expected_auxiliary_vars).get(i));
+    }
+    // The evolved variables are untouched by both passes.
+    CHECK_ITERABLE_APPROX(get(get<Tags::Var1>(box)),
+                          get(get<Tags::Var1>(evolved_vars)));
+    for (size_t i = 0; i < Dim; ++i) {
+      CHECK_ITERABLE_APPROX(get<Tags::Var2<Dim>>(box).get(i),
+                            get<Tags::Var2<Dim>>(evolved_vars).get(i));
+    }
+  };
   // DemandOutgoingCharSpeeds +xi, GhostAndTimeDerivative -xi
   check_ghost_and_dt_combined_bc(Direction<Dim>::upper_xi());
   // DemandOutgoingCharSpeeds -xi, GhostAndTimeDerivative +xi
@@ -2652,12 +3385,14 @@ void test_cartoon_mesh_compatibility() {
       domain::Tags::InverseJacobian<1, Frame::ElementLogical, Frame::Inertial>,
       domain::Tags::DetInvJacobian<Frame::ElementLogical, Frame::Inertial>,
       evolution::dg::Tags::NormalCovectorAndMagnitude<1>,
-      typename TestSystem::variables_tag, dt_variables_tag,
-      Tags::BoundaryConditionVolumeTag, Tags::BoundaryCorrectionVolumeTag,
-      ::dg::Tags::Formulation>;
+      typename TestSystem::variables_tag,
+      ::Tags::Variables<typename TestSystem::auxiliary_variables>,
+      dt_variables_tag, Tags::BoundaryConditionVolumeTag,
+      Tags::BoundaryCorrectionVolumeTag, ::dg::Tags::Formulation>;
   using compute_tags = tmpl::list<>;
 
   Variables<typename TestSystem::variables_tag::tags_list> evolved_vars{3, 1.0};
+  Variables<typename TestSystem::auxiliary_variables> auxiliary_vars{3, 1.0};
   Variables<db::wrap_tags_in<::Tags::dt,
                              typename TestSystem::variables_tag::tags_list>>
       dt_evolved_vars{3, 0.0};
@@ -2680,11 +3415,11 @@ void test_cartoon_mesh_compatibility() {
           3_st, 1.0},
       Scalar<DataVector>{3_st, 1.0},
       evolution::dg::Tags::NormalCovectorAndMagnitude<1>::type{}, evolved_vars,
-      dt_evolved_vars, boundary_condition_volume_tag_number,
+      auxiliary_vars, dt_evolved_vars, boundary_condition_volume_tag_number,
       boundary_correction_volume_tag_number, dg::Formulation::StrongInertial);
 
   // Create minimal temporaries, fluxes, and partial derivatives
-  const Variables<tmpl::list<Tags::Var3Squared>> temporaries{3, 1.0};
+  const Variables<tmpl::list<Tags::TempVar>> temporaries{3, 1.0};
   const Variables<
       db::wrap_tags_in<::Tags::Flux, tmpl::list<Tags::Var1, Tags::Var2<1>>,
                        tmpl::size_t<1>, Frame::Inertial>>
@@ -2721,6 +3456,7 @@ void test_cartoon_mesh_compatibility() {
 
     Variables<typename TestSystem::variables_tag::tags_list> evolved_vars2{3,
                                                                            1.0};
+    Variables<typename TestSystem::auxiliary_variables> auxiliary_vars2{3, 1.0};
     Variables<db::wrap_tags_in<::Tags::dt,
                                typename TestSystem::variables_tag::tags_list>>
         dt_evolved_vars2{3, 0.0};
@@ -2743,7 +3479,8 @@ void test_cartoon_mesh_compatibility() {
             3_st, 1.0},
         Scalar<DataVector>{3_st, 1.0},
         evolution::dg::Tags::NormalCovectorAndMagnitude<1>::type{},
-        evolved_vars2, dt_evolved_vars2, boundary_condition_volume_tag_number,
+        evolved_vars2, auxiliary_vars2, dt_evolved_vars2,
+        boundary_condition_volume_tag_number,
         boundary_correction_volume_tag_number, dg::Formulation::StrongInertial);
 
     CHECK_NOTHROW(
@@ -2772,10 +3509,10 @@ SPECTRE_TEST_CASE("Unit.Evolution.DG.ComputeTimeDerivative.BoundaryConditions",
   //   generalization have a `static_assert(Dim == 1)`. Going to more dimensions
   //   is straightforward but _extremely_ tedious.
   for (const bool moving_mesh : {true, false}) {
-    for (const dg::Formulation formulation :
-         {dg::Formulation::WeakInertial, dg::Formulation::StrongInertial}) {
-      for (const Spectral::Quadrature quadrature :
-           {Spectral::Quadrature::Gauss, Spectral::Quadrature::GaussLobatto}) {
+    for (const Spectral::Quadrature quadrature :
+         {Spectral::Quadrature::Gauss, Spectral::Quadrature::GaussLobatto}) {
+      for (const dg::Formulation formulation :
+           {dg::Formulation::WeakInertial, dg::Formulation::StrongInertial}) {
         // Second last template parameter on System:
         // - true: has primitive variables
         // - false: no primitive variables
@@ -2809,6 +3546,38 @@ SPECTRE_TEST_CASE("Unit.Evolution.DG.ComputeTimeDerivative.BoundaryConditions",
         test_1d<System<1, SystemType::Mixed, true, true>>(
             moving_mesh, formulation, quadrature);
       }
+
+      // auxiliary-pass analogues across the same System configurations. The
+      // LDG auxiliary pass is designed for the strong formulation only, so it
+      // is not run with WeakInertial.
+      // last template parameter on System being `false` means flat background
+      test_1d<System<1, SystemType::Conservative, false, false>, true>(
+          moving_mesh, dg::Formulation::StrongInertial, quadrature);
+      test_1d<System<1, SystemType::Conservative, true, false>, true>(
+          moving_mesh, dg::Formulation::StrongInertial, quadrature);
+
+      test_1d<System<1, SystemType::Nonconservative, false, false>, true>(
+          moving_mesh, dg::Formulation::StrongInertial, quadrature);
+
+      test_1d<System<1, SystemType::Mixed, false, false>, true>(
+          moving_mesh, dg::Formulation::StrongInertial, quadrature);
+      test_1d<System<1, SystemType::Mixed, true, false>, true>(
+          moving_mesh, dg::Formulation::StrongInertial, quadrature);
+
+      // last template parameter on System being `true` means curved
+      // background
+      test_1d<System<1, SystemType::Conservative, false, true>, true>(
+          moving_mesh, dg::Formulation::StrongInertial, quadrature);
+      test_1d<System<1, SystemType::Conservative, true, true>, true>(
+          moving_mesh, dg::Formulation::StrongInertial, quadrature);
+
+      test_1d<System<1, SystemType::Nonconservative, false, true>, true>(
+          moving_mesh, dg::Formulation::StrongInertial, quadrature);
+
+      test_1d<System<1, SystemType::Mixed, false, true>, true>(
+          moving_mesh, dg::Formulation::StrongInertial, quadrature);
+      test_1d<System<1, SystemType::Mixed, true, true>, true>(
+          moving_mesh, dg::Formulation::StrongInertial, quadrature);
     }
   }
   test_cartoon_mesh_compatibility();


### PR DESCRIPTION
Extend the external boundary machinery in BoundaryConditionsImpl with a ComputeAuxiliary template parameter that selects between the physical pass and the LDG auxiliary pass on boundary faces.

In the auxiliary pass, ghost-type boundary conditions supply exterior data as usual, but the face data are packaged with the boundary correction's dg_auxiliary_* interface and the resulting correction is lifted into the auxiliary-variable storage instead of the evolved-variable time derivatives. Time-derivative boundary conditions contribute nothing in the auxiliary pass; DemandOutgoingCharSpeeds conditions validate as usual.

In the physical pass, systems with auxiliary variables now have them projected to the external faces and passed to dg_package_data in addition to the evolved variables, so the physical boundary correction can read them.

Does not affect current systems.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent was used, have a co-author trailer of the form
      "Co-Authored-By: <agent name> <agent email>" as the last line of the
      commit, e.g. "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>".

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
