### PR TITLE
Modify GhValenciaDivClean to allow Cartoon bases

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/Actions/VolumeTermsImpl.tpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/VolumeTermsImpl.tpp
@@ -250,7 +250,7 @@ void volume_terms(
     }
     if (dg_formulation == ::dg::Formulation::StrongInertial) {
       divergence(div_fluxes, *volume_fluxes, mesh,
-                 logical_to_inertial_inverse_jacobian);
+                 logical_to_inertial_inverse_jacobian, inertial_coordinates);
     } else if (dg_formulation == ::dg::Formulation::WeakInertial) {
       // We should ideally not recompute the
       // det_jac_times_inverse_jacobian for non-moving meshes.

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -448,7 +448,8 @@ struct GhValenciaDivCleanTemplateBase<
               gr::Tags::SpatialChristoffelSecondKind<DataVector, volume_dim>,
               ::Events::Tags::ObserverInverseJacobian<
                   volume_dim, Frame::ElementLogical, Frame::Inertial>,
-              ::Events::Tags::ObserverMesh<volume_dim>>,
+              ::Events::Tags::ObserverMesh<volume_dim>,
+              ::Events::Tags::ObserverCoordinates<volume_dim, Frame::Inertial>>,
           gr::Tags::SpatialRicciCompute<DataVector, volume_dim,
                                         ::Frame::Inertial>,
           gr::Tags::SpatialRicciScalarCompute<DataVector, volume_dim,
@@ -508,7 +509,8 @@ struct GhValenciaDivCleanTemplateBase<
               gr::Tags::ExtrinsicCurvature<DataVector, 3>,
               ::Events::Tags::ObserverInverseJacobian<
                   volume_dim, Frame::ElementLogical, Frame::Inertial>,
-              ::Events::Tags::ObserverMesh<volume_dim>>,
+              ::Events::Tags::ObserverMesh<volume_dim>,
+              ::Events::Tags::ObserverCoordinates<volume_dim, Frame::Inertial>>,
           gr::Tags::WeylElectricCompute<DataVector, 3, Frame::Inertial>,
           gr::Tags::Psi4RealCompute<Frame::Inertial>,
           ::Events::Tags::ObserverMeshVelocity<3>>,
@@ -584,15 +586,17 @@ struct GhValenciaDivCleanTemplateBase<
                          Frame::ElementLogical, Frame::Inertial>,
                      ::Events::Tags::ObserverMeshVelocityCompute<3>>>,
       tmpl::list<analytic_compute, error_compute>,
-      tmpl::list<::Tags::DerivCompute<
-                     typename system::variables_tag,
-                     ::Events::Tags::ObserverMesh<volume_dim>,
-                     ::Events::Tags::ObserverInverseJacobian<
-                         volume_dim, Frame::ElementLogical, Frame::Inertial>,
-                     typename system::gradient_variables>,
-                 gh::gauges::Tags::GaugeAndDerivativeCompute<
-                     volume_dim, ghmhd::GhValenciaDivClean::InitialData::
-                                     analytic_solutions_and_data_list>>>;
+      tmpl::list<
+          ::Tags::DerivCompute<
+              typename system::variables_tag,
+              ::Events::Tags::ObserverMesh<volume_dim>,
+              ::Events::Tags::ObserverInverseJacobian<
+                  volume_dim, Frame::ElementLogical, Frame::Inertial>,
+              typename system::gradient_variables,
+              ::Events::Tags::ObserverCoordinates<volume_dim, Frame::Inertial>>,
+          gh::gauges::Tags::GaugeAndDerivativeCompute<
+              volume_dim, ghmhd::GhValenciaDivClean::InitialData::
+                              analytic_solutions_and_data_list>>>;
 
   struct factory_creation
       : tt::ConformsTo<Options::protocols::FactoryCreation> {

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Derivatives.cpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Derivatives.cpp
@@ -31,7 +31,8 @@ void spacetime_derivatives(
     const size_t& deriv_order, const Mesh<3>& volume_mesh,
     const InverseJacobian<DataVector, 3, Frame::ElementLogical,
                           Frame::Inertial>&
-        cell_centered_logical_to_inertial_inv_jacobian) {
+        cell_centered_logical_to_inertial_inv_jacobian,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& inertial_coords) {
   using gradients_tags = typename System::gradients_tags;
   if (UNLIKELY(result->number_of_grid_points() !=
                volume_evolved_variables.number_of_grid_points())) {
@@ -53,15 +54,10 @@ void spacetime_derivatives(
       make_not_null(&ghost_cell_spacetime_vars), all_ghost_data,
       number_of_gh_components);
 
-  const auto volume_gh_vars =
-      gsl::make_span(get<FirstGhTag>(volume_evolved_variables)[0].data(),
-                     number_of_gh_components *
-                         volume_evolved_variables.number_of_grid_points());
-
   ::fd::partial_derivatives<gradients_tags>(
-      result, volume_gh_vars, ghost_cell_spacetime_vars, volume_mesh,
+      result, volume_evolved_variables, ghost_cell_spacetime_vars, volume_mesh,
       number_of_gh_components, deriv_order,
-      cell_centered_logical_to_inertial_inv_jacobian);
+      cell_centered_logical_to_inertial_inv_jacobian, inertial_coords);
 }
 
 // Instantiate here
@@ -84,7 +80,8 @@ void spacetime_derivatives(
       const size_t& deriv_order, const Mesh<3>& volume_mesh,                \
       const InverseJacobian<DataVector, 3, Frame::ElementLogical,           \
                             Frame::Inertial>&                               \
-          cell_centered_logical_to_inertial_inv_jacobian);
+          cell_centered_logical_to_inertial_inv_jacobian,                   \
+      const tnsr::I<DataVector, 3, Frame::Inertial>& inertial_coords);
 
 GENERATE_INSTANTIATIONS(INSTANTIATION,
                         (RadiationTransport::NoNeutrinos::System))

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Derivatives.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Derivatives.hpp
@@ -38,10 +38,9 @@ namespace grmhd::GhValenciaDivClean::fd {
  */
 template <typename System>
 void spacetime_derivatives(
-    gsl::not_null<
-        Variables<db::wrap_tags_in<::Tags::deriv,
-                                   typename System::gradients_tags,
-                                   tmpl::size_t<3>, Frame::Inertial>>*>
+    gsl::not_null<Variables<
+        db::wrap_tags_in<::Tags::deriv, typename System::gradients_tags,
+                         tmpl::size_t<3>, Frame::Inertial>>*>
         result,
     const Variables<typename System::variables_tag::tags_list>&
         volume_evolved_variables,
@@ -50,5 +49,6 @@ void spacetime_derivatives(
     const size_t& deriv_order, const Mesh<3>& volume_mesh,
     const InverseJacobian<DataVector, 3, Frame::ElementLogical,
                           Frame::Inertial>&
-        cell_centered_logical_to_inertial_inv_jacobian);
+        cell_centered_logical_to_inertial_inv_jacobian,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& inertial_coords);
 }  // namespace grmhd::GhValenciaDivClean::fd

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/ReconstructWork.tpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/ReconstructWork.tpp
@@ -21,6 +21,7 @@
 #include "Domain/Structure/Element.hpp"
 #include "Domain/Structure/ElementId.hpp"
 #include "Evolution/DgSubcell/GhostData.hpp"
+#include "Evolution/DgSubcell/Mesh.hpp"
 #include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
 #include "Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/ReconstructWork.hpp"
 #include "Evolution/Systems/GrMhd/GhValenciaDivClean/Tags.hpp"
@@ -62,9 +63,21 @@ void reconstruct_prims_work(
     const bool compute_conservatives,
     const bool reconstruct_density_times_temperature,
     const VariableFixing::FixToAtmosphere<3>* fix_to_atmosphere) {
-  ASSERT(Mesh<3>(subcell_mesh.extents(0), subcell_mesh.basis(0),
-                 subcell_mesh.quadrature(0)) == subcell_mesh,
-         "The subcell mesh should be isotropic but got " << subcell_mesh);
+  // computation dimension accounts for "skipped" cartoon bases
+  const size_t comp_dim =
+      evolution::dg::subcell::fd::get_computational_dim(subcell_mesh);
+  evolution::dg::subcell::fd::verify_subcell_mesh(subcell_mesh);
+  const auto cartoon_neighbors =
+      comp_dim == 3
+          ? std::unordered_set<Direction<3>>{}
+          : (comp_dim == 2
+                 // Axially symmetric
+                 ? std::unordered_set<Direction<3>>{Direction<3>::lower_zeta(),
+                                                    Direction<3>::upper_zeta()}
+                 // Spherically symmetric
+                 : std::unordered_set<Direction<3>>{
+                       Direction<3>::lower_eta(), Direction<3>::upper_eta(),
+                       Direction<3>::lower_zeta(), Direction<3>::upper_zeta()});
   const size_t volume_num_pts = subcell_mesh.number_of_grid_points();
   const size_t reconstructed_num_pts =
       (subcell_mesh.extents(0) + 1) *
@@ -84,8 +97,9 @@ void reconstruct_prims_work(
                                   reconstructed_num_pts, volume_num_pts,
                                   &volume_prims, &vars_in_neighbor_count,
                                   &vars_on_lower_face, &vars_on_upper_face,
-                                  &subcell_mesh](auto tag_v) {
-    using tag = tmpl::type_from<decltype(tag_v)>;
+                                  &subcell_mesh, comp_dim,
+                                  &cartoon_neighbors]<typename tag>(
+                                     tmpl::type_<tag> /*meta*/) {
     const typename tag::type* volume_tensor_ptr = nullptr;
     Variables<tmpl::list<
         hydro::Tags::LorentzFactorTimesSpatialVelocity<DataVector, 3>>>
@@ -153,6 +167,10 @@ void reconstruct_prims_work(
                    << direction);
         id = DirectionalId<3>{direction, *neighbors_in_direction.begin()};
       } else {
+        // we don't need cartoon ghost data
+        if (cartoon_neighbors.contains(direction)) {
+          continue;
+        }
         // retrieve boundary ghost data from neighbor_data
         ASSERT(
             element.external_boundaries().count(direction) == 1,
@@ -192,7 +210,7 @@ void reconstruct_prims_work(
 
     if constexpr (std::is_same_v<tag, hydro::Tags::Temperature<DataVector>>) {
       if (reconstruct_density_times_temperature) {
-        for (size_t i = 0; i < 3; ++i) {
+        for (size_t i = 0; i < comp_dim; ++i) {
           get(get<tag>(gsl::at(*vars_on_upper_face, i))) /=
               get(get<hydro::Tags::RestMassDensity<DataVector>>(
                   gsl::at(*vars_on_upper_face, i)));
@@ -209,7 +227,7 @@ void reconstruct_prims_work(
       [&element, &neighbor_data, neighbor_num_pts, &spacetime_reconstructor,
        reconstructed_num_pts, volume_num_pts, &volume_spacetime_and_cons_vars,
        &vars_in_neighbor_count, &vars_on_lower_face, &vars_on_upper_face,
-       &subcell_mesh](auto tag_v) {
+       &subcell_mesh, &cartoon_neighbors](auto tag_v) {
         using tag = tmpl::type_from<decltype(tag_v)>;
         const typename tag::type& volume_tensor =
             get<tag>(volume_spacetime_and_cons_vars);
@@ -244,6 +262,10 @@ void reconstruct_prims_work(
                     .data(),
                 number_of_variables * neighbor_num_pts);
           } else {
+            // we don't use cartoon ghost data
+            if (cartoon_neighbors.contains(direction)) {
+              continue;
+            }
             // retrieve boundary ghost data from neighbor_data
             ASSERT(element.external_boundaries().count(direction) == 1,
                    "Element has neither neighbor nor external boundary to "
@@ -265,7 +287,7 @@ void reconstruct_prims_work(
         vars_in_neighbor_count += number_of_variables;
       });
 
-  for (size_t i = 0; i < 3; ++i) {
+  for (size_t i = 0; i < comp_dim; ++i) {
     if constexpr (tmpl::size<SpacetimeTagsToReconstruct>::value != 0) {
       spacetime_vars_for_grmhd(make_not_null(&gsl::at(*vars_on_lower_face, i)));
       spacetime_vars_for_grmhd(make_not_null(&gsl::at(*vars_on_upper_face, i)));

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Instantiations/VolumeTerms.cpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Instantiations/VolumeTerms.cpp
@@ -82,6 +82,8 @@
       const double& constraint_damping_parameter,                              \
       const ::VariableFixing::FixToAtmosphere<3>& fix_to_atmosphere);          \
   INSTANTIATE_PARTIAL_DERIVATIVES_WITH_SYSTEM(                                 \
+      grmhd::GhValenciaDivClean::System<NEUTRINO(data)>, 3, Frame::Inertial)   \
+  INSTANTIATE_CARTOON_PARTIAL_DERIVATIVES_WITH_SYSTEM(                         \
       grmhd::GhValenciaDivClean::System<NEUTRINO(data)>, 3, Frame::Inertial)
 
 GENERATE_INSTANTIATIONS(INSTANTIATION,

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/TimeDerivative.hpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/TimeDerivative.hpp
@@ -25,6 +25,7 @@
 #include "Evolution/DgSubcell/CartesianFluxDivergence.hpp"
 #include "Evolution/DgSubcell/ComputeBoundaryTerms.hpp"
 #include "Evolution/DgSubcell/CorrectPackagedData.hpp"
+#include "Evolution/DgSubcell/Mesh.hpp"
 #include "Evolution/DgSubcell/Projection.hpp"
 #include "Evolution/DgSubcell/ReconstructionOrder.hpp"
 #include "Evolution/DgSubcell/Tags/Coordinates.hpp"
@@ -87,7 +88,7 @@ struct ComputeTimeDerivImpl<
     tmpl::list<GrmhdArgumentSourceTags...>, System> {
   template <class DbTagsList>
   static void apply(
-      const gsl::not_null<db::DataBox<DbTagsList>*> box,
+      const gsl::not_null<db::DataBox<DbTagsList>*> box, const size_t comp_dim,
       const tnsr::I<DataVector, 3, Frame::Inertial>& inertial_coords,
       const Scalar<DataVector>& cell_centered_det_inv_jacobian,
       const InverseJacobian<DataVector, 3, Frame::ElementLogical,
@@ -412,21 +413,34 @@ struct ComputeTimeDerivImpl<
         get<Tags::TraceReversedStressEnergy>(temp_tags),
         get<gr::Tags::Lapse<DataVector>>(temp_tags));
 
-    for (size_t dim = 0; dim < 3; ++dim) {
+    for (size_t dim = 0; dim < comp_dim; ++dim) {
       const auto& boundary_correction_in_axis =
           gsl::at(boundary_corrections, dim);
       const double inverse_delta = gsl::at(one_over_delta_xi, dim);
       EXPAND_PACK_LEFT_TO_RIGHT([&dt_vars_ptr, &boundary_correction_in_axis,
                                  &cell_centered_det_inv_jacobian, dim,
-                                 inverse_delta, &subcell_mesh]() {
+                                 inverse_delta, &subcell_mesh, &inertial_coords,
+                                 comp_dim, time, &functions_of_time, &box]() {
         auto& dt_var = *get<::Tags::dt<GrmhdDtTags>>(dt_vars_ptr);
         const auto& var_correction =
             get<GrmhdDtTags>(boundary_correction_in_axis);
         for (size_t i = 0; i < dt_var.size(); ++i) {
-          evolution::dg::subcell::add_cartesian_flux_divergence(
-              make_not_null(&dt_var[i]), inverse_delta,
-              get(cell_centered_det_inv_jacobian), var_correction[i],
-              subcell_mesh.extents(), dim);
+          if (comp_dim == 3) {
+            evolution::dg::subcell::add_cartesian_flux_divergence(
+                make_not_null(&dt_var[i]), inverse_delta,
+                get(cell_centered_det_inv_jacobian), var_correction[i],
+                subcell_mesh.extents(), dim);
+
+          } else {
+            evolution::dg::subcell::add_cartoon_cartesian_flux_divergence(
+                make_not_null(&dt_var[i]), inverse_delta,
+                get(cell_centered_det_inv_jacobian), var_correction[i],
+                subcell_mesh.extents(), dim, inertial_coords,
+                get<domain::Tags::ElementMap<3, Frame::Grid>>(*box),
+                get<domain::CoordinateMaps::Tags::CoordinateMap<
+                    3, Frame::Grid, Frame::Inertial>>(*box),
+                time, functions_of_time);
+          }
         }
       }());
     }
@@ -467,12 +481,9 @@ struct TimeDerivative {
     const Mesh<3>& dg_mesh = db::get<domain::Tags::Mesh<3>>(*box);
     const Mesh<3>& subcell_mesh =
         db::get<evolution::dg::subcell::Tags::Mesh<3>>(*box);
-    ASSERT(
-        subcell_mesh == Mesh<3>(subcell_mesh.extents(0), subcell_mesh.basis(0),
-                                subcell_mesh.quadrature(0)),
-        "The subcell/FD mesh must be isotropic for the FD time derivative but "
-        "got "
-            << subcell_mesh);
+    const size_t comp_dim =
+        evolution::dg::subcell::fd::get_computational_dim(subcell_mesh);
+    evolution::dg::subcell::fd::verify_subcell_mesh(subcell_mesh);
     const size_t num_pts = subcell_mesh.number_of_grid_points();
     const size_t reconstructed_num_pts =
         (subcell_mesh.extents(0) + 1) *
@@ -569,7 +580,7 @@ struct TimeDerivative {
         db::get<evolution::dg::subcell::Tags::GhostDataForReconstruction<3>>(
             *box),
         recons.ghost_zone_size() * 2, subcell_mesh,
-        cell_centered_logical_to_inertial_inv_jacobian);
+        cell_centered_logical_to_inertial_inv_jacobian, inertial_coords);
 
     // Now package the data and compute the correction
     //
@@ -648,7 +659,7 @@ struct TimeDerivative {
               reconstructed_num_pts};
 
           // Compute fluxes on faces
-          for (size_t i = 0; i < 3; ++i) {
+          for (size_t i = 0; i < comp_dim; ++i) {
             auto& vars_upper_face = gsl::at(package_data_argvars_upper_face, i);
             auto& vars_lower_face = gsl::at(package_data_argvars_lower_face, i);
             grmhd::ValenciaDivClean::subcell::compute_fluxes(
@@ -658,8 +669,7 @@ struct TimeDerivative {
 
             // Build extents of mesh shifted by half a grid cell in direction i
             const unsigned long& num_subcells_1d = subcell_mesh.extents(0);
-            Index<3> face_mesh_extents(std::array<size_t, 3>{
-                num_subcells_1d, num_subcells_1d, num_subcells_1d});
+            Index<3> face_mesh_extents = subcell_mesh.extents();
             face_mesh_extents[i] = num_subcells_1d + 1;
             // Add moving mesh corrections to the fluxes, if needed
             std::optional<tnsr::I<DataVector, 3, Frame::Inertial>>
@@ -824,7 +834,7 @@ struct TimeDerivative {
     detail::ComputeTimeDerivImpl<
         gh_variables_tags, gh_temporary_tags, gh_gradient_tags, gh_extra_tags,
         grmhd_evolved_vars_tags, grmhd_source_tags, grmhd_source_argument_tags,
-        System>::apply(box, inertial_coords,
+        System>::apply(box, comp_dim, inertial_coords,
                        db::get<evolution::dg::subcell::fd::Tags::
                                    DetInverseJacobianLogicalToInertial>(*box),
                        cell_centered_logical_to_inertial_inv_jacobian,

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovCartoon.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovCartoon.yaml
@@ -1,0 +1,235 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+Executable: EvolveGhValenciaDivClean
+Testing:
+  Check: parse;execute
+  Timeout: 8
+  Priority: High
+
+---
+
+Parallelization:
+  ElementDistribution: NumGridPoints
+
+ResourceInfo:
+  AvoidGlobalProc0: false
+  Singletons: Auto
+
+Evolution:
+  InitialTime: 0.0
+  InitialTimeStep: &initial_time_step 0.001
+  InitialSlabSize: *initial_time_step
+  MinimumTimeStep: 1e-7
+  LocalTimeStepping: Off
+  TimeStepper:
+    # Both RK3 and AM-PC 3 should work. These are the "standard" time steppers
+    # for spectre for hydro right now.
+    Rk3HesthavenSsp:
+    # AdamsMoultonPc:
+    #   Order: 3
+  LtsStepChoosers:
+  VariableOrderAlgorithm:
+    GoalOrder: 3
+
+
+PhaseChangeAndTriggers:
+  - Trigger:
+      Slabs:
+        EvenlySpaced:
+          Interval: 1000
+          Offset: 5
+    PhaseChanges:
+      - VisitAndReturn(LoadBalancing)
+
+InitialData: &InitialData
+  GeneralizedHarmonic(MagnetizedTovStar):
+    CentralDensity: 1.28e-3
+    EquationOfState:
+        PolytropicFluid:
+            PolytropicConstant: 100.0
+            PolytropicExponent: 2.0
+    Coordinates: Isotropic
+    MagneticFields:
+      - Poloidal:
+          PressureExponent: 2
+          VectorPotentialAmplitude: 2500
+          CutoffPressure: 6.5536e-06
+          Center: [0.0, 0.0, 0.0]
+          MaxDistanceFromCenter: 100.0
+
+EquationOfState:
+  FromInitialData
+
+DomainCreator:
+  CartoonSphere2D:
+    InnerRadius: 2.0
+    OuterRadius: 7.0
+    InitialAngularRefinement: 2
+    InitialRadialRefinement: 1
+    InitialGridPoints: [10, 10]
+    RadialPartitioning: [5.0]
+    RadialDistribution: Linear
+    TimeDependence: None
+    UseEquiangularMap: True
+    Interior:
+      ExciseWithBoundaryCondition:
+        DirichletAnalytic:
+          AnalyticPrescription: *InitialData
+    OuterBoundaryCondition:
+      DirichletAnalytic:
+        AnalyticPrescription: *InitialData
+
+VariableFixing:
+  FixConservatives:
+    Enable: false # Only needed when not using Kastaun for recovery
+    CutoffD: &CutoffD 1.1e-15
+    MinimumValueOfD: &MinimumD 1.0e-15
+    CutoffYe: 0.0
+    MinimumValueOfYe: 0.0
+    SafetyFactorForB: &BSafetyFactor 1.0e-12
+    SafetyFactorForS: 1.0e-12
+    SafetyFactorForSCutoffD: 1.0e-8
+    SafetyFactorForSSlope: 0.0001
+    MagneticField: AssumeNonZero
+  FixToAtmosphere:
+    DensityOfAtmosphere: 1.0e-15
+    DensityCutoff: &AtmosphereDensityCutoff 1.1e-15
+    VelocityLimiting:
+      AtmosphereMaxVelocity: 0
+      NearAtmosphereMaxVelocity: 1.0e-4
+      AtmosphereDensityCutoff: 3.0e-15
+      TransitionDensityBound: 3.0e-14
+    KappaLimiting:
+      DensityLowerBound: 2.0e-14
+      EplisonKappaMinus: 1.0e-3
+      DensityUpperBound: 2.0e-13
+      EpsilonKappaMax: 0.01
+      LimitAboveDensityUpperBound: False
+      MinTemperature: FromEos
+  LimitLorentzFactor:
+    Enable: false # Only needed when not using Kastaun for recovery
+    MaxDensityCutoff: 1.0e-12
+    LorentzFactorCap: 1.0
+
+PrimitiveFromConservative:
+  CutoffDForInversion: *CutoffD
+  DensityWhenSkippingInversion: *MinimumD
+  KastaunMaxLorentzFactor: 10.0
+
+EvolutionSystem:
+  ValenciaDivClean:
+    DampingParameter: 0.0
+  GeneralizedHarmonic:
+    GaugeCondition:
+      AnalyticChristoffel:
+        AnalyticPrescription: *InitialData
+    DampingFunctionGamma0:
+      GaussianPlusConstant:
+        Constant: 0.01
+        Amplitude: 0.12
+        # Width comes from the radius of the star in code units.
+        Width: 7.884855
+        Center: [0.0, 0.0, 0.0]
+    DampingFunctionGamma1:
+      GaussianPlusConstant:
+        Constant: -0.999
+        Amplitude: 0.999
+        # Width is chosen so that the outer boundary is a few sigma out,
+        # but large enough that the bulk dynamics have gamma_2=0
+        Width: 30.0
+        Center: [0.0, 0.0, 0.0]
+    DampingFunctionGamma2:
+      GaussianPlusConstant:
+        Constant: 0.01
+        Amplitude: 1.2
+        # Width comes from the radius of the star in code units.
+        Width: 7.884855
+        Center: [0.0, 0.0, 0.0]
+
+
+SpatialDiscretization:
+  BoundaryCorrection:
+    ProductUpwindPenaltyAndRusanov:
+      UpwindPenalty:
+      Rusanov:
+  DiscontinuousGalerkin:
+    Formulation: StrongInertial
+    Quadrature: GaussLobatto
+    Filtering:
+      - Hypercube:
+          HalfPower: 32
+          Enable: false
+          BlocksToFilter: All
+          VolumeFilterOnSubstep: true
+          BoundaryCorrectionFilterOnSubstep: false
+          VolumeFilterEveryNSteps: None
+          BoundaryCorrectionFilterEveryNSteps: None
+    Subcell:
+      FdInterpolationOrder: 3
+      TroubledCellIndicator:
+        PerssonTci:
+          Exponent: 4.0
+          NumHighestModes: 1
+        RdmpTci:
+          Delta0: 1.0e-7
+          Epsilon: 1.0e-3
+        FdToDgTci:
+          NumberOfStepsBetweenTciCalls: 1
+          MinTciCallsAfterRollback: 1
+          MinimumClearTcis: 1
+        AlwaysUseSubcells: true
+        EnableExtensionDirections: false
+        UseHalo: false
+        OnlyDgBlocksAndGroups: [Shell0]
+      SubcellToDgReconstructionMethod: DimByDim
+      FiniteDifferenceDerivativeOrder: 2
+    TciOptions:
+      MinimumValueOfD: 1.0e-20
+      MinimumValueOfYe: 1.0e-20
+      MinimumValueOfTildeTau: 1.0e-50
+      AtmosphereDensity: *AtmosphereDensityCutoff
+      SafetyFactorForB: *BSafetyFactor
+      MagneticFieldCutoff: DoNotCheckMagneticField
+  SubcellSolver:
+    Reconstructor:
+      MonotonisedCentralPrim:
+        AtmosphereTreatment: Never
+        ReconstructRhoTimesTemperature: true
+    FilterOptions:
+      SpacetimeDissipation: 0.1
+
+EventsAndTriggersAtCheckpoints:
+
+EventsAndTriggersAtSlabs:
+  - Trigger:
+      Slabs:
+        Specified:
+          Values: [5]
+    Events:
+      - Completion
+
+InterpolationTargets:
+  BondiSachsInterpolation:
+    LMax: 16
+    Radius: [1]
+    Center: [0, 0, 0]
+    AngularOrdering: Cce
+
+Cce:
+  BondiSachsOutputFilePrefix: "BondiSachs"
+
+Observers:
+  VolumeFileName: "GhMhdTovStarVolume"
+  ReductionFileName: "GhMhdTovStarReductions"
+
+Interpolator:
+  Verbosity: Silent
+
+EventsAndTriggersAtSteps:
+
+EventsAndDenseTriggers:
+
+EventsRunAtCleanup:
+  ObservationValue: -1000.0
+  Events:

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Test_Derivatives.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/FiniteDifference/Test_Derivatives.cpp
@@ -75,10 +75,14 @@ SPECTRE_TEST_CASE(
                              tmpl::size_t<3>, Frame::Inertial>>
       deriv_of_gh_vars{subcell_mesh.number_of_grid_points()};
 
+  // needed for cartoon derivatives, not tested here
+  const tnsr::I<DataVector, 3, Frame::Inertial> inertial_coords(
+      subcell_mesh.number_of_grid_points(), 0.0);
+
   grmhd::GhValenciaDivClean::fd::spacetime_derivatives<System>(
       make_not_null(&deriv_of_gh_vars), volume_evolved_vars, all_ghost_data,
       fd_deriv_order, subcell_mesh,
-      cell_centered_logical_to_inertial_inv_jacobian);
+      cell_centered_logical_to_inertial_inv_jacobian, inertial_coords);
 
   Variables<db::wrap_tags_in<Tags::deriv,
                              typename System::gradients_tags,
@@ -170,12 +174,12 @@ SPECTRE_TEST_CASE(
         << Variables<grmhd::GhValenciaDivClean::Tags::
                          primitive_grmhd_and_spacetime_reconstruction_tags>::
                number_of_independent_components};
-    CHECK_THROWS_WITH(grmhd::GhValenciaDivClean::fd::spacetime_derivatives<
-                          System>(
-                          make_not_null(&deriv_of_gh_vars), volume_evolved_vars,
-                          bad_ghost_data, fd_deriv_order, subcell_mesh,
-                          cell_centered_logical_to_inertial_inv_jacobian),
-                      Catch::Matchers::ContainsSubstring(match_string));
+    CHECK_THROWS_WITH(
+        grmhd::GhValenciaDivClean::fd::spacetime_derivatives<System>(
+            make_not_null(&deriv_of_gh_vars), volume_evolved_vars,
+            bad_ghost_data, fd_deriv_order, subcell_mesh,
+            cell_centered_logical_to_inertial_inv_jacobian, inertial_coords),
+        Catch::Matchers::ContainsSubstring(match_string));
   }
 #endif  // SPECTRE_DEBUG
 }

--- a/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_TimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/Test_TimeDerivative.cpp
@@ -785,7 +785,7 @@ double test(const size_t num_dg_pts, std::optional<double> expansion_velocity,
       make_not_null(&cell_centered_gh_derivs), gh_evolved_vars,
       db::get<evolution::dg::subcell::Tags::GhostDataForReconstruction<3>>(box),
       fd_deriv_order, subcell_mesh,
-      cell_centered_logical_to_inertial_inv_jacobian);
+      cell_centered_logical_to_inertial_inv_jacobian, dg_coords);
 
   auto& temp = get<gr::Tags::SpacetimeMetric<DataVector, 3>>(
       output_minus_expected_dt_vars);


### PR DESCRIPTION
## Proposed changes

Primarily passing inertial coordinates for partial derivatives, as well as making sure certain operations only act on non-cartoon bases (i.e. using a "computational dimension" in loops)

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent was used, have a co-author trailer of the form
      "Co-Authored-By: <agent name> <agent email>" as the last line of the
      commit, e.g. "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>".

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
