### PR TITLE
Add SoScalarWave system part two

### DIFF
--- a/src/Evolution/Systems/SecondOrderScalarWave/CMakeLists.txt
+++ b/src/Evolution/Systems/SecondOrderScalarWave/CMakeLists.txt
@@ -3,7 +3,13 @@
 
 set(LIBRARY SecondOrderScalarWave)
 
-add_spectre_library(${LIBRARY} INTERFACE)
+add_spectre_library(${LIBRARY})
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
+  TimeDerivative.cpp
+  )
 
 spectre_target_headers(
   ${LIBRARY}
@@ -12,11 +18,13 @@ spectre_target_headers(
   System.hpp
   Tags.hpp
   TagsDeclarations.hpp
+  TimeDerivative.hpp
   )
 
 target_link_libraries(
   ${LIBRARY}
-  INTERFACE
+  PUBLIC
   DataStructures
+  DiscontinuousGalerkin
   Utilities
   )

--- a/src/Evolution/Systems/SecondOrderScalarWave/System.hpp
+++ b/src/Evolution/Systems/SecondOrderScalarWave/System.hpp
@@ -8,6 +8,7 @@
 
 #include "DataStructures/VariablesTag.hpp"
 #include "Evolution/Systems/SecondOrderScalarWave/Tags.hpp"
+#include "Evolution/Systems/SecondOrderScalarWave/TimeDerivative.hpp"
 #include "Utilities/TMPL.hpp"
 
 /*!
@@ -32,6 +33,13 @@ struct System {
   using variables_tag = ::Tags::Variables<tmpl::list<Tags::Psi, Tags::Pi>>;
   using flux_variables = tmpl::list<>;
   using auxiliary_variables = tmpl::list<Tags::Phi<Dim>>;
-  using gradient_variables = tmpl::list<Tags::Phi<Dim>>;
+  // The time derivative reads only the derivative of Phi, but the evolved
+  // variables must also be listed: `volume_terms` unconditionally instantiates
+  // reads of every evolved variable's derivative for the moving-mesh term, so
+  // a nonconservative system's `gradient_variables` must contain its evolved
+  // variables.
+  using gradient_variables = tmpl::list<Tags::Psi, Tags::Pi, Tags::Phi<Dim>>;
+
+  using compute_volume_time_derivative_terms = TimeDerivative<Dim>;
 };
 }  // namespace SecondOrderScalarWave

--- a/src/Evolution/Systems/SecondOrderScalarWave/TimeDerivative.cpp
+++ b/src/Evolution/Systems/SecondOrderScalarWave/TimeDerivative.cpp
@@ -1,0 +1,32 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/SecondOrderScalarWave/TimeDerivative.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace SecondOrderScalarWave {
+template <size_t Dim>
+evolution::dg::TimeDerivativeDecisions<Dim> TimeDerivative<Dim>::apply(
+    const gsl::not_null<Scalar<DataVector>*> dt_psi,
+    const gsl::not_null<Scalar<DataVector>*> dt_pi,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& /*d_psi*/,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& /*d_pi*/,
+    const tnsr::ij<DataVector, Dim, Frame::Inertial>& d_phi,
+    const Scalar<DataVector>& pi) {
+  get(*dt_psi) = -get(pi);
+  get(*dt_pi) = 0.0;
+  for (size_t d = 0; d < Dim; ++d) {
+    get(*dt_pi) -= d_phi.get(d, d);
+  }
+  return {false};
+}
+
+template class TimeDerivative<1>;
+template class TimeDerivative<2>;
+template class TimeDerivative<3>;
+}  // namespace SecondOrderScalarWave

--- a/src/Evolution/Systems/SecondOrderScalarWave/TimeDerivative.hpp
+++ b/src/Evolution/Systems/SecondOrderScalarWave/TimeDerivative.hpp
@@ -1,0 +1,47 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/DiscontinuousGalerkin/TimeDerivativeDecisions.hpp"
+#include "Evolution/Systems/SecondOrderScalarWave/Tags.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+
+class DataVector;
+/// \endcond
+
+namespace SecondOrderScalarWave {
+/*!
+ * \brief Compute the time derivatives for the second-order scalar wave system
+ */
+template <size_t Dim>
+struct TimeDerivative {
+  using temporary_tags = tmpl::list<>;
+
+  using argument_tags = tmpl::list<Tags::Pi>;
+
+  static evolution::dg::TimeDerivativeDecisions<Dim> apply(
+      gsl::not_null<Scalar<DataVector>*> dt_psi,
+      gsl::not_null<Scalar<DataVector>*> dt_pi,
+
+      // Partial derivative arguments. Listed in the system struct as
+      // gradient_variables. Only the derivative of Phi enters the time
+      // derivatives; the evolved variables' derivatives are in
+      // gradient_variables solely for the framework's moving-mesh term.
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& /*d_psi*/,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& /*d_pi*/,
+      const tnsr::ij<DataVector, Dim, Frame::Inertial>& d_phi,
+
+      // Terms list in argument_tags above
+      const Scalar<DataVector>& pi);
+};
+}  // namespace SecondOrderScalarWave

