### PR TITLE
Disable OpenMP when running tests

### DIFF
--- a/cmake/AddInputFileTests.cmake
+++ b/cmake/AddInputFileTests.cmake
@@ -32,6 +32,8 @@ set(_INPUT_FILE_TEST_ENV_VARS "")
 list(APPEND _INPUT_FILE_TEST_ENV_VARS "ASAN_OPTIONS=detect_leaks=0")
 # - Set PYTHONPATH to find Python modules
 list(APPEND _INPUT_FILE_TEST_ENV_VARS "PYTHONPATH=${PYTHONPATH}")
+# - Disable OpenMP because it causes segfaults
+list(APPEND _INPUT_FILE_TEST_ENV_VARS "OMP_NUM_THREADS=1")
 
 function(add_single_input_file_test)
   cmake_parse_arguments(

--- a/cmake/AddStandaloneTests.cmake
+++ b/cmake/AddStandaloneTests.cmake
@@ -39,7 +39,7 @@ function(set_standalone_test_properties TEST_NAME)
     PROPERTIES
     TIMEOUT "${TIMEOUT}"
     LABELS "standalone"
-    ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0")
+    ENVIRONMENT "ASAN_OPTIONS=detect_leaks=0;OMP_NUM_THREADS=1")
 endfunction()
 
 # For tests that result in a failure it is necessary to redirect

--- a/cmake/SpectreAddCatchTests.cmake
+++ b/cmake/SpectreAddCatchTests.cmake
@@ -47,6 +47,8 @@ set(_CATCH_TEST_ENV_VARS "")
 list(APPEND _CATCH_TEST_ENV_VARS "ASAN_OPTIONS=detect_leaks=0")
 # - Set PYTHONPATH to find Python modules
 list(APPEND _CATCH_TEST_ENV_VARS "PYTHONPATH=${PYTHONPATH}")
+# - Disable OpenMP because it causes segfaults
+list(APPEND _CATCH_TEST_ENV_VARS "OMP_NUM_THREADS=1")
 
 # Main function - the only one designed to be called from outside this module.
 function(spectre_add_catch_tests TEST_TARGET)

--- a/cmake/SpectreSetupPythonPackage.cmake
+++ b/cmake/SpectreSetupPythonPackage.cmake
@@ -339,7 +339,7 @@ function(SPECTRE_ADD_PYTHON_TEST TEST_NAME FILE TAGS
 
   spectre_test_timeout(TIMEOUT PYTHON ${TIMEOUT})
 
-  set(_PY_TEST_ENV_VARS "PYTHONPATH=${PYTHONPATH}")
+  set(_PY_TEST_ENV_VARS "PYTHONPATH=${PYTHONPATH};OMP_NUM_THREADS=1")
 
   # The fail regular expression is what Python.unittest returns when no
   # tests are found to be run. We treat this as a test failure.

--- a/tests/support/Python/CMakeLists.txt
+++ b/tests/support/Python/CMakeLists.txt
@@ -9,7 +9,8 @@ if (BUILD_PYTHON_BINDINGS AND NOT PY_DEV_MODE)
   set_tests_properties(
     "support.Python.Cli" PROPERTIES
     PASS_REGULAR_EXPRESSION "${SPECTRE_VERSION}"
-    LABELS "python")
+    LABELS "python"
+    ENVIRONMENT "OMP_NUM_THREADS=1")
 
   add_test(NAME "support.Python.python-spectre"
     COMMAND ${CMAKE_BINARY_DIR}/bin/python-spectre -c
@@ -17,7 +18,8 @@ if (BUILD_PYTHON_BINDINGS AND NOT PY_DEV_MODE)
   set_tests_properties(
     "support.Python.python-spectre" PROPERTIES
     PASS_REGULAR_EXPRESSION "${SPECTRE_VERSION}"
-    LABELS "python")
+    LABELS "python"
+    ENVIRONMENT "OMP_NUM_THREADS=1")
 endif()
 
 spectre_add_python_bindings_test(


### PR DESCRIPTION
I've seen OpenMP cause memory corruption locally when running executables.  It might be related to the occasional segfaults we get in CI.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent was used, have a co-author trailer of the form
      "Co-Authored-By: <agent name> <agent email>" as the last line of the
      commit, e.g. "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>".

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
