### PR TITLE
Add WithNoise initial data wrapper

### DIFF
--- a/src/Evolution/ComputeTags.hpp
+++ b/src/Evolution/ComputeTags.hpp
@@ -58,9 +58,11 @@ struct AnalyticSolutionsCompute
       const evolution::initial_data::InitialData& initial_data,
       const tnsr::I<DataVector, Dim, Frame::Inertial>& inertial_coords,
       const double time) {
+    // Unwrap wrapper types (e.g. WithNoise) to reach the underlying analytic
+    // solution for error computation.
     call_with_dynamic_type<void, InitialDataList>(
-        &initial_data, [&analytic_solution, &inertial_coords,
-                        time](const auto* const data_or_solution) {
+        &initial_data.unwrap(), [&analytic_solution, &inertial_coords,
+                                 time](const auto* const data_or_solution) {
           function(analytic_solution, *data_or_solution, inertial_coords, time);
         });
   }

--- a/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
@@ -125,6 +125,7 @@
 #include "PointwiseFunctions/GeneralRelativity/WeylTypeD1.hpp"
 #include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
 #include "PointwiseFunctions/InitialDataUtilities/Tags/InitialData.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/WithNoise.hpp"
 #include "PointwiseFunctions/MathFunctions/Factory.hpp"
 #include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
 #include "Time/ChangeTimeStepperOrder.hpp"
@@ -313,6 +314,7 @@ struct FactoryCreation : tt::ConformsTo<Options::protocols::FactoryCreation> {
       tmpl::pair<
           evolution::initial_data::InitialData,
           tmpl::append<gh::Solutions::all_solutions<volume_dim>,
+                       tmpl::list<evolution::initial_data::WithNoise>,
                        tmpl::conditional_t<volume_dim == 3,
                                            tmpl::list<gh::NumericInitialData>,
                                            tmpl::list<>>>>,

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -97,6 +97,7 @@
 #include "PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/WaveEquation/RegularSphericalWave.hpp"
 #include "PointwiseFunctions/InitialDataUtilities/NumericData.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/WithNoise.hpp"
 #include "PointwiseFunctions/MathFunctions/Factory.hpp"
 #include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
 #include "Time/Actions/SelfStartActions.hpp"
@@ -201,7 +202,8 @@ struct EvolutionMetavars {
                        standard_boundary_corrections<volume_dim>>,
         tmpl::pair<evolution::initial_data::InitialData,
                    tmpl::push_back<initial_data_list,
-                                   evolution::initial_data::NumericData>>,
+                                   evolution::initial_data::NumericData,
+                                   evolution::initial_data::WithNoise>>,
         tmpl::pair<MathFunction<1, Frame::Inertial>,
                    MathFunctions::all_math_functions<1, Frame::Inertial>>,
         tmpl::pair<PhaseChange, PhaseControl::factory_creatable_classes>,

--- a/src/Evolution/Initialization/SetVariables.hpp
+++ b/src/Evolution/Initialization/SetVariables.hpp
@@ -9,6 +9,7 @@
 #include <utility>
 
 #include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/TagName.hpp"
 #include "DataStructures/TaggedTuple.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Domain/CoordinateMaps/Tags.hpp"
@@ -25,10 +26,13 @@
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
 #include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
 #include "PointwiseFunctions/InitialDataUtilities/Tags/InitialData.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/WithNoise.hpp"
 #include "Time/Tags/Time.hpp"
+#include "Utilities/Algorithm.hpp"
 #include "Utilities/CallWithDynamicType.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/Gsl.hpp"
+#include "Utilities/StdHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
@@ -42,9 +46,18 @@ namespace evolution::Initialization::Actions {
 /// \ingroup InitializationGroup
 /// \brief Sets variables needed for evolution of hyperbolic systems
 ///
+/// Supports analytic solutions, analytic data, and
+/// `evolution::initial_data::WithNoise` wrappers. For `WithNoise`, the inner
+/// analytic solution sets variables normally, then uniform random noise is
+/// added to the requested evolution variables.
+///
 /// Uses:
 /// - DataBox:
 ///   * `CoordinatesTag`
+///   * `domain::CoordinateMaps::Tags::CoordinateMap` (for `WithNoise`)
+///   * `domain::Tags::ElementMap` (for `WithNoise`)
+///   * `domain::Tags::FunctionsOfTime` (for `WithNoise`)
+///   * `::Tags::Time`
 /// - GlobalCache:
 ///   * `evolution::initial_data::Tags::InitialData`
 ///
@@ -78,6 +91,75 @@ struct SetVariables {
           if constexpr (is_analytic_data_v<initial_data_subclass> or
                         is_analytic_solution_v<initial_data_subclass>) {
             impl<Metavariables>(make_not_null(&box), *data_or_solution);
+          } else if constexpr (std::is_same_v<
+                                   initial_data_subclass,
+                                   evolution::initial_data::WithNoise>) {
+            // Dispatch on the inner solution to set variables normally.
+            call_with_dynamic_type<void, derived_classes>(
+                &data_or_solution->solution(), [&box](const auto* const inner) {
+                  using inner_type = std::decay_t<decltype(*inner)>;
+                  if constexpr (is_analytic_data_v<inner_type> or
+                                is_analytic_solution_v<inner_type>) {
+                    impl<Metavariables>(make_not_null(&box), *inner);
+                  } else {
+                    ERROR(
+                        "WithNoise: the inner Solution must be an analytic "
+                        "solution or analytic data. Numeric initial data "
+                        "cannot be wrapped by WithNoise.");
+                  }
+                });
+            // Compute inertial coordinates for per-element seed mixing.
+            const double initial_time = db::get<::Tags::Time>(box);
+            const auto inertial_coords =
+                db::get<::domain::CoordinateMaps::Tags::CoordinateMap<
+                    Metavariables::volume_dim, Frame::Grid, Frame::Inertial>>(
+                    box)(db::get<::domain::Tags::ElementMap<
+                             Metavariables::volume_dim, Frame::Grid>>(box)(
+                             db::get<LogicalCoordinatesTag>(box)),
+                         initial_time,
+                         db::get<::domain::Tags::FunctionsOfTime>(box));
+            const size_t element_seed =
+                evolution::initial_data::make_element_seed(
+                    data_or_solution->seed(), inertial_coords);
+            // Apply noise to each requested variable in variables_tag.
+            using variables_tag = typename Metavariables::system::variables_tag;
+            const auto& targets = data_or_solution->variables();
+            const bool noise_all = alg::found(targets, std::string{"All"});
+            // Validate variable names against the actual tags list.
+            if (not noise_all) {
+              std::vector<std::string> valid_names{};
+              tmpl::for_each<typename variables_tag::tags_list>(
+                  [&valid_names]<typename Tag>(tmpl::type_<Tag> /*meta*/) {
+                    valid_names.push_back(db::tag_name<Tag>());
+                  });
+              for (const auto& target : targets) {
+                if (not alg::found(valid_names, target)) {
+                  ERROR("WithNoise: unknown variable name '"
+                        << target
+                        << "'. Valid names for this system are: " << valid_names
+                        << ". Use [\"All\"] to noise every variable.");
+                }
+              }
+            }
+            size_t component_offset = 0;
+            db::mutate<variables_tag>(
+                [&targets, noise_all, &data_or_solution, element_seed,
+                 &component_offset](
+                    const gsl::not_null<typename variables_tag::type*> vars) {
+                  tmpl::for_each<typename variables_tag::tags_list>(
+                      [&]<typename Tag>(tmpl::type_<Tag> /*meta*/) {
+                        if (noise_all or
+                            alg::found(targets, db::tag_name<Tag>())) {
+                          evolution::initial_data::add_noise_to_tensor(
+                              make_not_null(&get<Tag>(*vars)),
+                              data_or_solution->amplitude(), element_seed,
+                              component_offset);
+                        }
+                        component_offset +=
+                            std::decay_t<typename Tag::type>::size();
+                      });
+                },
+                make_not_null(&box));
           } else {
             ERROR(
                 "Trying to use "

--- a/src/Evolution/Systems/GeneralizedHarmonic/Actions/SetInitialData.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Actions/SetInitialData.hpp
@@ -7,9 +7,11 @@
 #include <pup.h>
 #include <string>
 #include <variant>
+#include <vector>
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataBox/TagName.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/TaggedTuple.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
@@ -17,6 +19,7 @@
 #include "Domain/Tags.hpp"
 #include "Evolution/Initialization/InitialData.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/SetPiAndPhiFromConstraints.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/System.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
 #include "IO/Importers/Actions/ReadVolumeData.hpp"
 #include "IO/Importers/ElementDataReader.hpp"
@@ -26,13 +29,18 @@
 #include "Parallel/AlgorithmExecution.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Invoke.hpp"
+#include "PointwiseFunctions/AnalyticData/AnalyticData.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
 #include "PointwiseFunctions/InitialDataUtilities/Tags/InitialData.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/WithNoise.hpp"
+#include "Utilities/Algorithm.hpp"
 #include "Utilities/CallWithDynamicType.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/StdHelpers.hpp"
 #include "Utilities/TMPL.hpp"
 
 /// \cond
@@ -338,6 +346,80 @@ struct SetInitialData {
         reader_component, initial_data.importer_options(),
         initial_data.volume_data_id(), std::move(selected_fields));
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
+  }
+
+  // WithNoise initial data — applies analytic inner solution then adds noise
+  template <typename DbTagsList, typename Metavariables, typename ArrayIndex,
+            typename ParallelComponent>
+  static Parallel::iterable_action_return_t apply(
+      const gsl::not_null<db::DataBox<DbTagsList>*> box,
+      const evolution::initial_data::WithNoise& with_noise,
+      Parallel::GlobalCache<Metavariables>& cache,
+      const ArrayIndex& array_index,
+      const ParallelComponent* const parallel_component) {
+    static constexpr size_t Dim = Metavariables::volume_dim;
+    // Dispatch on the inner solution to set GH variables normally.
+    using initial_data_classes =
+        tmpl::at<typename Metavariables::factory_creation::factory_classes,
+                 evolution::initial_data::InitialData>;
+    const auto result =
+        call_with_dynamic_type<Parallel::iterable_action_return_t,
+                               initial_data_classes>(
+            &with_noise.solution(),
+            [&box, &cache, &array_index, &parallel_component](
+                const auto* const inner) -> Parallel::iterable_action_return_t {
+              using inner_type = std::decay_t<decltype(*inner)>;
+              if constexpr (is_analytic_data_v<inner_type> or
+                            is_analytic_solution_v<inner_type>) {
+                return apply(box, *inner, cache, array_index,
+                             parallel_component);
+              } else {
+                ERROR(
+                    "WithNoise: the inner Solution must be an analytic "
+                    "solution or analytic data. Numeric initial data "
+                    "cannot be wrapped by WithNoise.");
+              }
+            });
+    // Compute inertial-coordinate-based per-element seed.
+    const size_t element_seed = evolution::initial_data::make_element_seed(
+        with_noise.seed(),
+        db::get<domain::Tags::Coordinates<Dim, Frame::Inertial>>(*box));
+    // Apply noise to each evolved GH variable.
+    using evolved_vars_list =
+        typename gh::System<Dim>::variables_tag::tags_list;
+    const auto& targets = with_noise.variables();
+    const bool noise_all = alg::found(targets, std::string{"All"});
+    // Validate variable names against the system's evolved variables.
+    if (not noise_all) {
+      std::vector<std::string> valid_names{};
+      tmpl::for_each<evolved_vars_list>(
+          [&valid_names]<typename Tag>(tmpl::type_<Tag> /*meta*/) {
+            valid_names.push_back(db::tag_name<Tag>());
+          });
+      for (const auto& target : targets) {
+        if (not alg::found(valid_names, target)) {
+          ERROR("WithNoise: unknown variable name '"
+                << target << "'. Valid names for this system are: "
+                << valid_names << ". Use [\"All\"] to noise every variable.");
+        }
+      }
+    }
+    size_t component_offset = 0;
+    tmpl::for_each<evolved_vars_list>([&]<typename Tag>(
+                                          tmpl::type_<Tag> /*meta*/) {
+      const size_t this_offset = component_offset;
+      if (noise_all or alg::found(targets, db::tag_name<Tag>())) {
+        db::mutate<Tag>(
+            [&with_noise, element_seed,
+             this_offset](const gsl::not_null<typename Tag::type*> tensor) {
+              evolution::initial_data::add_noise_to_tensor(
+                  tensor, with_noise.amplitude(), element_seed, this_offset);
+            },
+            box);
+      }
+      component_offset += std::decay_t<typename Tag::type>::size();
+    });
+    return result;
   }
 
   // "AnalyticData"-type initial data

--- a/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/DirichletAnalytic.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/DirichletAnalytic.cpp
@@ -81,10 +81,12 @@ std::optional<std::string> DirichletAnalytic<Dim>::dg_ghost(
   ASSERT(analytic_prescription_.get() != nullptr,
          "The analytic prescription must be set.");
   using evolved_vars_tags = typename System<Dim>::variables_tag::tags_list;
+  // Unwrap wrapper types (e.g. WithNoise) so boundary conditions use the
+  // inner analytic solution, not the noisy initial data wrapper.
   auto boundary_values = call_with_dynamic_type<
       tuples::tagged_tuple_from_typelist<evolved_vars_tags>,
       gh::Solutions::all_solutions<Dim>>(
-      analytic_prescription_.get(),
+      &analytic_prescription_->unwrap(),
       [&coords, &time](const auto* const analytic_solution_or_data) {
         if constexpr (is_analytic_solution_v<
                           std::decay_t<decltype(*analytic_solution_or_data)>>) {

--- a/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/AnalyticChristoffel.hpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/AnalyticChristoffel.hpp
@@ -95,10 +95,11 @@ class AnalyticChristoffel final : public GaugeCondition {
     // out-of-line instantiation, causing a linker error.
     ASSERT(analytic_prescription_.get() != nullptr,
            "The analytic prescription cannot be nullptr.");
+    // Unwrap wrapper types (e.g. WithNoise) to reach inner analytic solution
     const auto solution_vars = call_with_dynamic_type<
         tuples::tagged_tuple_from_typelist<solution_tags<SpatialDim>>,
         AllSolutionsForChristoffelAnalytic>(
-        analytic_prescription_.get(),
+        &analytic_prescription_->unwrap(),
         [&inertial_coords, &time](const auto* const analytic_solution_or_data) {
           if constexpr (is_analytic_solution_v<std::decay_t<
                             decltype(*analytic_solution_or_data)>>) {

--- a/src/Evolution/Systems/ScalarWave/BoundaryConditions/DirichletAnalytic.cpp
+++ b/src/Evolution/Systems/ScalarWave/BoundaryConditions/DirichletAnalytic.cpp
@@ -61,11 +61,13 @@ std::optional<std::string> DirichletAnalytic<Dim>::dg_ghost(
     const tnsr::I<DataVector, Dim, Frame::Inertial>& coords,
     const Scalar<DataVector>& interior_gamma2,
     [[maybe_unused]] const double time) const {
+  // Unwrap wrapper types (e.g. WithNoise) so boundary conditions use the
+  // inner analytic solution, not the noisy initial data wrapper.
   auto boundary_values = call_with_dynamic_type<
       tuples::TaggedTuple<ScalarWave::Tags::Psi, ScalarWave::Tags::Pi,
                           ScalarWave::Tags::Phi<Dim>>,
       tmpl::append<ScalarWave::Solutions::all_solutions<Dim>>>(
-      analytic_prescription_.get(),
+      &analytic_prescription_->unwrap(),
       [&coords, &time](const auto* const analytic_solution_or_data) {
         if constexpr (is_analytic_solution_v<
                           std::decay_t<decltype(*analytic_solution_or_data)>>) {

--- a/src/Evolution/Systems/ScalarWave/CMakeLists.txt
+++ b/src/Evolution/Systems/ScalarWave/CMakeLists.txt
@@ -45,6 +45,7 @@ target_link_libraries(
   ErrorHandling
   Events
   Evolution
+  InitialDataUtilities
   LinearOperators
   Options
   Utilities

--- a/src/PointwiseFunctions/InitialDataUtilities/CMakeLists.txt
+++ b/src/PointwiseFunctions/InitialDataUtilities/CMakeLists.txt
@@ -9,6 +9,7 @@ spectre_target_sources(
   ${LIBRARY}
   PRIVATE
   NumericData.cpp
+  WithNoise.cpp
   )
 
 spectre_target_headers(
@@ -20,11 +21,13 @@ spectre_target_headers(
   InitialData.hpp
   InitialGuess.hpp
   NumericData.hpp
+  WithNoise.hpp
   )
 
 target_link_libraries(
   ${LIBRARY}
   PUBLIC
+  Boost::boost
   DataStructures
   Exporter
   Options

--- a/src/PointwiseFunctions/InitialDataUtilities/InitialData.hpp
+++ b/src/PointwiseFunctions/InitialDataUtilities/InitialData.hpp
@@ -27,6 +27,17 @@ class InitialData : public PUP::able {
 
   virtual auto get_clone() const -> std::unique_ptr<InitialData> = 0;
 
+  /*!
+   * \brief Unwrap wrapper types (e.g. `WithNoise`, which wraps analytic
+   * initial data and adds random noise) to reach the underlying analytic
+   * solution or data.
+   *
+   * Most classes return `*this`. `WithNoise` overrides this to return its
+   * inner solution, allowing dispatch sites to transparently look through
+   * the wrapper without knowing about it explicitly.
+   */
+  virtual const InitialData& unwrap() const { return *this; }
+
   /// \cond
   explicit InitialData(CkMigrateMessage* msg) : PUP::able(msg) {}
   WRAPPED_PUPable_abstract(InitialData);

--- a/src/PointwiseFunctions/InitialDataUtilities/WithNoise.cpp
+++ b/src/PointwiseFunctions/InitialDataUtilities/WithNoise.cpp
@@ -1,0 +1,87 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/InitialDataUtilities/WithNoise.hpp"
+
+#include <pup.h>
+#include <pup_stl.h>
+#include <random>
+#include <utility>
+#include <vector>
+
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/Serialization/Serialize.hpp"
+
+namespace evolution::initial_data {
+
+WithNoise::WithNoise(const WithNoise& rhs)
+    : InitialData(rhs),
+      solution_(rhs.solution_ != nullptr ? rhs.solution_->get_clone()
+                                         : nullptr),
+      amplitude_(rhs.amplitude_),
+      seed_(rhs.seed_),
+      variables_(rhs.variables_) {}
+
+WithNoise& WithNoise::operator=(const WithNoise& rhs) {
+  if (this == &rhs) {
+    return *this;
+  }
+  InitialData::operator=(rhs);
+  solution_ = rhs.solution_ != nullptr ? rhs.solution_->get_clone() : nullptr;
+  amplitude_ = rhs.amplitude_;
+  seed_ = rhs.seed_;
+  variables_ = rhs.variables_;
+  return *this;
+}
+
+WithNoise::WithNoise(
+    std::unique_ptr<evolution::initial_data::InitialData> solution,
+    const double amplitude, std::optional<size_t> seed,
+    std::vector<std::string> variables)
+    : solution_(std::move(solution)),
+      amplitude_(amplitude),
+      seed_(seed.value_or(std::random_device{}())),
+      variables_(std::move(variables)) {
+  if (dynamic_cast<const WithNoise*>(solution_.get()) != nullptr) {
+    ERROR("WithNoise cannot wrap another WithNoise. Nesting is not supported.");
+  }
+}
+
+WithNoise::WithNoise(CkMigrateMessage* msg) : InitialData(msg) {}
+
+std::unique_ptr<evolution::initial_data::InitialData> WithNoise::get_clone()
+    const {
+  return std::make_unique<WithNoise>(*this);
+}
+
+void WithNoise::pup(PUP::er& p) {
+  evolution::initial_data::InitialData::pup(p);
+  p | solution_;
+  p | amplitude_;
+  p | seed_;
+  p | variables_;
+}
+
+bool operator==(const WithNoise& lhs, const WithNoise& rhs) {
+  if (lhs.amplitude_ != rhs.amplitude_ or lhs.seed_ != rhs.seed_ or
+      lhs.variables_ != rhs.variables_) {
+    return false;
+  }
+  if ((lhs.solution_ == nullptr) != (rhs.solution_ == nullptr)) {
+    return false;
+  }
+  if (lhs.solution_ == nullptr) {
+    return true;
+  }
+  // Compare inner solutions via PUP serialization. Requires Charm++ factory
+  // classes to be registered (register_factory_classes_with_charm) before use.
+  return serialize(lhs.solution_) == serialize(rhs.solution_);
+}
+
+bool operator!=(const WithNoise& lhs, const WithNoise& rhs) {
+  return not(lhs == rhs);
+}
+
+PUP::able::PUP_ID WithNoise::my_PUP_ID = 0;  // NOLINT
+
+}  // namespace evolution::initial_data

--- a/src/PointwiseFunctions/InitialDataUtilities/WithNoise.hpp
+++ b/src/PointwiseFunctions/InitialDataUtilities/WithNoise.hpp
@@ -1,0 +1,221 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <boost/functional/hash.hpp>
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <random>
+#include <string>
+#include <vector>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Options/Auto.hpp"
+#include "Options/String.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace evolution::initial_data {
+
+/*!
+ * \brief Add uniform random noise to all stored components of \p tensor.
+ *
+ * Each independent stored component receives noise drawn independently from
+ * \f$\text{Uniform}[-A,\,A]\f$, where \f$A\f$ is \p amplitude. The RNG seed
+ * for component \f$i\f$ is `hash(element_seed, component_offset + i)`, so
+ * calling this function with different \p component_offset values keeps
+ * separate tensor fields independent even when \p element_seed is the same.
+ *
+ * \param tensor Tensor to perturb in place.
+ * \param amplitude Half-width \f$A\f$ of the noise interval.
+ * \param element_seed Per-element seed, typically constructed by hashing a
+ *   base seed with the inertial coordinates of the element's first grid point.
+ * \param component_offset Offset added to the component index before hashing,
+ *   used to keep different tensor fields independent.
+ */
+template <typename TensorType>
+void add_noise_to_tensor(gsl::not_null<TensorType*> tensor, double amplitude,
+                         size_t element_seed, size_t component_offset) {
+  if (amplitude == 0.0) {
+    return;
+  }
+  std::uniform_real_distribution<double> dist{-amplitude, amplitude};
+  for (size_t i = 0; i < TensorType::size(); ++i) {
+    size_t comp_seed = element_seed;
+    boost::hash_combine(comp_seed, component_offset + i);
+    std::mt19937_64 gen{comp_seed};
+    for (double& val : (*tensor)[i]) {
+      val += dist(gen);
+    }
+  }
+}
+
+/*!
+ * \brief Combine \p base_seed with the first grid point of \p inertial_coords
+ * to produce a per-element RNG seed.
+ *
+ * Because most domains have elements have distinct first grid points, this
+ * gives independent noise on almost every element even when `base_seed` is the
+ * same.
+ */
+template <size_t Dim>
+size_t make_element_seed(
+    size_t base_seed,
+    const tnsr::I<DataVector, Dim, Frame::Inertial>& inertial_coords) {
+  size_t element_seed = base_seed;
+  for (size_t d = 0; d < Dim; ++d) {
+    boost::hash_combine(element_seed, inertial_coords.get(d)[0]);
+  }
+  return element_seed;
+}
+
+/*!
+ * \brief Wraps any analytic `InitialData` and adds uniform random noise to
+ * selected evolution variables after the inner solution has initialized them.
+ *
+ * \details The inner solution first sets all evolution variables in the normal
+ * way. Then each variable whose `db::tag_name` appears in `Variables` (or
+ * every variable if `All` is listed) has independent noise from
+ * \f$\text{Uniform}[-A,\,A]\f$ added to every grid point and every independent
+ * tensor component, where \f$A\f$ is `Amplitude`.
+ *
+ * Valid variable names are the `db::tag_name`s of the system's evolution
+ * variables. Examples:
+ * - **ScalarWave**: `Psi`, `Pi`, `Phi`
+ * - **GeneralizedHarmonic**: `SpacetimeMetric`, `Pi`, `Phi`
+ *
+ * Different elements receive independent noise because the RNG seed is mixed
+ * with the inertial coordinates of each element's first grid point. Set
+ * `Seed` to a fixed integer for reproducible results.
+ *
+ * \note Only analytic initial data (analytic solutions or analytic data) are
+ * supported as the inner `Solution`. Numeric initial data uses a two-phase
+ * asynchronous loading process: the `SetInitialData` action dispatches a file
+ * read request to `ElementDataReader` and returns immediately; variables are
+ * only set later when `ReceiveNumericInitialData` processes the inbox data.
+ * Because `WithNoise` applies noise immediately after the inner solution
+ * initializes variables, it has no hook into that second action and therefore
+ * cannot wrap numeric initial data.
+ *
+ * \note Nesting `WithNoise` inside `WithNoise` is not supported.
+ *
+ * \note **GeneralizedHarmonic systems**: the initialization phase
+ * `InitializeInitialDataDependentQuantities` runs
+ * `gh::gauges::SetPiAndPhiFromConstraints` *after* `WithNoise` applies noise.
+ * That action unconditionally overwrites `Phi` with the numerical spatial
+ * derivative of `SpacetimeMetric` and recomputes `Pi` from the gauge source
+ * function and the current geometry. As a result, noise added to `Pi` or `Phi`
+ * is effectively erased. Only noise added to `SpacetimeMetric` persists and
+ * propagates into the other variables: it appears in `Phi` amplified by
+ * roughly one over the grid spacing (due to differentiation), and in `Pi`
+ * through the geometric quantities (lapse, shift) extracted from the metric.
+ *
+ * Example input-file snippet for ScalarWave:
+ * \code{.yaml}
+ * InitialData:
+ *   WithNoise:
+ *     Amplitude: 1.0e-6
+ *     Seed: 42
+ *     Variables: [Psi, Pi]
+ *     Solution:
+ *       PlaneWave:
+ *         ...
+ * \endcode
+ */
+class WithNoise : public evolution::initial_data::InitialData {
+ public:
+  /// The analytic initial data to wrap.
+  struct Solution {
+    using type = std::unique_ptr<evolution::initial_data::InitialData>;
+    static constexpr Options::String help =
+        "The analytic initial data to wrap. Must be an analytic solution or "
+        "analytic data (not numeric initial data).";
+  };
+
+  /// Half-amplitude \f$A\f$ of the noise interval \f$[-A,\,A]\f$.
+  struct Amplitude {
+    using type = double;
+    static constexpr Options::String help =
+        "Half-amplitude A of the noise interval [-A, A] applied "
+        "independently to each grid point and tensor component.";
+  };
+
+  /// Seed for the random number generator.
+  struct Seed {
+    using type = Options::Auto<size_t, Options::AutoLabel::None>;
+    static constexpr Options::String help =
+        "Seed for the noise RNG. Set to 'None' for a random seed chosen at "
+        "runtime (runs will not be reproducible).";
+  };
+
+  /// Names of evolution variables to perturb, or `[All]` for all.
+  struct Variables {
+    using type = std::vector<std::string>;
+    static constexpr Options::String help =
+        "List of variable names to add noise to, or [All] to noise every "
+        "evolution variable. Valid names depend on the system; see class "
+        "documentation.";
+  };
+
+  using options = tmpl::list<Solution, Amplitude, Seed, Variables>;
+  static constexpr Options::String help =
+      "Wraps any analytic initial data and adds uniform random noise to "
+      "selected evolution variables after the inner solution sets them.";
+
+  WithNoise() = default;
+  WithNoise(const WithNoise& rhs);
+  WithNoise& operator=(const WithNoise& rhs);
+  WithNoise(WithNoise&&) = default;
+  WithNoise& operator=(WithNoise&&) = default;
+  ~WithNoise() override = default;
+
+  WithNoise(std::unique_ptr<evolution::initial_data::InitialData> solution,
+            double amplitude, std::optional<size_t> seed,
+            std::vector<std::string> variables);
+
+  /// \cond
+  explicit WithNoise(CkMigrateMessage* msg);
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(WithNoise);
+  /// \endcond
+
+  std::unique_ptr<evolution::initial_data::InitialData> get_clone()
+      const override;
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p) override;
+
+  const evolution::initial_data::InitialData& solution() const {
+    return *solution_;
+  }
+  /// Unwrap to the inner analytic solution, recursively resolving nested
+  /// `WithNoise` wrappers.
+  const evolution::initial_data::InitialData& unwrap() const override {
+    return solution_->unwrap();
+  }
+  double amplitude() const { return amplitude_; }
+  size_t seed() const { return seed_; }
+  const std::vector<std::string>& variables() const { return variables_; }
+
+  friend bool operator==(const WithNoise& lhs, const WithNoise& rhs);
+
+  friend bool operator!=(const WithNoise& lhs, const WithNoise& rhs);
+
+ private:
+  std::unique_ptr<evolution::initial_data::InitialData> solution_{};
+  double amplitude_{0.};
+  size_t seed_{0};
+  std::vector<std::string> variables_{};
+};
+
+}  // namespace evolution::initial_data

--- a/tests/Unit/Evolution/Initialization/CMakeLists.txt
+++ b/tests/Unit/Evolution/Initialization/CMakeLists.txt
@@ -23,5 +23,6 @@ target_link_libraries(
   Domain
   Evolution
   Hydro
+  InitialDataUtilities
   Utilities
   )

--- a/tests/Unit/Evolution/Initialization/Test_SetVariables.cpp
+++ b/tests/Unit/Evolution/Initialization/Test_SetVariables.cpp
@@ -7,6 +7,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataVector.hpp"
@@ -40,6 +41,7 @@
 #include "PointwiseFunctions/Hydro/EquationsOfState/Factory.hpp"
 #include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
 #include "PointwiseFunctions/InitialDataUtilities/Tags/InitialData.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/WithNoise.hpp"
 #include "Time/Tags/Time.hpp"
 #include "Utilities/CloneUniquePtrs.hpp"
 #include "Utilities/ConstantExpressions.hpp"
@@ -414,6 +416,108 @@ void test_analytic_data() {
         get<PrimVar>(prim_var));
 }
 
+template <size_t Dim>
+struct MetavariablesWithNoise {
+  static constexpr size_t volume_dim = Dim;
+  using component_list = tmpl::list<component<Dim, MetavariablesWithNoise>>;
+  using system = System<Dim, false>;
+  using temporal_id = TimeId;
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes =
+        tmpl::map<tmpl::pair<evolution::initial_data::InitialData,
+                             tmpl::list<SystemAnalyticSolution,
+                                        evolution::initial_data::WithNoise>>>;
+  };
+  using const_global_cache_tags =
+      tmpl::list<evolution::initial_data::Tags::InitialData>;
+};
+
+template <size_t Dim>
+void test_with_noise() {
+  using metavars = MetavariablesWithNoise<Dim>;
+  using comp = component<Dim, metavars>;
+  const double initial_time = 1.3;
+  const double expiration_time = 2.5;
+
+  {
+    INFO("WithNoise amplitude=0 gives exact analytic result");
+    ActionTesting::MockRuntimeSystem<metavars> runner{
+        {std::unique_ptr<evolution::initial_data::InitialData>(
+            std::make_unique<evolution::initial_data::WithNoise>(
+                std::make_unique<SystemAnalyticSolution>(),
+                /*amplitude=*/0.0, /*seed=*/size_t{42},
+                /*variables=*/std::vector<std::string>{"All"}))}};
+    const auto inertial_coords = emplace_component<Dim>(
+        make_not_null(&runner), initial_time, expiration_time);
+    ActionTesting::next_action<comp>(make_not_null(&runner), 0);
+    const auto expected_vars = SystemAnalyticSolution{}.variables(
+        inertial_coords, initial_time, tmpl::list<Var, NonConservativeVar>{});
+    CHECK(ActionTesting::get_databox_tag<comp, Var>(runner, 0) ==
+          get<Var>(expected_vars));
+    CHECK(ActionTesting::get_databox_tag<comp, NonConservativeVar>(runner, 0) ==
+          get<NonConservativeVar>(expected_vars));
+  }
+
+  {
+    INFO("WithNoise amplitude>0 perturbs the analytic result");
+    ActionTesting::MockRuntimeSystem<metavars> runner{
+        {std::unique_ptr<evolution::initial_data::InitialData>(
+            std::make_unique<evolution::initial_data::WithNoise>(
+                std::make_unique<SystemAnalyticSolution>(),
+                /*amplitude=*/1.0, /*seed=*/size_t{42},
+                /*variables=*/std::vector<std::string>{"All"}))}};
+    const auto inertial_coords = emplace_component<Dim>(
+        make_not_null(&runner), initial_time, expiration_time);
+    ActionTesting::next_action<comp>(make_not_null(&runner), 0);
+    const auto& result_var =
+        ActionTesting::get_databox_tag<comp, Var>(runner, 0);
+    const auto analytic_var = get<Var>(SystemAnalyticSolution{}.variables(
+        inertial_coords, initial_time, tmpl::list<Var>{}));
+    bool any_perturbed = false;
+    for (size_t i = 0; i < get(result_var).size() and not any_perturbed; ++i) {
+      if (get(result_var)[i] != get(analytic_var)[i]) {
+        any_perturbed = true;
+      }
+    }
+    CHECK(any_perturbed);
+  }
+
+  {
+    INFO("WithNoise only noises the named variable, leaving others unchanged");
+    ActionTesting::MockRuntimeSystem<metavars> runner{
+        {std::unique_ptr<evolution::initial_data::InitialData>(
+            std::make_unique<evolution::initial_data::WithNoise>(
+                std::make_unique<SystemAnalyticSolution>(),
+                /*amplitude=*/1.0, /*seed=*/size_t{42},
+                /*variables=*/std::vector<std::string>{"Var"}))}};
+    const auto inertial_coords = emplace_component<Dim>(
+        make_not_null(&runner), initial_time, expiration_time);
+    ActionTesting::next_action<comp>(make_not_null(&runner), 0);
+
+    // Var should be perturbed away from the analytic value.
+    const auto& result_var =
+        ActionTesting::get_databox_tag<comp, Var>(runner, 0);
+    const auto analytic_var = get<Var>(SystemAnalyticSolution{}.variables(
+        inertial_coords, initial_time, tmpl::list<Var>{}));
+    bool var_perturbed = false;
+    for (size_t i = 0; i < get(result_var).size() and not var_perturbed; ++i) {
+      if (get(result_var)[i] != get(analytic_var)[i]) {
+        var_perturbed = true;
+      }
+    }
+    CHECK(var_perturbed);
+
+    // NonConservativeVar was not listed -> must match the analytic solution.
+    const auto& result_nc =
+        ActionTesting::get_databox_tag<comp, NonConservativeVar>(runner, 0);
+    const auto analytic_nc =
+        get<NonConservativeVar>(SystemAnalyticSolution{}.variables(
+            inertial_coords, initial_time, tmpl::list<NonConservativeVar>{}));
+    CHECK(get(result_nc) == get(analytic_nc));
+  }
+}
+
 template <size_t Dim, bool HasPrimitives>
 void test_impl() {
   // Test setting variables from analytic solution
@@ -433,12 +537,14 @@ void test() {
 
   test_impl<Dim, true>();
   test_impl<Dim, false>();
+  test_with_noise<Dim>();
 }
 
 SPECTRE_TEST_CASE("Unit.Evolution.Initialization.SetVariables",
                   "[Unit][Evolution][Actions]") {
   domain::FunctionsOfTime::register_derived_with_charm();
-  register_classes_with_charm<SystemAnalyticData, SystemAnalyticSolution>();
+  register_classes_with_charm<SystemAnalyticData, SystemAnalyticSolution,
+                              evolution::initial_data::WithNoise>();
   test<1>();
   test<2>();
   test<3>();

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Actions/Test_SetInitialData.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/Actions/Test_SetInitialData.cpp
@@ -5,11 +5,13 @@
 
 #include <cstddef>
 #include <limits>
+#include <memory>
 #include <optional>
 #include <string>
 #include <tuple>
 #include <utility>
 #include <variant>
+#include <vector>
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataVector.hpp"
@@ -35,6 +37,7 @@
 #include "Parallel/Phase.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/WrappedGr.tpp"
+#include "PointwiseFunctions/InitialDataUtilities/WithNoise.hpp"
 #include "Time/Tags/Time.hpp"
 #include "Utilities/GetOutput.hpp"
 #include "Utilities/MakeString.hpp"
@@ -150,7 +153,8 @@ struct Metavariables {
     using factory_classes = tmpl::map<tmpl::pair<
         evolution::initial_data::InitialData,
         tmpl::list<NumericInitialData,
-                   gh::Solutions::WrappedGr<gr::Solutions::KerrSchild>>>>;
+                   gh::Solutions::WrappedGr<gr::Solutions::KerrSchild>,
+                   evolution::initial_data::WithNoise>>>;
   };
 };
 
@@ -297,6 +301,79 @@ void test_set_initial_data(
                                (get<Tags::Phi<DataVector, 3>>(kerr_gh_vars)),
                                custom_approx);
 }
+void test_analytic_with_noise() {
+  using element_array = MockElementArray<Metavariables>;
+  using reader_component = MockVolumeDataReader<Metavariables>;
+
+  const gh::Solutions::WrappedGr<gr::Solutions::KerrSchild> kerr{
+      1., {{0., 0., 0.}}, {{0., 0., 0.}}};
+  const Mesh<3> mesh{8, Spectral::Basis::Legendre,
+                     Spectral::Quadrature::GaussLobatto};
+  const auto map =
+      domain::make_coordinate_map<Frame::ElementLogical, Frame::Inertial>(
+          domain::CoordinateMaps::Wedge<3>{
+              2., 4., 1., 1., OrientationMap<3>::create_aligned(), true});
+  const auto logical_coords = logical_coordinates(mesh);
+  const auto coords = map(logical_coords);
+  const auto inv_jacobian = map.inv_jacobian(logical_coords);
+  const auto kerr_gh_vars = kerr.variables(coords, 0., gh_system_vars{});
+  const ElementId<3> element_id{0};
+
+  auto run_with_noise = [&](const double noise_amplitude) {
+    const evolution::initial_data::WithNoise with_noise{
+        std::make_unique<gh::Solutions::WrappedGr<gr::Solutions::KerrSchild>>(
+            kerr),
+        noise_amplitude, 123_st, std::vector<std::string>{"All"}};
+    ActionTesting::MockRuntimeSystem<Metavariables> runner{
+        {with_noise.get_clone()}, {true}};
+    ActionTesting::emplace_nodegroup_component<reader_component>(
+        make_not_null(&runner));
+    ActionTesting::emplace_component_and_initialize<element_array>(
+        make_not_null(&runner), element_id,
+        {tnsr::aa<DataVector, 3>{}, tnsr::aa<DataVector, 3>{},
+         tnsr::iaa<DataVector, 3>{}, mesh, coords, inv_jacobian, 0.});
+    ActionTesting::set_phase(make_not_null(&runner), Parallel::Phase::Testing);
+    ActionTesting::next_action<element_array>(make_not_null(&runner),
+                                              element_id);
+    return std::make_tuple(
+        ActionTesting::get_databox_tag<
+            element_array, gr::Tags::SpacetimeMetric<DataVector, 3>>(
+            runner, element_id),
+        ActionTesting::get_databox_tag<element_array, Tags::Pi<DataVector, 3>>(
+            runner, element_id),
+        ActionTesting::get_databox_tag<element_array, Tags::Phi<DataVector, 3>>(
+            runner, element_id));
+  };
+
+  {
+    INFO("WithNoise amplitude=0 gives clean analytic result");
+    const auto [g, pi, phi] = run_with_noise(0.0);
+    const Approx custom_approx = Approx::custom().epsilon(1.e-3).scale(1.0);
+    CHECK_ITERABLE_CUSTOM_APPROX(
+        g, (get<gr::Tags::SpacetimeMetric<DataVector, 3>>(kerr_gh_vars)),
+        custom_approx);
+    CHECK_ITERABLE_CUSTOM_APPROX(
+        pi, (get<Tags::Pi<DataVector, 3>>(kerr_gh_vars)), custom_approx);
+    CHECK_ITERABLE_CUSTOM_APPROX(
+        phi, (get<Tags::Phi<DataVector, 3>>(kerr_gh_vars)), custom_approx);
+  }
+
+  {
+    INFO("WithNoise amplitude>0 perturbs the analytic result");
+    const auto [g, pi, phi] = run_with_noise(1.0e-4);
+    const auto& clean_g =
+        get<gr::Tags::SpacetimeMetric<DataVector, 3>>(kerr_gh_vars);
+    bool any_different = false;
+    for (size_t i = 0;
+         i < tnsr::aa<DataVector, 3>::size(); ++i) {
+      if (max(abs(g[i] - clean_g[i])) > 0.0) {
+        any_different = true;
+        break;
+      }
+    }
+    CHECK(any_different);
+  }
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.Gh.NumericInitialData",
@@ -355,6 +432,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Gh.NumericInitialData",
       "  Center: [0, 0, 0]\n"
       "  Velocity: [0, 0, 0]",
       false);
+  test_analytic_with_noise();
 }
 
 }  // namespace gh

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Test_DirichletAnalytic.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Test_DirichletAnalytic.cpp
@@ -3,9 +3,18 @@
 
 #include "Framework/TestingFramework.hpp"
 
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
 #include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
 #include "DataStructures/Index.hpp"
 #include "DataStructures/TaggedTuple.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/DirichletAnalytic.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/BoundaryConditions/Factory.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/BoundaryCorrections/UpwindPenalty.hpp"
@@ -19,6 +28,7 @@
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/WrappedGr.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/WithNoise.hpp"
 #include "PointwiseFunctions/MathFunctions/Gaussian.hpp"
 #include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
 #include "Time/Tags/Time.hpp"
@@ -114,6 +124,77 @@ void test() {
                           helpers::Tags::Range<gh::Tags::ConstraintGamma2>>{
           std::array{0.0, 1.0}, std::array{0.0, 1.0}});
 }
+// Verify that DirichletAnalytic unwraps WithNoise and uses only the inner
+// analytic solution for boundary values, so noise has no effect on the BC.
+template <size_t Dim>
+void test_with_noise_unwrapping() {
+  CAPTURE(Dim);
+  const size_t n_pts = 3;
+
+  const double amplitude = 0.2;
+  const double wavelength = 10.0;
+  auto make_gauge_wave = [&]() {
+    return std::make_unique<
+        gh::Solutions::WrappedGr<gr::Solutions::GaugeWave<Dim>>>(amplitude,
+                                                                 wavelength);
+  };
+
+  const gh::BoundaryConditions::DirichletAnalytic<Dim> bc_plain{
+      make_gauge_wave()};
+  const gh::BoundaryConditions::DirichletAnalytic<Dim> bc_with_noise{
+      std::make_unique<evolution::initial_data::WithNoise>(
+          make_gauge_wave(), 1.0, 132_st, std::vector<std::string>{"All"})};
+
+  tnsr::I<DataVector, Dim, Frame::Inertial> coords{n_pts};
+  for (size_t d = 0; d < Dim; ++d) {
+    for (size_t i = 0; i < n_pts; ++i) {
+      coords.get(d)[i] =
+          0.1 * static_cast<double>(i + 1) + 0.05 * static_cast<double>(d);
+    }
+  }
+  const tnsr::i<DataVector, Dim, Frame::Inertial> normal_covector{n_pts, 0.0};
+  const tnsr::I<DataVector, Dim, Frame::Inertial> normal_vector{n_pts, 0.0};
+  const Scalar<DataVector> interior_gamma1{DataVector(n_pts, 0.1)};
+  const Scalar<DataVector> interior_gamma2{DataVector(n_pts, 0.5)};
+  const double time = 0.5;
+
+  tnsr::aa<DataVector, Dim> g_plain{n_pts};
+  tnsr::aa<DataVector, Dim> pi_plain{n_pts};
+  tnsr::iaa<DataVector, Dim> phi_plain{n_pts};
+  Scalar<DataVector> lapse_plain{n_pts};
+  Scalar<DataVector> gamma1_plain{n_pts};
+  Scalar<DataVector> gamma2_plain{n_pts};
+  tnsr::I<DataVector, Dim> shift_plain{n_pts};
+  tnsr::II<DataVector, Dim> inv_spatial_plain{n_pts};
+  bc_plain.dg_ghost(make_not_null(&g_plain), make_not_null(&pi_plain),
+                    make_not_null(&phi_plain), make_not_null(&gamma1_plain),
+                    make_not_null(&gamma2_plain), make_not_null(&lapse_plain),
+                    make_not_null(&shift_plain),
+                    make_not_null(&inv_spatial_plain), std::nullopt,
+                    normal_covector, normal_vector, coords, interior_gamma1,
+                    interior_gamma2, time);
+
+  tnsr::aa<DataVector, Dim> g_noise{n_pts};
+  tnsr::aa<DataVector, Dim> pi_noise{n_pts};
+  tnsr::iaa<DataVector, Dim> phi_noise{n_pts};
+  Scalar<DataVector> lapse_noise{n_pts};
+  Scalar<DataVector> gamma1_noise{n_pts};
+  Scalar<DataVector> gamma2_noise{n_pts};
+  tnsr::I<DataVector, Dim> shift_noise{n_pts};
+  tnsr::II<DataVector, Dim> inv_spatial_noise{n_pts};
+  bc_with_noise.dg_ghost(
+      make_not_null(&g_noise), make_not_null(&pi_noise),
+      make_not_null(&phi_noise), make_not_null(&gamma1_noise),
+      make_not_null(&gamma2_noise), make_not_null(&lapse_noise),
+      make_not_null(&shift_noise), make_not_null(&inv_spatial_noise),
+      std::nullopt, normal_covector, normal_vector, coords, interior_gamma1,
+      interior_gamma2, time);
+
+  // WithNoise is unwrapped for BCs: results must be identical to the plain BC
+  CHECK_ITERABLE_APPROX(g_plain, g_noise);
+  CHECK_ITERABLE_APPROX(pi_plain, pi_noise);
+  CHECK_ITERABLE_APPROX(phi_plain, phi_noise);
+}
 }  // namespace
 
 SPECTRE_TEST_CASE(
@@ -123,4 +204,7 @@ SPECTRE_TEST_CASE(
   test<1>();
   test<2>();
   test<3>();
+  test_with_noise_unwrapping<1>();
+  test_with_noise_unwrapping<2>();
+  test_with_noise_unwrapping<3>();
 }

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/CMakeLists.txt
@@ -50,6 +50,7 @@ target_link_libraries(
   GeneralRelativitySolutions
   GeneralizedHarmonic
   Importers
+  InitialDataUtilities
   LinearOperators
   MathFunctions
   Options

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/CMakeLists.txt
@@ -25,6 +25,7 @@ target_link_libraries(
   FunctionsOfTime
   GeneralRelativity
   GeneralizedHarmonic
+  InitialDataUtilities
   LinearOperators
   Options
   Parallel

--- a/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_AnalyticChristoffel.cpp
+++ b/tests/Unit/Evolution/Systems/GeneralizedHarmonic/GaugeSourceFunctions/Test_AnalyticChristoffel.cpp
@@ -6,6 +6,8 @@
 #include <cstddef>
 #include <limits>
 #include <memory>
+#include <string>
+#include <vector>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
@@ -36,6 +38,7 @@
 #include "PointwiseFunctions/GeneralRelativity/SpacetimeNormalVector.hpp"
 #include "PointwiseFunctions/GeneralRelativity/SpatialMetric.hpp"
 #include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/WithNoise.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
 #include "Utilities/Serialization/Serialize.hpp"
@@ -190,6 +193,52 @@ void test_ks(const Mesh<3>& mesh) {
   }
   CHECK_ITERABLE_APPROX(d4_gauge_h, expected_d4_gauge_h);
 }
+// Verify that AnalyticChristoffel::gauge_and_spacetime_derivative unwraps a
+// WithNoise wrapper and produces the same result as using the inner solution
+// directly, so noise has no effect on the gauge condition.
+template <size_t Dim>
+void test_with_noise_unwrapping(const Mesh<Dim>& mesh) {
+  const double amplitude = 0.0012;
+  const double wavelength = 1.4;
+  auto make_gauge_wave = [&]() {
+    return std::make_unique<
+        gh::Solutions::WrappedGr<gr::Solutions::GaugeWave<Dim>>>(amplitude,
+                                                                 wavelength);
+  };
+
+  const double time = 1.2;
+  const auto coord_map = make_coord_map<Dim>();
+  const auto logical_coords = logical_coordinates(mesh);
+  const tnsr::I<DataVector, Dim, Frame::Inertial> inertial_coords =
+      coord_map(logical_coords);
+  const auto inverse_jacobian = coord_map.inv_jacobian(logical_coords);
+  const size_t num_points = mesh.number_of_grid_points();
+
+  // Plain AnalyticChristoffel
+  const gh::gauges::AnalyticChristoffel plain_gauge{make_gauge_wave()};
+  tnsr::a<DataVector, Dim, Frame::Inertial> gauge_h_plain(num_points);
+  tnsr::ab<DataVector, Dim, Frame::Inertial> d4_gauge_h_plain(num_points);
+  gh::gauges::dispatch<gh::Solutions::all_solutions<Dim>>(
+      make_not_null(&gauge_h_plain), make_not_null(&d4_gauge_h_plain), {}, {},
+      {}, {}, {}, {}, {}, {}, {}, mesh, time, inertial_coords, inverse_jacobian,
+      plain_gauge);
+
+  // AnalyticChristoffel wrapping WithNoise (large amplitude to catch any
+  // leakage)
+  const gh::gauges::AnalyticChristoffel noisy_gauge{
+      std::make_unique<evolution::initial_data::WithNoise>(
+          make_gauge_wave(), 1.0, 9_st, std::vector<std::string>{"All"})};
+  tnsr::a<DataVector, Dim, Frame::Inertial> gauge_h_noisy(num_points);
+  tnsr::ab<DataVector, Dim, Frame::Inertial> d4_gauge_h_noisy(num_points);
+  gh::gauges::dispatch<gh::Solutions::all_solutions<Dim>>(
+      make_not_null(&gauge_h_noisy), make_not_null(&d4_gauge_h_noisy), {}, {},
+      {}, {}, {}, {}, {}, {}, {}, mesh, time, inertial_coords, inverse_jacobian,
+      noisy_gauge);
+
+  // WithNoise is unwrapped: gauge results must be identical to the plain case
+  CHECK_ITERABLE_APPROX(gauge_h_plain, gauge_h_noisy);
+  CHECK_ITERABLE_APPROX(d4_gauge_h_plain, d4_gauge_h_noisy);
+}
 }  // namespace
 
 SPECTRE_TEST_CASE(
@@ -208,5 +257,11 @@ SPECTRE_TEST_CASE(
     test_gauge_wave<3>(
         {5, basis_and_quadrature.first, basis_and_quadrature.second});
     test_ks({5, basis_and_quadrature.first, basis_and_quadrature.second});
+    test_with_noise_unwrapping<1>(
+        {5, basis_and_quadrature.first, basis_and_quadrature.second});
+    test_with_noise_unwrapping<2>(
+        {5, basis_and_quadrature.first, basis_and_quadrature.second});
+    test_with_noise_unwrapping<3>(
+        {5, basis_and_quadrature.first, basis_and_quadrature.second});
   }
 }

--- a/tests/Unit/Evolution/Systems/ScalarWave/BoundaryConditions/Test_DirichletAnalytic.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarWave/BoundaryConditions/Test_DirichletAnalytic.cpp
@@ -3,9 +3,18 @@
 
 #include "Framework/TestingFramework.hpp"
 
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
 #include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
 #include "DataStructures/Index.hpp"
 #include "DataStructures/TaggedTuple.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
 #include "Evolution/Systems/ScalarWave/BoundaryConditions/DirichletAnalytic.hpp"
 #include "Evolution/Systems/ScalarWave/BoundaryConditions/Factory.hpp"
 #include "Evolution/Systems/ScalarWave/BoundaryCorrections/UpwindPenalty.hpp"
@@ -17,6 +26,7 @@
 #include "PointwiseFunctions/AnalyticSolutions/Tags.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/WaveEquation/Factory.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/WithNoise.hpp"
 #include "PointwiseFunctions/MathFunctions/Factory.hpp"
 #include "PointwiseFunctions/MathFunctions/Gaussian.hpp"
 #include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
@@ -129,6 +139,72 @@ void test() {
           helpers::Tags::Range<ScalarWave::Tags::ConstraintGamma2>>{
           std::array{0.0, 1.0}});
 }
+// Verify that DirichletAnalytic unwraps WithNoise and uses only the inner
+// analytic solution for boundary values, so noise has no effect on the BC.
+template <size_t Dim>
+void test_with_noise_unwrapping() {
+  CAPTURE(Dim);
+  const size_t n_pts = 3;
+
+  std::array<double, Dim> wave_vector{};
+  std::array<double, Dim> center{};
+  for (size_t d = 0; d < Dim; ++d) {
+    gsl::at(wave_vector, d) = 0.1 + static_cast<double>(d);
+    gsl::at(center, d) = 1.1 - static_cast<double>(d);
+  }
+
+  auto make_plane_wave = [&]() {
+    return std::make_unique<ScalarWave::Solutions::PlaneWave<Dim>>(
+        wave_vector, center,
+        std::make_unique<MathFunctions::Gaussian<1, Frame::Inertial>>(0.9, 0.6,
+                                                                      0.0));
+  };
+
+  // Plain boundary condition
+  const ScalarWave::BoundaryConditions::DirichletAnalytic<Dim> bc_plain{
+      make_plane_wave()};
+  // Boundary condition with a WithNoise wrapper (non-zero amplitude)
+  const ScalarWave::BoundaryConditions::DirichletAnalytic<Dim> bc_with_noise{
+      std::make_unique<evolution::initial_data::WithNoise>(
+          make_plane_wave(), /*amplitude=*/1.0, /*seed=*/size_t{42},
+          /*variables=*/std::vector<std::string>{"All"})};
+
+  tnsr::I<DataVector, Dim, Frame::Inertial> coords{n_pts};
+  for (size_t d = 0; d < Dim; ++d) {
+    for (size_t i = 0; i < n_pts; ++i) {
+      coords.get(d)[i] =
+          0.1 * static_cast<double>(i + 1) + 0.05 * static_cast<double>(d);
+    }
+  }
+  const tnsr::i<DataVector, Dim, Frame::Inertial> normal_covector{n_pts, 0.0};
+  const Scalar<DataVector> interior_gamma2{DataVector(n_pts, 0.5)};
+  const double time = 0.5;
+
+  Scalar<DataVector> psi_plain{n_pts};
+  Scalar<DataVector> pi_plain{n_pts};
+  Scalar<DataVector> gamma2_plain{n_pts};
+  tnsr::i<DataVector, Dim, Frame::Inertial> phi_plain{n_pts};
+  bc_plain.dg_ghost(make_not_null(&psi_plain), make_not_null(&pi_plain),
+                    make_not_null(&phi_plain), make_not_null(&gamma2_plain),
+                    std::nullopt, normal_covector, coords, interior_gamma2,
+                    time);
+
+  Scalar<DataVector> psi_noise{n_pts};
+  Scalar<DataVector> pi_noise{n_pts};
+  Scalar<DataVector> gamma2_noise{n_pts};
+  tnsr::i<DataVector, Dim, Frame::Inertial> phi_noise{n_pts};
+  bc_with_noise.dg_ghost(make_not_null(&psi_noise), make_not_null(&pi_noise),
+                         make_not_null(&phi_noise),
+                         make_not_null(&gamma2_noise), std::nullopt,
+                         normal_covector, coords, interior_gamma2, time);
+
+  // WithNoise is unwrapped for BCs: results must be identical to the plain BC
+  CHECK_ITERABLE_APPROX(get(psi_plain), get(psi_noise));
+  CHECK_ITERABLE_APPROX(get(pi_plain), get(pi_noise));
+  for (size_t d = 0; d < Dim; ++d) {
+    CHECK_ITERABLE_APPROX(phi_plain.get(d), phi_noise.get(d));
+  }
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.ScalarWave.BoundaryConditions.DirichletAnalytic",
@@ -138,4 +214,7 @@ SPECTRE_TEST_CASE("Unit.ScalarWave.BoundaryConditions.DirichletAnalytic",
   test<1>();
   test<2>();
   test<3>();
+  test_with_noise_unwrapping<1>();
+  test_with_noise_unwrapping<2>();
+  test_with_noise_unwrapping<3>();
 }

--- a/tests/Unit/Evolution/Systems/ScalarWave/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/ScalarWave/CMakeLists.txt
@@ -26,6 +26,7 @@ target_link_libraries(
   ${LIBRARY}
   PRIVATE
   DataStructures
+  InitialDataUtilities
   MathFunctions
   ScalarWave
   Time

--- a/tests/Unit/PointwiseFunctions/InitialDataUtilities/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/InitialDataUtilities/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY Test_InitialDataUtilities)
 set(LIBRARY_SOURCES
   Tags/Test_InitialData.cpp
   Test_NumericData.cpp
+  Test_WithNoise.cpp
   )
 
 add_test_library(${LIBRARY} "${LIBRARY_SOURCES}")
@@ -14,5 +15,7 @@ target_link_libraries(
   ${LIBRARY}
   PUBLIC
   InitialDataUtilities
+  MathFunctions
   Parallel
+  WaveEquationSolutions
   )

--- a/tests/Unit/PointwiseFunctions/InitialDataUtilities/Test_WithNoise.cpp
+++ b/tests/Unit/PointwiseFunctions/InitialDataUtilities/Test_WithNoise.cpp
@@ -1,0 +1,292 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/WithNoise.hpp"
+#include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
+#include "PointwiseFunctions/MathFunctions/PowX.hpp"
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+
+struct Metavariables {
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes = tmpl::map<
+        tmpl::pair<MathFunction<1, Frame::Inertial>,
+                   tmpl::list<MathFunctions::PowX<1, Frame::Inertial>>>,
+        tmpl::pair<evolution::initial_data::InitialData,
+                   tmpl::list<ScalarWave::Solutions::PlaneWave<1>,
+                              evolution::initial_data::WithNoise>>>;
+  };
+};
+
+void test_add_noise_to_tensor() {
+  const size_t n_pts = 5;
+  {
+    INFO("Amplitude 0 is a no-op");
+    Scalar<DataVector> s{DataVector(n_pts, 3.0)};
+    evolution::initial_data::add_noise_to_tensor(make_not_null(&s), 0.0, 6, 0);
+    CHECK(get(s) == DataVector(n_pts, 3.0));
+  }
+  {
+    INFO("Non-zero amplitude changes value");
+    Scalar<DataVector> s{DataVector(n_pts, 0.0)};
+    evolution::initial_data::add_noise_to_tensor(make_not_null(&s), 1.0, 7, 0);
+    bool any_nonzero = false;
+    for (const double v : get(s)) {
+      CHECK(std::abs(v) <= 1.0);
+      if (v != 0.0) {
+        any_nonzero = true;
+      }
+    }
+    CHECK(any_nonzero);
+  }
+  {
+    INFO("Same seed and offset -> identical noise (reproducibility)");
+    Scalar<DataVector> s1{DataVector(n_pts, 0.0)};
+    Scalar<DataVector> s2{DataVector(n_pts, 0.0)};
+    evolution::initial_data::add_noise_to_tensor(make_not_null(&s1), 1.0, 99,
+                                                 0);
+    evolution::initial_data::add_noise_to_tensor(make_not_null(&s2), 1.0, 99,
+                                                 0);
+    CHECK(get(s1) == get(s2));
+  }
+  {
+    INFO("Different seeds -> different noise");
+    Scalar<DataVector> s1{DataVector(n_pts, 0.0)};
+    Scalar<DataVector> s2{DataVector(n_pts, 0.0)};
+    evolution::initial_data::add_noise_to_tensor(make_not_null(&s1), 1.0, 10,
+                                                 0);
+    evolution::initial_data::add_noise_to_tensor(make_not_null(&s2), 1.0, 11,
+                                                 0);
+    CHECK(get(s1) != get(s2));
+  }
+  {
+    INFO(
+        "Different component offsets -> different noise on separate tensor "
+        "fields");
+    tnsr::i<DataVector, 2> v1{DataVector(n_pts, 0.0)};
+    tnsr::i<DataVector, 2> v2{DataVector(n_pts, 0.0)};
+    evolution::initial_data::add_noise_to_tensor(make_not_null(&v1), 1.0, 42,
+                                                 0);
+    evolution::initial_data::add_noise_to_tensor(make_not_null(&v2), 1.0, 42,
+                                                 2);
+    CHECK(get<0>(v1) != get<0>(v2));
+    CHECK(get<1>(v1) != get<1>(v2));
+  }
+  {
+    INFO(
+        "Noise values are within amplitude bounds and tensor-type independent");
+    const double amplitude = 2.5;
+    tnsr::ii<DataVector, 2> sym_tensor{DataVector(n_pts, 0.0)};
+    evolution::initial_data::add_noise_to_tensor(make_not_null(&sym_tensor),
+                                                 amplitude, 13, 0);
+    for (size_t a = 0; a < 2; ++a) {
+      for (size_t b = a; b < 2; ++b) {
+        for (const double v : sym_tensor.get(a, b)) {
+          CHECK(std::abs(v) <= amplitude);
+        }
+      }
+    }
+  }
+}
+
+void test_make_element_seed() {
+  const size_t n_pts = 3;
+  tnsr::I<DataVector, 2, Frame::Inertial> coords_a{n_pts};
+  tnsr::I<DataVector, 2, Frame::Inertial> coords_b{n_pts};
+  for (size_t i = 0; i < n_pts; ++i) {
+    coords_a.get(0)[i] = 1.0 + static_cast<double>(i);
+    coords_a.get(1)[i] = 2.0 + static_cast<double>(i);
+    coords_b.get(0)[i] =
+        9.0 + static_cast<double>(i);  // different first grid point
+    coords_b.get(1)[i] = 2.0 + static_cast<double>(i);
+  }
+  {
+    INFO("Same base seed and coords -> same element seed (reproducibility)");
+    CHECK(evolution::initial_data::make_element_seed(42, coords_a) ==
+          evolution::initial_data::make_element_seed(42, coords_a));
+  }
+  {
+    INFO("Different base seeds -> different element seeds");
+    CHECK(evolution::initial_data::make_element_seed(42, coords_a) !=
+          evolution::initial_data::make_element_seed(43, coords_a));
+  }
+  {
+    INFO("Different first grid point -> different element seed");
+    CHECK(evolution::initial_data::make_element_seed(42, coords_a) !=
+          evolution::initial_data::make_element_seed(42, coords_b));
+  }
+}
+
+void test_unwrap() {
+  // Single WithNoise: unwrap() reaches the inner solution.
+  auto plane_wave = std::make_unique<ScalarWave::Solutions::PlaneWave<1>>(
+      std::array<double, 1>{{1.0}}, std::array<double, 1>{{0.0}},
+      std::make_unique<MathFunctions::PowX<1, Frame::Inertial>>(2));
+  const auto* const plane_wave_ptr = plane_wave.get();
+  const evolution::initial_data::WithNoise with_noise{
+      std::move(plane_wave), /*amplitude=*/1.0e-4, /*seed=*/size_t{0},
+      /*variables=*/std::vector<std::string>{"All"}};
+  CHECK(&with_noise.unwrap() == plane_wave_ptr);
+
+  // Nested WithNoise: construction must be rejected at the outer wrapper.
+  auto inner = std::make_unique<ScalarWave::Solutions::PlaneWave<1>>(
+      std::array<double, 1>{{1.0}}, std::array<double, 1>{{0.0}},
+      std::make_unique<MathFunctions::PowX<1, Frame::Inertial>>(1));
+  CHECK_THROWS_WITH(
+      (evolution::initial_data::WithNoise{
+          std::make_unique<evolution::initial_data::WithNoise>(
+              std::move(inner), 1.0e-4, 0_st, std::vector<std::string>{"All"}),
+          1.0e-4, 0_st, std::vector<std::string>{"All"}}),
+      Catch::Matchers::ContainsSubstring(
+          "WithNoise cannot wrap another WithNoise"));
+}
+
+void test_with_noise_construction() {
+  // Directly construct a WithNoise with a PlaneWave inner solution
+  auto plane_wave = std::make_unique<ScalarWave::Solutions::PlaneWave<1>>(
+      std::array<double, 1>{{1.0}}, std::array<double, 1>{{0.0}},
+      std::make_unique<MathFunctions::PowX<1, Frame::Inertial>>(2));
+  const evolution::initial_data::WithNoise with_noise{
+      std::move(plane_wave), 1.0e-4, 43_st,
+      std::vector<std::string>{"Psi", "Pi"}};
+
+  CHECK(with_noise.amplitude() == approx(1.0e-4));
+  CHECK(with_noise.seed() == 43);
+  CHECK(with_noise.variables() == std::vector<std::string>{"Psi", "Pi"});
+
+  test_copy_semantics(with_noise);
+}
+
+void test_with_noise_serialization() {
+  auto plane_wave = std::make_unique<ScalarWave::Solutions::PlaneWave<1>>(
+      std::array<double, 1>{{1.0}}, std::array<double, 1>{{0.0}},
+      std::make_unique<MathFunctions::PowX<1, Frame::Inertial>>(2));
+  const evolution::initial_data::WithNoise with_noise{
+      std::move(plane_wave), 1.0e-4, 44_st, std::vector<std::string>{"All"}};
+
+  test_serialization(with_noise);
+
+  // Test round-trip via unique_ptr base type
+  const auto cloned = with_noise.get_clone();
+  const auto& cloned_wn =
+      dynamic_cast<const evolution::initial_data::WithNoise&>(*cloned);
+  CHECK(cloned_wn.amplitude() == approx(with_noise.amplitude()));
+  CHECK(cloned_wn.seed() == with_noise.seed());
+  CHECK(cloned_wn.variables() == with_noise.variables());
+}
+
+// Verify that the selective variable mechanism correctly applies noise to only
+// the named fields and leaves the others untouched, using the same building
+// blocks (add_noise_to_tensor + variables() list) that the actions use.
+void test_selective_variable_noise() {
+  const size_t n_pts = 4;
+  const size_t element_seed = 77;
+  const double amplitude = 1.0;
+
+  auto plane_wave = std::make_unique<ScalarWave::Solutions::PlaneWave<1>>(
+      std::array<double, 1>{{1.0}}, std::array<double, 1>{{0.0}},
+      std::make_unique<MathFunctions::PowX<1, Frame::Inertial>>(1));
+  const evolution::initial_data::WithNoise wn{std::move(plane_wave), amplitude,
+                                              size_t{0},
+                                              std::vector<std::string>{"Psi"}};
+
+  // Simulate action selection: two scalars with tag names "Psi" and "Pi".
+  Scalar<DataVector> psi{DataVector(n_pts, 5.0)};
+  Scalar<DataVector> pi{DataVector(n_pts, 5.0)};
+  const auto& targets = wn.variables();
+  size_t offset = 0;
+  if (alg::found(targets, std::string{"Psi"})) {
+    evolution::initial_data::add_noise_to_tensor(make_not_null(&psi), amplitude,
+                                                 element_seed, offset);
+  }
+  offset += Scalar<DataVector>::size();
+  if (alg::found(targets, std::string{"Pi"})) {
+    evolution::initial_data::add_noise_to_tensor(make_not_null(&pi), amplitude,
+                                                 element_seed, offset);
+  }
+
+  // "Psi" is in variables() -> must be perturbed
+  bool psi_changed = false;
+  for (const double v : get(psi)) {
+    if (v != 5.0) {
+      psi_changed = true;
+    }
+  }
+  CHECK(psi_changed);
+  // "Pi" is not in variables() -> must be unchanged
+  CHECK(get(pi) == DataVector(n_pts, 5.0));
+}
+
+void test_with_noise_option_parsing() {
+  {
+    const auto created =
+        TestHelpers::test_creation<evolution::initial_data::WithNoise,
+                                   Metavariables>(
+            "Amplitude: 1.0e-6\n"
+            "Seed: 41\n"
+            "Variables: [Psi, Pi]\n"
+            "Solution:\n"
+            "  PlaneWave:\n"
+            "    WaveVector: [1.0]\n"
+            "    Center: [0.0]\n"
+            "    Profile:\n"
+            "      PowX:\n"
+            "        Power: 2\n");
+    CHECK(created.amplitude() == approx(1.0e-6));
+    CHECK(created.seed() == 41);
+    CHECK(created.variables() == std::vector<std::string>{"Psi", "Pi"});
+  }
+  {
+    INFO("Test with `All`");
+    const auto created =
+        TestHelpers::test_creation<evolution::initial_data::WithNoise,
+                                   Metavariables>(
+            "Amplitude: 0.5\n"
+            "Seed: None\n"
+            "Variables: [All]\n"
+            "Solution:\n"
+            "  PlaneWave:\n"
+            "    WaveVector: [1.0]\n"
+            "    Center: [0.0]\n"
+            "    Profile:\n"
+            "      PowX:\n"
+            "        Power: 1\n");
+    CHECK(created.amplitude() == approx(0.5));
+    CHECK(created.variables() == std::vector<std::string>{"All"});
+  }
+}
+
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.PointwiseFunctions.InitialDataUtilities.WithNoise",
+                  "[Unit][PointwiseFunctions]") {
+  register_factory_classes_with_charm<Metavariables>();
+  test_add_noise_to_tensor();
+  test_make_element_seed();
+  test_unwrap();
+  test_with_noise_construction();
+  test_with_noise_serialization();
+  test_with_noise_option_parsing();
+  test_selective_variable_noise();
+}


### PR DESCRIPTION
## Proposed changes

 Adds a generic WithNoise wrapper that applies uniform random noise to any analytic initial data after the inner solution initializes the evolution variables. This is intended for testing purposes.

An example usage:
```yaml
InitialData: &InitialData
  WithNoise:
    Amplitude: 1e-14
    Seed: 101 # or None
    Variables: [Psi]
    Solution:
      PlaneWave:
        WaveVector: [1.0, 1.0, 1.0]
        ...
```

The first commit creates the `WithNoise` class and required supporting functions, as well as creating a new virtual method `InitialData::unwrap()` (default returns `*this`; `WithNoise` returns the inner solution) enabling dispatch through wrappers at boundary conditions, gauge functions, and error-computation sites.

The second commit uses `WithNoise` in the ScalarWave and GeneralizedHarmonic systems:
  - SetVariables: handles `WithNoise` by dispatching to the inner solution, then applying noise to the requested variables. This can be used for systems that don't have their own system-specific SetInitialData action, e.g. ScalarWave
  - gh::Actions::SetInitialData: dedicated `WithNoise` implementation, nearly identical to the SetVariables'
  - Both system then also have to update certain calls to now use unwrap() so the code uses the true analytic solution rather than the noise wrapper.


Some notes (that are in the documentation):
  - Cannot support numeric initial data this way: the code for that does not cleanly mesh with the current infrastructure, but I figured the main use case was in testing domains on known analytic solutions so I didn't bother trying to find a solution to this
  - For GH system, noise added to Pi or Phi is erased by SetPiAndPhiFromConstraints in the subsequent InitializeInitialDataDependentQuantities phase. Only noise on SpacetimeMetric persists (and propagates into Phi and Pi).


<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent was used, have a co-author trailer of the form
      "Co-Authored-By: <agent name> <agent email>" as the last line of the
      commit, e.g. "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>".

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
