### PR TITLE
Enable runtime LTS

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp
@@ -354,7 +354,7 @@ struct get_primitive_tags_for_face {
  *   - `evolution::dg::Tags::MortarData<Dim>`
  */
 template <size_t Dim, typename EvolutionSystem, typename DgStepChoosers,
-          bool LocalTimeStepping, bool UseNodegroupDgElements>
+          bool UseNodegroupDgElements>
 struct ComputeTimeDerivative {
   using inbox_tags =
       tmpl::list<evolution::dg::Tags::BoundaryCorrectionAndGhostCellsInbox<
@@ -362,10 +362,7 @@ struct ComputeTimeDerivative {
   using const_global_cache_tags = tmpl::append<
       tmpl::list<::dg::Tags::Formulation, evolution::Tags::BoundaryCorrection,
                  domain::Tags::ExternalBoundaryConditions<Dim>>,
-      tmpl::conditional_t<
-          LocalTimeStepping,
-          typename ChangeStepSize<DgStepChoosers>::const_global_cache_tags,
-          tmpl::list<>>>;
+      typename ChangeStepSize<DgStepChoosers>::const_global_cache_tags>;
 
   template <typename DbTagsList, typename... InboxTags, typename ArrayIndex,
             typename ActionList, typename ParallelComponent,
@@ -389,13 +386,12 @@ struct ComputeTimeDerivative {
 };
 
 template <size_t Dim, typename EvolutionSystem, typename DgStepChoosers,
-          bool LocalTimeStepping, bool UseNodegroupDgElements>
+          bool UseNodegroupDgElements>
 template <typename DbTagsList, typename... InboxTags, typename ArrayIndex,
           typename ActionList, typename ParallelComponent,
           typename Metavariables>
-Parallel::iterable_action_return_t
-ComputeTimeDerivative<Dim, EvolutionSystem, DgStepChoosers, LocalTimeStepping,
-                      UseNodegroupDgElements>::
+Parallel::iterable_action_return_t ComputeTimeDerivative<
+    Dim, EvolutionSystem, DgStepChoosers, UseNodegroupDgElements>::
     apply(db::DataBox<DbTagsList>& box,
           tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
           Parallel::GlobalCache<Metavariables>& cache,
@@ -702,9 +698,7 @@ ComputeTimeDerivative<Dim, EvolutionSystem, DgStepChoosers, LocalTimeStepping,
         }
       });
 
-  if constexpr (LocalTimeStepping) {
-    db::mutate_apply<ChangeStepSize<DgStepChoosers>>(make_not_null(&box));
-  }
+  db::mutate_apply<ChangeStepSize<DgStepChoosers>>(make_not_null(&box));
 
   send_data_for_fluxes<ParallelComponent>(make_not_null(&cache),
                                           make_not_null(&box), volume_fluxes);
@@ -712,11 +706,11 @@ ComputeTimeDerivative<Dim, EvolutionSystem, DgStepChoosers, LocalTimeStepping,
 }
 
 template <size_t Dim, typename EvolutionSystem, typename DgStepChoosers,
-          bool LocalTimeStepping, bool UseNodegroupDgElements>
+          bool UseNodegroupDgElements>
 template <typename ParallelComponent, typename DbTagsList,
           typename Metavariables>
 void ComputeTimeDerivative<Dim, EvolutionSystem, DgStepChoosers,