--- a/tests/Unit/Evolution/Systems/SecondOrderScalarWave/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/SecondOrderScalarWave/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY Test_SecondOrderScalarWave)
 set(LIBRARY_SOURCES
   Test_System.cpp
   Test_Tags.cpp
+  Test_TimeDerivative.cpp
   )
 
 add_test_library(${LIBRARY} "${LIBRARY_SOURCES}")

--- a/tests/Unit/Evolution/Systems/SecondOrderScalarWave/Test_TimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/SecondOrderScalarWave/Test_TimeDerivative.cpp
@@ -1,0 +1,68 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <random>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/SecondOrderScalarWave/TimeDerivative.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace {
+// The volume time derivatives are the exact, linear relations
+// \f$\partial_t \Psi = -\Pi\f$ and
+// \f$\partial_t \Pi = -\delta^{ij}\partial_i \Phi_j\f$, so we can check them
+// against arbitrary random inputs without invoking an analytic solution.
+template <size_t Dim>
+void test_time_derivative(const gsl::not_null<std::mt19937*> generator) {
+  CAPTURE(Dim);
+  std::uniform_real_distribution<> distribution(-1.0, 1.0);
+  const auto nn_distribution = make_not_null(&distribution);
+  const size_t num_pts = 5;
+  const DataVector used_for_size(num_pts);
+
+  const auto pi = make_with_random_values<Scalar<DataVector>>(
+      generator, nn_distribution, used_for_size);
+  // The evolved variables' derivatives are unused by the time derivative
+  // (they are in gradient_variables only for the framework's moving-mesh
+  // term); random values prove they do not enter the result.
+  const auto d_psi =
+      make_with_random_values<tnsr::i<DataVector, Dim, Frame::Inertial>>(
+          generator, nn_distribution, used_for_size);
+  const auto d_pi =
+      make_with_random_values<tnsr::i<DataVector, Dim, Frame::Inertial>>(
+          generator, nn_distribution, used_for_size);
+  const auto d_phi =
+      make_with_random_values<tnsr::ij<DataVector, Dim, Frame::Inertial>>(
+          generator, nn_distribution, used_for_size);
+
+  Scalar<DataVector> dt_psi{num_pts};
+  Scalar<DataVector> dt_pi{num_pts};
+  const auto decisions = SecondOrderScalarWave::TimeDerivative<Dim>::apply(
+      make_not_null(&dt_psi), make_not_null(&dt_pi), d_psi, d_pi, d_phi, pi);
+
+  CHECK_ITERABLE_APPROX(dt_psi, Scalar<DataVector>(-1.0 * get(pi)));
+
+  DataVector expected_dt_pi(num_pts, 0.0);
+  for (size_t d = 0; d < Dim; ++d) {
+    expected_dt_pi -= d_phi.get(d, d);
+  }
+  CHECK_ITERABLE_APPROX(dt_pi, Scalar<DataVector>(expected_dt_pi));
+
+  // The LDG scheme is flux-free, so no flux divergence is computed.
+  CHECK(decisions.compute_flux_divergence == false);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.SecondOrderScalarWave.TimeDerivative",
+                  "[Unit][Evolution]") {
+  MAKE_GENERATOR(generator);
+  test_time_derivative<1>(make_not_null(&generator));
+  test_time_derivative<2>(make_not_null(&generator));
+  test_time_derivative<3>(make_not_null(&generator));
+}


### PR DESCRIPTION
## Proposed changes
Prepare the first evolution system, a second-order in space scalar wave system, that uses the local discontinuous Galerkin (LDG) infrastructure.

Add `TimeDerivative` and its unit test.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent was used, have a co-author trailer of the form
      "Co-Authored-By: <agent name> <agent email>" as the last line of the
      commit, e.g. "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>".

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
