### PR TITLE
Center CBCO OuterSphere at origin

### DIFF
--- a/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
+++ b/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
@@ -38,6 +38,7 @@
 #include "NumericalAlgorithms/RootFinding/QuadraticEquation.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Spherepack.hpp"
 #include "Options/ParseError.hpp"
+#include "Utilities/MakeArray.hpp"
 
 namespace {
 std::array<double, 3> rotate_to_z_axis(const std::array<double, 3> input) {
@@ -1144,8 +1145,7 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const {
                                first_cb_side_block);
 
   auto outer_sh_map = make_spherical_shell_coord_map(
-      inner_radius_C, outer_radius_,
-      rotate_from_z_to_x_axis(center_cutting_plane));
+      inner_radius_C, outer_radius_, make_array<3>(0.0));
 
   DirectionMap<3, BlockNeighbors<3>> outer_sh_neighbors;
   outer_sh_neighbors.emplace(


### PR DESCRIPTION
## Proposed changes

This fixes a small bug that shouldn't have been affecting anything so far given that the cutting plane has been at the center thus far, but the OuterSphere should be centered at the origin based on SpEC.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent was used, have a co-author trailer of the form
      "Co-Authored-By: <agent name> <agent email>" as the last line of the
      commit, e.g. "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>".

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