-                           LocalTimeStepping, UseNodegroupDgElements>::
+                           UseNodegroupDgElements>::
     send_data_for_fluxes(
         const gsl::not_null<Parallel::GlobalCache<Metavariables>*> cache,
         const gsl::not_null<db::DataBox<DbTagsList>*> box,

--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -235,20 +235,16 @@ struct EvolutionMetavars {
 
   using dg_step_actions = tmpl::flatten<tmpl::list<
       evolution::dg::Actions::ComputeTimeDerivative<
-          volume_dim, system, AllStepChoosers, local_time_stepping,
-          use_dg_element_collection>,
+          volume_dim, system, AllStepChoosers, use_dg_element_collection>,
       evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
           volume_dim, use_dg_element_collection>,
       Actions::MutateApply<RecordTimeStepperData<system>>,
       evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<
           evolution::dg::ApplyLtsDenseBoundaryCorrections<EvolutionMetavars>>>,
-      Actions::MutateApply<UpdateU<system, local_time_stepping>>,
+      Actions::MutateApply<UpdateU<system>>,
       evolution::dg::Actions::ApplyLtsBoundaryCorrections<
           volume_dim, use_dg_element_collection>,
-      tmpl::conditional_t<
-          local_time_stepping,
-          tmpl::list<Actions::MutateApply<ChangeTimeStepperOrder<system>>>,
-          tmpl::list<>>,
+      Actions::MutateApply<ChangeTimeStepperOrder<system>>,
       tmpl::conditional_t<use_dg_subcell,
                           evolution::dg::subcell::Actions::TciAndRollback<
                               Burgers::subcell::TciOnDgGrid>,
@@ -263,11 +259,9 @@ struct EvolutionMetavars {
       dg_step_actions,
       Actions::Goto<evolution::dg::subcell::Actions::Labels::EndOfSolvers>,
       Actions::Label<evolution::dg::subcell::Actions::Labels::BeginSubcell>,
-      tmpl::conditional_t<local_time_stepping,
-                          // This is just to adjust for FixedLtsRatio, so we
-                          // can pass an empty list of StepChoosers.
-                          Actions::MutateApply<ChangeStepSize<tmpl::list<>>>,
-                          tmpl::list<>>,
+      // This is just to adjust for FixedLtsRatio, so we
+      // can pass an empty list of StepChoosers.
+      Actions::MutateApply<ChangeStepSize<tmpl::list<>>>,
       evolution::dg::subcell::Actions::SendDataForReconstruction<
           volume_dim, Burgers::subcell::GhostVariables,
           use_dg_element_collection>,
@@ -278,7 +272,7 @@ struct EvolutionMetavars {
           Burgers::subcell::TimeDerivative>,
       Actions::MutateApply<RecordTimeStepperData<system>>,
       evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
-      Actions::MutateApply<UpdateU<system, local_time_stepping>>,
+      Actions::MutateApply<UpdateU<system>>,
       Actions::MutateApply<CleanHistory<system>>,
       Actions::MutateApply<evolution::dg::CleanMortarHistory<volume_dim>>,
       evolution::dg::subcell::Actions::TciAndSwitchToDg<

--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -356,17 +356,15 @@ struct EvolutionMetavars {
 
           Parallel::PhaseActions<
               Parallel::Phase::Evolve,
-              tmpl::flatten<tmpl::list<
-                  std::conditional_t<local_time_stepping,
-                                     evolution::Actions::RunEventsAndTriggers<
-                                         Triggers::WhenToCheck::AtSteps>,
-                                     tmpl::list<>>,
-                  evolution::Actions::RunEventsAndTriggers<
-                      Triggers::WhenToCheck::AtSlabs>,
-                  Actions::ChangeSlabSize,
-                  evolution::dg::Actions::ChangeFixedLtsRatio, step_actions,
-                  Actions::MutateApply<AdvanceTime<>>,
-                  PhaseControl::Actions::ExecutePhaseChange>>>>>;
+              tmpl::flatten<
+                  tmpl::list<evolution::Actions::RunEventsAndTriggers<
+                                 Triggers::WhenToCheck::AtSteps>,
+                             evolution::Actions::RunEventsAndTriggers<
+                                 Triggers::WhenToCheck::AtSlabs>,
+                             Actions::ChangeSlabSize,
+                             evolution::dg::Actions::ChangeFixedLtsRatio,
+                             step_actions, Actions::MutateApply<AdvanceTime<>>,
+                             PhaseControl::Actions::ExecutePhaseChange>>>>>;
 
   struct registration
       : tt::ConformsTo<Parallel::protocols::RegistrationMetavariables> {

--- a/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
+++ b/src/Evolution/Executables/Burgers/EvolveBurgers.hpp
@@ -299,8 +299,8 @@ struct EvolutionMetavars {
 
   using initialization_actions = tmpl::list<
       Initialization::Actions::InitializeItems<
-          Initialization::TimeStepping<EvolutionMetavars, TimeStepperBase,
-                                       false, local_time_stepping>,
+          Initialization::TimeStepping<EvolutionMetavars, TimeStepper, false,
+                                       true>,
           evolution::dg::Initialization::Domain<EvolutionMetavars>,
           Initialization::TimeStepperHistory<EvolutionMetavars>>,
       Initialization::Actions::ConservativeSystem<system>,

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
@@ -265,20 +265,16 @@ struct EvolutionMetavars {
   using step_actions = tmpl::flatten<tmpl::list<
       CurvedScalarWave::Actions::CalculateGrVars<system, true>,
       evolution::dg::Actions::ComputeTimeDerivative<
-          volume_dim, system, AllStepChoosers, local_time_stepping,
-          use_dg_element_collection>,
+          volume_dim, system, AllStepChoosers, use_dg_element_collection>,
       evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
           volume_dim, use_dg_element_collection>,
       Actions::MutateApply<RecordTimeStepperData<system>>,
       evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<
           evolution::dg::ApplyLtsDenseBoundaryCorrections<EvolutionMetavars>>>,
-      Actions::MutateApply<UpdateU<system, local_time_stepping>>,
+      Actions::MutateApply<UpdateU<system>>,
       evolution::dg::Actions::ApplyLtsBoundaryCorrections<
           volume_dim, use_dg_element_collection>,
-      tmpl::conditional_t<
-          local_time_stepping,
-          tmpl::list<Actions::MutateApply<ChangeTimeStepperOrder<system>>>,
-          tmpl::list<>>,
+      Actions::MutateApply<ChangeTimeStepperOrder<system>>,
       Actions::MutateApply<CleanHistory<system>>,
       Actions::MutateApply<evolution::dg::CleanMortarHistory<volume_dim>>,
       dg::Actions::SpectralFilter>>;

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
@@ -343,17 +343,15 @@ struct EvolutionMetavars {
                          Parallel::Actions::TerminatePhase>>,
           Parallel::PhaseActions<
               Parallel::Phase::Evolve,
-              tmpl::flatten<tmpl::list<
-                  std::conditional_t<local_time_stepping,
-                                     evolution::Actions::RunEventsAndTriggers<
-                                         Triggers::WhenToCheck::AtSteps>,
-                                     tmpl::list<>>,
-                  evolution::Actions::RunEventsAndTriggers<
-                      Triggers::WhenToCheck::AtSlabs>,
-                  Actions::ChangeSlabSize,
-                  evolution::dg::Actions::ChangeFixedLtsRatio, step_actions,
-                  Actions::MutateApply<AdvanceTime<>>,
-                  PhaseControl::Actions::ExecutePhaseChange>>>>>;
+              tmpl::flatten<
+                  tmpl::list<evolution::Actions::RunEventsAndTriggers<
+                                 Triggers::WhenToCheck::AtSteps>,
+                             evolution::Actions::RunEventsAndTriggers<
+                                 Triggers::WhenToCheck::AtSlabs>,
+                             Actions::ChangeSlabSize,
+                             evolution::dg::Actions::ChangeFixedLtsRatio,
+                             step_actions, Actions::MutateApply<AdvanceTime<>>,
+                             PhaseControl::Actions::ExecutePhaseChange>>>>>;
 
   struct registration
       : tt::ConformsTo<Parallel::protocols::RegistrationMetavariables> {

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveCurvedScalarWave.hpp
@@ -291,8 +291,8 @@ struct EvolutionMetavars {
 
   using initialization_actions = tmpl::list<
       Initialization::Actions::InitializeItems<
-          Initialization::TimeStepping<EvolutionMetavars, TimeStepperBase,
-                                       false, local_time_stepping>,
+          Initialization::TimeStepping<EvolutionMetavars, TimeStepper, false,
+                                       true>,
           evolution::dg::Initialization::Domain<EvolutionMetavars>,
           Initialization::TimeStepperHistory<EvolutionMetavars>>,
       Initialization::Actions::NonconservativeSystem<system>,

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
@@ -230,6 +230,9 @@ struct EvolutionMetavars {
                    tmpl::list<PhaseControl::VisitAndReturn<
                                   Parallel::Phase::LoadBalancing>,
                               PhaseControl::CheckpointAndExitAfterWallclock>>,
+        tmpl::pair<StepChooser<StepChooserUse::LtsStep>,
+                   tmpl::push_back<StepChoosers::standard_step_choosers<system>,
+                                   StepChoosers::ByBlock<volume_dim>>>,
         tmpl::pair<StepChooser<StepChooserUse::Slab>,
                    tmpl::push_back<StepChoosers::standard_slab_choosers<system>,
                                    StepChoosers::ByBlock<volume_dim>>>,
@@ -256,13 +259,12 @@ struct EvolutionMetavars {
       CurvedScalarWave::Worldtube::Actions::IteratePunctureField,
       CurvedScalarWave::Worldtube::Actions::ReceiveWorldtubeData,
       evolution::dg::Actions::ComputeTimeDerivative<
-          volume_dim, system, AllStepChoosers, local_time_stepping,
-          use_dg_element_collection>,
+          volume_dim, system, AllStepChoosers, use_dg_element_collection>,
       evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
           volume_dim, use_dg_element_collection>,
       Actions::MutateApply<RecordTimeStepperData<system>>,
       evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<>>,
-      Actions::MutateApply<UpdateU<system, local_time_stepping>>,
+      Actions::MutateApply<UpdateU<system>>,
       Actions::MutateApply<CleanHistory<system>>,
       Actions::MutateApply<evolution::dg::CleanMortarHistory<volume_dim>>,
       dg::Actions::SpectralFilter>>;

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
@@ -349,10 +349,8 @@ struct EvolutionMetavars {
               Parallel::Phase::Evolve,
               tmpl::flatten<tmpl::list<
                   domain::Actions::CheckFunctionsOfTimeAreReady<volume_dim>,
-                  std::conditional_t<local_time_stepping,
-                                     evolution::Actions::RunEventsAndTriggers<
-                                         Triggers::WhenToCheck::AtSteps>,
-                                     tmpl::list<>>,
+                  evolution::Actions::RunEventsAndTriggers<
+                      Triggers::WhenToCheck::AtSteps>,
                   evolution::Actions::RunEventsAndTriggers<
                       Triggers::WhenToCheck::AtSlabs>,
                   Actions::ChangeSlabSize, step_actions,

--- a/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
+++ b/src/Evolution/Executables/CurvedScalarWave/EvolveWorldtubeCurvedScalarWave.hpp
@@ -290,8 +290,8 @@ struct EvolutionMetavars {
 
   using initialization_actions = tmpl::list<
       Initialization::Actions::InitializeItems<
-          Initialization::TimeStepping<EvolutionMetavars, TimeStepperBase,
-                                       false, local_time_stepping>,
+          Initialization::TimeStepping<EvolutionMetavars, TimeStepper, false,
+                                       false>,
           evolution::dg::Initialization::Domain<EvolutionMetavars>,
           Initialization::TimeStepperHistory<EvolutionMetavars>>,
       Initialization::Actions::NonconservativeSystem<system>,

--- a/src/Evolution/Executables/ForceFree/EvolveForceFree.hpp
+++ b/src/Evolution/Executables/ForceFree/EvolveForceFree.hpp
@@ -193,20 +193,16 @@ struct EvolutionMetavars {
       Actions::MutateApply<
           evolution::dg::BackgroundGrVars<system, EvolutionMetavars>>,
       evolution::dg::Actions::ComputeTimeDerivative<
-          volume_dim, system, AllStepChoosers, local_time_stepping,
-          use_dg_element_collection>,
+          volume_dim, system, AllStepChoosers, use_dg_element_collection>,
       evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
           volume_dim, use_dg_element_collection>,
       Actions::MutateApply<RecordTimeStepperData<system>>,
       evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<
           evolution::dg::ApplyLtsDenseBoundaryCorrections<EvolutionMetavars>>>,
-      Actions::MutateApply<UpdateU<system, local_time_stepping>>,
+      Actions::MutateApply<UpdateU<system>>,
       evolution::dg::Actions::ApplyLtsBoundaryCorrections<
           volume_dim, use_dg_element_collection>,
-      tmpl::conditional_t<
-          local_time_stepping,
-          tmpl::list<Actions::MutateApply<ChangeTimeStepperOrder<system>>>,
-          tmpl::list<>>,
+      Actions::MutateApply<ChangeTimeStepperOrder<system>>,
       Actions::MutateApply<CleanHistory<system>>,
       Actions::MutateApply<evolution::dg::CleanMortarHistory<volume_dim>>,
 

--- a/src/Evolution/Executables/ForceFree/EvolveForceFree.hpp
+++ b/src/Evolution/Executables/ForceFree/EvolveForceFree.hpp
@@ -221,8 +221,8 @@ struct EvolutionMetavars {
 
   using initialization_actions = tmpl::list<
       Initialization::Actions::InitializeItems<
-          Initialization::TimeStepping<EvolutionMetavars, TimeStepperBase,
-                                       false, local_time_stepping>,
+          Initialization::TimeStepping<EvolutionMetavars, TimeStepper, false,
+                                       true>,
           evolution::dg::Initialization::Domain<EvolutionMetavars>,
           Initialization::TimeStepperHistory<EvolutionMetavars>>,
       Initialization::Actions::AddSimpleTags<

--- a/src/Evolution/Executables/ForceFree/EvolveForceFree.hpp
+++ b/src/Evolution/Executables/ForceFree/EvolveForceFree.hpp
@@ -275,10 +275,8 @@ struct EvolutionMetavars {
           Parallel::PhaseActions<
               Parallel::Phase::Evolve,
               tmpl::flatten<tmpl::list<
-                  std::conditional_t<local_time_stepping,
-                                     evolution::Actions::RunEventsAndTriggers<
-                                         Triggers::WhenToCheck::AtSteps>,
-                                     tmpl::list<>>,
+                  evolution::Actions::RunEventsAndTriggers<
+                      Triggers::WhenToCheck::AtSteps>,
                   evolution::Actions::RunEventsAndTriggers<
                       Triggers::WhenToCheck::AtSlabs>,
                   Actions::ChangeSlabSize,

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -683,10 +683,8 @@ struct EvolutionMetavars {
               Parallel::Phase::Evolve,
               tmpl::flatten<tmpl::list<
                   ::domain::Actions::CheckFunctionsOfTimeAreReady<volume_dim>,
-                  std::conditional_t<local_time_stepping,
-                                     evolution::Actions::RunEventsAndTriggers<
-                                         Triggers::WhenToCheck::AtSteps>,
-                                     tmpl::list<>>,
+                  evolution::Actions::RunEventsAndTriggers<
+                      Triggers::WhenToCheck::AtSteps>,
                   evolution::Actions::RunEventsAndTriggers<
                       Triggers::WhenToCheck::AtSlabs>,
                   Actions::ChangeSlabSize,

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -615,9 +615,8 @@ struct EvolutionMetavars {
 
   using initialization_actions = tmpl::list<
       Initialization::Actions::InitializeItems<
-          Initialization::TimeStepping<EvolutionMetavars, TimeStepperBase,
-                                       use_control_systems,
-                                       local_time_stepping>,
+          Initialization::TimeStepping<EvolutionMetavars, TimeStepper,
+                                       use_control_systems, true>,
           evolution::dg::Initialization::Domain<EvolutionMetavars,
                                                 use_control_systems>,
           ::amr::Initialization::Initialize<volume_dim, EvolutionMetavars>,

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -732,7 +732,7 @@ struct EvolutionMetavars {
             volume_dim, typename system::variables_tag::tags_list>,
         ::amr::projectors::DefaultInitialize<
             Initialization::Tags::InitialTimeDelta,
-            Initialization::Tags::InitialSlabSize<local_time_stepping>,
+            Initialization::Tags::InitialSlabSize,
             ::domain::Tags::InitialExtents<volume_dim>,
             ::domain::Tags::InitialRefinementLevels<volume_dim>,
             evolution::dg::Tags::Quadrature,

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhBinaryBlackHole.hpp
@@ -597,8 +597,7 @@ struct EvolutionMetavars {
 
   using step_actions = tmpl::list<
       evolution::dg::Actions::ComputeTimeDerivative<
-          volume_dim, system, AllStepChoosers, local_time_stepping,
-          use_dg_element_collection>,
+          volume_dim, system, AllStepChoosers, use_dg_element_collection>,
       evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
           volume_dim, use_dg_element_collection>,
       Actions::MutateApply<RecordTimeStepperData<system>>,
@@ -606,13 +605,10 @@ struct EvolutionMetavars {
           ::domain::CheckFunctionsOfTimeAreReadyPostprocessor<volume_dim>,
           evolution::dg::ApplyLtsDenseBoundaryCorrections<EvolutionMetavars>>>,
       control_system::Actions::LimitTimeStep<control_systems>,
-      Actions::MutateApply<UpdateU<system, local_time_stepping>>,
+      Actions::MutateApply<UpdateU<system>>,
       evolution::dg::Actions::ApplyLtsBoundaryCorrections<
           volume_dim, use_dg_element_collection>,
-      tmpl::conditional_t<
-          local_time_stepping,
-          tmpl::list<Actions::MutateApply<ChangeTimeStepperOrder<system>>>,
-          tmpl::list<>>,
+      Actions::MutateApply<ChangeTimeStepperOrder<system>>,
       Actions::MutateApply<CleanHistory<system>>,
       Actions::MutateApply<evolution::dg::CleanMortarHistory<volume_dim>>,
       dg::Actions::SpectralFilter>;

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhNoBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhNoBlackHole.hpp
@@ -110,7 +110,7 @@ struct EvolutionMetavars
             volume_dim, typename system::variables_tag::tags_list>,
         ::amr::projectors::DefaultInitialize<
             Initialization::Tags::InitialTimeDelta,
-            Initialization::Tags::InitialSlabSize<local_time_stepping>,
+            Initialization::Tags::InitialSlabSize,
             ::domain::Tags::InitialExtents<volume_dim>,
             ::domain::Tags::InitialRefinementLevels<volume_dim>,
             evolution::dg::Tags::Quadrature,

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhNoBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhNoBlackHole.hpp
@@ -86,17 +86,15 @@ struct EvolutionMetavars
                                             Parallel::Actions::TerminatePhase>>,
           Parallel::PhaseActions<
               Parallel::Phase::Evolve,
-              tmpl::flatten<tmpl::list<
-                  std::conditional_t<local_time_stepping,
-                                     evolution::Actions::RunEventsAndTriggers<
-                                         Triggers::WhenToCheck::AtSteps>,
-                                     tmpl::list<>>,
-                  ::evolution::Actions::RunEventsAndTriggers<
-                      Triggers::WhenToCheck::AtSlabs>,
-                  Actions::ChangeSlabSize,
-                  evolution::dg::Actions::ChangeFixedLtsRatio, step_actions,
-                  Actions::MutateApply<AdvanceTime<>>,
-                  PhaseControl::Actions::ExecutePhaseChange>>>>>>;
+              tmpl::flatten<
+                  tmpl::list<evolution::Actions::RunEventsAndTriggers<
+                                 Triggers::WhenToCheck::AtSteps>,
+                             ::evolution::Actions::RunEventsAndTriggers<
+                                 Triggers::WhenToCheck::AtSlabs>,
+                             Actions::ChangeSlabSize,
+                             evolution::dg::Actions::ChangeFixedLtsRatio,
+                             step_actions, Actions::MutateApply<AdvanceTime<>>,
+                             PhaseControl::Actions::ExecutePhaseChange>>>>>>;
 
   struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
     using element_array = gh_dg_element_array;

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhSingleBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhSingleBlackHole.hpp
@@ -304,7 +304,7 @@ struct EvolutionMetavars : public GeneralizedHarmonicTemplateBase<3, UseLts> {
             volume_dim, typename system::variables_tag::tags_list>,
         ::amr::projectors::DefaultInitialize<
             Initialization::Tags::InitialTimeDelta,
-            Initialization::Tags::InitialSlabSize<gh_base::local_time_stepping>,
+            Initialization::Tags::InitialSlabSize,
             ::domain::Tags::InitialExtents<volume_dim>,
             ::domain::Tags::InitialRefinementLevels<volume_dim>,
             evolution::dg::Tags::Quadrature,

--- a/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhSingleBlackHole.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/EvolveGhSingleBlackHole.hpp
@@ -277,10 +277,8 @@ struct EvolutionMetavars : public GeneralizedHarmonicTemplateBase<3, UseLts> {
               Parallel::Phase::Evolve,
               tmpl::flatten<tmpl::list<
                   ::domain::Actions::CheckFunctionsOfTimeAreReady<volume_dim>,
-                  std::conditional_t<local_time_stepping,
-                                     evolution::Actions::RunEventsAndTriggers<
-                                         Triggers::WhenToCheck::AtSteps>,
-                                     tmpl::list<>>,
+                  evolution::Actions::RunEventsAndTriggers<
+                      Triggers::WhenToCheck::AtSteps>,
                   evolution::Actions::RunEventsAndTriggers<
                       Triggers::WhenToCheck::AtSlabs>,
                   Actions::ChangeSlabSize,

--- a/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
@@ -416,8 +416,8 @@ struct GeneralizedHarmonicTemplateBase {
   template <typename DerivedMetavars, bool UseControlSystems>
   using initialization_actions = tmpl::list<
       Initialization::Actions::InitializeItems<
-          Initialization::TimeStepping<DerivedMetavars, TimeStepperBase,
-                                       UseControlSystems, local_time_stepping>,
+          Initialization::TimeStepping<DerivedMetavars, TimeStepper,
+                                       UseControlSystems, true>,
           evolution::dg::Initialization::Domain<DerivedMetavars,
                                                 UseControlSystems>,
           ::amr::Initialization::Initialize<volume_dim, DerivedMetavars>,

--- a/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
+++ b/src/Evolution/Executables/GeneralizedHarmonic/GeneralizedHarmonicBase.hpp
@@ -397,8 +397,7 @@ struct GeneralizedHarmonicTemplateBase {
   template <typename DerivedMetavars, typename ControlSystems>
   using step_actions = tmpl::list<
       evolution::dg::Actions::ComputeTimeDerivative<
-          volume_dim, system, AllStepChoosers, local_time_stepping,
-          use_dg_element_collection>,
+          volume_dim, system, AllStepChoosers, use_dg_element_collection>,
       evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
           volume_dim, use_dg_element_collection>,
       Actions::MutateApply<RecordTimeStepperData<system>>,
@@ -406,13 +405,10 @@ struct GeneralizedHarmonicTemplateBase {
           ::domain::CheckFunctionsOfTimeAreReadyPostprocessor<volume_dim>,
           evolution::dg::ApplyLtsDenseBoundaryCorrections<DerivedMetavars>>>,
       control_system::Actions::LimitTimeStep<ControlSystems>,
-      Actions::MutateApply<UpdateU<system, local_time_stepping>>,
+      Actions::MutateApply<UpdateU<system>>,
       evolution::dg::Actions::ApplyLtsBoundaryCorrections<
           volume_dim, use_dg_element_collection>,
-      tmpl::conditional_t<
-          local_time_stepping,
-          tmpl::list<Actions::MutateApply<ChangeTimeStepperOrder<system>>>,
-          tmpl::list<>>,
+      Actions::MutateApply<ChangeTimeStepperOrder<system>>,
       Actions::MutateApply<CleanHistory<system>>,
       Actions::MutateApply<evolution::dg::CleanMortarHistory<volume_dim>>,
       dg::Actions::SpectralFilter>;

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -864,9 +864,8 @@ struct GhValenciaDivCleanTemplateBase<
 
   using initialization_actions = tmpl::list<
       Initialization::Actions::InitializeItems<
-          Initialization::TimeStepping<derived_metavars, TimeStepperBase,
-                                       use_control_systems,
-                                       local_time_stepping>,
+          Initialization::TimeStepping<derived_metavars, TimeStepper,
+                                       use_control_systems, true>,
           evolution::dg::Initialization::Domain<derived_metavars,
                                                 use_control_systems>,
           Initialization::TimeStepperHistory<derived_metavars>>,

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -946,10 +946,8 @@ struct GhValenciaDivCleanTemplateBase<
                   VariableFixing::Actions::FixVariables<
                       VariableFixing::LimitLorentzFactor>,
                   Actions::UpdateConservatives,
-                  std::conditional_t<local_time_stepping,
-                                     evolution::Actions::RunEventsAndTriggers<
-                                         Triggers::WhenToCheck::AtSteps>,
-                                     tmpl::list<>>,
+                  evolution::Actions::RunEventsAndTriggers<
+                      Triggers::WhenToCheck::AtSteps>,
                   evolution::Actions::RunEventsAndTriggers<
                       Triggers::WhenToCheck::AtSlabs>,
                   Actions::ChangeSlabSize,

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -770,8 +770,7 @@ struct GhValenciaDivCleanTemplateBase<
   using dg_step_actions = tmpl::flatten<tmpl::list<
       dg::Actions::SpectralFilter,
       evolution::dg::Actions::ComputeTimeDerivative<
-          volume_dim, system, AllStepChoosers, local_time_stepping,
-          use_dg_element_collection>,
+          volume_dim, system, AllStepChoosers, use_dg_element_collection>,
       evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
           volume_dim, use_dg_element_collection>,
       tmpl::conditional_t<
@@ -783,13 +782,10 @@ struct GhValenciaDivCleanTemplateBase<
       evolution::Actions::RunEventsAndDenseTriggers<
           events_and_dense_triggers_dg_postprocessors>,
       control_system::Actions::LimitTimeStep<control_systems>,
-      Actions::MutateApply<UpdateU<system, local_time_stepping>>,
+      Actions::MutateApply<UpdateU<system>>,
       evolution::dg::Actions::ApplyLtsBoundaryCorrections<
           volume_dim, use_dg_element_collection>,
-      tmpl::conditional_t<
-          local_time_stepping,
-          tmpl::list<Actions::MutateApply<ChangeTimeStepperOrder<system>>>,
-          tmpl::list<>>,
+      Actions::MutateApply<ChangeTimeStepperOrder<system>>,
       tmpl::conditional_t<
           use_dg_subcell,
           // Note: The primitive variables are computed as part of the TCI.
@@ -820,11 +816,9 @@ struct GhValenciaDivCleanTemplateBase<
       Actions::Goto<evolution::dg::subcell::Actions::Labels::EndOfSolvers>,
 
       Actions::Label<evolution::dg::subcell::Actions::Labels::BeginSubcell>,
-      tmpl::conditional_t<local_time_stepping,
-                          // This is just to adjust for FixedLtsRatio, so we
-                          // can pass an empty list of StepChoosers.
-                          Actions::MutateApply<ChangeStepSize<tmpl::list<>>>,
-                          tmpl::list<>>,
+      // This is just to adjust for FixedLtsRatio, so we
+      // can pass an empty list of StepChoosers.
+      Actions::MutateApply<ChangeStepSize<tmpl::list<>>>,
       Actions::MutateApply<evolution::dg::subcell::fd::CellCenteredFlux<
           system, grmhd::ValenciaDivClean::ComputeFluxes, volume_dim, false>>,
       evolution::dg::subcell::Actions::SendDataForReconstruction<
@@ -845,7 +839,7 @@ struct GhValenciaDivCleanTemplateBase<
       evolution::Actions::RunEventsAndDenseTriggers<
           events_and_dense_triggers_subcell_postprocessors>,
       control_system::Actions::LimitTimeStep<control_systems>,
-      Actions::MutateApply<UpdateU<system, local_time_stepping>>,
+      Actions::MutateApply<UpdateU<system>>,
       Actions::MutateApply<CleanHistory<system>>,
       Actions::MutateApply<evolution::dg::CleanMortarHistory<volume_dim>>,
       Actions::MutateApply<

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -605,29 +605,27 @@ struct EvolutionMetavars<tmpl::list<InterpolationTargetTags...>,
                      tmpl::push_back<dg_registration_list,
                                      Parallel::Actions::TerminatePhase>>,
 
-          Parallel::PhaseActions<
-              Parallel::Phase::WriteCheckpoint,
-              tmpl::list<evolution::Actions::RunEventsAndTriggers<
-                             Triggers::WhenToCheck::AtCheckpoints>,
-                         Parallel::Actions::TerminatePhase>>,
+                 Parallel::PhaseActions<
+                     Parallel::Phase::WriteCheckpoint,
+                     tmpl::list<evolution::Actions::RunEventsAndTriggers<
+                                    Triggers::WhenToCheck::AtCheckpoints>,
+                                Parallel::Actions::TerminatePhase>>,
 
-          Parallel::PhaseActions<
-              Parallel::Phase::Evolve,
-              tmpl::flatten<tmpl::list<
-                  std::conditional_t<local_time_stepping,
-                                     evolution::Actions::RunEventsAndTriggers<
-                                         Triggers::WhenToCheck::AtSteps>,
-                                     tmpl::list<>>,
-                  evolution::Actions::RunEventsAndTriggers<
-                      Triggers::WhenToCheck::AtSlabs>,
-                  Actions::ChangeSlabSize,
-                  evolution::dg::Actions::ChangeFixedLtsRatio, step_actions,
-                  Actions::MutateApply<AdvanceTime<>>,
-                  PhaseControl::Actions::ExecutePhaseChange>>>,
-          Parallel::PhaseActions<
-              Parallel::Phase::PostFailureCleanup,
-              tmpl::list<Actions::RunEventsOnFailure<Tags::Time>,
-                         Parallel::Actions::TerminatePhase>>>>;
+                 Parallel::PhaseActions<
+                     Parallel::Phase::Evolve,
+                     tmpl::flatten<tmpl::list<
+                         evolution::Actions::RunEventsAndTriggers<
+                             Triggers::WhenToCheck::AtSteps>,
+                         evolution::Actions::RunEventsAndTriggers<
+                             Triggers::WhenToCheck::AtSlabs>,
+                         Actions::ChangeSlabSize,
+                         evolution::dg::Actions::ChangeFixedLtsRatio,
+                         step_actions, Actions::MutateApply<AdvanceTime<>>,
+                         PhaseControl::Actions::ExecutePhaseChange>>>,
+                 Parallel::PhaseActions<
+                     Parallel::Phase::PostFailureCleanup,
+                     tmpl::list<Actions::RunEventsOnFailure<Tags::Time>,
+                                Parallel::Actions::TerminatePhase>>>>;
 
   struct registration
       : tt::ConformsTo<Parallel::protocols::RegistrationMetavariables> {

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -521,8 +521,8 @@ struct EvolutionMetavars<tmpl::list<InterpolationTargetTags...>,
 
   using initialization_actions = tmpl::flatten<tmpl::list<
       Initialization::Actions::InitializeItems<
-          Initialization::TimeStepping<EvolutionMetavars, TimeStepperBase,
-                                       false, local_time_stepping>,
+          Initialization::TimeStepping<EvolutionMetavars, TimeStepper, false,
+                                       true>,
           evolution::dg::Initialization::Domain<EvolutionMetavars>,
           evolution::dg::subcell::GhostZoneInverseJacobian<
               volume_dim, grmhd::ValenciaDivClean::fd::Tags::Reconstructor>,

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -419,20 +419,16 @@ struct EvolutionMetavars<tmpl::list<InterpolationTargetTags...>,
       Actions::MutateApply<
           evolution::dg::BackgroundGrVars<system, EvolutionMetavars>>,
       evolution::dg::Actions::ComputeTimeDerivative<
-          volume_dim, system, AllStepChoosers, local_time_stepping,
-          use_dg_element_collection>,
+          volume_dim, system, AllStepChoosers, use_dg_element_collection>,
       evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
           volume_dim, use_dg_element_collection>,
       Actions::MutateApply<RecordTimeStepperData<system>>,
       evolution::Actions::RunEventsAndDenseTriggers<
           events_and_dense_triggers_dg_postprocessors>,
-      Actions::MutateApply<UpdateU<system, local_time_stepping>>,
+      Actions::MutateApply<UpdateU<system>>,
       evolution::dg::Actions::ApplyLtsBoundaryCorrections<
           volume_dim, use_dg_element_collection>,
-      tmpl::conditional_t<
-          local_time_stepping,
-          tmpl::list<Actions::MutateApply<ChangeTimeStepperOrder<system>>>,
-          tmpl::list<>>,
+      Actions::MutateApply<ChangeTimeStepperOrder<system>>,
       tmpl::conditional_t<
           use_dg_subcell,
           // Note: The primitive variables are computed as part of the TCI.
@@ -462,11 +458,9 @@ struct EvolutionMetavars<tmpl::list<InterpolationTargetTags...>,
       Actions::Goto<evolution::dg::subcell::Actions::Labels::EndOfSolvers>,
 
       Actions::Label<evolution::dg::subcell::Actions::Labels::BeginSubcell>,
-      tmpl::conditional_t<local_time_stepping,
-                          // This is just to adjust for FixedLtsRatio, so we
-                          // can pass an empty list of StepChoosers.
-                          Actions::MutateApply<ChangeStepSize<tmpl::list<>>>,
-                          tmpl::list<>>,
+      // This is just to adjust for FixedLtsRatio, so we
+      // can pass an empty list of StepChoosers.
+      Actions::MutateApply<ChangeStepSize<tmpl::list<>>>,
       Actions::MutateApply<evolution::dg::subcell::BackgroundGrVars<
           system, EvolutionMetavars, false>>,
       Actions::MutateApply<evolution::dg::subcell::fd::CellCenteredFlux<
@@ -492,7 +486,7 @@ struct EvolutionMetavars<tmpl::list<InterpolationTargetTags...>,
       Actions::MutateApply<RecordTimeStepperData<system>>,
       evolution::Actions::RunEventsAndDenseTriggers<
           events_and_dense_triggers_subcell_postprocessors>,
-      Actions::MutateApply<UpdateU<system, local_time_stepping>>,
+      Actions::MutateApply<UpdateU<system>>,
       Actions::MutateApply<CleanHistory<system>>,
       Actions::MutateApply<evolution::dg::CleanMortarHistory<volume_dim>>,
       Actions::MutateApply<

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -267,8 +267,8 @@ struct EvolutionMetavars {
 
   using initialization_actions = tmpl::flatten<tmpl::list<
       Initialization::Actions::InitializeItems<
-          Initialization::TimeStepping<EvolutionMetavars, TimeStepperBase,
-                                       false, local_time_stepping>,
+          Initialization::TimeStepping<EvolutionMetavars, TimeStepper, false,
+                                       true>,
           evolution::dg::Initialization::Domain<EvolutionMetavars>,
           Initialization::TimeStepperHistory<EvolutionMetavars>>,
       Initialization::Actions::ConservativeSystem<system>,

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -312,21 +312,17 @@ struct EvolutionMetavars {
 
   using dg_step_actions = tmpl::flatten<tmpl::list<
       evolution::dg::Actions::ComputeTimeDerivative<
-          volume_dim, system, AllStepChoosers, local_time_stepping,
-          use_dg_element_collection>,
+          volume_dim, system, AllStepChoosers, use_dg_element_collection>,
       evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
           volume_dim, use_dg_element_collection>,
       Actions::MutateApply<RecordTimeStepperData<system>>,
       evolution::Actions::RunEventsAndDenseTriggers<tmpl::push_front<
           events_and_dense_triggers_postprocessors,
           evolution::dg::ApplyLtsDenseBoundaryCorrections<EvolutionMetavars>>>,
-      Actions::MutateApply<UpdateU<system, local_time_stepping>>,
+      Actions::MutateApply<UpdateU<system>>,
       evolution::dg::Actions::ApplyLtsBoundaryCorrections<
           volume_dim, use_dg_element_collection>,
-      tmpl::conditional_t<
-          local_time_stepping,
-          tmpl::list<Actions::MutateApply<ChangeTimeStepperOrder<system>>>,
-          tmpl::list<>>,
+      Actions::MutateApply<ChangeTimeStepperOrder<system>>,
       tmpl::conditional_t<
           use_dg_subcell,
           // Note: The primitive variables are computed as part of the TCI.
@@ -372,11 +368,9 @@ struct EvolutionMetavars {
       Actions::Goto<evolution::dg::subcell::Actions::Labels::EndOfSolvers>,
 
       Actions::Label<evolution::dg::subcell::Actions::Labels::BeginSubcell>,
-      tmpl::conditional_t<local_time_stepping,
-                          // This is just to adjust for FixedLtsRatio, so we
-                          // can pass an empty list of StepChoosers.
-                          Actions::MutateApply<ChangeStepSize<tmpl::list<>>>,
-                          tmpl::list<>>,
+      // This is just to adjust for FixedLtsRatio, so we
+      // can pass an empty list of StepChoosers.
+      Actions::MutateApply<ChangeStepSize<tmpl::list<>>>,
       evolution::dg::subcell::Actions::SendDataForReconstruction<
           volume_dim,
           NewtonianEuler::subcell::PrimitiveGhostVariables<volume_dim>,
@@ -391,7 +385,7 @@ struct EvolutionMetavars {
       Actions::MutateApply<RecordTimeStepperData<system>>,
       evolution::Actions::RunEventsAndDenseTriggers<
           events_and_dense_triggers_postprocessors>,
-      Actions::MutateApply<UpdateU<system, local_time_stepping>>,
+      Actions::MutateApply<UpdateU<system>>,
       Actions::MutateApply<CleanHistory<system>>,
       Actions::MutateApply<evolution::dg::CleanMortarHistory<volume_dim>>,
       Actions::MutateApply<typename system::primitive_from_conservative>,

--- a/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
+++ b/src/Evolution/Executables/NewtonianEuler/EvolveNewtonianEuler.hpp
@@ -426,17 +426,15 @@ struct EvolutionMetavars {
 
           Parallel::PhaseActions<
               Parallel::Phase::Evolve,
-              tmpl::flatten<tmpl::list<
-                  std::conditional_t<local_time_stepping,
-                                     evolution::Actions::RunEventsAndTriggers<
-                                         Triggers::WhenToCheck::AtSteps>,
-                                     tmpl::list<>>,
-                  evolution::Actions::RunEventsAndTriggers<
-                      Triggers::WhenToCheck::AtSlabs>,
-                  Actions::ChangeSlabSize,
-                  evolution::dg::Actions::ChangeFixedLtsRatio, step_actions,
-                  Actions::MutateApply<AdvanceTime<>>,
-                  PhaseControl::Actions::ExecutePhaseChange>>>>>;
+              tmpl::flatten<
+                  tmpl::list<evolution::Actions::RunEventsAndTriggers<
+                                 Triggers::WhenToCheck::AtSteps>,
+                             evolution::Actions::RunEventsAndTriggers<
+                                 Triggers::WhenToCheck::AtSlabs>,
+                             Actions::ChangeSlabSize,
+                             evolution::dg::Actions::ChangeFixedLtsRatio,
+                             step_actions, Actions::MutateApply<AdvanceTime<>>,
+                             PhaseControl::Actions::ExecutePhaseChange>>>>>;
 
   struct registration
       : tt::ConformsTo<Parallel::protocols::RegistrationMetavariables> {

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
@@ -280,17 +280,15 @@ struct EvolutionMetavars {
 
           Parallel::PhaseActions<
               Parallel::Phase::Evolve,
-              tmpl::flatten<tmpl::list<
-                  std::conditional_t<local_time_stepping,
-                                     evolution::Actions::RunEventsAndTriggers<
-                                         Triggers::WhenToCheck::AtSteps>,
-                                     tmpl::list<>>,
-                  evolution::Actions::RunEventsAndTriggers<
-                      Triggers::WhenToCheck::AtSlabs>,
-                  Actions::ChangeSlabSize,
-                  evolution::dg::Actions::ChangeFixedLtsRatio, step_actions,
-                  Actions::MutateApply<AdvanceTime<>>,
-                  PhaseControl::Actions::ExecutePhaseChange>>>>>;
+              tmpl::flatten<
+                  tmpl::list<evolution::Actions::RunEventsAndTriggers<
+                                 Triggers::WhenToCheck::AtSteps>,
+                             evolution::Actions::RunEventsAndTriggers<
+                                 Triggers::WhenToCheck::AtSlabs>,
+                             Actions::ChangeSlabSize,
+                             evolution::dg::Actions::ChangeFixedLtsRatio,
+                             step_actions, Actions::MutateApply<AdvanceTime<>>,
+                             PhaseControl::Actions::ExecutePhaseChange>>>>>;
 
   struct registration
       : tt::ConformsTo<Parallel::protocols::RegistrationMetavariables> {

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
@@ -231,8 +231,8 @@ struct EvolutionMetavars {
 
   using initialization_actions = tmpl::list<
       Initialization::Actions::InitializeItems<
-          Initialization::TimeStepping<EvolutionMetavars, TimeStepperBase,
-                                       false, local_time_stepping>,
+          Initialization::TimeStepping<EvolutionMetavars, ImexTimeStepper,
+                                       false, true>,
           evolution::dg::Initialization::Domain<EvolutionMetavars>,
           Initialization::TimeStepperHistory<EvolutionMetavars>>,
       Initialization::Actions::AddSimpleTags<

--- a/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
+++ b/src/Evolution/Executables/RadiationTransport/M1Grey/EvolveM1Grey.hpp
@@ -203,8 +203,7 @@ struct EvolutionMetavars {
       Actions::MutateApply<
           evolution::dg::BackgroundGrVars<system, EvolutionMetavars>>,
       evolution::dg::Actions::ComputeTimeDerivative<
-          volume_dim, system, AllStepChoosers, local_time_stepping,
-          use_dg_element_collection>,
+          volume_dim, system, AllStepChoosers, use_dg_element_collection>,
       evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
           volume_dim, use_dg_element_collection>,
       Actions::MutateApply<RecordTimeStepperData<system>>,
@@ -212,14 +211,11 @@ struct EvolutionMetavars {
       evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<
           evolution::dg::ApplyLtsDenseBoundaryCorrections<EvolutionMetavars>,
           imex::ImplicitDenseOutput<system>>>,
-      Actions::MutateApply<UpdateU<system, local_time_stepping>>,
+      Actions::MutateApply<UpdateU<system>>,
       evolution::dg::Actions::ApplyLtsBoundaryCorrections<
           volume_dim, use_dg_element_collection>,
       imex::Actions::DoImplicitStep<system>,
-      tmpl::conditional_t<
-          local_time_stepping,
-          tmpl::list<Actions::MutateApply<ChangeTimeStepperOrder<system>>>,
-          tmpl::list<>>,
+      Actions::MutateApply<ChangeTimeStepperOrder<system>>,
       Actions::MutateApply<CleanHistory<system>>,
       Actions::MutateApply<imex::CleanHistory<system>>,
       Actions::MutateApply<evolution::dg::CleanMortarHistory<volume_dim>>,

--- a/src/Evolution/Executables/RadiationTransport/MonteCarlo/EvolveMonteCarlo.hpp
+++ b/src/Evolution/Executables/RadiationTransport/MonteCarlo/EvolveMonteCarlo.hpp
@@ -80,9 +80,9 @@
 #include "Time/Actions/SelfStartActions.hpp"
 #include "Time/AdvanceTime.hpp"
 #include "Time/ChangeSlabSize/Action.hpp"
+#include "Time/NoStepperErrorEstimates.hpp"
 #include "Time/StepChoosers/Factory.hpp"
 #include "Time/StepChoosers/StepChooser.hpp"
-#include "Time/Tags/StepperErrorTolerancesCompute.hpp"
 #include "Time/Tags/Time.hpp"
 #include "Time/Tags/TimeStepId.hpp"
 #include "Time/TimeSequence.hpp"
@@ -202,6 +202,7 @@ struct EvolutionMetavars {
                                        false, local_time_stepping>,
           evolution::dg::Initialization::Domain<EvolutionMetavars>>,
       Initialization::Actions::AddSimpleTags<
+          NoStepperErrorEstimates,
           evolution::dg::BackgroundGrVars<system, EvolutionMetavars>>,
       evolution::dg::subcell::Actions::SetSubcellGrid<volume_dim, system,
                                                       false>,
@@ -215,8 +216,7 @@ struct EvolutionMetavars {
           Particles::MonteCarlo::CellLightCrossingTimeCompute,
           Particles::MonteCarlo::InertialFrameEnergyDensityCompute,
           Particles::MonteCarlo::InverseJacobianInertialToFluidCompute,
-          domain::Tags::JacobianCompute<4, Frame::Inertial, Frame::Fluid>,
-          ::Tags::StepperErrorEstimatesEnabledCompute<false>>>,
+          domain::Tags::JacobianCompute<4, Frame::Inertial, Frame::Fluid>>>,
       evolution::Actions::InitializeRunEventsAndDenseTriggers,
       Parallel::Actions::TerminatePhase>;
 

--- a/src/Evolution/Executables/RadiationTransport/MonteCarlo/EvolveMonteCarlo.hpp
+++ b/src/Evolution/Executables/RadiationTransport/MonteCarlo/EvolveMonteCarlo.hpp
@@ -198,8 +198,8 @@ struct EvolutionMetavars {
 
   using initialization_actions = tmpl::list<
       Initialization::Actions::InitializeItems<
-          Initialization::TimeStepping<EvolutionMetavars, TimeStepperBase,
-                                       false, local_time_stepping>,
+          Initialization::TimeStepping<EvolutionMetavars, TimeStepper, false,
+                                       false>,
           evolution::dg::Initialization::Domain<EvolutionMetavars>>,
       Initialization::Actions::AddSimpleTags<
           NoStepperErrorEstimates,

--- a/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
+++ b/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
@@ -260,20 +260,16 @@ struct EvolutionMetavars {
 
   using dg_step_actions = tmpl::flatten<tmpl::list<
       evolution::dg::Actions::ComputeTimeDerivative<
-          volume_dim, system, AllStepChoosers, local_time_stepping,
-          use_dg_element_collection>,
+          volume_dim, system, AllStepChoosers, use_dg_element_collection>,
       evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
           volume_dim, use_dg_element_collection>,
       Actions::MutateApply<RecordTimeStepperData<system>>,
       evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<
           evolution::dg::ApplyLtsDenseBoundaryCorrections<EvolutionMetavars>>>,
-      Actions::MutateApply<UpdateU<system, local_time_stepping>>,
+      Actions::MutateApply<UpdateU<system>>,
       evolution::dg::Actions::ApplyLtsBoundaryCorrections<
           volume_dim, use_dg_element_collection>,
-      tmpl::conditional_t<
-          local_time_stepping,
-          tmpl::list<Actions::MutateApply<ChangeTimeStepperOrder<system>>>,
-          tmpl::list<>>,
+      Actions::MutateApply<ChangeTimeStepperOrder<system>>,
       tmpl::conditional_t<use_dg_subcell,
                           evolution::dg::subcell::Actions::TciAndRollback<
                               ScalarAdvection::subcell::TciOnDgGrid<Dim>>,
@@ -288,11 +284,9 @@ struct EvolutionMetavars {
       dg_step_actions,
       Actions::Goto<evolution::dg::subcell::Actions::Labels::EndOfSolvers>,
       Actions::Label<evolution::dg::subcell::Actions::Labels::BeginSubcell>,
-      tmpl::conditional_t<local_time_stepping,
-                          // This is just to adjust for FixedLtsRatio, so we
-                          // can pass an empty list of StepChoosers.
-                          Actions::MutateApply<ChangeStepSize<tmpl::list<>>>,
-                          tmpl::list<>>,
+      // This is just to adjust for FixedLtsRatio, so we
+      // can pass an empty list of StepChoosers.
+      Actions::MutateApply<ChangeStepSize<tmpl::list<>>>,
       evolution::dg::subcell::Actions::SendDataForReconstruction<
           volume_dim, ScalarAdvection::subcell::GhostVariables,
           use_dg_element_collection>,
@@ -302,7 +296,7 @@ struct EvolutionMetavars {
       evolution::dg::subcell::fd::Actions::TakeTimeStep<
           ScalarAdvection::subcell::TimeDerivative<volume_dim>>,
       Actions::MutateApply<RecordTimeStepperData<system>>,
-      Actions::MutateApply<UpdateU<system, local_time_stepping>>,
+      Actions::MutateApply<UpdateU<system>>,
       Actions::MutateApply<CleanHistory<system>>,
       Actions::MutateApply<evolution::dg::CleanMortarHistory<volume_dim>>,
       evolution::dg::subcell::Actions::TciAndSwitchToDg<

--- a/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
+++ b/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
@@ -390,17 +390,15 @@ struct EvolutionMetavars {
 
           Parallel::PhaseActions<
               Parallel::Phase::Evolve,
-              tmpl::flatten<tmpl::list<
-                  std::conditional_t<local_time_stepping,
-                                     evolution::Actions::RunEventsAndTriggers<
-                                         Triggers::WhenToCheck::AtSteps>,
-                                     tmpl::list<>>,
-                  evolution::Actions::RunEventsAndTriggers<
-                      Triggers::WhenToCheck::AtSlabs>,
-                  Actions::ChangeSlabSize,
-                  evolution::dg::Actions::ChangeFixedLtsRatio, step_actions,
-                  Actions::MutateApply<AdvanceTime<>>,
-                  PhaseControl::Actions::ExecutePhaseChange>>>>>;
+              tmpl::flatten<
+                  tmpl::list<evolution::Actions::RunEventsAndTriggers<
+                                 Triggers::WhenToCheck::AtSteps>,
+                             evolution::Actions::RunEventsAndTriggers<
+                                 Triggers::WhenToCheck::AtSlabs>,
+                             Actions::ChangeSlabSize,
+                             evolution::dg::Actions::ChangeFixedLtsRatio,
+                             step_actions, Actions::MutateApply<AdvanceTime<>>,
+                             PhaseControl::Actions::ExecutePhaseChange>>>>>;
 
   struct registration
       : tt::ConformsTo<Parallel::protocols::RegistrationMetavariables> {

--- a/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
+++ b/src/Evolution/Executables/ScalarAdvection/EvolveScalarAdvection.hpp
@@ -327,8 +327,8 @@ struct EvolutionMetavars {
 
   using initialization_actions = tmpl::list<
       Initialization::Actions::InitializeItems<
-          Initialization::TimeStepping<EvolutionMetavars, TimeStepperBase,
-                                       false, local_time_stepping>,
+          Initialization::TimeStepping<EvolutionMetavars, TimeStepper, false,
+                                       true>,
           evolution::dg::Initialization::Domain<EvolutionMetavars>,
           Initialization::TimeStepperHistory<EvolutionMetavars>>,
       Initialization::Actions::ConservativeSystem<system>,

--- a/src/Evolution/Executables/ScalarTensor/EvolveScalarTensorSingleBlackHole.hpp
+++ b/src/Evolution/Executables/ScalarTensor/EvolveScalarTensorSingleBlackHole.hpp
@@ -277,10 +277,8 @@ struct EvolutionMetavars : public ScalarTensorTemplateBase<EvolutionMetavars> {
               Parallel::Phase::Evolve,
               tmpl::flatten<tmpl::list<
                   ::domain::Actions::CheckFunctionsOfTimeAreReady<volume_dim>,
-                  std::conditional_t<local_time_stepping,
-                                     evolution::Actions::RunEventsAndTriggers<
-                                         Triggers::WhenToCheck::AtSteps>,
-                                     tmpl::list<>>,
+                  evolution::Actions::RunEventsAndTriggers<
+                      Triggers::WhenToCheck::AtSteps>,
                   evolution::Actions::RunEventsAndTriggers<
                       Triggers::WhenToCheck::AtSlabs>,
                   Actions::ChangeSlabSize,

--- a/src/Evolution/Executables/ScalarTensor/ScalarTensorBase.hpp
+++ b/src/Evolution/Executables/ScalarTensor/ScalarTensorBase.hpp
@@ -462,8 +462,8 @@ struct ScalarTensorTemplateBase {
   template <bool UseControlSystems>
   using initialization_actions = tmpl::list<
       Initialization::Actions::InitializeItems<
-          Initialization::TimeStepping<derived_metavars, TimeStepperBase,
-                                       UseControlSystems, local_time_stepping>,
+          Initialization::TimeStepping<derived_metavars, TimeStepper,
+                                       UseControlSystems, true>,
           evolution::dg::Initialization::Domain<derived_metavars,
                                                 UseControlSystems>,
           Initialization::TimeStepperHistory<derived_metavars>>,

--- a/src/Evolution/Executables/ScalarTensor/ScalarTensorBase.hpp
+++ b/src/Evolution/Executables/ScalarTensor/ScalarTensorBase.hpp
@@ -443,8 +443,7 @@ struct ScalarTensorTemplateBase {
   template <typename ControlSystems>
   using step_actions = tmpl::list<
       evolution::dg::Actions::ComputeTimeDerivative<
-          volume_dim, system, AllStepChoosers, local_time_stepping,
-          use_dg_element_collection>,
+          volume_dim, system, AllStepChoosers, use_dg_element_collection>,
       evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
           volume_dim, use_dg_element_collection>,
       Actions::MutateApply<RecordTimeStepperData<system>>,
@@ -452,13 +451,10 @@ struct ScalarTensorTemplateBase {
           ::domain::CheckFunctionsOfTimeAreReadyPostprocessor<volume_dim>,
           evolution::dg::ApplyLtsDenseBoundaryCorrections<derived_metavars>>>,
       control_system::Actions::LimitTimeStep<ControlSystems>,
-      Actions::MutateApply<UpdateU<system, local_time_stepping>>,
+      Actions::MutateApply<UpdateU<system>>,
       evolution::dg::Actions::ApplyLtsBoundaryCorrections<
           volume_dim, use_dg_element_collection>,
-      tmpl::conditional_t<
-          local_time_stepping,
-          tmpl::list<Actions::MutateApply<ChangeTimeStepperOrder<system>>>,
-          tmpl::list<>>,
+      Actions::MutateApply<ChangeTimeStepperOrder<system>>,
       Actions::MutateApply<CleanHistory<system>>,
       Actions::MutateApply<evolution::dg::CleanMortarHistory<volume_dim>>,
       dg::Actions::SpectralFilter>;

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -248,20 +248,16 @@ struct EvolutionMetavars {
 
   using step_actions = tmpl::flatten<tmpl::list<
       evolution::dg::Actions::ComputeTimeDerivative<
-          volume_dim, system, AllStepChoosers, local_time_stepping,
-          use_dg_element_collection>,
+          volume_dim, system, AllStepChoosers, use_dg_element_collection>,
       evolution::dg::Actions::ApplyBoundaryCorrectionsToTimeDerivative<
           volume_dim, use_dg_element_collection>,
       Actions::MutateApply<RecordTimeStepperData<system>>,
       evolution::Actions::RunEventsAndDenseTriggers<tmpl::list<
           evolution::dg::ApplyLtsDenseBoundaryCorrections<EvolutionMetavars>>>,
-      Actions::MutateApply<UpdateU<system, local_time_stepping>>,
+      Actions::MutateApply<UpdateU<system>>,
       evolution::dg::Actions::ApplyLtsBoundaryCorrections<
           volume_dim, use_dg_element_collection>,
-      tmpl::conditional_t<
-          local_time_stepping,
-          tmpl::list<Actions::MutateApply<ChangeTimeStepperOrder<system>>>,
-          tmpl::list<>>,
+      Actions::MutateApply<ChangeTimeStepperOrder<system>>,
       Actions::MutateApply<CleanHistory<system>>,
       Actions::MutateApply<evolution::dg::CleanMortarHistory<volume_dim>>,
       dg::Actions::SpectralFilter>>;

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -349,7 +349,7 @@ struct EvolutionMetavars {
             volume_dim, typename system::variables_tag::tags_list>,
         ::amr::projectors::DefaultInitialize<
             Initialization::Tags::InitialTimeDelta,
-            Initialization::Tags::InitialSlabSize<local_time_stepping>,
+            Initialization::Tags::InitialSlabSize,
             ::domain::Tags::InitialExtents<volume_dim>,
             ::domain::Tags::InitialRefinementLevels<volume_dim>,
             evolution::dg::Tags::Quadrature,

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -323,17 +323,15 @@ struct EvolutionMetavars {
 
           Parallel::PhaseActions<
               Parallel::Phase::Evolve,
-              tmpl::flatten<tmpl::list<
-                  std::conditional_t<local_time_stepping,
-                                     evolution::Actions::RunEventsAndTriggers<
-                                         Triggers::WhenToCheck::AtSteps>,
-                                     tmpl::list<>>,
-                  evolution::Actions::RunEventsAndTriggers<
-                      Triggers::WhenToCheck::AtSlabs>,
-                  Actions::ChangeSlabSize,
-                  evolution::dg::Actions::ChangeFixedLtsRatio, step_actions,
-                  Actions::MutateApply<AdvanceTime<>>,
-                  PhaseControl::Actions::ExecutePhaseChange>>>>>;
+              tmpl::flatten<
+                  tmpl::list<evolution::Actions::RunEventsAndTriggers<
+                                 Triggers::WhenToCheck::AtSteps>,
+                             evolution::Actions::RunEventsAndTriggers<
+                                 Triggers::WhenToCheck::AtSlabs>,
+                             Actions::ChangeSlabSize,
+                             evolution::dg::Actions::ChangeFixedLtsRatio,
+                             step_actions, Actions::MutateApply<AdvanceTime<>>,
+                             PhaseControl::Actions::ExecutePhaseChange>>>>>;
 
   struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
     using element_array = dg_element_array;

--- a/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
+++ b/src/Evolution/Executables/ScalarWave/EvolveScalarWave.hpp
@@ -273,8 +273,8 @@ struct EvolutionMetavars {
 
   using initialization_actions = tmpl::list<
       Initialization::Actions::InitializeItems<
-          Initialization::TimeStepping<EvolutionMetavars, TimeStepperBase,
-                                       false, local_time_stepping>,
+          Initialization::TimeStepping<EvolutionMetavars, TimeStepper, false,
+                                       true>,
           evolution::dg::Initialization::Domain<EvolutionMetavars>,
           ::amr::Initialization::Initialize<volume_dim, EvolutionMetavars>,
           Initialization::TimeStepperHistory<EvolutionMetavars>>,

--- a/src/Evolution/Initialization/Evolution.hpp
+++ b/src/Evolution/Initialization/Evolution.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <algorithm>
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <optional>
@@ -80,30 +81,6 @@ struct MortarInfo;
 /// \endcond
 
 namespace Initialization {
-
-namespace detail {
-inline Time initial_time(const bool time_runs_forward,
-                         const double initial_time_value,
-                         const double initial_slab_size) {
-  const Slab initial_slab =
-      time_runs_forward
-          ? Slab::with_duration_from_start(initial_time_value,
-                                           initial_slab_size)
-          : Slab::with_duration_to_end(initial_time_value, initial_slab_size);
-  return time_runs_forward ? initial_slab.start() : initial_slab.end();
-}
-
-template <typename TimeStepper>
-void set_next_time_step_id(const gsl::not_null<TimeStepId*> next_time_step_id,
-                           const Time& initial_time,
-                           const bool time_runs_forward,
-                           const TimeStepper& time_stepper) {
-  *next_time_step_id = TimeStepId(
-      time_runs_forward,
-      -static_cast<int64_t>(time_stepper.number_of_past_steps()), initial_time);
-}
-}  // namespace detail
-
 /// \ingroup InitializationGroup
 /// \brief Initialize items related to time stepping
 ///
@@ -129,14 +106,12 @@ struct TimeStepping {
 
   /// Tags for items fetched by the DataBox and passed to the apply function
   using argument_tags =
-      tmpl::list<::Tags::Time, Tags::InitialTimeDelta,
-                 Tags::InitialSlabSize<AllowLocalTimeStepping>,
-                 ::Tags::TimeStepper<TimeStepperBase>>;
+      tmpl::list<::Tags::Time, Tags::InitialTimeDelta, Tags::InitialSlabSize,
+                 ::Tags::TimeStepper<TimeStepperBase>, ::Tags::LtsMode>;
 
   /// Tags for simple DataBox items that are initialized from input file options
   using simple_tags_from_options =
-      tmpl::list<::Tags::Time, Tags::InitialTimeDelta,
-                 Tags::InitialSlabSize<AllowLocalTimeStepping>>;
+      tmpl::list<::Tags::Time, Tags::InitialTimeDelta, Tags::InitialSlabSize>;
 
   /// Tags for simple DataBox items that are default initialized.
   using default_initialized_simple_tags =
@@ -159,42 +134,44 @@ struct TimeStepping {
   using compute_tags =
       time_stepper_ref_tags<TimeStepperBase, WithControlSystems>;
 
-  /// Given the items fetched from a DataBox by the argument_tags when using
-  /// LTS, mutate the items in the DataBox corresponding to return_tags
   static void apply(const gsl::not_null<TimeStepId*> next_time_step_id,
                     const gsl::not_null<TimeDelta*> time_step,
                     const gsl::not_null<double*> slab_size_goal,
                     const double initial_time_value,
                     const double initial_dt_value,
                     const double initial_slab_size,
-                    const LtsTimeStepper& time_stepper) {
-    const bool time_runs_forward = initial_dt_value > 0.0;
-    const Time initial_time = detail::initial_time(
-        time_runs_forward, initial_time_value, initial_slab_size);
-    detail::set_next_time_step_id(next_time_step_id, initial_time,
-                                  time_runs_forward, time_stepper);
-    *time_step = choose_lts_step_size(initial_time, initial_dt_value);
-    *slab_size_goal =
-        time_runs_forward ? initial_slab_size : -initial_slab_size;
-  }
+                    const TimeStepper& time_stepper, const LtsMode lts_mode) {
+    // Ignore the sign of initial_slab_size for user convenience.  GTS
+    // evolutions can set the initial slab size and time step the same
+    // even if they are negative.
 
-  /// Given the items fetched from a DataBox by the argument_tags, when not
-  /// using LTS, mutate the items in the DataBox corresponding to return_tags
-  static void apply(const gsl::not_null<TimeStepId*> next_time_step_id,
-                    const gsl::not_null<TimeDelta*> time_step,
-                    const gsl::not_null<double*> slab_size_goal,
-                    const double initial_time_value,
-                    const double initial_dt_value,
-                    const double initial_slab_size,
-                    const TimeStepper& time_stepper) {
     const bool time_runs_forward = initial_dt_value > 0.0;
-    const Time initial_time = detail::initial_time(
-        time_runs_forward, initial_time_value, initial_slab_size);
-    detail::set_next_time_step_id(next_time_step_id, initial_time,
-                                  time_runs_forward, time_stepper);
-    *time_step = (time_runs_forward ? 1 : -1) * initial_time.slab().duration();
+    const Slab initial_slab =
+        time_runs_forward
+            ? Slab::with_duration_from_start(initial_time_value,
+                                             std::abs(initial_slab_size))
+            : Slab::with_duration_to_end(initial_time_value,
+                                         std::abs(initial_slab_size));
+    const auto initial_time =
+        time_runs_forward ? initial_slab.start() : initial_slab.end();
+
+    *next_time_step_id =
+        TimeStepId(time_runs_forward,
+                   -static_cast<int64_t>(time_stepper.number_of_past_steps()),
+                   initial_time);
     *slab_size_goal =
-        time_runs_forward ? initial_slab_size : -initial_slab_size;
+        (time_runs_forward ? 1.0 : -1.0) * std::abs(initial_slab_size);
+
+    if (lts_mode == LtsMode::Off) {
+      if (std::abs(initial_slab_size) != std::abs(initial_dt_value)) {
+        ERROR_NO_TRACE(
+            "InitialSlabSize and InitialTimeStep must be equal with "
+            "LocalTimeStepping off.");
+      }
+      *time_step = (time_runs_forward ? 1 : -1) * initial_slab.duration();
+    } else {
+      *time_step = choose_lts_step_size(initial_time, initial_dt_value);
+    }
   }
 };
 

--- a/src/Evolution/Initialization/Tags.hpp
+++ b/src/Evolution/Initialization/Tags.hpp
@@ -3,13 +3,12 @@
 
 #pragma once
 
-#include <cmath>
 #include <string>
 
 #include "DataStructures/DataBox/Tag.hpp"
-#include "DataStructures/TaggedTuple.hpp"
 #include "Time/OptionTags/InitialSlabSize.hpp"
 #include "Time/OptionTags/InitialTimeStep.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace Initialization {
@@ -22,29 +21,23 @@ struct InitialTimeDelta : db::SimpleTag {
 
   static constexpr bool pass_metavariables = false;
   static double create_from_options(const double initial_time_step) {
+    if (initial_time_step == 0.0) {
+      ERROR_NO_TRACE("InitialTimeStep must be nonzero");
+    }
     return initial_time_step;
   }
 };
 
-template <bool UsingLocalTimeStepping>
 struct InitialSlabSize : db::SimpleTag {
   using type = double;
   using option_tags = tmpl::list<OptionTags::InitialSlabSize>;
 
   static constexpr bool pass_metavariables = false;
   static double create_from_options(const double initial_slab_size) {
+    if (initial_slab_size == 0.0) {
+      ERROR_NO_TRACE("InitialSlabSize must be nonzero");
+    }
     return initial_slab_size;
-  }
-};
-
-template <>
-struct InitialSlabSize<false> : db::SimpleTag {
-  using type = double;
-  using option_tags = tmpl::list<OptionTags::InitialTimeStep>;
-
-  static constexpr bool pass_metavariables = false;
-  static double create_from_options(const double initial_time_step) {
-    return std::abs(initial_time_step);
   }
 };
 }  // namespace Tags

--- a/src/Evolution/Systems/Burgers/Instantiations/TimeStepping.cpp
+++ b/src/Evolution/Systems/Burgers/Instantiations/TimeStepping.cpp
@@ -10,5 +10,4 @@
 template class ChangeTimeStepperOrder<Burgers::System>;
 template class CleanHistory<Burgers::System>;
 template class RecordTimeStepperData<Burgers::System>;
-template class UpdateU<Burgers::System, false>;
-template class UpdateU<Burgers::System, true>;
+template class UpdateU<Burgers::System>;

--- a/src/Evolution/Systems/Cce/Actions/InitializeCharacteristicEvolutionTime.hpp
+++ b/src/Evolution/Systems/Cce/Actions/InitializeCharacteristicEvolutionTime.hpp
@@ -11,6 +11,7 @@
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/TaggedTuple.hpp"
 #include "DataStructures/VariablesTag.hpp"
+#include "Evolution/Initialization/Evolution.hpp"
 #include "Evolution/Initialization/Tags.hpp"
 #include "Evolution/Systems/Cce/OptionTags.hpp"
 #include "Parallel/AlgorithmExecution.hpp"
@@ -68,11 +69,10 @@ namespace Actions {
  * ```
  * - Removes: nothing
  */
-template <typename EvolvedCoordinatesVariablesTag, typename EvolvedSwshTag,
-          bool local_time_stepping>
+template <typename EvolvedCoordinatesVariablesTag, typename EvolvedSwshTag>
 struct InitializeCharacteristicEvolutionTime {
   using simple_tags_from_options =
-      tmpl::list<Initialization::Tags::InitialSlabSize<local_time_stepping>,
+      tmpl::list<Initialization::Tags::InitialSlabSize,
                  ::Initialization::Tags::InitialTimeDelta>;
 
   using const_global_cache_tags = tmpl::list<
@@ -99,28 +99,21 @@ struct InitializeCharacteristicEvolutionTime {
       const Parallel::GlobalCache<Metavariables>& /*cache*/,
       const ArrayIndex& /*array_index*/, const ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) {
-    const double initial_time_value = db::get<Tags::StartTime>(box);
-    const double slab_size =
-        db::get<::Initialization::Tags::InitialSlabSize<local_time_stepping>>(
-            box);
-
-    const Slab single_step_slab{initial_time_value,
-                                initial_time_value + slab_size};
-    const Time initial_time = single_step_slab.start();
-    TimeDelta initial_time_step;
-    const double initial_time_delta =
-        db::get<Initialization::Tags::InitialTimeDelta>(box);
-    if constexpr (local_time_stepping) {
-      initial_time_step =
-          choose_lts_step_size(initial_time, initial_time_delta);
-    } else {
-      (void)initial_time_delta;
-      initial_time_step = initial_time.slab().duration();
-    }
-
     const auto& time_stepper =
         db::get<Tags::CceEvolutionPrefix<::Tags::TimeStepper<TimeStepper>>>(
             box);
+    const double initial_time_value = db::get<Tags::StartTime>(box);
+
+    double unused_slab_size_goal{};
+    db::mutate_apply<
+        tmpl::list<::Tags::Next<::Tags::TimeStepId>, ::Tags::TimeStep>,
+        tmpl::list<>>(
+        Initialization::TimeStepping<Metavariables, TimeStepper, false, true>{},
+        make_not_null(&box), make_not_null(&unused_slab_size_goal),
+        initial_time_value,
+        db::get<::Initialization::Tags::InitialTimeDelta>(box),
+        db::get<::Initialization::Tags::InitialSlabSize>(box), time_stepper,
+        LtsMode::Conservative);
 
     const size_t starting_order =
         visit(
@@ -142,16 +135,11 @@ struct InitializeCharacteristicEvolutionTime {
     typename ::Tags::HistoryEvolvedVariables<evolved_swsh_variables_tag>::type
         swsh_history(starting_order);
     Initialization::mutate_assign<tmpl::list<
-        ::Tags::TimeStepId, ::Tags::Next<::Tags::TimeStepId>, ::Tags::TimeStep,
-        ::Tags::Time,
+        ::Tags::TimeStepId, ::Tags::Time,
         ::Tags::HistoryEvolvedVariables<EvolvedCoordinatesVariablesTag>,
         ::Tags::HistoryEvolvedVariables<evolved_swsh_variables_tag>>>(
-        make_not_null(&box), TimeStepId{},
-        TimeStepId{true,
-                   -static_cast<int64_t>(time_stepper.number_of_past_steps()),
-                   initial_time},
-        initial_time_step, initial_time_value, std::move(coordinate_history),
-        std::move(swsh_history));
+        make_not_null(&box), TimeStepId{}, initial_time_value,
+        std::move(coordinate_history), std::move(swsh_history));
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }
 };

--- a/src/Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp
+++ b/src/Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp
@@ -111,8 +111,7 @@ struct CharacteristicEvolution {
       Actions::InitializeCharacteristicEvolutionVariables<Metavariables>,
       Actions::InitializeCharacteristicEvolutionTime<
           typename Metavariables::evolved_coordinates_variables_tag,
-          typename Metavariables::evolved_swsh_tags,
-          Metavariables::local_time_stepping>,
+          typename Metavariables::evolved_swsh_tags>,
       Actions::InitializeCharacteristicEvolutionScri<
           typename Metavariables::scri_values_to_observe,
           typename Metavariables::cce_boundary_component>,

--- a/src/Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp
+++ b/src/Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp
@@ -224,13 +224,10 @@ struct CharacteristicEvolution {
       Actions::FilterSwshVolumeQuantity<Tags::BondiH>,
       tmpl::conditional_t<
           evolve_ccm, tmpl::list<>,
-          tmpl::flatten<tmpl::list<
-              std::conditional_t<Metavariables::local_time_stepping,
-                                 evolution::Actions::RunEventsAndTriggers<
-                                     Triggers::WhenToCheck::AtSteps>,
-                                 tmpl::list<>>,
-              evolution::Actions::RunEventsAndTriggers<
-                  Triggers::WhenToCheck::AtSlabs>>>>,
+          tmpl::flatten<tmpl::list<evolution::Actions::RunEventsAndTriggers<
+                                       Triggers::WhenToCheck::AtSteps>,
+                                   evolution::Actions::RunEventsAndTriggers<
+                                       Triggers::WhenToCheck::AtSlabs>>>>,
       compute_scri_quantities_and_observe,
       ::Actions::MutateApply<ChangeStepSize<
           typename Metavariables::cce_step_choosers, Tags::CceEvolutionPrefix>>,

--- a/src/Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp
+++ b/src/Evolution/Systems/Cce/Components/CharacteristicEvolution.hpp
@@ -197,9 +197,7 @@ struct CharacteristicEvolution {
                       tmpl::bind<::Actions::MutateApply,
                                  tmpl::bind<CalculateScriPlusValue, tmpl::_1>>>,
       ::Actions::MutateApply<RecordTimeStepperData<cce_system>>,
-      ::Actions::MutateApply<
-          UpdateU<cce_system, Metavariables::local_time_stepping,
-                  Tags::CceEvolutionPrefix>>,
+      ::Actions::MutateApply<UpdateU<cce_system, Tags::CceEvolutionPrefix>>,
       ::Actions::MutateApply<
           CleanHistory<cce_system, Tags::CceEvolutionPrefix>>>;
 
@@ -237,9 +235,7 @@ struct CharacteristicEvolution {
       ::Actions::MutateApply<ChangeStepSize<
           typename Metavariables::cce_step_choosers, Tags::CceEvolutionPrefix>>,
       ::Actions::MutateApply<RecordTimeStepperData<cce_system>>,
-      ::Actions::MutateApply<
-          UpdateU<cce_system, Metavariables::local_time_stepping,
-                  Tags::CceEvolutionPrefix>>,
+      ::Actions::MutateApply<UpdateU<cce_system, Tags::CceEvolutionPrefix>>,
       ::Actions::MutateApply<
           ChangeTimeStepperOrder<cce_system, Tags::CceEvolutionPrefix>>,
       ::Actions::MutateApply<

--- a/src/Evolution/Systems/Cce/Components/KleinGordonCharacteristicEvolution.hpp
+++ b/src/Evolution/Systems/Cce/Components/KleinGordonCharacteristicEvolution.hpp
@@ -121,9 +121,7 @@ struct KleinGordonCharacteristicEvolution
                       tmpl::bind<::Actions::MutateApply,
                                  tmpl::bind<CalculateScriPlusValue, tmpl::_1>>>,
       ::Actions::MutateApply<RecordTimeStepperData<cce_system>>,
-      ::Actions::MutateApply<
-          UpdateU<cce_system, Metavariables::local_time_stepping,
-                  Tags::CceEvolutionPrefix>>>;
+      ::Actions::MutateApply<UpdateU<cce_system, Tags::CceEvolutionPrefix>>>;
 
   using extract_action_list = tmpl::list<
       Actions::RequestBoundaryData<
@@ -170,9 +168,7 @@ struct KleinGordonCharacteristicEvolution
       ::Actions::MutateApply<ChangeStepSize<
           typename Metavariables::cce_step_choosers, Tags::CceEvolutionPrefix>>,
       ::Actions::MutateApply<RecordTimeStepperData<cce_system>>,
-      ::Actions::MutateApply<
-          UpdateU<cce_system, Metavariables::local_time_stepping,
-                  Tags::CceEvolutionPrefix>>,
+      ::Actions::MutateApply<UpdateU<cce_system, Tags::CceEvolutionPrefix>>,
       ::Actions::MutateApply<
           ChangeTimeStepperOrder<cce_system, Tags::CceEvolutionPrefix>>,
       ::Actions::MutateApply<

--- a/src/Evolution/Systems/Cce/Components/KleinGordonCharacteristicEvolution.hpp
+++ b/src/Evolution/Systems/Cce/Components/KleinGordonCharacteristicEvolution.hpp
@@ -130,13 +130,10 @@ struct KleinGordonCharacteristicEvolution
       ::Actions::Label<CceEvolutionLabelTag>,
       tmpl::conditional_t<
           evolve_ccm, tmpl::list<>,
-          tmpl::flatten<tmpl::list<
-              std::conditional_t<Metavariables::local_time_stepping,
-                                 evolution::Actions::RunEventsAndTriggers<
-                                     Triggers::WhenToCheck::AtSteps>,
-                                 tmpl::list<>>,
-              evolution::Actions::RunEventsAndTriggers<
-                  Triggers::WhenToCheck::AtSlabs>>>>,
+          tmpl::flatten<tmpl::list<evolution::Actions::RunEventsAndTriggers<
+                                       Triggers::WhenToCheck::AtSteps>,
+                                   evolution::Actions::RunEventsAndTriggers<
+                                       Triggers::WhenToCheck::AtSlabs>>>>,
       Actions::ReceiveWorldtubeData<
           Metavariables,
           typename Metavariables::cce_boundary_communication_tags>,

--- a/src/Evolution/Systems/Cce/Instantiations/TimeStepping.cpp
+++ b/src/Evolution/Systems/Cce/Instantiations/TimeStepping.cpp
@@ -12,26 +12,22 @@
 
 #define EVOLVE_CCM(data) BOOST_PP_TUPLE_ELEM(0, data)
 
-#define INSTANTIATION(r, data)                                            \
-  template class ChangeTimeStepperOrder<                                  \
-      Cce::KleinGordonSystem<EVOLVE_CCM(data)>,                           \
-      Cce::Tags::CceEvolutionPrefix>;                                     \
-  template class CleanHistory<Cce::KleinGordonSystem<EVOLVE_CCM(data)>,   \
-                              Cce::Tags::CceEvolutionPrefix>;             \
-  template class RecordTimeStepperData<                                   \
-      Cce::KleinGordonSystem<EVOLVE_CCM(data)>>;                          \
-  template class UpdateU<Cce::KleinGordonSystem<EVOLVE_CCM(data)>, false, \
-                         Cce::Tags::CceEvolutionPrefix>;                  \
-  template class UpdateU<Cce::KleinGordonSystem<EVOLVE_CCM(data)>, true,  \
-                         Cce::Tags::CceEvolutionPrefix>;                  \
-  template class ChangeTimeStepperOrder<Cce::System<EVOLVE_CCM(data)>,    \
-                                        Cce::Tags::CceEvolutionPrefix>;   \
-  template class CleanHistory<Cce::System<EVOLVE_CCM(data)>,              \
-                              Cce::Tags::CceEvolutionPrefix>;             \
-  template class RecordTimeStepperData<Cce::System<EVOLVE_CCM(data)>>;    \
-  template class UpdateU<Cce::System<EVOLVE_CCM(data)>, false,            \
-                         Cce::Tags::CceEvolutionPrefix>;                  \
-  template class UpdateU<Cce::System<EVOLVE_CCM(data)>, true,             \
+#define INSTANTIATION(r, data)                                          \
+  template class ChangeTimeStepperOrder<                                \
+      Cce::KleinGordonSystem<EVOLVE_CCM(data)>,                         \
+      Cce::Tags::CceEvolutionPrefix>;                                   \
+  template class CleanHistory<Cce::KleinGordonSystem<EVOLVE_CCM(data)>, \
+                              Cce::Tags::CceEvolutionPrefix>;           \
+  template class RecordTimeStepperData<                                 \
+      Cce::KleinGordonSystem<EVOLVE_CCM(data)>>;                        \
+  template class UpdateU<Cce::KleinGordonSystem<EVOLVE_CCM(data)>,      \
+                         Cce::Tags::CceEvolutionPrefix>;                \
+  template class ChangeTimeStepperOrder<Cce::System<EVOLVE_CCM(data)>,  \
+                                        Cce::Tags::CceEvolutionPrefix>; \
+  template class CleanHistory<Cce::System<EVOLVE_CCM(data)>,            \
+                              Cce::Tags::CceEvolutionPrefix>;           \
+  template class RecordTimeStepperData<Cce::System<EVOLVE_CCM(data)>>;  \
+  template class UpdateU<Cce::System<EVOLVE_CCM(data)>,                 \
                          Cce::Tags::CceEvolutionPrefix>;
 
 GENERATE_INSTANTIATIONS(INSTANTIATION, (false, true))

--- a/src/Evolution/Systems/CurvedScalarWave/Instantiations/TimeStepping.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Instantiations/TimeStepping.cpp
@@ -14,8 +14,7 @@
   template class ChangeTimeStepperOrder<CurvedScalarWave::System<DIM(data)>>; \
   template class CleanHistory<CurvedScalarWave::System<DIM(data)>>;           \
   template class RecordTimeStepperData<CurvedScalarWave::System<DIM(data)>>;  \
-  template class UpdateU<CurvedScalarWave::System<DIM(data)>, false>;         \
-  template class UpdateU<CurvedScalarWave::System<DIM(data)>, true>;
+  template class UpdateU<CurvedScalarWave::System<DIM(data)>>;
 
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/Instantiations/TimeStepping.cpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/Instantiations/TimeStepping.cpp
@@ -16,9 +16,7 @@
   template class CleanHistory<CurvedScalarWave::Worldtube::System<DIM(data)>>; \
   template class RecordTimeStepperData<                                        \
       CurvedScalarWave::Worldtube::System<DIM(data)>>;                         \
-  template class UpdateU<CurvedScalarWave::Worldtube::System<DIM(data)>,       \
-                         false>;                                               \
-  template class UpdateU<CurvedScalarWave::Worldtube::System<DIM(data)>, true>;
+  template class UpdateU<CurvedScalarWave::Worldtube::System<DIM(data)>>;
 
 GENERATE_INSTANTIATIONS(INSTANTIATION, (3))
 

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonChare.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonChare.hpp
@@ -76,8 +76,8 @@ struct WorldtubeSingleton {
 
   using initialization_actions = tmpl::list<
       ::Initialization::Actions::InitializeItems<
-          ::Initialization::TimeStepping<Metavariables, TimeStepperBase, false,
-                                         local_time_stepping>,
+          ::Initialization::TimeStepping<Metavariables, TimeStepper, false,
+                                         false>,
           Initialization::InitializeEvolvedVariables,
           Initialization::InitializeElementFacesGridCoordinates<Dim>>,
       ::Initialization::Actions::AddComputeTags<

--- a/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonChare.hpp
+++ b/src/Evolution/Systems/CurvedScalarWave/Worldtube/SingletonChare.hpp
@@ -94,7 +94,7 @@ struct WorldtubeSingleton {
       Actions::SendAccelerationTerms<Metavariables>,
       ::Actions::MutateApply<UpdateAcceleration>,
       ::Actions::MutateApply<RecordTimeStepperData<worldtube_system>>,
-      ::Actions::MutateApply<UpdateU<worldtube_system, local_time_stepping>>,
+      ::Actions::MutateApply<UpdateU<worldtube_system>>,
       ::Actions::MutateApply<CleanHistory<worldtube_system>>,
       Actions::SendToElements<Metavariables>,
       domain::Actions::CheckFunctionsOfTimeAreReady<Dim>>;

--- a/src/Evolution/Systems/ForceFree/Instantiations/TimeStepping.cpp
+++ b/src/Evolution/Systems/ForceFree/Instantiations/TimeStepping.cpp
@@ -10,5 +10,4 @@
 template class ChangeTimeStepperOrder<ForceFree::System>;
 template class CleanHistory<ForceFree::System>;
 template class RecordTimeStepperData<ForceFree::System>;
-template class UpdateU<ForceFree::System, false>;
-template class UpdateU<ForceFree::System, true>;
+template class UpdateU<ForceFree::System>;

--- a/src/Evolution/Systems/GeneralizedHarmonic/Instantiations/TimeStepping.cpp
+++ b/src/Evolution/Systems/GeneralizedHarmonic/Instantiations/TimeStepping.cpp
@@ -14,8 +14,7 @@
   template class ChangeTimeStepperOrder<gh::System<DIM(data)>>; \
   template class CleanHistory<gh::System<DIM(data)>>;           \
   template class RecordTimeStepperData<gh::System<DIM(data)>>;  \
-  template class UpdateU<gh::System<DIM(data)>, false>;         \
-  template class UpdateU<gh::System<DIM(data)>, true>;
+  template class UpdateU<gh::System<DIM(data)>>;
 
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Instantiations/TimeStepping.cpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Instantiations/TimeStepping.cpp
@@ -11,17 +11,14 @@
 
 #define NEUTRINO(data) BOOST_PP_TUPLE_ELEM(0, data)
 
-#define INSTANTIATION(_, data)                                              \
-  template class ChangeTimeStepperOrder<                                    \
-      grmhd::GhValenciaDivClean::System<NEUTRINO(data)>>;                   \
-  template class CleanHistory<                                              \
-      grmhd::GhValenciaDivClean::System<NEUTRINO(data)>>;                   \
-  template class RecordTimeStepperData<                                     \
-      grmhd::GhValenciaDivClean::System<NEUTRINO(data)>>;                   \
-  template class UpdateU<grmhd::GhValenciaDivClean::System<NEUTRINO(data)>, \
-                         false>;                                            \
-  template class UpdateU<grmhd::GhValenciaDivClean::System<NEUTRINO(data)>, \
-                         true>;
+#define INSTANTIATION(_, data)                            \
+  template class ChangeTimeStepperOrder<                  \
+      grmhd::GhValenciaDivClean::System<NEUTRINO(data)>>; \
+  template class CleanHistory<                            \
+      grmhd::GhValenciaDivClean::System<NEUTRINO(data)>>; \
+  template class RecordTimeStepperData<                   \
+      grmhd::GhValenciaDivClean::System<NEUTRINO(data)>>; \
+  template class UpdateU<grmhd::GhValenciaDivClean::System<NEUTRINO(data)>>;
 
 GENERATE_INSTANTIATIONS(INSTANTIATION,
                         (RadiationTransport::NoNeutrinos::System))

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Instantiations/TimeStepping.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Instantiations/TimeStepping.cpp
@@ -10,5 +10,4 @@
 template class ChangeTimeStepperOrder<grmhd::ValenciaDivClean::System>;
 template class CleanHistory<grmhd::ValenciaDivClean::System>;
 template class RecordTimeStepperData<grmhd::ValenciaDivClean::System>;
-template class UpdateU<grmhd::ValenciaDivClean::System, false>;
-template class UpdateU<grmhd::ValenciaDivClean::System, true>;
+template class UpdateU<grmhd::ValenciaDivClean::System>;

--- a/src/Evolution/Systems/NewtonianEuler/Instantiations/TimeStepping.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/Instantiations/TimeStepping.cpp
@@ -14,8 +14,7 @@
   template class ChangeTimeStepperOrder<NewtonianEuler::System<DIM(data)>>; \
   template class CleanHistory<NewtonianEuler::System<DIM(data)>>;           \
   template class RecordTimeStepperData<NewtonianEuler::System<DIM(data)>>;  \
-  template class UpdateU<NewtonianEuler::System<DIM(data)>, false>;         \
-  template class UpdateU<NewtonianEuler::System<DIM(data)>, true>;
+  template class UpdateU<NewtonianEuler::System<DIM(data)>>;
 
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 

--- a/src/Evolution/Systems/RadiationTransport/M1Grey/Instantiations/TimeStepping.cpp
+++ b/src/Evolution/Systems/RadiationTransport/M1Grey/Instantiations/TimeStepping.cpp
@@ -16,8 +16,4 @@ template class CleanHistory<RadiationTransport::M1Grey::System<
 template class RecordTimeStepperData<RadiationTransport::M1Grey::System<
     tmpl::list<neutrinos::ElectronNeutrinos<1>>>>;
 template class UpdateU<RadiationTransport::M1Grey::System<
-                           tmpl::list<neutrinos::ElectronNeutrinos<1>>>,
-                       false>;
-template class UpdateU<RadiationTransport::M1Grey::System<
-                           tmpl::list<neutrinos::ElectronNeutrinos<1>>>,
-                       true>;
+    tmpl::list<neutrinos::ElectronNeutrinos<1>>>>;

--- a/src/Evolution/Systems/ScalarAdvection/Instantiations/TimeStepping.cpp
+++ b/src/Evolution/Systems/ScalarAdvection/Instantiations/TimeStepping.cpp
@@ -14,8 +14,7 @@
   template class ChangeTimeStepperOrder<ScalarAdvection::System<DIM(data)>>; \
   template class CleanHistory<ScalarAdvection::System<DIM(data)>>;           \
   template class RecordTimeStepperData<ScalarAdvection::System<DIM(data)>>;  \
-  template class UpdateU<ScalarAdvection::System<DIM(data)>, false>;         \
-  template class UpdateU<ScalarAdvection::System<DIM(data)>, true>;
+  template class UpdateU<ScalarAdvection::System<DIM(data)>>;
 
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 

--- a/src/Evolution/Systems/ScalarTensor/Instantiations/TimeStepping.cpp
+++ b/src/Evolution/Systems/ScalarTensor/Instantiations/TimeStepping.cpp
@@ -10,5 +10,4 @@
 template class ChangeTimeStepperOrder<ScalarTensor::System>;
 template class CleanHistory<ScalarTensor::System>;
 template class RecordTimeStepperData<ScalarTensor::System>;
-template class UpdateU<ScalarTensor::System, false>;
-template class UpdateU<ScalarTensor::System, true>;
+template class UpdateU<ScalarTensor::System>;

--- a/src/Evolution/Systems/ScalarWave/Instantiations/TimeStepping.cpp
+++ b/src/Evolution/Systems/ScalarWave/Instantiations/TimeStepping.cpp
@@ -14,8 +14,7 @@
   template class ChangeTimeStepperOrder<ScalarWave::System<DIM(data)>>; \
   template class CleanHistory<ScalarWave::System<DIM(data)>>;           \
   template class RecordTimeStepperData<ScalarWave::System<DIM(data)>>;  \
-  template class UpdateU<ScalarWave::System<DIM(data)>, false>;         \
-  template class UpdateU<ScalarWave::System<DIM(data)>, true>;
+  template class UpdateU<ScalarWave::System<DIM(data)>>;
 
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
 

--- a/src/Executables/ExportCoordinates/ExportCoordinates.hpp
+++ b/src/Executables/ExportCoordinates/ExportCoordinates.hpp
@@ -339,9 +339,8 @@ struct Metavariables {
               Parallel::Phase::Initialization,
               tmpl::list<
                   Initialization::Actions::InitializeItems<
-                      Initialization::TimeStepping<Metavariables,
-                                                   TimeStepperBase, false,
-                                                   local_time_stepping>,
+                      Initialization::TimeStepping<Metavariables, TimeStepper,
+                                                   false, false>,
                       evolution::dg::Initialization::Domain<Metavariables>,
                       ::amr::Initialization::Initialize<volume_dim,
                                                         Metavariables>,

--- a/src/Executables/ExportCoordinates/ExportCoordinates.hpp
+++ b/src/Executables/ExportCoordinates/ExportCoordinates.hpp
@@ -366,17 +366,15 @@ struct Metavariables {
                                             Parallel::Actions::TerminatePhase>>,
           Parallel::PhaseActions<
               Parallel::Phase::Execute,
-              tmpl::flatten<tmpl::list<
-                  Actions::MutateApply<AdvanceTime<>>,
-                  Actions::ExportCoordinates<Dim>,
-                  Actions::FindGlobalMinimumGridSpacing,
-                  std::conditional_t<local_time_stepping,
-                                     evolution::Actions::RunEventsAndTriggers<
-                                         Triggers::WhenToCheck::AtSteps>,
-                                     tmpl::list<>>,
-                  evolution::Actions::RunEventsAndTriggers<
-                      Triggers::WhenToCheck::AtSlabs>,
-                  PhaseControl::Actions::ExecutePhaseChange>>>>>;
+              tmpl::flatten<
+                  tmpl::list<Actions::MutateApply<AdvanceTime<>>,
+                             Actions::ExportCoordinates<Dim>,
+                             Actions::FindGlobalMinimumGridSpacing,
+                             evolution::Actions::RunEventsAndTriggers<
+                                 Triggers::WhenToCheck::AtSteps>,
+                             evolution::Actions::RunEventsAndTriggers<
+                                 Triggers::WhenToCheck::AtSlabs>,
+                             PhaseControl::Actions::ExecutePhaseChange>>>>>;
 
   struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
     using element_array = dg_element_array;

--- a/src/Executables/ExportCoordinates/ExportCoordinates.hpp
+++ b/src/Executables/ExportCoordinates/ExportCoordinates.hpp
@@ -378,17 +378,17 @@ struct Metavariables {
 
   struct amr : tt::ConformsTo<::amr::protocols::AmrMetavariables> {
     using element_array = dg_element_array;
-    using projectors = tmpl::list<
-        Initialization::ProjectTimeStepping<volume_dim>,
-        evolution::dg::Initialization::ProjectDomain<volume_dim>,
-        ::amr::projectors::DefaultInitialize<
-            Initialization::Tags::InitialTimeDelta,
-            Initialization::Tags::InitialSlabSize<local_time_stepping>,
-            ::domain::Tags::InitialExtents<Dim>,
-            ::domain::Tags::InitialRefinementLevels<Dim>,
-            evolution::dg::Tags::Quadrature>,
-        ::amr::projectors::CopyFromCreatorOrLeaveAsIs<
-            Tags::StepperErrorEstimatesEnabled>>;
+    using projectors =
+        tmpl::list<Initialization::ProjectTimeStepping<volume_dim>,
+                   evolution::dg::Initialization::ProjectDomain<volume_dim>,
+                   ::amr::projectors::DefaultInitialize<
+                       Initialization::Tags::InitialTimeDelta,
+                       Initialization::Tags::InitialSlabSize,
+                       ::domain::Tags::InitialExtents<Dim>,
+                       ::domain::Tags::InitialRefinementLevels<Dim>,
+                       evolution::dg::Tags::Quadrature>,
+                   ::amr::projectors::CopyFromCreatorOrLeaveAsIs<
+                       Tags::StepperErrorEstimatesEnabled>>;
     static constexpr bool keep_coarse_grids = false;
     static constexpr bool p_refine_only_in_event = false;
   };

--- a/src/Executables/ExportCoordinates/ExportCoordinates.hpp
+++ b/src/Executables/ExportCoordinates/ExportCoordinates.hpp
@@ -51,6 +51,7 @@
 #include "Parallel/Reduction.hpp"
 #include "Parallel/TypeTraits.hpp"
 #include "ParallelAlgorithms/Actions/AddComputeTags.hpp"
+#include "ParallelAlgorithms/Actions/AddSimpleTags.hpp"
 #include "ParallelAlgorithms/Actions/InitializeItems.hpp"
 #include "ParallelAlgorithms/Actions/MemoryMonitor/ContributeMemoryData.hpp"
 #include "ParallelAlgorithms/Actions/MutateApply.hpp"
@@ -66,6 +67,7 @@
 #include "ParallelAlgorithms/Amr/Criteria/Tags/Criteria.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/TruncationError.hpp"
 #include "ParallelAlgorithms/Amr/Criteria/Type.hpp"
+#include "ParallelAlgorithms/Amr/Projectors/CopyFromCreatorOrLeaveAsIs.hpp"
 #include "ParallelAlgorithms/Amr/Projectors/DefaultInitialize.hpp"
 #include "ParallelAlgorithms/Amr/Protocols/AmrMetavariables.hpp"
 #include "ParallelAlgorithms/Events/Completion.hpp"
@@ -75,7 +77,7 @@
 #include "ParallelAlgorithms/EventsAndTriggers/LogicalTriggers.hpp"
 #include "ParallelAlgorithms/EventsAndTriggers/Trigger.hpp"
 #include "Time/AdvanceTime.hpp"
-#include "Time/Tags/StepperErrorTolerancesCompute.hpp"
+#include "Time/NoStepperErrorEstimates.hpp"
 #include "Time/TimeSteppers/Factory.hpp"
 #include "Time/TimeSteppers/TimeStepper.hpp"
 #include "Time/Triggers/SlabCompares.hpp"
@@ -344,11 +346,12 @@ struct Metavariables {
                       ::amr::Initialization::Initialize<volume_dim,
                                                         Metavariables>,
                       Initialization::SetMeshType<Dim>>,
+                  Initialization::Actions::AddSimpleTags<
+                      NoStepperErrorEstimates>,
                   Initialization::Actions::AddComputeTags<tmpl::list<
                       ::domain::Tags::MinimumGridSpacingCompute<
                           Dim, Frame::Inertial>,
-                      ::domain::Tags::FlatLogicalMetricCompute<Dim>,
-                      ::Tags::StepperErrorEstimatesEnabledCompute<false>>>,
+                      ::domain::Tags::FlatLogicalMetricCompute<Dim>>>,
                   Parallel::Actions::TerminatePhase>>,
           Parallel::PhaseActions<
               Parallel::Phase::Register,
@@ -385,7 +388,9 @@ struct Metavariables {
             Initialization::Tags::InitialSlabSize<local_time_stepping>,
             ::domain::Tags::InitialExtents<Dim>,
             ::domain::Tags::InitialRefinementLevels<Dim>,
-            evolution::dg::Tags::Quadrature>>;
+            evolution::dg::Tags::Quadrature>,
+        ::amr::projectors::CopyFromCreatorOrLeaveAsIs<
+            Tags::StepperErrorEstimatesEnabled>>;
     static constexpr bool keep_coarse_grids = false;
     static constexpr bool p_refine_only_in_event = false;
   };

--- a/src/Time/CMakeLists.txt
+++ b/src/Time/CMakeLists.txt
@@ -49,6 +49,7 @@ spectre_target_headers(
   History.hpp
   LargestStepperError.hpp
   LtsMode.hpp
+  NoStepperErrorEstimates.hpp
   RecordTimeStepperData.hpp
   RecordTimeStepperData.tpp
   RequestsStepperErrorTolerances.hpp

--- a/src/Time/NoStepperErrorEstimates.hpp
+++ b/src/Time/NoStepperErrorEstimates.hpp
@@ -1,0 +1,18 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "DataStructures/DataBox/Protocols/Mutator.hpp"
+#include "Time/Tags/StepperErrorEstimatesEnabled.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// Initialization mutator disabling error estimates for executables
+/// with non-standard time-stepping.
+struct NoStepperErrorEstimates : tt::ConformsTo<db::protocols::Mutator> {
+  using return_tags = tmpl::list<::Tags::StepperErrorEstimatesEnabled>;
+  using argument_tags = tmpl::list<>;
+  static void apply(const gsl::not_null<bool*> needed) { *needed = false; }
+};

--- a/src/Time/OptionTags/InitialSlabSize.hpp
+++ b/src/Time/OptionTags/InitialSlabSize.hpp
@@ -13,7 +13,6 @@ namespace OptionTags {
 struct InitialSlabSize {
   using type = double;
   static constexpr Options::String help = "The initial slab size";
-  static type lower_bound() { return 0.; }
   using group = evolution::OptionTags::Group;
 };
 }  // namespace OptionTags

--- a/src/Time/Tags/LtsMode.hpp
+++ b/src/Time/Tags/LtsMode.hpp
@@ -5,6 +5,7 @@
 
 #include "DataStructures/DataBox/Tag.hpp"
 #include "Time/LtsMode.hpp"
+#include "Time/OptionTags/LocalTimeStepping.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -15,16 +16,10 @@ namespace Tags {
 struct LtsMode : db::SimpleTag {
   using type = ::LtsMode;
 
-  static constexpr bool pass_metavariables = true;
+  static constexpr bool pass_metavariables = false;
+  using option_tags = tmpl::list<::OptionTags::LocalTimeStepping>;
 
-  template <typename Metavars>
-  using option_tags = tmpl::list<>;
-
-  template <typename Metavars>
-  static type create_from_options() {
-    return Metavars::local_time_stepping ? ::LtsMode::Conservative
-                                         : ::LtsMode::Off;
-  }
+  static type create_from_options(const type lts_mode) { return lts_mode; }
 };
 
 /// \ingroup DataBoxTagsGroup
@@ -35,14 +30,10 @@ template <::LtsMode Mode>
 struct LtsModeForced : LtsMode {
   using base = LtsMode;
 
-  template <typename Metavars>
-  static type create_from_options() {
+  static type create_from_options(const type lts_mode) {
     // Check consistency rather than just returning the forced mode so
     // that other tag creation functions can rely on the parsed value
     // being correct.
-    const auto lts_mode = Metavars::local_time_stepping
-                              ? ::LtsMode::Conservative
-                              : ::LtsMode::Off;
     if (lts_mode != Mode) {
       ERROR_NO_TRACE(
           "This executable only supports LocalTimeStepping: " << Mode);

--- a/src/Time/Tags/StepperErrorTolerancesCompute.cpp
+++ b/src/Time/Tags/StepperErrorTolerancesCompute.cpp
@@ -21,7 +21,7 @@
 
 namespace Tags {
 namespace StepperErrorEstimatesEnabledCompute_detail {
-void lts_function(
+void function(
     const gsl::not_null<bool*> error_estimates_enabled,
     const ::EventsAndTriggers& events_and_triggers,
     const std::vector<std::unique_ptr<::StepChooser<StepChooserUse::LtsStep>>>&
@@ -53,30 +53,10 @@ void lts_function(
     }
   }
 }
-
-void gts_function(const gsl::not_null<bool*> error_estimates_enabled,
-                  const ::EventsAndTriggers& events_and_triggers) {
-  // In principle the slab size could be changed based on a dense
-  // trigger, but it's not clear that there is ever a good reason to
-  // do so, and it wouldn't make sense to use error control in that
-  // context in any case.
-  *error_estimates_enabled = false;
-  events_and_triggers.for_each_event([&](const auto& event) {
-    if (*error_estimates_enabled) {
-      return;
-    }
-
-    std::unordered_map<std::type_index, ::StepperErrorTolerances> tolerances{};
-    collect_stepper_error_tolerances(&tolerances, event);
-    if (not tolerances.empty()) {
-      *error_estimates_enabled = true;
-    }
-  });
-}
 }  // namespace StepperErrorEstimatesEnabledCompute_detail
 
 namespace StepperErrorTolerancesCompute_detail {
-void lts_impl(
+void function(
     const gsl::not_null<::StepperErrorTolerances*> tolerances,
     const ::EventsAndTriggers& events_and_triggers,
     const std::vector<std::unique_ptr<::StepChooser<StepChooserUse::LtsStep>>>&
@@ -87,6 +67,10 @@ void lts_impl(
   std::unordered_map<std::type_index, ::StepperErrorTolerances>
       all_tolerances{};
 
+  // In principle the slab size could be changed based on a dense
+  // trigger, but it's not clear that there is ever a good reason to
+  // do so, and it wouldn't make sense to use error control in that
+  // context in any case.
   events_and_triggers.for_each_event([&](const auto& event) {
     collect_stepper_error_tolerances(&all_tolerances, event);
   });
@@ -111,27 +95,6 @@ void lts_impl(
           time_stepper.order())) {
     tolerances->estimates = std::max(
         tolerances->estimates, variable_order_algorithm.required_estimates());
-  }
-}
-
-void gts_impl(const gsl::not_null<::StepperErrorTolerances*> tolerances,
-              const ::EventsAndTriggers& events_and_triggers,
-              const std::type_index& tag_type) {
-  std::unordered_map<std::type_index, ::StepperErrorTolerances>
-      all_tolerances{};
-  // In principle the slab size could be changed based on a dense
-  // trigger, but it's not clear that there is ever a good reason to
-  // do so, and it wouldn't make sense to use error control in that
-  // context in any case.
-  events_and_triggers.for_each_event([&](const auto& event) {
-    collect_stepper_error_tolerances(&all_tolerances, event);
-  });
-
-  if (const auto this_tolerance = all_tolerances.find(tag_type);
-      this_tolerance != all_tolerances.end()) {
-    *tolerances = this_tolerance->second;
-  } else {
-    *tolerances = ::StepperErrorTolerances{};
   }
 }
 }  // namespace StepperErrorTolerancesCompute_detail

--- a/src/Time/Tags/StepperErrorTolerancesCompute.hpp
+++ b/src/Time/Tags/StepperErrorTolerancesCompute.hpp
@@ -37,41 +37,30 @@ struct VariableOrderAlgorithm;
 
 namespace Tags {
 namespace StepperErrorEstimatesEnabledCompute_detail {
-void lts_function(
+void function(
     gsl::not_null<bool*> error_estimates_enabled,
     const ::EventsAndTriggers& events_and_triggers,
     const std::vector<std::unique_ptr<::StepChooser<StepChooserUse::LtsStep>>>&
         step_choosers);
-
-void gts_function(gsl::not_null<bool*> error_estimates_enabled,
-                  const ::EventsAndTriggers& events_and_triggers);
 }  // namespace StepperErrorEstimatesEnabledCompute_detail
 
 /// \ingroup TimeGroup
 /// \brief Searches the StepChoosers for any requesting error estimates.
-template <bool LocalTimeStepping,
-          template <typename> typename CacheTagPrefix = std::type_identity_t>
+template <template <typename> typename CacheTagPrefix = std::type_identity_t>
 struct StepperErrorEstimatesEnabledCompute : db::ComputeTag,
                                              StepperErrorEstimatesEnabled {
   using base = StepperErrorEstimatesEnabled;
   using return_type = type;
-  using argument_tags = tmpl::conditional_t<
-      LocalTimeStepping,
+  using argument_tags =
       tmpl::list<::Tags::EventsAndTriggers<Triggers::WhenToCheck::AtSlabs>,
-                 CacheTagPrefix<::Tags::LtsStepChoosers>>,
-      tmpl::list<::Tags::EventsAndTriggers<Triggers::WhenToCheck::AtSlabs>>>;
+                 CacheTagPrefix<::Tags::LtsStepChoosers>>;
 
-  static constexpr auto function = []() {
-    if constexpr (LocalTimeStepping) {
-      return &StepperErrorEstimatesEnabledCompute_detail::lts_function;
-    } else {
-      return &StepperErrorEstimatesEnabledCompute_detail::gts_function;
-    }
-  }();
+  static constexpr auto function =
+      &StepperErrorEstimatesEnabledCompute_detail::function;
 };
 
 namespace StepperErrorTolerancesCompute_detail {
-void lts_impl(
+void function(
     gsl::not_null<::StepperErrorTolerances*> tolerances,
     const ::EventsAndTriggers& events_and_triggers,
     const std::vector<std::unique_ptr<::StepChooser<StepChooserUse::LtsStep>>>&
@@ -79,31 +68,24 @@ void lts_impl(
     const ::TimeStepper& time_stepper,
     const ::VariableOrderAlgorithm& variable_order_algorithm,
     const std::type_index& tag_type);
-
-void gts_impl(gsl::not_null<::StepperErrorTolerances*> tolerances,
-              const ::EventsAndTriggers& events_and_triggers,
-              const std::type_index& tag_type);
 }  // namespace StepperErrorTolerancesCompute_detail
 
 /// \ingroup TimeGroup
 /// \brief A tag that contains the error tolerances if any StepChooser
 /// requests an error estimate for the variable.
-template <typename EvolvedVariableTag, bool LocalTimeStepping,
+template <typename EvolvedVariableTag,
           template <typename> typename CacheTagPrefix = std::type_identity_t>
 struct StepperErrorTolerancesCompute
     : db::ComputeTag,
       StepperErrorTolerances<EvolvedVariableTag> {
   using base = StepperErrorTolerances<EvolvedVariableTag>;
   using return_type = typename base::type;
-  using argument_tags = tmpl::conditional_t<
-      LocalTimeStepping,
+  using argument_tags =
       tmpl::list<::Tags::EventsAndTriggers<Triggers::WhenToCheck::AtSlabs>,
                  CacheTagPrefix<::Tags::LtsStepChoosers>,
                  CacheTagPrefix<::Tags::TimeStepper<::TimeStepper>>,
-                 CacheTagPrefix<::Tags::VariableOrderAlgorithm>>,
-      tmpl::list<::Tags::EventsAndTriggers<Triggers::WhenToCheck::AtSlabs>>>;
+                 CacheTagPrefix<::Tags::VariableOrderAlgorithm>>;
 
-  // local time stepping
   static void function(
       const gsl::not_null<::StepperErrorTolerances*> tolerances,
       const ::EventsAndTriggers& events_and_triggers,
@@ -112,17 +94,9 @@ struct StepperErrorTolerancesCompute
           step_choosers,
       const ::TimeStepper& time_stepper,
       const ::VariableOrderAlgorithm& variable_order_algorithm) {
-    StepperErrorTolerancesCompute_detail::lts_impl(
+    StepperErrorTolerancesCompute_detail::function(
         tolerances, events_and_triggers, step_choosers, time_stepper,
         variable_order_algorithm, typeid(EvolvedVariableTag));
-  }
-
-  // global time stepping
-  static void function(
-      const gsl::not_null<::StepperErrorTolerances*> tolerances,
-      const ::EventsAndTriggers& events_and_triggers) {
-    StepperErrorTolerancesCompute_detail::gts_impl(
-        tolerances, events_and_triggers, typeid(EvolvedVariableTag));
   }
 };
 }  // namespace Tags

--- a/src/Time/Tags/TimeStepper.hpp
+++ b/src/Time/Tags/TimeStepper.hpp
@@ -10,6 +10,7 @@
 
 #include "DataStructures/DataBox/Tag.hpp"
 #include "Time/LtsMode.hpp"
+#include "Time/OptionTags/LocalTimeStepping.hpp"
 #include "Time/OptionTags/TimeStepper.hpp"
 #include "Time/TimeSteppers/LtsTimeStepper.hpp"
 #include "Time/TimeSteppers/TimeStepper.hpp"
@@ -36,15 +37,14 @@ template <typename StepperType, bool MonotonicLts = false>
 struct ConcreteTimeStepper : db::SimpleTag {
   using type = std::unique_ptr<StepperType>;
   template <typename Metavars>
-  using option_tags = tmpl::list<::OptionTags::TimeStepper<StepperType>>;
+  using option_tags = tmpl::list<::OptionTags::TimeStepper<StepperType>,
+                                 ::OptionTags::LocalTimeStepping>;
 
   static constexpr bool pass_metavariables = true;
   template <typename Metavars>
   static std::unique_ptr<StepperType> create_from_options(
-      const std::unique_ptr<StepperType>& time_stepper) {
-    const ::LtsMode lts_mode = Metavars::local_time_stepping
-                                   ? ::LtsMode::Conservative
-                                   : ::LtsMode::Off;
+      const std::unique_ptr<StepperType>& time_stepper,
+      const ::LtsMode lts_mode) {
     using factory_types =
         tmpl::at<typename Metavars::factory_creation::factory_classes,
                  StepperType>;

--- a/src/Time/UpdateU.hpp
+++ b/src/Time/UpdateU.hpp
@@ -7,8 +7,12 @@
 #include <optional>
 #include <type_traits>
 
+#include "ParallelAlgorithms/EventsAndTriggers/Tags.hpp"
+#include "ParallelAlgorithms/EventsAndTriggers/WhenToCheck.hpp"
+#include "Time/Tags/LtsStepChoosers.hpp"
 #include "Time/Tags/StepperErrorTolerancesCompute.hpp"
 #include "Time/Tags/StepperErrors.hpp"
+#include "Time/Tags/VariableOrderAlgorithm.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TypeTraits/IsA.hpp"
 
@@ -44,7 +48,7 @@ class not_null;
 /// \ingroup TimeGroup
 /// \brief Perform variable updates for one substep
 /// @{
-template <typename System, bool LocalTimeStepping,
+template <typename System,
           template <typename> typename CacheTagPrefix = std::type_identity_t,
           typename = tmpl::conditional_t<
               tt::is_a_v<tmpl::list, typename System::variables_tag>,
@@ -52,17 +56,17 @@ template <typename System, bool LocalTimeStepping,
               tmpl::list<typename System::variables_tag>>>
 struct UpdateU;
 
-template <typename System, bool LocalTimeStepping,
-          template <typename> typename CacheTagPrefix,
+template <typename System, template <typename> typename CacheTagPrefix,
           typename... VariablesTags>
-struct UpdateU<System, LocalTimeStepping, CacheTagPrefix,
-               tmpl::list<VariablesTags...>> {
+struct UpdateU<System, CacheTagPrefix, tmpl::list<VariablesTags...>> {
+  using const_global_cache_tags =
+      tmpl::list<::Tags::EventsAndTriggers<Triggers::WhenToCheck::AtSlabs>,
+                 CacheTagPrefix<::Tags::LtsStepChoosers>,
+                 CacheTagPrefix<::Tags::VariableOrderAlgorithm>>;
   using simple_tags = tmpl::list<::Tags::StepperErrors<VariablesTags>...>;
-  using compute_tags =
-      tmpl::list<Tags::StepperErrorEstimatesEnabledCompute<LocalTimeStepping,
-                                                           CacheTagPrefix>,
-                 Tags::StepperErrorTolerancesCompute<
-                     VariablesTags, LocalTimeStepping, CacheTagPrefix>...>;
+  using compute_tags = tmpl::list<
+      Tags::StepperErrorEstimatesEnabledCompute<CacheTagPrefix>,
+      Tags::StepperErrorTolerancesCompute<VariablesTags, CacheTagPrefix>...>;
 
   using return_tags =
       tmpl::list<VariablesTags..., Tags::StepperErrors<VariablesTags>...>;

--- a/src/Time/UpdateU.tpp
+++ b/src/Time/UpdateU.tpp
@@ -19,11 +19,9 @@
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
-template <typename System, bool LocalTimeStepping,
-          template <typename> typename CacheTagPrefix,
+template <typename System, template <typename> typename CacheTagPrefix,
           typename... VariablesTags>
-void UpdateU<System, LocalTimeStepping, CacheTagPrefix,
-             tmpl::list<VariablesTags...>>::
+void UpdateU<System, CacheTagPrefix, tmpl::list<VariablesTags...>>::
     apply(
         const gsl::not_null<typename VariablesTags::type*>... vars,
         const typename tmpl::has_type<

--- a/support/Pipelines/Bbh/Cce.yaml
+++ b/support/Pipelines/Bbh/Cce.yaml
@@ -74,6 +74,7 @@ EventsAndTriggersAtSteps:
 
 Cce:
   Evolution:
+    LocalTimeStepping: Conservative
     TimeStepper:
       AdamsBashforth:
         Order: 3 # Going to higher order doesn't seem necessary for CCE

--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -223,6 +223,7 @@ Evolution:
   # you need it smaller you can edit it, but make sure to change the slab
   # intervals in the EventsAndTriggersAtSlabs
   InitialSlabSize: 0.1
+  LocalTimeStepping: Conservative
   VariableOrderAlgorithm:
     GoalOrder: 4
   LtsStepChoosers:

--- a/support/Pipelines/Bbh/Ringdown.yaml
+++ b/support/Pipelines/Bbh/Ringdown.yaml
@@ -93,6 +93,7 @@ Evolution:
   # This is the smallest interval we'd need to observe time step/constraints. If
   # you would like more frequent output, consider using dense output.
   InitialSlabSize: 0.1
+  LocalTimeStepping: Conservative
   VariableOrderAlgorithm:
     GoalOrder: 4
   LtsStepChoosers:

--- a/tests/InputFiles/Burgers/Step.yaml
+++ b/tests/InputFiles/Burgers/Step.yaml
@@ -26,6 +26,7 @@ Evolution:
   InitialSlabSize: 0.01
   InitialTimeStep: 0.001
   MinimumTimeStep: 1e-7
+  LocalTimeStepping: Conservative
   TimeStepper:
     AdamsBashforth:
       Order: 3

--- a/tests/InputFiles/Burgers/StepVariableRatio.yaml
+++ b/tests/InputFiles/Burgers/StepVariableRatio.yaml
@@ -26,6 +26,7 @@ Evolution:
   InitialSlabSize: 0.01
   InitialTimeStep: 0.001
   MinimumTimeStep: 1e-7
+  LocalTimeStepping: Conservative
   TimeStepper:
     AdamsBashforth:
       Order: 3

--- a/tests/InputFiles/Cce/AnalyticTestBouncingBlackHole.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestBouncingBlackHole.yaml
@@ -50,6 +50,7 @@ EventsAndTriggersAtSteps:
 
 Cce:
   Evolution:
+    LocalTimeStepping: Conservative
     TimeStepper:
       AdamsBashforth:
         Order: 3

--- a/tests/InputFiles/Cce/AnalyticTestGaugeWave.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestGaugeWave.yaml
@@ -50,6 +50,7 @@ EventsAndTriggersAtSteps:
 
 Cce:
   Evolution:
+    LocalTimeStepping: Conservative
     TimeStepper:
       AdamsBashforth:
         Order: 3

--- a/tests/InputFiles/Cce/AnalyticTestLinearizedBondiSachs.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestLinearizedBondiSachs.yaml
@@ -50,6 +50,7 @@ EventsAndTriggersAtSteps:
 
 Cce:
   Evolution:
+    LocalTimeStepping: Conservative
     TimeStepper:
       AdamsBashforth:
         Order: 3

--- a/tests/InputFiles/Cce/AnalyticTestRobinsonTrautman.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestRobinsonTrautman.yaml
@@ -50,6 +50,7 @@ EventsAndTriggersAtSteps:
 
 Cce:
   Evolution:
+    LocalTimeStepping: Conservative
     TimeStepper:
       AdamsBashforth:
         Order: 3

--- a/tests/InputFiles/Cce/AnalyticTestRotatingSchwarzschild.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestRotatingSchwarzschild.yaml
@@ -50,6 +50,7 @@ EventsAndTriggersAtSteps:
 
 Cce:
   Evolution:
+    LocalTimeStepping: Conservative
     TimeStepper:
       AdamsBashforth:
         Order: 3

--- a/tests/InputFiles/Cce/AnalyticTestTeukolskyWave.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestTeukolskyWave.yaml
@@ -50,6 +50,7 @@ EventsAndTriggersAtSteps:
 
 Cce:
   Evolution:
+    LocalTimeStepping: Conservative
     TimeStepper:
       AdamsBashforth:
         Order: 3

--- a/tests/InputFiles/Cce/AnalyticTestVolumeNewmanPenroseSpinCoefficients.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestVolumeNewmanPenroseSpinCoefficients.yaml
@@ -112,6 +112,7 @@ EventsAndTriggersAtSteps:
 
 Cce:
   Evolution:
+    LocalTimeStepping: Conservative
     TimeStepper:
       AdamsBashforth:
         Order: 3

--- a/tests/InputFiles/Cce/AnalyticTestVolumeWeylScalars.yaml
+++ b/tests/InputFiles/Cce/AnalyticTestVolumeWeylScalars.yaml
@@ -67,6 +67,7 @@ EventsAndTriggersAtSteps:
 
 Cce:
   Evolution:
+    LocalTimeStepping: Conservative
     TimeStepper:
       AdamsBashforth:
         Order: 3

--- a/tests/InputFiles/Cce/CharacteristicExtract.yaml
+++ b/tests/InputFiles/Cce/CharacteristicExtract.yaml
@@ -70,6 +70,7 @@ EventsAndTriggersAtSteps:
 
 Cce:
   Evolution:
+    LocalTimeStepping: Conservative
     TimeStepper:
       AdamsBashforth:
         Order: 3 # Going to higher order doesn't seem necessary for CCE

--- a/tests/InputFiles/Cce/KleinGordonCharacteristicExtract.yaml
+++ b/tests/InputFiles/Cce/KleinGordonCharacteristicExtract.yaml
@@ -49,6 +49,7 @@ EventsAndTriggersAtSteps:
 
 Cce:
   Evolution:
+    LocalTimeStepping: Conservative
     TimeStepper:
       AdamsBashforth:
         Order: 3 # Going to higher order doesn't seem necessary for CCE

--- a/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski1D.yaml
+++ b/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski1D.yaml
@@ -33,6 +33,7 @@ Evolution:
   InitialTimeStep: 0.001
   MinimumTimeStep: 1e-7
   InitialSlabSize: 0.01
+  LocalTimeStepping: Conservative
   VariableOrderAlgorithm:
     GoalOrder: 3
   TimeStepper:

--- a/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski2D.yaml
+++ b/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski2D.yaml
@@ -33,6 +33,7 @@ Evolution:
   InitialTimeStep: 0.001
   MinimumTimeStep: 1e-7
   InitialSlabSize: 0.01
+  LocalTimeStepping: Conservative
   VariableOrderAlgorithm:
     GoalOrder: 3
   TimeStepper:

--- a/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski3D.yaml
+++ b/tests/InputFiles/CurvedScalarWave/PlaneWaveMinkowski3D.yaml
@@ -48,6 +48,7 @@ Evolution:
   InitialTimeStep: 0.001
   MinimumTimeStep: 1e-7
   InitialSlabSize: 0.01
+  LocalTimeStepping: Conservative
   VariableOrderAlgorithm:
     GoalOrder: 3
   TimeStepper:

--- a/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
+++ b/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
@@ -154,6 +154,8 @@ EventsAndTriggersAtSlabs:
             - Cfl:
                 SafetyFactor: 0.35
 
+EventsAndTriggersAtSteps:
+
 Worldtube:
   ExcisionSphere: ExcisionSphereA
   PunctureField:

--- a/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
+++ b/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
@@ -32,7 +32,8 @@ PhaseChangeAndTriggers:
 
 Evolution:
   InitialTime: 0.0
-  InitialTimeStep: 0.0001
+  InitialTimeStep: &initial_time_step 0.0001
+  InitialSlabSize: *initial_time_step
   MinimumTimeStep: 1e-7
   TimeStepper: Rk5Tsitouras
   LtsStepChoosers:

--- a/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
+++ b/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
@@ -35,6 +35,7 @@ Evolution:
   InitialTimeStep: &initial_time_step 0.0001
   InitialSlabSize: *initial_time_step
   MinimumTimeStep: 1e-7
+  LocalTimeStepping: Off
   TimeStepper: Rk5Tsitouras
   LtsStepChoosers:
   VariableOrderAlgorithm:

--- a/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
+++ b/tests/InputFiles/CurvedScalarWave/WorldtubeKerrSchild.yaml
@@ -35,6 +35,9 @@ Evolution:
   InitialTimeStep: 0.0001
   MinimumTimeStep: 1e-7
   TimeStepper: Rk5Tsitouras
+  LtsStepChoosers:
+  VariableOrderAlgorithm:
+    GoalOrder: 5
 
 DomainCreator:
   BinaryCompactObject:

--- a/tests/InputFiles/ExportCoordinates/Input1D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input1D.yaml
@@ -62,6 +62,8 @@ EventsAndTriggersAtSlabs:
     Events:
       - Completion
 
+EventsAndTriggersAtSteps:
+
 Evolution:
   InitialTime: 0.0
   InitialTimeStep: 0.1

--- a/tests/InputFiles/ExportCoordinates/Input1D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input1D.yaml
@@ -66,7 +66,8 @@ EventsAndTriggersAtSteps:
 
 Evolution:
   InitialTime: 0.0
-  InitialTimeStep: 0.1
+  InitialTimeStep: &initial_time_step 0.1
+  InitialSlabSize: *initial_time_step
   TimeStepper:
     AdamsBashforth:
       Order: 1

--- a/tests/InputFiles/ExportCoordinates/Input1D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input1D.yaml
@@ -68,6 +68,7 @@ Evolution:
   InitialTime: 0.0
   InitialTimeStep: &initial_time_step 0.1
   InitialSlabSize: *initial_time_step
+  LocalTimeStepping: Off
   TimeStepper:
     AdamsBashforth:
       Order: 1

--- a/tests/InputFiles/ExportCoordinates/Input2D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input2D.yaml
@@ -61,7 +61,8 @@ EventsAndTriggersAtSteps:
 
 Evolution:
   InitialTime: 0.0
-  InitialTimeStep: 0.1
+  InitialTimeStep: &initial_time_step 0.1
+  InitialSlabSize: *initial_time_step
   TimeStepper:
     AdamsBashforth:
       Order: 1

--- a/tests/InputFiles/ExportCoordinates/Input2D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input2D.yaml
@@ -57,6 +57,8 @@ EventsAndTriggersAtSlabs:
     Events:
       - Completion
 
+EventsAndTriggersAtSteps:
+
 Evolution:
   InitialTime: 0.0
   InitialTimeStep: 0.1

--- a/tests/InputFiles/ExportCoordinates/Input2D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input2D.yaml
@@ -63,6 +63,7 @@ Evolution:
   InitialTime: 0.0
   InitialTimeStep: &initial_time_step 0.1
   InitialSlabSize: *initial_time_step
+  LocalTimeStepping: Off
   TimeStepper:
     AdamsBashforth:
       Order: 1

--- a/tests/InputFiles/ExportCoordinates/Input3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input3D.yaml
@@ -51,7 +51,8 @@ SpatialDiscretization:
 
 Evolution:
   InitialTime: 0.0
-  InitialTimeStep: 0.1
+  InitialTimeStep: &initial_time_step 0.1
+  InitialSlabSize: *initial_time_step
   TimeStepper:
     AdamsBashforth:
       Order: 1

--- a/tests/InputFiles/ExportCoordinates/Input3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input3D.yaml
@@ -64,6 +64,8 @@ EventsAndTriggersAtSlabs:
     Events:
       - Completion
 
+EventsAndTriggersAtSteps:
+
 Observers:
   VolumeFileName: "ExportCoordinates3DVolume"
   ReductionFileName: "ExportCoordinates3DReductions"

--- a/tests/InputFiles/ExportCoordinates/Input3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input3D.yaml
@@ -53,6 +53,7 @@ Evolution:
   InitialTime: 0.0
   InitialTimeStep: &initial_time_step 0.1
   InitialSlabSize: *initial_time_step
+  LocalTimeStepping: Off
   TimeStepper:
     AdamsBashforth:
       Order: 1

--- a/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
@@ -107,6 +107,7 @@ Evolution:
   InitialTime: 0.0
   InitialTimeStep: &initial_time_step 0.5
   InitialSlabSize: *initial_time_step
+  LocalTimeStepping: Off
   TimeStepper:
     AdamsBashforth:
       Order: 1

--- a/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
@@ -105,7 +105,8 @@ SpatialDiscretization:
 
 Evolution:
   InitialTime: 0.0
-  InitialTimeStep: 0.5
+  InitialTimeStep: &initial_time_step 0.5
+  InitialSlabSize: *initial_time_step
   TimeStepper:
     AdamsBashforth:
       Order: 1

--- a/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
@@ -122,6 +122,8 @@ EventsAndTriggersAtSlabs:
       - MonitorMemory:
           ComponentsToMonitor: All
 
+EventsAndTriggersAtSteps:
+
 Observers:
   VolumeFileName: "ExportCoordinates3DVolume"
   ReductionFileName: "ExportCoordinates3DReductions"

--- a/tests/InputFiles/ForceFree/FastWave.yaml
+++ b/tests/InputFiles/ForceFree/FastWave.yaml
@@ -22,6 +22,7 @@ Evolution:
   InitialTimeStep: &initial_time_step 0.005
   InitialSlabSize: *initial_time_step
   MinimumTimeStep: 1e-7
+  LocalTimeStepping: Off
   TimeStepper:
     ClassicalRungeKutta4
   LtsStepChoosers:

--- a/tests/InputFiles/ForceFree/FastWave.yaml
+++ b/tests/InputFiles/ForceFree/FastWave.yaml
@@ -23,6 +23,9 @@ Evolution:
   MinimumTimeStep: 1e-7
   TimeStepper:
     ClassicalRungeKutta4
+  LtsStepChoosers:
+  VariableOrderAlgorithm:
+    GoalOrder: 4
 
 EvolutionSystem:
   ForceFree:

--- a/tests/InputFiles/ForceFree/FastWave.yaml
+++ b/tests/InputFiles/ForceFree/FastWave.yaml
@@ -79,6 +79,8 @@ EventsAndTriggersAtSlabs:
     Events:
       - Completion
 
+EventsAndTriggersAtSteps:
+
 EventsAndDenseTriggers:
 
 PhaseChangeAndTriggers:

--- a/tests/InputFiles/ForceFree/FastWave.yaml
+++ b/tests/InputFiles/ForceFree/FastWave.yaml
@@ -19,7 +19,8 @@ InitialData: &InitialData
 
 Evolution:
   InitialTime: 0.0
-  InitialTimeStep: 0.005
+  InitialTimeStep: &initial_time_step 0.005
+  InitialSlabSize: *initial_time_step
   MinimumTimeStep: 1e-7
   TimeStepper:
     ClassicalRungeKutta4

--- a/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
@@ -21,6 +21,7 @@ Evolution:
   InitialTimeStep: 0.0002
   MinimumTimeStep: 1e-7
   InitialSlabSize: 0.25
+  LocalTimeStepping: Conservative
   VariableOrderAlgorithm:
     GoalOrder: 3
   LtsStepChoosers:

--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave1D.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave1D.yaml
@@ -164,6 +164,8 @@ EventsAndTriggersAtSlabs:
     Events:
       - Completion
 
+EventsAndTriggersAtSteps:
+
 EventsAndDenseTriggers:
 
 Observers:

--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave1D.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave1D.yaml
@@ -20,7 +20,8 @@ ResourceInfo:
 
 Evolution:
   InitialTime: 0.0
-  InitialTimeStep: 0.002
+  InitialTimeStep: &initial_time_step 0.002
+  InitialSlabSize: *initial_time_step
   MinimumTimeStep: 1e-7
   TimeStepper:
     AdamsBashforth:

--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave1D.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave1D.yaml
@@ -23,6 +23,7 @@ Evolution:
   InitialTimeStep: &initial_time_step 0.002
   InitialSlabSize: *initial_time_step
   MinimumTimeStep: 1e-7
+  LocalTimeStepping: Off
   TimeStepper:
     AdamsBashforth:
       Order: 3

--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave1D.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave1D.yaml
@@ -25,6 +25,9 @@ Evolution:
   TimeStepper:
     AdamsBashforth:
       Order: 3
+  LtsStepChoosers:
+  VariableOrderAlgorithm:
+    GoalOrder: 3
 
 Amr:
   Criteria:

--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave1DLts.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave1DLts.yaml
@@ -1,0 +1,182 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+Executable: EvolveGhNoBlackHole1D
+Testing:
+  Check: parse;execute
+  Timeout: 8
+ExpectedOutput:
+  - GhGaugeWave1DVolume0.h5
+  - GhGaugeWave1DReductions.h5
+
+---
+
+Parallelization:
+  ElementDistribution: NumGridPointsAndGridSpacing
+
+ResourceInfo:
+  AvoidGlobalProc0: false
+  Singletons: Auto
+
+Evolution:
+  InitialTime: 0.0
+  InitialTimeStep: 0.002
+  InitialSlabSize: 0.1
+  MinimumTimeStep: 1e-7
+  LocalTimeStepping: Conservative
+  TimeStepper:
+    AdamsBashforth:
+      Order: 3
+  LtsStepChoosers:
+    - PreventRapidIncrease
+    - ErrorControl:
+        AbsoluteTolerance: 1.0e-8
+        RelativeTolerance: 1.0e-6
+        SafetyFactor: 0.95
+        MaxFactor: 2.0
+        MinFactor: 0.25
+  VariableOrderAlgorithm:
+    GoalOrder: 3
+
+Amr:
+  Criteria:
+  EnableInBlocks: All
+  Policies:
+    EnforceTwoToOneBalanceInNormalDirection: true
+    Isotropy: Anisotropic
+    Limits:
+      RefinementLevel: Auto
+      NumGridPoints: Auto
+      ErrorBeyondLimits: False
+    AllowCoarsening: True
+  Verbosity: Quiet
+
+PhaseChangeAndTriggers:
+  - Trigger:
+      Slabs:
+       EvenlySpaced:
+         # Current implementation checks wallclock at these global syncs
+         Interval: 100
+         Offset: 0
+    PhaseChanges:
+      - CheckpointAndExitAfterWallclock:
+          WallclockHours: None
+
+InitialData: &InitialData
+  GeneralizedHarmonic(GaugeWave):
+    Amplitude: 0.5
+    Wavelength: 6.283185307179586
+
+DomainCreator:
+  RotatedIntervals:
+    LowerBound: [0.0]
+    Midpoint: [3.0]
+    UpperBound: [6.283185307179586]
+    InitialRefinement: [1]
+    InitialGridPoints: [[7,7]]
+    TimeDependence:
+      UniformTranslation:
+         InitialTime: 0.0
+         Velocity: [0.5]
+    BoundaryConditions:
+      LowerBoundary:
+        DirichletAnalytic:
+          AnalyticPrescription: *InitialData
+      UpperBoundary:
+        DirichletAnalytic:
+          AnalyticPrescription: *InitialData
+
+EvolutionSystem:
+  GeneralizedHarmonic:
+    GaugeCondition:
+      AnalyticChristoffel:
+        AnalyticPrescription: *InitialData
+    DampingFunctionGamma0:
+      GaussianPlusConstant:
+        Constant: 1.0
+        Amplitude: 0.0
+        Width: 1.0
+        Center: [0.0]
+    DampingFunctionGamma1:
+      GaussianPlusConstant:
+        Constant: -1.0
+        Amplitude: 0.0
+        Width: 1.0
+        Center: [0.0]
+    DampingFunctionGamma2:
+      GaussianPlusConstant:
+        Constant: 1.0
+        Amplitude: 0.0
+        Width: 1.0
+        Center: [0.0]
+
+SpatialDiscretization:
+  DiscontinuousGalerkin:
+    Formulation: StrongInertial
+    Quadrature: Gauss
+    Filtering:
+      - Hypercube:
+          HalfPower: 64
+          Enable: false
+          BlocksToFilter: All
+          VolumeFilterOnSubstep: true
+          BoundaryCorrectionFilterOnSubstep: false
+          VolumeFilterEveryNSteps: None
+          BoundaryCorrectionFilterEveryNSteps: None
+  BoundaryCorrection:
+    AveragedUpwindPenalty:
+
+EventsAndTriggersAtCheckpoints:
+
+EventsAndTriggersAtSlabs:
+  - Trigger:
+      Slabs:
+        EvenlySpaced:
+          Interval: 2
+          Offset: 0
+    Events:
+      - ObserveNorms:
+          SubfileName: Errors
+          TensorsToObserve:
+            - Name: Error(SpacetimeMetric)
+              NormType: L2Norm
+              Components: Sum
+            - Name: Error(Pi)
+              NormType: L2Norm
+              Components: Sum
+            - Name: Error(Phi)
+              NormType: L2Norm
+              Components: Sum
+  - Trigger:
+      Slabs:
+        EvenlySpaced:
+          Interval: 5
+          Offset: 0
+    Events:
+      - ObserveFields:
+          SubfileName: VolumeData
+          VariablesToObserve:
+            - SpacetimeMetric
+            - Pi
+            - Phi
+            - PointwiseL2Norm(GaugeConstraint)
+            - PointwiseL2Norm(ThreeIndexConstraint)
+          InterpolateToMesh: None
+          ProjectToMesh: None
+          CoordinatesFloatingPointType: Double
+          FloatingPointTypes: [Double]
+          BlocksToObserve: All
+  - Trigger:
+      Slabs:
+        Specified:
+          Values: [5]
+    Events:
+      - Completion
+
+EventsAndTriggersAtSteps:
+
+EventsAndDenseTriggers:
+
+Observers:
+  VolumeFileName: "GhGaugeWave1DVolume"
+  ReductionFileName: "GhGaugeWave1DReductions"

--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave3D.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave3D.yaml
@@ -21,7 +21,8 @@ ResourceInfo:
 
 Evolution:
   InitialTime: 0.0
-  InitialTimeStep: 0.0002
+  InitialTimeStep: &initial_time_step 0.0002
+  InitialSlabSize: *initial_time_step
   MinimumTimeStep: 1e-7
   TimeStepper:
     AdamsBashforth:

--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave3D.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave3D.yaml
@@ -24,6 +24,7 @@ Evolution:
   InitialTimeStep: &initial_time_step 0.0002
   InitialSlabSize: *initial_time_step
   MinimumTimeStep: 1e-7
+  LocalTimeStepping: Off
   TimeStepper:
     AdamsBashforth:
       Order: 3

--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave3D.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave3D.yaml
@@ -26,6 +26,9 @@ Evolution:
   TimeStepper:
     AdamsBashforth:
       Order: 3
+  LtsStepChoosers:
+  VariableOrderAlgorithm:
+    GoalOrder: 3
 
 Amr:
   Criteria:

--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave3D.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave3D.yaml
@@ -157,6 +157,8 @@ EventsAndTriggersAtSlabs:
     Events:
       - Completion
 
+EventsAndTriggersAtSteps:
+
 EventsAndDenseTriggers:
 
 Observers:

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -33,6 +33,7 @@ Evolution:
   # slab size for evolutions would be 0.1 to observe constraints. If you would
   # like more frequent output, consider using dense output.
   InitialSlabSize: 0.001
+  LocalTimeStepping: Conservative
   VariableOrderAlgorithm:
     GoalOrder: 4
   LtsStepChoosers:

--- a/tests/InputFiles/GeneralizedHarmonic/SchwarzschildCartoonSphere1D.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/SchwarzschildCartoonSphere1D.yaml
@@ -21,7 +21,8 @@ ResourceInfo:
 
 Evolution:
   InitialTime: 0.0
-  InitialTimeStep: 0.0002
+  InitialTimeStep: &initial_time_step 0.0002
+  InitialSlabSize: *initial_time_step
   MinimumTimeStep: 1e-7
   TimeStepper:
     DormandPrince5:

--- a/tests/InputFiles/GeneralizedHarmonic/SchwarzschildCartoonSphere1D.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/SchwarzschildCartoonSphere1D.yaml
@@ -25,6 +25,9 @@ Evolution:
   MinimumTimeStep: 1e-7
   TimeStepper:
     DormandPrince5:
+  LtsStepChoosers:
+  VariableOrderAlgorithm:
+    GoalOrder: 5
 
 Amr:
   Criteria:

--- a/tests/InputFiles/GeneralizedHarmonic/SchwarzschildCartoonSphere1D.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/SchwarzschildCartoonSphere1D.yaml
@@ -154,6 +154,8 @@ EventsAndTriggersAtSlabs:
     Events:
       - Completion
 
+EventsAndTriggersAtSteps:
+
 EventsAndDenseTriggers:
 
 Observers:

--- a/tests/InputFiles/GeneralizedHarmonic/SchwarzschildCartoonSphere1D.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/SchwarzschildCartoonSphere1D.yaml
@@ -24,6 +24,7 @@ Evolution:
   InitialTimeStep: &initial_time_step 0.0002
   InitialSlabSize: *initial_time_step
   MinimumTimeStep: 1e-7
+  LocalTimeStepping: Off
   TimeStepper:
     DormandPrince5:
   LtsStepChoosers:

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
@@ -26,6 +26,9 @@ Evolution:
   TimeStepper:
     AdamsMoultonPcMonotonic:
       Order: 3
+  LtsStepChoosers:
+  VariableOrderAlgorithm:
+    GoalOrder: 3
 
 PhaseChangeAndTriggers:
   - Trigger:

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
@@ -23,7 +23,7 @@ Evolution:
   InitialTimeStep: &initial_time_step 0.075
   InitialSlabSize: *initial_time_step
   MinimumTimeStep: 1e-7
-  # Control systems only work with AdamsBashforth
+  LocalTimeStepping: Off
   TimeStepper:
     AdamsMoultonPcMonotonic:
       Order: 3

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
@@ -445,6 +445,8 @@ EventsAndTriggersAtSlabs:
     Events:
       - Completion
 
+EventsAndTriggersAtSteps:
+
 InterpolationTargets:
   BondiSachsInterpolation:
     LMax: 16

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/BinaryNeutronStar.yaml
@@ -20,7 +20,8 @@ ResourceInfo:
 Evolution:
   InitialTime: 0.0
   # The initial time step gets overridden by `ChangeSlabSize` below
-  InitialTimeStep: 0.075
+  InitialTimeStep: &initial_time_step 0.075
+  InitialSlabSize: *initial_time_step
   MinimumTimeStep: 1e-7
   # Control systems only work with AdamsBashforth
   TimeStepper:

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/CoreCollapseSupernova.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/CoreCollapseSupernova.yaml
@@ -23,6 +23,7 @@ Evolution:
   InitialTimeStep: &initial_time_step 1.0e-5
   InitialSlabSize: *initial_time_step
   MinimumTimeStep: 1.0e-7
+  LocalTimeStepping: Off
   TimeStepper:
     Rk3HesthavenSsp:
   LtsStepChoosers:

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/CoreCollapseSupernova.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/CoreCollapseSupernova.yaml
@@ -24,6 +24,9 @@ Evolution:
   MinimumTimeStep: 1.0e-7
   TimeStepper:
     Rk3HesthavenSsp:
+  LtsStepChoosers:
+  VariableOrderAlgorithm:
+    GoalOrder: 3
 
 PhaseChangeAndTriggers:
 

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/CoreCollapseSupernova.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/CoreCollapseSupernova.yaml
@@ -286,6 +286,8 @@ EventsAndTriggersAtSlabs:
     Events:
       - Completion
 
+EventsAndTriggersAtSteps:
+
 InterpolationTargets:
   BondiSachsInterpolation:
     LMax: 16

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/CoreCollapseSupernova.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/CoreCollapseSupernova.yaml
@@ -20,7 +20,8 @@ ResourceInfo:
 
 Evolution:
   InitialTime: 0.0
-  InitialTimeStep: 1.0e-5
+  InitialTimeStep: &initial_time_step 1.0e-5
+  InitialSlabSize: *initial_time_step
   MinimumTimeStep: 1.0e-7
   TimeStepper:
     Rk3HesthavenSsp:

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
@@ -21,7 +21,8 @@ ResourceInfo:
 
 Evolution:
   InitialTime: 0.0
-  InitialTimeStep: 0.0001
+  InitialTimeStep: &initial_time_step 0.0001
+  InitialSlabSize: *initial_time_step
   MinimumTimeStep: 1e-7
   TimeStepper:
     AdamsBashforth:

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
@@ -24,6 +24,7 @@ Evolution:
   InitialTimeStep: &initial_time_step 0.0001
   InitialSlabSize: *initial_time_step
   MinimumTimeStep: 1e-7
+  LocalTimeStepping: Off
   TimeStepper:
     AdamsBashforth:
       Order: 3

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
@@ -26,6 +26,9 @@ Evolution:
   TimeStepper:
     AdamsBashforth:
       Order: 3
+  LtsStepChoosers:
+  VariableOrderAlgorithm:
+    GoalOrder: 3
 
 PhaseChangeAndTriggers:
   - Trigger:

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdBondiMichel.yaml
@@ -240,6 +240,8 @@ EventsAndTriggersAtSlabs:
     Events:
       - Completion
 
+EventsAndTriggersAtSteps:
+
 ApparentHorizons:
   LMax: 4
   AhA:

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
@@ -271,6 +271,8 @@ EventsAndTriggersAtSlabs:
     Events:
       - Completion
 
+EventsAndTriggersAtSteps:
+
 InterpolationTargets:
   BondiSachsInterpolation:
     LMax: 16

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
@@ -29,6 +29,9 @@ Evolution:
     Rk3HesthavenSsp:
     # AdamsMoultonPc:
     #   Order: 3
+  LtsStepChoosers:
+  VariableOrderAlgorithm:
+    GoalOrder: 3
 
 PhaseChangeAndTriggers:
   - Trigger:

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
@@ -24,6 +24,7 @@ Evolution:
   InitialTimeStep: &initial_time_step 0.0001
   InitialSlabSize: *initial_time_step
   MinimumTimeStep: 1e-7
+  LocalTimeStepping: Off
   TimeStepper:
     # Both RK3 and AM-PC 3 should work. These are the "standard" time steppers
     # for spectre for hydro right now.

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStar.yaml
@@ -21,7 +21,8 @@ ResourceInfo:
 
 Evolution:
   InitialTime: 0.0
-  InitialTimeStep: 0.0001
+  InitialTimeStep: &initial_time_step 0.0001
+  InitialSlabSize: *initial_time_step
   MinimumTimeStep: 1e-7
   TimeStepper:
     # Both RK3 and AM-PC 3 should work. These are the "standard" time steppers

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
@@ -155,6 +155,8 @@ EventsAndTriggersAtSlabs:
     Events:
       - Completion
 
+EventsAndTriggersAtSteps:
+
 EventsAndDenseTriggers:
 
 EventsRunAtCleanup:

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
@@ -20,6 +20,7 @@ Evolution:
   InitialTimeStep: &initial_time_step 0.01
   InitialSlabSize: *initial_time_step
   MinimumTimeStep: 1e-7
+  LocalTimeStepping: Off
   TimeStepper: Rk3HesthavenSsp
   LtsStepChoosers:
   VariableOrderAlgorithm:

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
@@ -20,6 +20,9 @@ Evolution:
   InitialTimeStep: 0.01
   MinimumTimeStep: 1e-7
   TimeStepper: Rk3HesthavenSsp
+  LtsStepChoosers:
+  VariableOrderAlgorithm:
+    GoalOrder: 3
 
 PhaseChangeAndTriggers:
   - Trigger:

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/BlastWave.yaml
@@ -17,7 +17,8 @@ ResourceInfo:
 
 Evolution:
   InitialTime: 0.0
-  InitialTimeStep: 0.01
+  InitialTimeStep: &initial_time_step 0.01
+  InitialSlabSize: *initial_time_step
   MinimumTimeStep: 1e-7
   TimeStepper: Rk3HesthavenSsp
   LtsStepChoosers:

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
@@ -24,6 +24,7 @@ Evolution:
   InitialTimeStep: &initial_time_step 0.01
   InitialSlabSize: *initial_time_step
   MinimumTimeStep: 1e-7
+  LocalTimeStepping: Off
   TimeStepper:
     AdamsBashforth:
       Order: 3

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
@@ -177,6 +177,8 @@ EventsAndTriggersAtSlabs:
                 SafetyFactor: 0.2
             - PreventRapidIncrease
 
+EventsAndTriggersAtSteps:
+
 EventsAndDenseTriggers:
 
 EventsRunAtCleanup:

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
@@ -26,15 +26,9 @@ Evolution:
   TimeStepper:
     AdamsBashforth:
       Order: 3
-  # StepChoosers are needed only for local time stepping
-  # LtsStepChoosers:
-  #   - LimitIncrease:
-  #       Factor: 2
-  #   - PreventRapidIncrease
-  #   - Cfl:
-  #       SafetyFactor: 0.2
-  # InitialSlabSize is only needed for local time stepping
-  # InitialSlabSize: 0.01
+  LtsStepChoosers:
+  VariableOrderAlgorithm:
+    GoalOrder: 3
 
 PhaseChangeAndTriggers:
   - Trigger:

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/FishboneMoncriefDisk.yaml
@@ -21,7 +21,8 @@ ResourceInfo:
 
 Evolution:
   InitialTime: 0.0
-  InitialTimeStep: 0.01
+  InitialTimeStep: &initial_time_step 0.01
+  InitialSlabSize: *initial_time_step
   MinimumTimeStep: 1e-7
   TimeStepper:
     AdamsBashforth:

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/TovStar.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/TovStar.yaml
@@ -28,6 +28,9 @@ Evolution:
     Rk3HesthavenSsp:
     # AdamsMoultonPc:
     #   Order: 3
+  LtsStepChoosers:
+  VariableOrderAlgorithm:
+    GoalOrder: 3
 
 PhaseChangeAndTriggers:
   - Trigger:

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/TovStar.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/TovStar.yaml
@@ -23,6 +23,7 @@ Evolution:
   InitialTimeStep: &initial_time_step 0.0001
   InitialSlabSize: *initial_time_step
   MinimumTimeStep: 1e-7
+  LocalTimeStepping: Off
   TimeStepper:
     # Both RK3 and AM-PC 3 should work. These are the "standard" time steppers
     # for spectre for hydro right now.

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/TovStar.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/TovStar.yaml
@@ -234,6 +234,8 @@ EventsAndTriggersAtSlabs:
     Events:
       - Completion
 
+EventsAndTriggersAtSteps:
+
 Observers:
   VolumeFileName: "TovStarVolume"
   ReductionFileName: "TovStarReductions"

--- a/tests/InputFiles/GrMhd/ValenciaDivClean/TovStar.yaml
+++ b/tests/InputFiles/GrMhd/ValenciaDivClean/TovStar.yaml
@@ -20,7 +20,8 @@ ResourceInfo:
 
 Evolution:
   InitialTime: 0.0
-  InitialTimeStep: 0.0001
+  InitialTimeStep: &initial_time_step 0.0001
+  InitialSlabSize: *initial_time_step
   MinimumTimeStep: 1e-7
   TimeStepper:
     # Both RK3 and AM-PC 3 should work. These are the "standard" time steppers

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem1D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem1D.yaml
@@ -18,6 +18,7 @@ Evolution:
   InitialTimeStep: &initial_time_step 0.0001
   InitialSlabSize: *initial_time_step
   MinimumTimeStep: 1e-7
+  LocalTimeStepping: Off
   TimeStepper:
     Rk3HesthavenSsp
   LtsStepChoosers:

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem1D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem1D.yaml
@@ -15,7 +15,8 @@ ResourceInfo:
 
 Evolution:
   InitialTime: 0.0
-  InitialTimeStep: 0.0001
+  InitialTimeStep: &initial_time_step 0.0001
+  InitialSlabSize: *initial_time_step
   MinimumTimeStep: 1e-7
   TimeStepper:
     Rk3HesthavenSsp

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem1D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem1D.yaml
@@ -19,6 +19,9 @@ Evolution:
   MinimumTimeStep: 1e-7
   TimeStepper:
     Rk3HesthavenSsp
+  LtsStepChoosers:
+  VariableOrderAlgorithm:
+    GoalOrder: 3
 
 PhaseChangeAndTriggers:
 

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem1D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem1D.yaml
@@ -127,6 +127,8 @@ EventsAndTriggersAtSlabs:
                 Factor: 2.0
             - PreventRapidIncrease
 
+EventsAndTriggersAtSteps:
+
 EventsAndDenseTriggers:
 
 Observers:

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem2D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem2D.yaml
@@ -104,6 +104,8 @@ EventsAndTriggersAtSlabs:
     Events:
       - Completion
 
+EventsAndTriggersAtSteps:
+
 EventsAndDenseTriggers:
 
 Observers:

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem2D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem2D.yaml
@@ -18,6 +18,7 @@ Evolution:
   InitialTimeStep: &initial_time_step 0.0001
   InitialSlabSize: *initial_time_step
   MinimumTimeStep: 1e-7
+  LocalTimeStepping: Off
   TimeStepper:
     Rk3HesthavenSsp
   LtsStepChoosers:

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem2D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem2D.yaml
@@ -15,7 +15,8 @@ ResourceInfo:
 
 Evolution:
   InitialTime: 0.0
-  InitialTimeStep: 0.0001
+  InitialTimeStep: &initial_time_step 0.0001
+  InitialSlabSize: *initial_time_step
   MinimumTimeStep: 1e-7
   TimeStepper:
     Rk3HesthavenSsp

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem2D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem2D.yaml
@@ -19,6 +19,9 @@ Evolution:
   MinimumTimeStep: 1e-7
   TimeStepper:
     Rk3HesthavenSsp
+  LtsStepChoosers:
+  VariableOrderAlgorithm:
+    GoalOrder: 3
 
 PhaseChangeAndTriggers:
 

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem3D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem3D.yaml
@@ -107,6 +107,8 @@ EventsAndTriggersAtSlabs:
     Events:
       - Completion
 
+EventsAndTriggersAtSteps:
+
 EventsAndDenseTriggers:
 
 Observers:

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem3D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem3D.yaml
@@ -18,6 +18,7 @@ Evolution:
   InitialTimeStep: &initial_time_step 0.0001
   InitialSlabSize: *initial_time_step
   MinimumTimeStep: 1e-7
+  LocalTimeStepping: Off
   TimeStepper:
     Rk3HesthavenSsp
   LtsStepChoosers:

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem3D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem3D.yaml
@@ -15,7 +15,8 @@ ResourceInfo:
 
 Evolution:
   InitialTime: 0.0
-  InitialTimeStep: 0.0001
+  InitialTimeStep: &initial_time_step 0.0001
+  InitialSlabSize: *initial_time_step
   MinimumTimeStep: 1e-7
   TimeStepper:
     Rk3HesthavenSsp

--- a/tests/InputFiles/NewtonianEuler/RiemannProblem3D.yaml
+++ b/tests/InputFiles/NewtonianEuler/RiemannProblem3D.yaml
@@ -19,6 +19,9 @@ Evolution:
   MinimumTimeStep: 1e-7
   TimeStepper:
     Rk3HesthavenSsp
+  LtsStepChoosers:
+  VariableOrderAlgorithm:
+    GoalOrder: 3
 
 PhaseChangeAndTriggers:
 

--- a/tests/InputFiles/RadiationTransport/M1Grey/ConstantM1.yaml
+++ b/tests/InputFiles/RadiationTransport/M1Grey/ConstantM1.yaml
@@ -22,6 +22,7 @@ Evolution:
   InitialTimeStep: &initial_time_step 0.01
   InitialSlabSize: *initial_time_step
   MinimumTimeStep: 1e-7
+  LocalTimeStepping: Off
   TimeStepper:
     Rk3Kennedy:
   Imex:

--- a/tests/InputFiles/RadiationTransport/M1Grey/ConstantM1.yaml
+++ b/tests/InputFiles/RadiationTransport/M1Grey/ConstantM1.yaml
@@ -88,6 +88,8 @@ EventsAndTriggersAtSlabs:
     Events:
       - Completion
 
+EventsAndTriggersAtSteps:
+
 EventsAndDenseTriggers:
 
 Observers:

--- a/tests/InputFiles/RadiationTransport/M1Grey/ConstantM1.yaml
+++ b/tests/InputFiles/RadiationTransport/M1Grey/ConstantM1.yaml
@@ -19,7 +19,8 @@ ResourceInfo:
 
 Evolution:
   InitialTime: 0.0
-  InitialTimeStep: 0.01
+  InitialTimeStep: &initial_time_step 0.01
+  InitialSlabSize: *initial_time_step
   MinimumTimeStep: 1e-7
   TimeStepper:
     Rk3Kennedy:

--- a/tests/InputFiles/RadiationTransport/M1Grey/ConstantM1.yaml
+++ b/tests/InputFiles/RadiationTransport/M1Grey/ConstantM1.yaml
@@ -26,6 +26,9 @@ Evolution:
   Imex:
     Mode: SemiImplicit
     SolveTolerance: 1.0e-5
+  LtsStepChoosers:
+  VariableOrderAlgorithm:
+    GoalOrder: 3
 
 PhaseChangeAndTriggers:
 

--- a/tests/InputFiles/ScalarAdvection/Krivodonova1D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Krivodonova1D.yaml
@@ -20,6 +20,7 @@ Evolution:
   InitialTimeStep: &initial_time_step 0.001
   InitialSlabSize: *initial_time_step
   MinimumTimeStep: 1e-7
+  LocalTimeStepping: Off
   TimeStepper: Rk3HesthavenSsp
   LtsStepChoosers:
   VariableOrderAlgorithm:

--- a/tests/InputFiles/ScalarAdvection/Krivodonova1D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Krivodonova1D.yaml
@@ -20,6 +20,9 @@ Evolution:
   InitialTimeStep: 0.001
   MinimumTimeStep: 1e-7
   TimeStepper: Rk3HesthavenSsp
+  LtsStepChoosers:
+  VariableOrderAlgorithm:
+    GoalOrder: 3
 
 PhaseChangeAndTriggers:
 

--- a/tests/InputFiles/ScalarAdvection/Krivodonova1D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Krivodonova1D.yaml
@@ -17,7 +17,8 @@ ResourceInfo:
 
 Evolution:
   InitialTime: 0.0
-  InitialTimeStep: 0.001
+  InitialTimeStep: &initial_time_step 0.001
+  InitialSlabSize: *initial_time_step
   MinimumTimeStep: 1e-7
   TimeStepper: Rk3HesthavenSsp
   LtsStepChoosers:

--- a/tests/InputFiles/ScalarAdvection/Krivodonova1D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Krivodonova1D.yaml
@@ -97,6 +97,8 @@ EventsAndTriggersAtSlabs:
           FloatingPointTypes: [Float, Float]
           BlocksToObserve: All
 
+EventsAndTriggersAtSteps:
+
 EventsAndDenseTriggers:
 
 Observers:

--- a/tests/InputFiles/ScalarAdvection/Kuzmin2D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Kuzmin2D.yaml
@@ -21,6 +21,9 @@ Evolution:
   InitialTimeStep: 0.001
   MinimumTimeStep: 1e-7
   TimeStepper: Rk3HesthavenSsp
+  LtsStepChoosers:
+  VariableOrderAlgorithm:
+    GoalOrder: 3
 
 PhaseChangeAndTriggers:
 

--- a/tests/InputFiles/ScalarAdvection/Kuzmin2D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Kuzmin2D.yaml
@@ -98,6 +98,8 @@ EventsAndTriggersAtSlabs:
           FloatingPointTypes: [Float, Float]
           BlocksToObserve: All
 
+EventsAndTriggersAtSteps:
+
 EventsAndDenseTriggers:
 
 Observers:

--- a/tests/InputFiles/ScalarAdvection/Kuzmin2D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Kuzmin2D.yaml
@@ -18,7 +18,8 @@ ResourceInfo:
 
 Evolution:
   InitialTime: 0.0
-  InitialTimeStep: 0.001
+  InitialTimeStep: &initial_time_step 0.001
+  InitialSlabSize: *initial_time_step
   MinimumTimeStep: 1e-7
   TimeStepper: Rk3HesthavenSsp
   LtsStepChoosers:

--- a/tests/InputFiles/ScalarAdvection/Kuzmin2D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Kuzmin2D.yaml
@@ -21,6 +21,7 @@ Evolution:
   InitialTimeStep: &initial_time_step 0.001
   InitialSlabSize: *initial_time_step
   MinimumTimeStep: 1e-7
+  LocalTimeStepping: Off
   TimeStepper: Rk3HesthavenSsp
   LtsStepChoosers:
   VariableOrderAlgorithm:

--- a/tests/InputFiles/ScalarAdvection/Sinusoid1D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Sinusoid1D.yaml
@@ -20,6 +20,7 @@ Evolution:
   InitialTimeStep: &initial_time_step 0.001
   InitialSlabSize: *initial_time_step
   MinimumTimeStep: 1e-7
+  LocalTimeStepping: Off
   TimeStepper: Rk3HesthavenSsp
   LtsStepChoosers:
   VariableOrderAlgorithm:

--- a/tests/InputFiles/ScalarAdvection/Sinusoid1D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Sinusoid1D.yaml
@@ -20,6 +20,9 @@ Evolution:
   InitialTimeStep: 0.001
   MinimumTimeStep: 1e-7
   TimeStepper: Rk3HesthavenSsp
+  LtsStepChoosers:
+  VariableOrderAlgorithm:
+    GoalOrder: 3
 
 PhaseChangeAndTriggers:
 

--- a/tests/InputFiles/ScalarAdvection/Sinusoid1D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Sinusoid1D.yaml
@@ -17,7 +17,8 @@ ResourceInfo:
 
 Evolution:
   InitialTime: 0.0
-  InitialTimeStep: 0.001
+  InitialTimeStep: &initial_time_step 0.001
+  InitialSlabSize: *initial_time_step
   MinimumTimeStep: 1e-7
   TimeStepper: Rk3HesthavenSsp
   LtsStepChoosers:

--- a/tests/InputFiles/ScalarAdvection/Sinusoid1D.yaml
+++ b/tests/InputFiles/ScalarAdvection/Sinusoid1D.yaml
@@ -97,6 +97,8 @@ EventsAndTriggersAtSlabs:
           FloatingPointTypes: [Float, Float]
           BlocksToObserve: All
 
+EventsAndTriggersAtSteps:
+
 EventsAndDenseTriggers:
 
 Observers:

--- a/tests/InputFiles/ScalarTensor/KerrSchildSphericalHarmonic.yaml
+++ b/tests/InputFiles/ScalarTensor/KerrSchildSphericalHarmonic.yaml
@@ -24,6 +24,7 @@ Evolution:
   InitialTime: 0.0
   InitialTimeStep: 0.001
   MinimumTimeStep: 1e-7
+  LocalTimeStepping: Conservative
   TimeStepper:
     AdamsBashforth:
       Order: 3

--- a/tests/InputFiles/ScalarWave/NonconformingSphericalWave.yaml
+++ b/tests/InputFiles/ScalarWave/NonconformingSphericalWave.yaml
@@ -39,7 +39,8 @@ PhaseChangeAndTriggers:
 
 Evolution:
   InitialTime: 0.0
-  InitialTimeStep: 0.001
+  InitialTimeStep: &initial_time_step 0.001
+  InitialSlabSize: *initial_time_step
   MinimumTimeStep: 1e-7
   TimeStepper:
     AdamsBashforth:

--- a/tests/InputFiles/ScalarWave/NonconformingSphericalWave.yaml
+++ b/tests/InputFiles/ScalarWave/NonconformingSphericalWave.yaml
@@ -44,6 +44,9 @@ Evolution:
   TimeStepper:
     AdamsBashforth:
       Order: 3
+  LtsStepChoosers:
+  VariableOrderAlgorithm:
+    GoalOrder: 3
 
 DomainCreator:
   NonconformingSphericalShells:

--- a/tests/InputFiles/ScalarWave/NonconformingSphericalWave.yaml
+++ b/tests/InputFiles/ScalarWave/NonconformingSphericalWave.yaml
@@ -87,6 +87,8 @@ EventsAndTriggersAtSlabs:
     Events:
       - Completion
 
+EventsAndTriggersAtSteps:
+
 EventsAndDenseTriggers:
 
 Observers:

--- a/tests/InputFiles/ScalarWave/NonconformingSphericalWave.yaml
+++ b/tests/InputFiles/ScalarWave/NonconformingSphericalWave.yaml
@@ -42,6 +42,7 @@ Evolution:
   InitialTimeStep: &initial_time_step 0.001
   InitialSlabSize: *initial_time_step
   MinimumTimeStep: 1e-7
+  LocalTimeStepping: Off
   TimeStepper:
     AdamsBashforth:
       Order: 3

--- a/tests/InputFiles/ScalarWave/PlaneWave1D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1D.yaml
@@ -72,6 +72,9 @@ Evolution:
   TimeStepper:
     AdamsBashforth:
       Order: 3
+  LtsStepChoosers:
+  VariableOrderAlgorithm:
+    GoalOrder: 3
 
 DomainCreator:
   RotatedIntervals:

--- a/tests/InputFiles/ScalarWave/PlaneWave1D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1D.yaml
@@ -126,6 +126,8 @@ EventsAndTriggersAtSlabs:
     Events:
       - Completion
 
+EventsAndTriggersAtSteps:
+
 EventsAndTriggersAtCheckpoints:
   - Trigger: Always
     Events:

--- a/tests/InputFiles/ScalarWave/PlaneWave1D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1D.yaml
@@ -70,6 +70,7 @@ Evolution:
   InitialTimeStep: &initial_time_step 0.001
   InitialSlabSize: *initial_time_step
   MinimumTimeStep: 1e-7
+  LocalTimeStepping: Off
   TimeStepper:
     AdamsBashforth:
       Order: 3

--- a/tests/InputFiles/ScalarWave/PlaneWave1D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1D.yaml
@@ -67,7 +67,8 @@ PhaseChangeAndTriggers:
 
 Evolution:
   InitialTime: 0.0
-  InitialTimeStep: 0.001
+  InitialTimeStep: &initial_time_step 0.001
+  InitialSlabSize: *initial_time_step
   MinimumTimeStep: 1e-7
   TimeStepper:
     AdamsBashforth:

--- a/tests/InputFiles/ScalarWave/PlaneWave1DEventsAndTriggersExample.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1DEventsAndTriggersExample.yaml
@@ -63,6 +63,7 @@ Evolution:
   InitialTimeStep: &initial_time_step 0.001
   InitialSlabSize: *initial_time_step
   MinimumTimeStep: 1e-7
+  LocalTimeStepping: Off
   TimeStepper:
     AdamsBashforth:
       Order: 3

--- a/tests/InputFiles/ScalarWave/PlaneWave1DEventsAndTriggersExample.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1DEventsAndTriggersExample.yaml
@@ -60,7 +60,8 @@ PhaseChangeAndTriggers:
 
 Evolution:
   InitialTime: 0.0
-  InitialTimeStep: 0.001
+  InitialTimeStep: &initial_time_step 0.001
+  InitialSlabSize: *initial_time_step
   MinimumTimeStep: 1e-7
   TimeStepper:
     AdamsBashforth:

--- a/tests/InputFiles/ScalarWave/PlaneWave1DEventsAndTriggersExample.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1DEventsAndTriggersExample.yaml
@@ -65,6 +65,9 @@ Evolution:
   TimeStepper:
     AdamsBashforth:
       Order: 3
+  LtsStepChoosers:
+  VariableOrderAlgorithm:
+    GoalOrder: 3
 
 DomainCreator:
   Interval:

--- a/tests/InputFiles/ScalarWave/PlaneWave1DEventsAndTriggersExample.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1DEventsAndTriggersExample.yaml
@@ -132,6 +132,8 @@ EventsAndTriggersAtSlabs:
       - Completion
 # [multiple_events]
 
+EventsAndTriggersAtSteps:
+
 Observers:
   VolumeFileName: "ScalarWavePlaneWave1DEventsAndTriggersExampleVolume"
   ReductionFileName: "ScalarWavePlaneWave1DEventsAndTriggersExampleReductions"

--- a/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
@@ -63,7 +63,8 @@ PhaseChangeAndTriggers:
 Evolution:
   InitialTime: &InitialTime
     0.0
-  InitialTimeStep: 0.001
+  InitialTimeStep: &initial_time_step 0.001
+  InitialSlabSize: *initial_time_step
   MinimumTimeStep: 1e-7
   TimeStepper:
     AdamsBashforth:

--- a/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
@@ -66,6 +66,7 @@ Evolution:
   InitialTimeStep: &initial_time_step 0.001
   InitialSlabSize: *initial_time_step
   MinimumTimeStep: 1e-7
+  LocalTimeStepping: Off
   TimeStepper:
     AdamsBashforth:
       Order: 3

--- a/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
@@ -156,6 +156,8 @@ EventsAndTriggersAtSlabs:
           BlocksToObserve: All
 # [observe_event_trigger]
 
+EventsAndTriggersAtSteps:
+
 Observers:
   VolumeFileName: "ScalarWavePlaneWave1DObserveExampleVolume"
   ReductionFileName: "ScalarWavePlaneWave1DObserveExampleReductions"

--- a/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
@@ -68,6 +68,9 @@ Evolution:
   TimeStepper:
     AdamsBashforth:
       Order: 3
+  LtsStepChoosers:
+  VariableOrderAlgorithm:
+    GoalOrder: 3
 
 DomainCreator:
   Interval:

--- a/tests/InputFiles/ScalarWave/PlaneWave2D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave2D.yaml
@@ -58,6 +58,7 @@ Evolution:
   InitialTimeStep: &initial_time_step -0.001
   InitialSlabSize: *initial_time_step
   MinimumTimeStep: 1e-7
+  LocalTimeStepping: Off
   TimeStepper:
     AdamsBashforth:
       Order: 3

--- a/tests/InputFiles/ScalarWave/PlaneWave2D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave2D.yaml
@@ -60,7 +60,9 @@ Evolution:
   TimeStepper:
     AdamsBashforth:
       Order: 3
-
+  LtsStepChoosers:
+  VariableOrderAlgorithm:
+    GoalOrder: 3
 
 DomainCreator:
   Rectangle:

--- a/tests/InputFiles/ScalarWave/PlaneWave2D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave2D.yaml
@@ -120,6 +120,8 @@ EventsAndTriggersAtSlabs:
   #         BlocksToObserve: All
   #     - Completion
 
+EventsAndTriggersAtSteps:
+
 EventsAndDenseTriggers:
   # Test LTS dense output at the initial time
   - Trigger:

--- a/tests/InputFiles/ScalarWave/PlaneWave2D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave2D.yaml
@@ -55,7 +55,8 @@ PhaseChangeAndTriggers:
 Evolution:
   InitialTime: &initial_time 0.0
   # Test backwards evolution in an integration test
-  InitialTimeStep: -0.001
+  InitialTimeStep: &initial_time_step -0.001
+  InitialSlabSize: *initial_time_step
   MinimumTimeStep: 1e-7
   TimeStepper:
     AdamsBashforth:

--- a/tests/InputFiles/ScalarWave/PlaneWave3D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave3D.yaml
@@ -46,6 +46,9 @@ Evolution:
   TimeStepper:
     AdamsBashforth:
       Order: 3
+  LtsStepChoosers:
+  VariableOrderAlgorithm:
+    GoalOrder: 3
 
 DomainCreator:
   Brick:

--- a/tests/InputFiles/ScalarWave/PlaneWave3D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave3D.yaml
@@ -41,7 +41,8 @@ PhaseChangeAndTriggers:
 
 Evolution:
   InitialTime: 0.0
-  InitialTimeStep: 0.001
+  InitialTimeStep: &initial_time_step 0.001
+  InitialSlabSize: *initial_time_step
   MinimumTimeStep: 1e-7
   TimeStepper:
     AdamsBashforth:

--- a/tests/InputFiles/ScalarWave/PlaneWave3D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave3D.yaml
@@ -95,6 +95,8 @@ EventsAndTriggersAtSlabs:
                   Specified:
                     Values: [*final_time]
 
+EventsAndTriggersAtSteps:
+
 EventsAndDenseTriggers:
 
 Observers:

--- a/tests/InputFiles/ScalarWave/PlaneWave3D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave3D.yaml
@@ -44,6 +44,7 @@ Evolution:
   InitialTimeStep: &initial_time_step 0.001
   InitialSlabSize: *initial_time_step
   MinimumTimeStep: 1e-7
+  LocalTimeStepping: Off
   TimeStepper:
     AdamsBashforth:
       Order: 3

--- a/tests/InputFiles/ScalarWave/PlaneWave3DCartoonSphere2D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave3DCartoonSphere2D.yaml
@@ -100,6 +100,8 @@ EventsAndTriggersAtSlabs:
                   Specified:
                     Values: [*final_time]
 
+EventsAndTriggersAtSteps:
+
 EventsAndDenseTriggers:
 
 Observers:

--- a/tests/InputFiles/ScalarWave/PlaneWave3DCartoonSphere2D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave3DCartoonSphere2D.yaml
@@ -39,7 +39,8 @@ PhaseChangeAndTriggers:
 
 Evolution:
   InitialTime: 0.0
-  InitialTimeStep: 0.001
+  InitialTimeStep: &initial_time_step 0.001
+  InitialSlabSize: *initial_time_step
   MinimumTimeStep: 1e-7
   TimeStepper:
     AdamsBashforth:

--- a/tests/InputFiles/ScalarWave/PlaneWave3DCartoonSphere2D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave3DCartoonSphere2D.yaml
@@ -42,6 +42,7 @@ Evolution:
   InitialTimeStep: &initial_time_step 0.001
   InitialSlabSize: *initial_time_step
   MinimumTimeStep: 1e-7
+  LocalTimeStepping: Off
   TimeStepper:
     AdamsBashforth:
       Order: 3

--- a/tests/InputFiles/ScalarWave/PlaneWave3DCartoonSphere2D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave3DCartoonSphere2D.yaml
@@ -44,6 +44,9 @@ Evolution:
   TimeStepper:
     AdamsBashforth:
       Order: 3
+  LtsStepChoosers:
+  VariableOrderAlgorithm:
+    GoalOrder: 3
 
 DomainCreator:
   CartoonSphere2D:

--- a/tests/Unit/Evolution/Initialization/Test_Evolution.cpp
+++ b/tests/Unit/Evolution/Initialization/Test_Evolution.cpp
@@ -57,12 +57,14 @@
 #include "Time/ChangeSlabSize/Tags.hpp"
 #include "Time/ChooseLtsStepSize.hpp"
 #include "Time/History.hpp"
+#include "Time/LtsMode.hpp"
 #include "Time/Slab.hpp"
 #include "Time/StepChoosers/LimitIncrease.hpp"
 #include "Time/StepChoosers/StepChooser.hpp"
 #include "Time/StepperErrorEstimate.hpp"
 #include "Time/Tags/AdaptiveSteppingDiagnostics.hpp"
 #include "Time/Tags/HistoryEvolvedVariables.hpp"
+#include "Time/Tags/LtsMode.hpp"
 #include "Time/Tags/StepNumberWithinSlab.hpp"
 #include "Time/Tags/StepperErrors.hpp"
 #include "Time/Tags/Time.hpp"
@@ -118,15 +120,15 @@ void test_gts() {
       db::AddSimpleTags<
           Parallel::Tags::GlobalCache<TestMetavariables<TimeStepper>>,
           ::Tags::Time, Initialization::Tags::InitialTimeDelta,
-          Initialization::Tags::InitialSlabSize<false>,
+          Initialization::Tags::InitialSlabSize, ::Tags::LtsMode,
           ::Tags::Next<::Tags::TimeStepId>, ::Tags::TimeStep,
           ::Tags::ChangeSlabSize::SlabSizeGoal>,
       tmpl::push_front<time_stepper_ref_tags<TimeStepper>,
                        Parallel::Tags::FromGlobalCache<
                            ::Tags::ConcreteTimeStepper<TimeStepper>,
                            TestMetavariables<TimeStepper>>>>(
-      &global_cache, initial_time, initial_dt, initial_slab_size, TimeStepId{},
-      TimeDelta{}, std::numeric_limits<double>::signaling_NaN());
+      &global_cache, initial_time, initial_dt, initial_slab_size, LtsMode::Off,
+      TimeStepId{}, TimeDelta{}, std::numeric_limits<double>::signaling_NaN());
 
   db::mutate_apply<Initialization::TimeStepping<TestMetavariables<TimeStepper>,
                                                 TimeStepper, false, false>>(
@@ -164,15 +166,16 @@ void test_lts() {
       db::AddSimpleTags<
           Parallel::Tags::GlobalCache<TestMetavariables<LtsTimeStepper>>,
           ::Tags::Time, Initialization::Tags::InitialTimeDelta,
-          Initialization::Tags::InitialSlabSize<true>,
+          Initialization::Tags::InitialSlabSize, ::Tags::LtsMode,
           ::Tags::Next<::Tags::TimeStepId>, ::Tags::TimeStep,
           ::Tags::ChangeSlabSize::SlabSizeGoal>,
       tmpl::push_front<time_stepper_ref_tags<LtsTimeStepper>,
                        Parallel::Tags::FromGlobalCache<
                            ::Tags::ConcreteTimeStepper<LtsTimeStepper>,
                            TestMetavariables<LtsTimeStepper>>>>(
-      &global_cache, initial_time, initial_dt, initial_slab_size, TimeStepId{},
-      TimeDelta{}, std::numeric_limits<double>::signaling_NaN());
+      &global_cache, initial_time, initial_dt, initial_slab_size,
+      LtsMode::Conservative, TimeStepId{}, TimeDelta{},
+      std::numeric_limits<double>::signaling_NaN());
 
   db::mutate_apply<Initialization::TimeStepping<
       TestMetavariables<LtsTimeStepper>, LtsTimeStepper, false, true>>(

--- a/tests/Unit/Evolution/Initialization/Test_Tags.cpp
+++ b/tests/Unit/Evolution/Initialization/Test_Tags.cpp
@@ -10,8 +10,6 @@ SPECTRE_TEST_CASE("Unit.Evolution.Initialization.Tags",
                   "[Unit][Evolution]") {
   TestHelpers::db::test_simple_tag<Initialization::Tags::InitialTimeDelta>(
       "InitialTimeDelta");
-  TestHelpers::db::test_simple_tag<Initialization::Tags::InitialSlabSize<true>>(
+  TestHelpers::db::test_simple_tag<Initialization::Tags::InitialSlabSize>(
       "InitialSlabSize");
-  TestHelpers::db::test_simple_tag<
-      Initialization::Tags::InitialSlabSize<false>>("InitialSlabSize");
 }

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_AnalyticBoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_AnalyticBoundaryCommunication.cpp
@@ -80,7 +80,7 @@ struct mock_characteristic_evolution {
       Actions::InitializeCharacteristicEvolutionVariables<Metavariables>,
       Actions::InitializeCharacteristicEvolutionTime<
           typename Metavariables::evolved_coordinates_variables_tag,
-          typename Metavariables::evolved_swsh_tags, false>,
+          typename Metavariables::evolved_swsh_tags>,
       // advance the time so that the current `TimeStepId` is valid without
       // having to perform self-start.
       ::Actions::MutateApply<AdvanceTime<Tags::CceEvolutionPrefix>>,

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_CharacteristicEvolutionBondiCalculations.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_CharacteristicEvolutionBondiCalculations.cpp
@@ -94,7 +94,7 @@ struct mock_characteristic_evolution {
       Actions::InitializeCharacteristicEvolutionVariables<Metavariables>,
       Actions::InitializeCharacteristicEvolutionTime<
           typename Metavariables::evolved_coordinates_variables_tag,
-          typename Metavariables::evolved_swsh_tags, false>,
+          typename Metavariables::evolved_swsh_tags>,
       // advance the time so that the current `TimeStepId` is valid without
       // having to perform self-start.
       ::Actions::MutateApply<AdvanceTime<Tags::CceEvolutionPrefix>>,

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_GhBoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_GhBoundaryCommunication.cpp
@@ -96,7 +96,7 @@ struct mock_characteristic_evolution {
       Actions::InitializeCharacteristicEvolutionVariables<Metavariables>,
       Actions::InitializeCharacteristicEvolutionTime<
           typename Metavariables::evolved_coordinates_variables_tag,
-          typename Metavariables::evolved_swsh_tags, false>,
+          typename Metavariables::evolved_swsh_tags>,
       // advance the time so that the current `TimeStepId` is valid without
       // having to perform self-start.
       ::Actions::MutateApply<AdvanceTime<Tags::CceEvolutionPrefix>>,

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_H5BoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_H5BoundaryCommunication.cpp
@@ -111,7 +111,7 @@ struct mock_characteristic_evolution {
       Actions::InitializeCharacteristicEvolutionVariables<Metavariables>,
       Actions::InitializeCharacteristicEvolutionTime<
           typename Metavariables::evolved_coordinates_variables_tag,
-          typename Metavariables::evolved_swsh_tags, false>,
+          typename Metavariables::evolved_swsh_tags>,
       // advance the time so that the current `TimeStepId` is valid without
       // having to perform self-start.
       ::Actions::MutateApply<AdvanceTime<Tags::CceEvolutionPrefix>>,

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeCharacteristicEvolution.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeCharacteristicEvolution.cpp
@@ -67,7 +67,7 @@ struct mock_characteristic_evolution {
       Actions::InitializeCharacteristicEvolutionVariables<Metavariables>,
       Actions::InitializeCharacteristicEvolutionTime<
           typename Metavariables::evolved_coordinates_variables_tag,
-          typename Metavariables::evolved_swsh_tags, false>,
+          typename Metavariables::evolved_swsh_tags>,
       // advance the time so that the current `TimeStepId` is valid without
       // having to perform self-start.
       ::Actions::MutateApply<AdvanceTime<Tags::CceEvolutionPrefix>>,

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeKleinGordonCharacteristicEvolution.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InitializeKleinGordonCharacteristicEvolution.cpp
@@ -35,7 +35,7 @@ struct mock_klein_gordon_characteristic_evolution {
       Actions::InitializeCharacteristicEvolutionVariables<Metavariables>,
       Actions::InitializeCharacteristicEvolutionTime<
           typename Metavariables::evolved_coordinates_variables_tag,
-          typename Metavariables::evolved_swsh_tags, false>,
+          typename Metavariables::evolved_swsh_tags>,
       // advance the time so that the current `TimeStepId` is valid without
       // having to perform self-start.
       ::Actions::MutateApply<AdvanceTime<Tags::CceEvolutionPrefix>>,

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_InsertInterpolationScriData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_InsertInterpolationScriData.cpp
@@ -154,7 +154,7 @@ struct MockCharacteristicEvolution {
       Actions::InitializeCharacteristicEvolutionVariables<Metavariables>,
       Actions::InitializeCharacteristicEvolutionTime<
           typename Metavariables::evolved_coordinates_variables_tag,
-          typename Metavariables::evolved_swsh_tags, false>,
+          typename Metavariables::evolved_swsh_tags>,
       // advance the time so that the current `TimeStepId` is valid without
       // having to perform self-start.
       ::Actions::MutateApply<AdvanceTime<Tags::CceEvolutionPrefix>>,

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_KleinGordonH5BoundaryCommunication.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_KleinGordonH5BoundaryCommunication.cpp
@@ -88,7 +88,7 @@ struct mock_klein_gordon_characteristic_evolution {
       Actions::InitializeCharacteristicEvolutionVariables<Metavariables>,
       Actions::InitializeCharacteristicEvolutionTime<
           typename Metavariables::evolved_coordinates_variables_tag,
-          typename Metavariables::evolved_swsh_tags, false>,
+          typename Metavariables::evolved_swsh_tags>,
       // advance the time so that the current `TimeStepId` is valid without
       // having to perform self-start.
       ::Actions::MutateApply<AdvanceTime<Tags::CceEvolutionPrefix>>,

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestBoundaryData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestBoundaryData.cpp
@@ -78,7 +78,7 @@ struct mock_characteristic_evolution {
       Actions::InitializeCharacteristicEvolutionVariables<Metavariables>,
       Actions::InitializeCharacteristicEvolutionTime<
           typename Metavariables::evolved_coordinates_variables_tag,
-          typename Metavariables::evolved_swsh_tags, false>,
+          typename Metavariables::evolved_swsh_tags>,
       // advance the time so that the current `TimeStepId` is valid without
       // having to perform self-start.
       ::Actions::MutateApply<AdvanceTime<Tags::CceEvolutionPrefix>>,

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestKleinGordonBoundaryData.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_RequestKleinGordonBoundaryData.cpp
@@ -65,7 +65,7 @@ struct mock_kg_characteristic_evolution {
       Actions::InitializeCharacteristicEvolutionVariables<Metavariables>,
       Actions::InitializeCharacteristicEvolutionTime<
           typename Metavariables::evolved_coordinates_variables_tag,
-          typename Metavariables::evolved_swsh_tags, false>,
+          typename Metavariables::evolved_swsh_tags>,
       // advance the time so that the current `TimeStepId` is valid without
       // having to perform self-start.
       ::Actions::MutateApply<AdvanceTime<Tags::CceEvolutionPrefix>>,

--- a/tests/Unit/Evolution/Systems/Cce/Actions/Test_ScriObserveInterpolated.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/Test_ScriObserveInterpolated.cpp
@@ -127,7 +127,7 @@ struct mock_characteristic_evolution {
       Actions::InitializeCharacteristicEvolutionVariables<Metavariables>,
       Actions::InitializeCharacteristicEvolutionTime<
           typename Metavariables::evolved_coordinates_variables_tag,
-          typename Metavariables::evolved_swsh_tags, false>,
+          typename Metavariables::evolved_swsh_tags>,
       Actions::InitializeCharacteristicEvolutionScri<
           typename Metavariables::scri_values_to_observe,
           typename Metavariables::cce_boundary_component>,

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
@@ -1103,8 +1103,7 @@ struct component {
           Parallel::Phase::Testing,
           tmpl::list<::evolution::dg::Actions::ComputeTimeDerivative<
               Metavariables::volume_dim, typename Metavariables::system,
-              AllStepChoosers, Metavariables::local_time_stepping,
-              Metavariables::use_nodegroup_dg_elements>>>>;
+              AllStepChoosers, Metavariables::use_nodegroup_dg_elements>>>>;
 };
 
 template <size_t Dim, SystemType SystemTypeIn, bool LocalTimeStepping,
@@ -1304,26 +1303,17 @@ void test_impl(const Spectral::Quadrature quadrature,
     domain.inject_time_dependent_map_for_block(
         1, grid_to_inertial_map->get_clone());
 
-    if constexpr (LocalTimeStepping) {
-      std::vector<std::unique_ptr<StepChooser<StepChooserUse::LtsStep>>>
-          step_choosers;
-      step_choosers.emplace_back(
-          std::make_unique<StepChoosers::Constant>(time_step.value()));
-      return MockRuntimeSystem{
-          {std::vector<std::array<size_t, Dim>>{extents, extents},
-           typename metavars::normal_dot_numerical_flux::type{},
-           std::move(domain), ::LtsMode::Conservative, dg_formulation,
-           std::make_unique<BoundaryTerms<Dim, HasPrims>>(),
-           std::move(boundary_conditions), 1e-8, std::move(step_choosers)}};
-    } else {
-      (void)time_step;
-      return MockRuntimeSystem{
-          {std::vector<std::array<size_t, Dim>>{extents, extents},
-           typename metavars::normal_dot_numerical_flux::type{},
-           std::move(domain), ::LtsMode::Off, dg_formulation,
-           std::make_unique<BoundaryTerms<Dim, HasPrims>>(),
-           std::move(boundary_conditions)}};
-    }
+    std::vector<std::unique_ptr<StepChooser<StepChooserUse::LtsStep>>>
+        step_choosers;
+    step_choosers.emplace_back(
+        std::make_unique<StepChoosers::Constant>(time_step.value()));
+    return MockRuntimeSystem{
+        {std::vector<std::array<size_t, Dim>>{extents, extents},
+         typename metavars::normal_dot_numerical_flux::type{},
+         std::move(domain),
+         LocalTimeStepping ? ::LtsMode::Conservative : ::LtsMode::Off,
+         dg_formulation, std::make_unique<BoundaryTerms<Dim, HasPrims>>(),
+         std::move(boundary_conditions), 1e-8, std::move(step_choosers)}};
   }();
   const auto get_tag = [&runner, &self_id](auto tag_v) -> decltype(auto) {
     using tag = std::decay_t<decltype(tag_v)>;

--- a/tests/Unit/Time/Actions/Test_SelfStartActions.cpp
+++ b/tests/Unit/Time/Actions/Test_SelfStartActions.cpp
@@ -14,6 +14,7 @@
 #include <optional>
 #include <string>
 #include <tuple>
+#include <vector>
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
@@ -35,6 +36,7 @@
 #include "Time/RecordTimeStepperData.hpp"
 #include "Time/RecordTimeStepperData.tpp"
 #include "Time/Slab.hpp"
+#include "Time/StepChoosers/StepChooser.hpp"
 #include "Time/Tags/AdaptiveSteppingDiagnostics.hpp"
 #include "Time/Tags/HistoryEvolvedVariables.hpp"
 #include "Time/Tags/StepNumberWithinSlab.hpp"
@@ -47,6 +49,7 @@
 #include "Time/TimeSteppers/AdamsBashforth.hpp"
 #include "Time/UpdateU.hpp"
 #include "Time/UpdateU.tpp"
+#include "Time/VariableOrderAlgorithm.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/PrettyType.hpp"
 #include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
@@ -165,7 +168,7 @@ struct Component {
       ComputeTimeDerivative,
       Actions::MutateApply<
           RecordTimeStepperData<typename metavariables::system>>,
-      Actions::MutateApply<UpdateU<typename metavariables::system, false>>,
+      Actions::MutateApply<UpdateU<typename metavariables::system>>,
       Actions::MutateApply<CleanHistory<typename metavariables::system>>,
       tmpl::conditional_t<has_primitives, Actions::UpdatePrimitives,
                           tmpl::list<>>>;
@@ -312,7 +315,9 @@ void test_actions(const size_t order, const int step_denominator) {
 
   MockRuntimeSystem<> runner{
       {std::make_unique<TimeSteppers::AdamsBashforth>(order),
-       EventsAndTriggers{}}};
+       EventsAndTriggers{},
+       std::vector<std::unique_ptr<StepChooser<StepChooserUse::LtsStep>>>{},
+       VariableOrderAlgorithm{order}}};
   emplace_component_and_initialize(make_not_null(&runner), forward_in_time,
                                    initial_time, initial_time_step, order,
                                    initial_value);
@@ -429,7 +434,9 @@ double error_in_step(const size_t order, const double step) {
   using component = Component<Metavariables<TestPrimitives, MultipleHistories>>;
   MockRuntimeSystem<TestPrimitives, MultipleHistories> runner{
       {std::make_unique<TimeSteppers::AdamsBashforth>(order),
-       EventsAndTriggers{}}};
+       EventsAndTriggers{},
+       std::vector<std::unique_ptr<StepChooser<StepChooserUse::LtsStep>>>{},
+       VariableOrderAlgorithm{order}}};
   emplace_component_and_initialize<TestPrimitives, MultipleHistories>(
       make_not_null(&runner), forward_in_time, initial_time, initial_time_step,
       order, initial_value);
@@ -438,9 +445,9 @@ double error_in_step(const size_t order, const double step) {
 
   run_past<std::is_same<SelfStart::Actions::Cleanup, tmpl::_1>,
            tmpl::bool_<true>, MultipleHistories>(make_not_null(&runner));
-  run_past<std::is_same<tmpl::pin<Actions::MutateApply<
-                            UpdateU<System<TestPrimitives>, false>>>,
-                        tmpl::_1>,
+  run_past<std::is_same<
+               tmpl::pin<Actions::MutateApply<UpdateU<System<TestPrimitives>>>>,
+               tmpl::_1>,
            tmpl::bool_<true>, MultipleHistories>(make_not_null(&runner));
 
   const double exact = -log(exp(-initial_value) - step);

--- a/tests/Unit/Time/Tags/Test_StepperErrorTolerancesCompute.cpp
+++ b/tests/Unit/Time/Tags/Test_StepperErrorTolerancesCompute.cpp
@@ -130,10 +130,10 @@ struct Metavariables {
 SPECTRE_TEST_CASE("Unit.Time.Tags.StepperErrorTolerancesCompute",
                   "[Unit][Time]") {
   TestHelpers::db::test_compute_tag<
-      Tags::StepperErrorEstimatesEnabledCompute<true>>(
+      Tags::StepperErrorEstimatesEnabledCompute<>>(
       "StepperErrorEstimatesEnabled");
   TestHelpers::db::test_compute_tag<
-      Tags::StepperErrorTolerancesCompute<EvolvedVariablesTag, true>>(
+      Tags::StepperErrorTolerancesCompute<EvolvedVariablesTag>>(
       "StepperErrorTolerances(Variables(EvolvedVar1,EvolvedVar2))");
 
   {
@@ -328,10 +328,9 @@ SPECTRE_TEST_CASE("Unit.Time.Tags.StepperErrorTolerancesCompute",
             Tags::VariableOrderAlgorithm>,
         tmpl::push_back<
             time_stepper_ref_tags<LtsTimeStepper>,
-            Tags::StepperErrorEstimatesEnabledCompute<true>,
-            Tags::StepperErrorTolerancesCompute<EvolvedVariablesTag, true>,
-            Tags::StepperErrorTolerancesCompute<AltEvolvedVariablesTag,
-                                                true>>>();
+            Tags::StepperErrorEstimatesEnabledCompute<>,
+            Tags::StepperErrorTolerancesCompute<EvolvedVariablesTag>,
+            Tags::StepperErrorTolerancesCompute<AltEvolvedVariablesTag>>>();
 
     db::mutate<Tags::ConcreteTimeStepper<LtsTimeStepper>,
                Tags::VariableOrderAlgorithm>(
@@ -370,12 +369,24 @@ SPECTRE_TEST_CASE("Unit.Time.Tags.StepperErrorTolerancesCompute",
     INFO("Compute tag GTS test");
     auto box = db::create<
         db::AddSimpleTags<
-            Tags::EventsAndTriggers<Triggers::WhenToCheck::AtSlabs>>,
+            Tags::LtsStepChoosers,
+            Tags::EventsAndTriggers<Triggers::WhenToCheck::AtSlabs>,
+            Tags::ConcreteTimeStepper<TimeStepper>,
+            Tags::VariableOrderAlgorithm>,
         db::AddComputeTags<
-            Tags::StepperErrorEstimatesEnabledCompute<false>,
-            Tags::StepperErrorTolerancesCompute<EvolvedVariablesTag, false>,
-            Tags::StepperErrorTolerancesCompute<AltEvolvedVariablesTag,
-                                                false>>>();
+            time_stepper_ref_tags<TimeStepper>,
+            Tags::StepperErrorEstimatesEnabledCompute<>,
+            Tags::StepperErrorTolerancesCompute<EvolvedVariablesTag>,
+            Tags::StepperErrorTolerancesCompute<AltEvolvedVariablesTag>>>();
+    db::mutate<Tags::ConcreteTimeStepper<TimeStepper>,
+               Tags::VariableOrderAlgorithm>(
+        [](const gsl::not_null<std::unique_ptr<TimeStepper>*> time_stepper,
+           const gsl::not_null<VariableOrderAlgorithm*> vo_algorithm) {
+          *time_stepper = std::make_unique<TimeSteppers::AdamsBashforth>(4);
+          *vo_algorithm = VariableOrderAlgorithm(4_st);
+        },
+        make_not_null(&box));
+
     db::mutate<Tags::EventsAndTriggers<Triggers::WhenToCheck::AtSlabs>>(
         [](const gsl::not_null<EventsAndTriggers*> events) {
           *events =

--- a/tests/Unit/Time/Tags/Test_TimeStepper.cpp
+++ b/tests/Unit/Time/Tags/Test_TimeStepper.cpp
@@ -11,6 +11,7 @@
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
 #include "Options/Protocols/FactoryCreation.hpp"
+#include "Time/LtsMode.hpp"
 #include "Time/Tags/TimeStepper.hpp"
 #include "Time/TimeSteppers/AdamsMoultonPc.hpp"
 #include "Time/TimeSteppers/LtsError.hpp"
@@ -55,10 +56,7 @@ static_assert(
                                                    std::bool_constant<false>>,
                               Tags::LtsOrError>>);
 
-template <bool LocalTimeStepping>
 struct Metavariables {
-  static constexpr bool local_time_stepping = LocalTimeStepping;
-
   struct factory_creation
       : tt::ConformsTo<Options::protocols::FactoryCreation> {
     using factory_classes = tmpl::map<
@@ -68,12 +66,14 @@ struct Metavariables {
   };
 };
 
-template <bool LocalTimeStepping, bool MonotonicLts, typename Stepper,
-          typename... Args>
-void try_create(Args&&... args) {
+template <bool MonotonicLts, typename Stepper, typename... TimeStepperArgs>
+void try_create(const LtsMode lts_mode,
+                TimeStepperArgs&&... time_stepper_args) {
   Tags::ConcreteTimeStepper<TimeStepper, MonotonicLts>::
-      template create_from_options<Metavariables<LocalTimeStepping>>(
-          std::make_unique<Stepper>(std::forward<Args>(args)...));
+      template create_from_options<Metavariables>(
+          std::make_unique<Stepper>(
+              std::forward<TimeStepperArgs>(time_stepper_args)...),
+          lts_mode);
 }
 }  // namespace
 
@@ -86,52 +86,59 @@ SPECTRE_TEST_CASE("Unit.Time.Tags.TimeStepper", "[Unit][Time]") {
       "TimeStepper");
   TestHelpers::db::test_reference_tag<Tags::LtsOrError>("TimeStepper");
 
-  register_factory_classes_with_charm<Metavariables<false>>();
+  register_factory_classes_with_charm<Metavariables>();
 
   // Check that everything is allowed in GTS except variable-order
-  try_create<false, false, TimeSteppers::Rk3HesthavenSsp>();
-  try_create<false, false, TimeSteppers::AdamsMoultonPc<false>>(3);
-  try_create<false, false, TimeSteppers::AdamsMoultonPc<true>>(3);
-  try_create<false, true, TimeSteppers::Rk3HesthavenSsp>();
-  try_create<false, true, TimeSteppers::AdamsMoultonPc<false>>(3);
-  try_create<false, true, TimeSteppers::AdamsMoultonPc<true>>(3);
+  try_create<false, TimeSteppers::Rk3HesthavenSsp>(LtsMode::Off);
+  try_create<false, TimeSteppers::AdamsMoultonPc<false>>(LtsMode::Off, 3);
+  try_create<false, TimeSteppers::AdamsMoultonPc<true>>(LtsMode::Off, 3);
+  try_create<true, TimeSteppers::Rk3HesthavenSsp>(LtsMode::Off);
+  try_create<true, TimeSteppers::AdamsMoultonPc<false>>(LtsMode::Off, 3);
+  try_create<true, TimeSteppers::AdamsMoultonPc<true>>(LtsMode::Off, 3);
   CHECK_THROWS_WITH(
-      (try_create<false, false, TimeSteppers::AdamsMoultonPc<false>>(
-          std::nullopt)),
+      (try_create<false, TimeSteppers::AdamsMoultonPc<false>>(LtsMode::Off,
+                                                              std::nullopt)),
       Catch::Matchers::ContainsSubstring(
           "Variable-order TimeSteppers are only supported in evolutions with "
           "local time-stepping."));
 
   // Check that LTS rejects non-LTS steppers
   CHECK_THROWS_WITH(
-      (try_create<true, false, TimeSteppers::Rk3HesthavenSsp>()),
+      (try_create<false, TimeSteppers::Rk3HesthavenSsp>(LtsMode::Conservative)),
       Catch::Matchers::ContainsSubstring(
           "Chosen TimeStepper does not support conservative local "
           "time-stepping.  Valid time steppers for your settings: "
           "(AdamsMoultonPc,AdamsMoultonPcMonotonic)"));
   CHECK_THROWS_WITH(
-      (try_create<true, true, TimeSteppers::Rk3HesthavenSsp>()),
+      (try_create<true, TimeSteppers::Rk3HesthavenSsp>(LtsMode::Conservative)),
       Catch::Matchers::ContainsSubstring(
           "Chosen TimeStepper does not support conservative local "
           "time-stepping.  Valid time steppers for your settings: "
           "(AdamsMoultonPcMonotonic)"));
 
   // Check that LTS rejects non-monotonic steppers if that's required.
-  try_create<true, false, TimeSteppers::AdamsMoultonPc<false>>(3);
-  try_create<true, false, TimeSteppers::AdamsMoultonPc<true>>(3);
-  try_create<true, true, TimeSteppers::AdamsMoultonPc<true>>(3);
+  try_create<false, TimeSteppers::AdamsMoultonPc<false>>(LtsMode::Conservative,
+                                                         3);
+  try_create<false, TimeSteppers::AdamsMoultonPc<true>>(LtsMode::Conservative,
+                                                        3);
+  try_create<true, TimeSteppers::AdamsMoultonPc<true>>(LtsMode::Conservative,
+                                                       3);
   CHECK_THROWS_WITH(
-      (try_create<true, true, TimeSteppers::AdamsMoultonPc<false>>(3)),
+      (try_create<true, TimeSteppers::AdamsMoultonPc<false>>(
+          LtsMode::Conservative, 3)),
       Catch::Matchers::ContainsSubstring(
           "Local time-stepping with control systems requires a monotonic "
           "TimeStepper to avoid deadlocks.  Valid time steppers for your "
           "settings: (AdamsMoultonPcMonotonic)"));
-  try_create<true, false, TimeSteppers::AdamsMoultonPc<false>>(std::nullopt);
-  try_create<true, false, TimeSteppers::AdamsMoultonPc<true>>(std::nullopt);
-  try_create<true, true, TimeSteppers::AdamsMoultonPc<true>>(std::nullopt);
+  try_create<false, TimeSteppers::AdamsMoultonPc<false>>(LtsMode::Conservative,
+                                                         std::nullopt);
+  try_create<false, TimeSteppers::AdamsMoultonPc<true>>(LtsMode::Conservative,
+                                                        std::nullopt);
+  try_create<true, TimeSteppers::AdamsMoultonPc<true>>(LtsMode::Conservative,
+                                                       std::nullopt);
   CHECK_THROWS_WITH(
-      (try_create<true, true, TimeSteppers::AdamsMoultonPc<false>>(
-          std::nullopt)),
+      (try_create<true, TimeSteppers::AdamsMoultonPc<false>>(
+          LtsMode::Conservative, std::nullopt)),
       Catch::Matchers::ContainsSubstring(
           "Local time-stepping with control systems requires a monotonic "
           "TimeStepper to avoid deadlocks.  Valid time steppers for your "

--- a/tests/Unit/Time/Test_ChangeTimeStepperOrder.cpp
+++ b/tests/Unit/Time/Test_ChangeTimeStepperOrder.cpp
@@ -373,8 +373,8 @@ double run(std::unique_ptr<LtsTimeStepper> time_stepper, const double tolerance,
           history_tag, ::Tags::StepperErrors<System::variables_tag>>,
       tmpl::push_back<
           time_stepper_ref_tags<LtsTimeStepper>,
-          ::Tags::StepperErrorEstimatesEnabledCompute<true>,
-          ::Tags::StepperErrorTolerancesCompute<System::variables_tag, true>>>(
+          ::Tags::StepperErrorEstimatesEnabledCompute<>,
+          ::Tags::StepperErrorTolerancesCompute<System::variables_tag>>>(
       Metavariables{}, LtsMode::Conservative, std::move(time_stepper),
       EventsAndTriggers{}, VariableOrderAlgorithm(0.1), initial_time_step_id,
       time_stepper->next_time_id(initial_time_step_id, initial_time_step),
@@ -411,7 +411,7 @@ double run(std::unique_ptr<LtsTimeStepper> time_stepper, const double tolerance,
     db::mutate_apply<System::compute_time_derivative>(make_not_null(&box));
     db::mutate_apply<ChangeStepSize<AllStepChoosers>>(make_not_null(&box));
     db::mutate_apply<RecordTimeStepperData<System>>(make_not_null(&box));
-    db::mutate_apply<UpdateU<System, true>>(make_not_null(&box));
+    db::mutate_apply<UpdateU<System>>(make_not_null(&box));
     db::mutate_apply<ChangeTimeStepperOrder<System>>(make_not_null(&box));
 
     db::mutate<::Tags::TimeStepId, ::Tags::Next<::Tags::TimeStepId>,

--- a/tests/Unit/Time/Test_UpdateU.cpp
+++ b/tests/Unit/Time/Test_UpdateU.cpp
@@ -49,7 +49,7 @@ struct TwoVariableSystem {
   using variables_tag = tmpl::list<Var, AlternativeVar>;
 };
 
-template <typename System, bool LocalTimeStepping, bool AlternativeUpdates>
+template <typename System, bool AlternativeUpdates>
 void test_integration() {
   using history_tag = Tags::HistoryEvolvedVariables<Var>;
   using alternative_history_tag = Tags::HistoryEvolvedVariables<AlternativeVar>;
@@ -99,7 +99,7 @@ void test_integration() {
         },
         make_not_null(&box), db::get<Tags::TimeStepId>(box), db::get<Var>(box));
 
-    db::mutate_apply<UpdateU<System, LocalTimeStepping>>(make_not_null(&box));
+    db::mutate_apply<UpdateU<System>>(make_not_null(&box));
     CHECK(db::get<Var>(box) == approx(gsl::at(expected_values, substep)));
     if (AlternativeUpdates) {
       CHECK(db::get<AlternativeVar>(box) ==
@@ -121,7 +121,6 @@ void test_integration() {
   }
 }
 
-template <bool LocalTimeStepping>
 void test_stepper_error() {
   using variables_tag = Var;
   using history_tag = Tags::HistoryEvolvedVariables<variables_tag>;
@@ -158,12 +157,10 @@ void test_stepper_error() {
         db::get<variables_tag>(box));
 
     if (repeat_substep) {
-      db::mutate_apply<UpdateU<SingleVariableSystem, LocalTimeStepping>>(
-          make_not_null(&box));
+      db::mutate_apply<UpdateU<SingleVariableSystem>>(make_not_null(&box));
     }
 
-    db::mutate_apply<UpdateU<SingleVariableSystem, LocalTimeStepping>>(
-        make_not_null(&box));
+    db::mutate_apply<UpdateU<SingleVariableSystem>>(make_not_null(&box));
 
     db::mutate<Tags::TimeStepId, Tags::Next<Tags::TimeStepId>, Tags::TimeStep,
                history_tag>(
@@ -211,7 +208,6 @@ void test_stepper_error() {
   CHECK(db::get<error_tag>(box)[1]->errors != first_step_errors);
 }
 
-template <bool LocalTimeStepping>
 void test_errors_for_restart() {
   // We should get low-order errors if we have all of
   //
@@ -255,8 +251,7 @@ void test_errors_for_restart() {
         time_stepper->next_time_id(initial_id, time_step), time_step, true,
         tolerances, 1., std::move(history),
         Tags::StepperErrors<variables_tag>::type{});
-    db::mutate_apply<UpdateU<SingleVariableSystem, LocalTimeStepping>>(
-        make_not_null(&box));
+    db::mutate_apply<UpdateU<SingleVariableSystem>>(make_not_null(&box));
     const auto& errors = db::get<Tags::StepperErrors<variables_tag>>(box)[1];
     if (not errors.has_value()) {
       return Estimates::None;
@@ -287,17 +282,9 @@ void test_errors_for_restart() {
 }
 
 SPECTRE_TEST_CASE("Unit.Time.UpdateU", "[Unit][Time]") {
-  test_integration<SingleVariableSystem, false, false>();
-  test_integration<TwoVariableSystem, false, true>();
-  test_stepper_error<false>();
-  test_errors_for_restart<false>();
-
-  // The mutator's behavior is the same for LTS and GTS.  The flag
-  // only affects the compute tags put into the box.  But the test is
-  // quick, so run it both ways.
-  test_integration<SingleVariableSystem, true, false>();
-  test_integration<TwoVariableSystem, true, true>();
-  test_stepper_error<true>();
-  test_errors_for_restart<true>();
+  test_integration<SingleVariableSystem, false>();
+  test_integration<TwoVariableSystem, true>();
+  test_stepper_error();
+  test_errors_for_restart();
 }
 }  // namespace


### PR DESCRIPTION
This PR turns on the runtime switching between time-stepping modes, including all the changes that affect input files.  There will be a follow-up PR that cleans up some no-longer-used code.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
**For evolutions using global time stepping** (for CCE, see below), there are several new input file options:

```yaml
Evolution:
  LocalTimeStepping: Off
```
This option should be "Off" to retain previous behavior.  Most evolution executables now support "Conservative" mode as well.

```yaml
Evolution:
  LtsStepChoosers:
  VariableOrderAlgorithm:
    GoalOrder: 3
```
These options are ignored with local time-stepping off, but must have valid values, such as those given here.

```yaml
EventsAndTriggersAtSteps:
```
This is similar to the existing `EventsAndTriggersAtSlabs`.  It is recommended that evolutions not using local time-stepping leave this blank.

```yaml
Evolution:
  InitialTimeStep: &initial_time_step 0.001
  InitialSlabSize: *initial_time_step
```
The new `InitialSlabSize` option must have the same value as the existing `InitialTimeStep` option.  This can be ensured using YAML references as shown here.

**For evolutions using local time-stepping, including CCE**, there is a single new option:

```yaml
Evolution:
  LocalTimeStepping: Conservative
```
For non-CCE evolutions, "Off" is now also supported.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent was used, have a co-author trailer of the form
      "Co-Authored-By: <agent name> <agent email>" as the last line of the
      commit, e.g. "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>".

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
