### PR TITLE
Remove `std::reference_wrapper` dependencies in coordinate maps

### DIFF
--- a/src/Domain/CoordinateMaps/BulgedCube.cpp
+++ b/src/Domain/CoordinateMaps/BulgedCube.cpp
@@ -191,28 +191,25 @@ std::optional<std::array<double, 3>> BulgedCube::inverse(
 }
 
 template <typename T>
-std::array<tt::remove_cvref_wrap_t<T>, 3> BulgedCube::xi_derivative(
-    const std::array<T, 3>& source_coords) const {
-  using ReturnType = tt::remove_cvref_wrap_t<T>;
-  const auto derivative_lambda = [this](
-      const ReturnType& cap_xi, const ReturnType& cap_eta,
-      const ReturnType& cap_zeta, const auto& cap_xi_deriv) {
-    const ReturnType one_over_rho_xi_cubed =
-        pow<3>(1.0 / sqrt(2.0 + square(cap_xi)));
-    const ReturnType one_over_rho_eta = 1.0 / sqrt(2.0 + square(cap_eta));
-    const ReturnType one_over_rho_zeta = 1.0 / sqrt(2.0 + square(cap_zeta));
-    const ReturnType one_over_rho_xi_eta_cubed =
+std::array<T, 3> BulgedCube::xi_derivative(const T& xi, const T& eta,
+                                           const T& zeta) const {
+  const auto derivative_lambda = [this](const T& cap_xi, const T& cap_eta,
+                                        const T& cap_zeta,
+                                        const auto& cap_xi_deriv) {
+    const T one_over_rho_xi_cubed = pow<3>(1.0 / sqrt(2.0 + square(cap_xi)));
+    const T one_over_rho_eta = 1.0 / sqrt(2.0 + square(cap_eta));
+    const T one_over_rho_zeta = 1.0 / sqrt(2.0 + square(cap_zeta));
+    const T one_over_rho_xi_eta_cubed =
         pow<3>(1.0 / sqrt(1.0 + square(cap_xi) + square(cap_eta)));
-    const ReturnType one_over_rho_xi_zeta_cubed =
+    const T one_over_rho_xi_zeta_cubed =
         pow<3>(1.0 / sqrt(1.0 + square(cap_xi) + square(cap_zeta)));
-    const ReturnType one_over_rho_eta_zeta =
+    const T one_over_rho_eta_zeta =
         1.0 / sqrt(1.0 + square(cap_eta) + square(cap_zeta));
-    const ReturnType common_factor =
-        sphericity_ * radius_ * cap_xi * cap_xi_deriv *
-        (one_over_rho_xi_cubed - one_over_rho_xi_eta_cubed -
-         one_over_rho_xi_zeta_cubed);
+    const T common_factor = sphericity_ * radius_ * cap_xi * cap_xi_deriv *
+                            (one_over_rho_xi_cubed - one_over_rho_xi_eta_cubed -
+                             one_over_rho_xi_zeta_cubed);
 
-    const ReturnType physical_x =
+    const T physical_x =
         radius_ * cap_xi_deriv *
         (1.0 / sqrt(3.0) +
          sphericity_ *
@@ -220,42 +217,31 @@ std::array<tt::remove_cvref_wrap_t<T>, 3> BulgedCube::xi_derivative(
                (1.0 + square(cap_zeta)) * one_over_rho_xi_zeta_cubed -
                2.0 * one_over_rho_xi_cubed) +
               one_over_rho_eta_zeta - one_over_rho_eta - one_over_rho_zeta));
-    const ReturnType physical_y = cap_eta * common_factor;
-    const ReturnType physical_z = cap_zeta * common_factor;
+    const T physical_y = cap_eta * common_factor;
+    const T physical_z = cap_zeta * common_factor;
 
-    return std::array<ReturnType, 3>{{physical_x, physical_y, physical_z}};
+    return std::array<T, 3>{{physical_x, physical_y, physical_z}};
   };
   if (use_equiangular_map_) {
-    return derivative_lambda(
-        tan(M_PI_4 * dereference_wrapper(source_coords[0])),
-        tan(M_PI_4 * dereference_wrapper(source_coords[1])),
-        tan(M_PI_4 * dereference_wrapper(source_coords[2])),
-        ReturnType{M_PI_4 *
-                   (1.0 + square(tan(M_PI_4 *
-                                     dereference_wrapper(source_coords[0]))))});
+    return derivative_lambda(tan(M_PI_4 * xi), tan(M_PI_4 * eta),
+                             tan(M_PI_4 * zeta),
+                             T{M_PI_4 * (1.0 + square(tan(M_PI_4 * xi)))});
   }
-  return derivative_lambda(dereference_wrapper(source_coords[0]),
-                           dereference_wrapper(source_coords[1]),
-                           dereference_wrapper(source_coords[2]), 1.0);
+  return derivative_lambda(xi, eta, zeta, 1.0);
 }
 
 template <typename T>
 tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame> BulgedCube::jacobian(
     const std::array<T, 3>& source_coords) const {
-  const auto dX_dxi = xi_derivative(source_coords);
-  const auto dX_deta = xi_derivative(
-      std::array<std::reference_wrapper<const tt::remove_cvref_wrap_t<T>>, 3>{
-          {std::cref(dereference_wrapper(source_coords[1])),
-           std::cref(dereference_wrapper(source_coords[0])),
-           std::cref(dereference_wrapper(source_coords[2]))}});
-  const auto dX_dzeta = xi_derivative(
-      std::array<std::reference_wrapper<const tt::remove_cvref_wrap_t<T>>, 3>{
-          {std::cref(dereference_wrapper(source_coords[2])),
-           std::cref(dereference_wrapper(source_coords[1])),
-           std::cref(dereference_wrapper(source_coords[0]))}});
+  const auto& xi = dereference_wrapper(source_coords[0]);
+  const auto& eta = dereference_wrapper(source_coords[1]);
+  const auto& zeta = dereference_wrapper(source_coords[2]);
+  const auto dX_dxi = xi_derivative(xi, eta, zeta);
+  const auto dX_deta = xi_derivative(eta, xi, zeta);
+  const auto dX_dzeta = xi_derivative(zeta, eta, xi);
   auto jacobian_matrix =
       make_with_value<tnsr::Ij<tt::remove_cvref_wrap_t<T>, 3, Frame::NoFrame>>(
-          dereference_wrapper(source_coords[0]), 0.0);
+          xi, 0.0);
 
   get<0, 0>(jacobian_matrix) = dX_dxi[0];
   get<0, 1>(jacobian_matrix) = dX_deta[1];

--- a/src/Domain/CoordinateMaps/BulgedCube.hpp
+++ b/src/Domain/CoordinateMaps/BulgedCube.hpp
@@ -525,9 +525,12 @@ class BulgedCube {
   static constexpr bool supports_hessian{true};
 
  private:
+  /// Derivative of the physical coordinates with respect to the first of the
+  /// three passed source coordinates. The Jacobian is assembled from calls
+  /// with permuted arguments, exploiting the symmetry of the map.
   template <typename T>
-  std::array<tt::remove_cvref_wrap_t<T>, 3> xi_derivative(
-      const std::array<T, 3>& source_coords) const;
+  std::array<T, 3> xi_derivative(const T& xi, const T& eta,
+                                 const T& zeta) const;
   friend bool operator==(const BulgedCube& lhs, const BulgedCube& rhs);
 
   double radius_{std::numeric_limits<double>::signaling_NaN()};

--- a/src/Domain/CoordinateMaps/CoordinateMapHelpers.hpp
+++ b/src/Domain/CoordinateMaps/CoordinateMapHelpers.hpp
@@ -9,6 +9,7 @@
 #include <type_traits>
 #include <unordered_map>
 
+#include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Identity.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
@@ -19,6 +20,20 @@
 
 namespace domain {
 namespace CoordinateMap_detail {
+/// Returns a value that aliases `x` where that is cheaper than copying: a
+/// non-owning view for `DataVector` and a copy for arithmetic types such as
+/// `double`. Coordinate maps that pass (a subset of) their source coordinates
+/// on to another map use this function to avoid copying the underlying data.
+/// Coordinate maps take their source coordinates by const reference, so the
+/// data is never modified through the view. The view must not outlive `x`.
+template <typename T>
+T view_or_copy(const T& x) {
+  if constexpr (std::is_same_v<T, DataVector>) {
+    return {const_cast<double*>(x.data()), x.size()};  // NOLINT
+  } else {
+    return x;
+  }
+}
 /// @{
 /// Call the map passing in the time and FunctionsOfTime if the map is
 /// time-dependent

--- a/src/Domain/CoordinateMaps/ProductMaps.hpp
+++ b/src/Domain/CoordinateMaps/ProductMaps.hpp
@@ -8,15 +8,12 @@
 
 #include <array>
 #include <cstddef>
-#include <functional>
 #include <optional>
 #include <utility>
 
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "Utilities/DereferenceWrapper.hpp"
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/TMPL.hpp"
-#include "Utilities/TypeTraits/RemoveReferenceWrapper.hpp"
 
 /// \cond
 namespace PUP {
@@ -45,8 +42,7 @@ class ProductOf2Maps {
   ProductOf2Maps(Map1 map1, Map2 map2);
 
   template <typename T>
-  std::array<tt::remove_cvref_wrap_t<T>, dim> operator()(
-      const std::array<T, dim>& source_coords) const;
+  std::array<T, dim> operator()(const std::array<T, dim>& source_coords) const;
 
   /// The inverse function is only callable with doubles because the inverse
   /// might fail if called for a point out of range, and it is unclear
@@ -56,11 +52,11 @@ class ProductOf2Maps {
       const std::array<double, dim>& target_coords) const;
 
   template <typename T>
-  tnsr::Ij<tt::remove_cvref_wrap_t<T>, dim, Frame::NoFrame> inv_jacobian(
+  tnsr::Ij<T, dim, Frame::NoFrame> inv_jacobian(
       const std::array<T, dim>& source_coords) const;
 
   template <typename T>
-  tnsr::Ij<tt::remove_cvref_wrap_t<T>, dim, Frame::NoFrame> jacobian(
+  tnsr::Ij<T, dim, Frame::NoFrame> jacobian(
       const std::array<T, dim>& source_coords) const;
 
   // NOLINTNEXTLINE(google-runtime-references)
@@ -101,18 +97,17 @@ class ProductOf3Maps {
   ProductOf3Maps(Map1 map1, Map2 map2, Map3 map3);
 
   template <typename T>
-  std::array<tt::remove_cvref_wrap_t<T>, dim> operator()(
-      const std::array<T, dim>& source_coords) const;
+  std::array<T, dim> operator()(const std::array<T, dim>& source_coords) const;
 
   std::optional<std::array<double, dim>> inverse(
       const std::array<double, dim>& target_coords) const;
 
   template <typename T>
-  tnsr::Ij<tt::remove_cvref_wrap_t<T>, dim, Frame::NoFrame> inv_jacobian(
+  tnsr::Ij<T, dim, Frame::NoFrame> inv_jacobian(
       const std::array<T, dim>& source_coords) const;
 
   template <typename T>
-  tnsr::Ij<tt::remove_cvref_wrap_t<T>, dim, Frame::NoFrame> jacobian(
+  tnsr::Ij<T, dim, Frame::NoFrame> jacobian(
       const std::array<T, dim>& source_coords) const;
 
   // NOLINTNEXTLINE(google-runtime-references)

--- a/src/Domain/CoordinateMaps/ProductMaps.tpp
+++ b/src/Domain/CoordinateMaps/ProductMaps.tpp
@@ -7,13 +7,12 @@
 
 #include <array>
 #include <cstddef>
-#include <functional>
 #include <optional>
 #include <pup.h>
 #include <utility>
 
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "Utilities/DereferenceWrapper.hpp"
+#include "Domain/CoordinateMaps/CoordinateMapHelpers.hpp"
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -23,20 +22,18 @@ namespace CoordinateMaps {
 namespace product_detail {
 template <typename T, size_t Size, typename Map1, typename Map2,
           typename Function, size_t... Is, size_t... Js>
-std::array<tt::remove_cvref_wrap_t<T>, Size> apply_call(
-    const std::array<T, Size>& coords, const Map1& map1, const Map2& map2,
-    const Function func, std::integer_sequence<size_t, Is...> /*meta*/,
-    std::integer_sequence<size_t, Js...> /*meta*/) {
-  using UnwrappedT = tt::remove_cvref_wrap_t<T>;
+std::array<T, Size> apply_call(const std::array<T, Size>& coords,
+                               const Map1& map1, const Map2& map2,
+                               const Function func,
+                               std::integer_sequence<size_t, Is...> /*meta*/,
+                               std::integer_sequence<size_t, Js...> /*meta*/) {
   return {
-      {func(
-           std::array<std::reference_wrapper<const UnwrappedT>, sizeof...(Is)>{
-               {coords[Is]...}},
-           map1)[Is]...,
-       func(
-           std::array<std::reference_wrapper<const UnwrappedT>, sizeof...(Js)>{
-               {coords[Map1::dim + Js]...}},
-           map2)[Js]...}};
+      {func(std::array<T, sizeof...(Is)>{{CoordinateMap_detail::view_or_copy(
+                coords[Is])...}},
+            map1)[Is]...,
+       func(std::array<T, sizeof...(Js)>{{CoordinateMap_detail::view_or_copy(
+                coords[Map1::dim + Js])...}},
+            map2)[Js]...}};
 }
 
 template <size_t Size, typename Map1, typename Map2, typename Function,
@@ -58,22 +55,21 @@ std::optional<std::array<double, Size>> apply_inverse(
 
 template <typename T, size_t Size, typename Map1, typename Map2,
           typename Function, size_t... Is, size_t... Js>
-tnsr::Ij<tt::remove_cvref_wrap_t<T>, Size, Frame::NoFrame> apply_jac(
+tnsr::Ij<T, Size, Frame::NoFrame> apply_jac(
     const std::array<T, Size>& source_coords, const Map1& map1,
     const Map2& map2, const Function func,
     std::integer_sequence<size_t, Is...> /*meta*/,
     std::integer_sequence<size_t, Js...> /*meta*/) {
-  using UnwrappedT = tt::remove_cvref_wrap_t<T>;
   auto map1_jac = func(
-      std::array<std::reference_wrapper<const UnwrappedT>, sizeof...(Is)>{
-          {source_coords[Is]...}},
+      std::array<T, sizeof...(Is)>{
+          {CoordinateMap_detail::view_or_copy(source_coords[Is])...}},
       map1);
-  auto map2_jac = func(
-      std::array<std::reference_wrapper<const UnwrappedT>, sizeof...(Js)>{
-          {source_coords[Map1::dim + Js]...}},
-      map2);
-  tnsr::Ij<UnwrappedT, Size, Frame::NoFrame> jac{
-      make_with_value<UnwrappedT>(dereference_wrapper(source_coords[0]), 0.0)};
+  auto map2_jac =
+      func(std::array<T, sizeof...(Js)>{{CoordinateMap_detail::view_or_copy(
+               source_coords[Map1::dim + Js])...}},
+           map2);
+  tnsr::Ij<T, Size, Frame::NoFrame> jac{
+      make_with_value<T>(source_coords[0], 0.0)};
   for (size_t i = 0; i < Map1::dim; ++i) {
     for (size_t j = 0; j < Map1::dim; ++j) {
       jac.get(i, j) = std::move(map1_jac.get(i, j));
@@ -96,7 +92,7 @@ ProductOf2Maps<Map1, Map2>::ProductOf2Maps(Map1 map1, Map2 map2)
 
 template <typename Map1, typename Map2>
 template <typename T>
-std::array<tt::remove_cvref_wrap_t<T>, ProductOf2Maps<Map1, Map2>::dim>
+std::array<T, ProductOf2Maps<Map1, Map2>::dim>
 ProductOf2Maps<Map1, Map2>::operator()(
     const std::array<T, dim>& source_coords) const {
   return product_detail::apply_call(
@@ -112,17 +108,14 @@ ProductOf2Maps<Map1, Map2>::inverse(
     const std::array<double, dim>& target_coords) const {
   return product_detail::apply_inverse(
       target_coords, map1_, map2_,
-      [](const auto& point, const auto& map) {
-        return map.inverse(point);
-      },
+      [](const auto& point, const auto& map) { return map.inverse(point); },
       std::make_index_sequence<Map1::dim>{},
       std::make_index_sequence<Map2::dim>{});
 }
 
 template <typename Map1, typename Map2>
 template <typename T>
-tnsr::Ij<tt::remove_cvref_wrap_t<T>, ProductOf2Maps<Map1, Map2>::dim,
-         Frame::NoFrame>
+tnsr::Ij<T, ProductOf2Maps<Map1, Map2>::dim, Frame::NoFrame>
 ProductOf2Maps<Map1, Map2>::inv_jacobian(
     const std::array<T, dim>& source_coords) const {
   return product_detail::apply_jac(
@@ -136,15 +129,12 @@ ProductOf2Maps<Map1, Map2>::inv_jacobian(
 
 template <typename Map1, typename Map2>
 template <typename T>
-tnsr::Ij<tt::remove_cvref_wrap_t<T>, ProductOf2Maps<Map1, Map2>::dim,
-         Frame::NoFrame>
+tnsr::Ij<T, ProductOf2Maps<Map1, Map2>::dim, Frame::NoFrame>
 ProductOf2Maps<Map1, Map2>::jacobian(
     const std::array<T, dim>& source_coords) const {
   return product_detail::apply_jac(
       source_coords, map1_, map2_,
-      [](const auto& point, const auto& map) {
-        return map.jacobian(point);
-      },
+      [](const auto& point, const auto& map) { return map.jacobian(point); },
       std::make_index_sequence<Map1::dim>{},
       std::make_index_sequence<Map2::dim>{});
 }
@@ -180,16 +170,15 @@ ProductOf3Maps<Map1, Map2, Map3>::ProductOf3Maps(Map1 map1, Map2 map2,
 
 template <typename Map1, typename Map2, typename Map3>
 template <typename T>
-std::array<tt::remove_cvref_wrap_t<T>, ProductOf3Maps<Map1, Map2, Map3>::dim>
+std::array<T, ProductOf3Maps<Map1, Map2, Map3>::dim>
 ProductOf3Maps<Map1, Map2, Map3>::operator()(
     const std::array<T, dim>& source_coords) const {
-  using UnwrappedT = tt::remove_cvref_wrap_t<T>;
-  return {{map1_(std::array<std::reference_wrapper<const UnwrappedT>, 1>{
-               {source_coords[0]}})[0],
-           map2_(std::array<std::reference_wrapper<const UnwrappedT>, 1>{
-               {source_coords[1]}})[0],
-           map3_(std::array<std::reference_wrapper<const UnwrappedT>, 1>{
-               {source_coords[2]}})[0]}};
+  return {{map1_(std::array<T, 1>{
+               {CoordinateMap_detail::view_or_copy(source_coords[0])}})[0],
+           map2_(std::array<T, 1>{
+               {CoordinateMap_detail::view_or_copy(source_coords[1])}})[0],
+           map3_(std::array<T, 1>{
+               {CoordinateMap_detail::view_or_copy(source_coords[2])}})[0]}};
 }
 
 template <typename Map1, typename Map2, typename Map3>
@@ -208,43 +197,36 @@ ProductOf3Maps<Map1, Map2, Map3>::inverse(
 
 template <typename Map1, typename Map2, typename Map3>
 template <typename T>
-tnsr::Ij<tt::remove_cvref_wrap_t<T>, ProductOf3Maps<Map1, Map2, Map3>::dim,
-         Frame::NoFrame>
+tnsr::Ij<T, ProductOf3Maps<Map1, Map2, Map3>::dim, Frame::NoFrame>
 ProductOf3Maps<Map1, Map2, Map3>::inv_jacobian(
     const std::array<T, dim>& source_coords) const {
-  using UnwrappedT = tt::remove_cvref_wrap_t<T>;
-  tnsr::Ij<UnwrappedT, dim, Frame::NoFrame> inv_jacobian_matrix{
-      make_with_value<UnwrappedT>(dereference_wrapper(source_coords[0]), 0.0)};
-  get<0, 0>(inv_jacobian_matrix) = get<0, 0>(map1_.inv_jacobian(
-      std::array<std::reference_wrapper<const UnwrappedT>, 1>{
-          {source_coords[0]}}));
-  get<1, 1>(inv_jacobian_matrix) = get<0, 0>(map2_.inv_jacobian(
-      std::array<std::reference_wrapper<const UnwrappedT>, 1>{
-          {source_coords[1]}}));
-  get<2, 2>(inv_jacobian_matrix) = get<0, 0>(map3_.inv_jacobian(
-      std::array<std::reference_wrapper<const UnwrappedT>, 1>{
-          {source_coords[2]}}));
+  tnsr::Ij<T, dim, Frame::NoFrame> inv_jacobian_matrix{
+      make_with_value<T>(source_coords[0], 0.0)};
+  get<0, 0>(inv_jacobian_matrix) =
+      get<0, 0>(map1_.inv_jacobian(std::array<T, 1>{
+          {CoordinateMap_detail::view_or_copy(source_coords[0])}}));
+  get<1, 1>(inv_jacobian_matrix) =
+      get<0, 0>(map2_.inv_jacobian(std::array<T, 1>{
+          {CoordinateMap_detail::view_or_copy(source_coords[1])}}));
+  get<2, 2>(inv_jacobian_matrix) =
+      get<0, 0>(map3_.inv_jacobian(std::array<T, 1>{
+          {CoordinateMap_detail::view_or_copy(source_coords[2])}}));
   return inv_jacobian_matrix;
 }
 
 template <typename Map1, typename Map2, typename Map3>
 template <typename T>
-tnsr::Ij<tt::remove_cvref_wrap_t<T>, ProductOf3Maps<Map1, Map2, Map3>::dim,
-         Frame::NoFrame>
+tnsr::Ij<T, ProductOf3Maps<Map1, Map2, Map3>::dim, Frame::NoFrame>
 ProductOf3Maps<Map1, Map2, Map3>::jacobian(
     const std::array<T, dim>& source_coords) const {
-  using UnwrappedT = tt::remove_cvref_wrap_t<T>;
-  tnsr::Ij<UnwrappedT, dim, Frame::NoFrame> jacobian_matrix{
-      make_with_value<UnwrappedT>(dereference_wrapper(source_coords[0]), 0.0)};
-  get<0, 0>(jacobian_matrix) = get<0, 0>(
-      map1_.jacobian(std::array<std::reference_wrapper<const UnwrappedT>, 1>{
-          {source_coords[0]}}));
-  get<1, 1>(jacobian_matrix) = get<0, 0>(
-      map2_.jacobian(std::array<std::reference_wrapper<const UnwrappedT>, 1>{
-          {source_coords[1]}}));
-  get<2, 2>(jacobian_matrix) = get<0, 0>(
-      map3_.jacobian(std::array<std::reference_wrapper<const UnwrappedT>, 1>{
-          {source_coords[2]}}));
+  tnsr::Ij<T, dim, Frame::NoFrame> jacobian_matrix{
+      make_with_value<T>(source_coords[0], 0.0)};
+  get<0, 0>(jacobian_matrix) = get<0, 0>(map1_.jacobian(std::array<T, 1>{
+      {CoordinateMap_detail::view_or_copy(source_coords[0])}}));
+  get<1, 1>(jacobian_matrix) = get<0, 0>(map2_.jacobian(std::array<T, 1>{
+      {CoordinateMap_detail::view_or_copy(source_coords[1])}}));
+  get<2, 2>(jacobian_matrix) = get<0, 0>(map3_.jacobian(std::array<T, 1>{
+      {CoordinateMap_detail::view_or_copy(source_coords[2])}}));
   return jacobian_matrix;
 }
 template <typename Map1, typename Map2, typename Map3>

--- a/src/Domain/CoordinateMaps/TimeDependent/ProductMaps.hpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/ProductMaps.hpp
@@ -5,7 +5,6 @@
 
 #include <array>
 #include <cstddef>
-#include <functional>
 #include <limits>
 #include <optional>
 #include <string>
@@ -16,10 +15,8 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/CoordinateMaps/TimeDependentHelpers.hpp"
 #include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
-#include "Utilities/DereferenceWrapper.hpp"
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/TMPL.hpp"
-#include "Utilities/TypeTraits/RemoveReferenceWrapper.hpp"
 
 /// \cond
 namespace PUP {
@@ -55,7 +52,7 @@ class ProductOf2Maps {
   ProductOf2Maps(Map1 map1, Map2 map2);
 
   template <typename T>
-  std::array<tt::remove_cvref_wrap_t<T>, dim> operator()(
+  std::array<T, dim> operator()(
       const std::array<T, dim>& source_coords, double time,
       const std::unordered_map<
           std::string,
@@ -74,7 +71,7 @@ class ProductOf2Maps {
           functions_of_time) const;
 
   template <typename T>
-  std::array<tt::remove_cvref_wrap_t<T>, dim> frame_velocity(
+  std::array<T, dim> frame_velocity(
       const std::array<T, dim>& source_coords, double time,
       const std::unordered_map<
           std::string,
@@ -82,7 +79,7 @@ class ProductOf2Maps {
           functions_of_time) const;
 
   template <typename T>
-  tnsr::Ij<tt::remove_cvref_wrap_t<T>, dim, Frame::NoFrame> inv_jacobian(
+  tnsr::Ij<T, dim, Frame::NoFrame> inv_jacobian(
       const std::array<T, dim>& source_coords, double time,
       const std::unordered_map<
           std::string,
@@ -90,7 +87,7 @@ class ProductOf2Maps {
           functions_of_time) const;
 
   template <typename T>
-  tnsr::Ij<tt::remove_cvref_wrap_t<T>, dim, Frame::NoFrame> jacobian(
+  tnsr::Ij<T, dim, Frame::NoFrame> jacobian(
       const std::array<T, dim>& source_coords, double time,
       const std::unordered_map<
           std::string,
@@ -147,7 +144,7 @@ class ProductOf3Maps {
   ProductOf3Maps(Map1 map1, Map2 map2, Map3 map3);
 
   template <typename T>
-  std::array<tt::remove_cvref_wrap_t<T>, dim> operator()(
+  std::array<T, dim> operator()(
       const std::array<T, dim>& source_coords, double time,
       const std::unordered_map<
           std::string,
@@ -162,7 +159,7 @@ class ProductOf3Maps {
           functions_of_time) const;
 
   template <typename T>
-  std::array<tt::remove_cvref_wrap_t<T>, dim> frame_velocity(
+  std::array<T, dim> frame_velocity(
       const std::array<T, dim>& source_coords, double time,
       const std::unordered_map<
           std::string,
@@ -170,7 +167,7 @@ class ProductOf3Maps {
           functions_of_time) const;
 
   template <typename T>
-  tnsr::Ij<tt::remove_cvref_wrap_t<T>, dim, Frame::NoFrame> inv_jacobian(
+  tnsr::Ij<T, dim, Frame::NoFrame> inv_jacobian(
       const std::array<T, dim>& source_coords, double time,
       const std::unordered_map<
           std::string,
@@ -178,7 +175,7 @@ class ProductOf3Maps {
           functions_of_time) const;
 
   template <typename T>
-  tnsr::Ij<tt::remove_cvref_wrap_t<T>, dim, Frame::NoFrame> jacobian(
+  tnsr::Ij<T, dim, Frame::NoFrame> jacobian(
       const std::array<T, dim>& source_coords, double time,
       const std::unordered_map<
           std::string,

--- a/src/Domain/CoordinateMaps/TimeDependent/ProductMaps.tpp
+++ b/src/Domain/CoordinateMaps/TimeDependent/ProductMaps.tpp
@@ -7,7 +7,6 @@
 
 #include <array>
 #include <cstddef>
-#include <functional>
 #include <optional>
 #include <pup.h>
 #include <unordered_set>
@@ -15,7 +14,6 @@
 
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/CoordinateMaps/CoordinateMapHelpers.hpp"
-#include "Utilities/DereferenceWrapper.hpp"
 #include "Utilities/MakeWithValue.hpp"
 #include "Utilities/TMPL.hpp"
 #include "Utilities/TypeTraits/CreateIsCallable.hpp"
@@ -26,7 +24,7 @@ namespace TimeDependent {
 namespace product_detail {
 template <typename T, size_t Size, typename Map1, typename Map2, size_t... Is,
           size_t... Js>
-std::array<tt::remove_cvref_wrap_t<T>, Size> apply_map(
+std::array<T, Size> apply_map(
     const std::array<T, Size>& coords, const Map1& map1, const Map2& map2,
     const double time,
     const std::unordered_map<
@@ -34,20 +32,18 @@ std::array<tt::remove_cvref_wrap_t<T>, Size> apply_map(
         functions_of_time,
     std::integer_sequence<size_t, Is...> /*meta*/,
     std::integer_sequence<size_t, Js...> /*meta*/) {
-  using UnwrappedT = tt::remove_cvref_wrap_t<T>;
-  return {
-      {CoordinateMap_detail::apply_map(
-           map1,
-           std::array<std::reference_wrapper<const UnwrappedT>, sizeof...(Is)>{
-               {coords[Is]...}},
-           time, functions_of_time,
-           domain::is_map_time_dependent_t<Map1>{})[Is]...,
-       CoordinateMap_detail::apply_map(
-           map2,
-           std::array<std::reference_wrapper<const UnwrappedT>, sizeof...(Js)>{
-               {coords[Map1::dim + Js]...}},
-           time, functions_of_time,
-           domain::is_map_time_dependent_t<Map2>{})[Js]...}};
+  return {{CoordinateMap_detail::apply_map(
+               map1,
+               std::array<T, sizeof...(Is)>{
+                   {CoordinateMap_detail::view_or_copy(coords[Is])...}},
+               time, functions_of_time,
+               domain::is_map_time_dependent_t<Map1>{})[Is]...,
+           CoordinateMap_detail::apply_map(
+               map2,
+               std::array<T, sizeof...(Js)>{{CoordinateMap_detail::view_or_copy(
+                   coords[Map1::dim + Js])...}},
+               time, functions_of_time,
+               domain::is_map_time_dependent_t<Map2>{})[Js]...}};
 }
 
 template <size_t Size, typename Map1, typename Map2, size_t... Is, size_t... Js>
@@ -74,7 +70,7 @@ std::optional<std::array<double, Size>> apply_inverse(
 
 template <typename T, size_t Size, typename Map1, typename Map2, size_t... Is,
           size_t... Js>
-std::array<tt::remove_cvref_wrap_t<T>, Size> apply_frame_velocity(
+std::array<T, Size> apply_frame_velocity(
     const std::array<T, Size>& coords, const Map1& map1, const Map2& map2,
     const double time,
     const std::unordered_map<
@@ -82,40 +78,37 @@ std::array<tt::remove_cvref_wrap_t<T>, Size> apply_frame_velocity(
         functions_of_time,
     std::integer_sequence<size_t, Is...> /*meta*/,
     std::integer_sequence<size_t, Js...> /*meta*/) {
-  using UnwrappedT = tt::remove_cvref_wrap_t<T>;
-  return {
-      {domain::CoordinateMap_detail::apply_frame_velocity(
-           map1,
-           std::array<std::reference_wrapper<const UnwrappedT>, sizeof...(Is)>{
-               {coords[Is]...}},
-           time, functions_of_time,
-           domain::is_map_time_dependent_t<Map1>{})[Is]...,
-       domain::CoordinateMap_detail::apply_frame_velocity(
-           map2,
-           std::array<std::reference_wrapper<const UnwrappedT>, sizeof...(Js)>{
-               {coords[Map1::dim + Js]...}},
-           time, functions_of_time,
-           domain::is_map_time_dependent_t<Map2>{})[Js]...}};
+  return {{domain::CoordinateMap_detail::apply_frame_velocity(
+               map1,
+               std::array<T, sizeof...(Is)>{
+                   {CoordinateMap_detail::view_or_copy(coords[Is])...}},
+               time, functions_of_time,
+               domain::is_map_time_dependent_t<Map1>{})[Is]...,
+           domain::CoordinateMap_detail::apply_frame_velocity(
+               map2,
+               std::array<T, sizeof...(Js)>{{CoordinateMap_detail::view_or_copy(
+                   coords[Map1::dim + Js])...}},
+               time, functions_of_time,
+               domain::is_map_time_dependent_t<Map2>{})[Js]...}};
 }
 
 template <typename T, size_t Size, typename Map1, typename Map2,
           typename Function, size_t... Is, size_t... Js>
-tnsr::Ij<tt::remove_cvref_wrap_t<T>, Size, Frame::NoFrame> apply_jac(
+tnsr::Ij<T, Size, Frame::NoFrame> apply_jac(
     const std::array<T, Size>& source_coords, const Map1& map1,
     const Map2& map2, const Function func,
     std::integer_sequence<size_t, Is...> /*meta*/,
     std::integer_sequence<size_t, Js...> /*meta*/) {
-  using UnwrappedT = tt::remove_cvref_wrap_t<T>;
   auto map1_jac = func(
-      std::array<std::reference_wrapper<const UnwrappedT>, sizeof...(Is)>{
-          {source_coords[Is]...}},
+      std::array<T, sizeof...(Is)>{
+          {CoordinateMap_detail::view_or_copy(source_coords[Is])...}},
       map1);
-  auto map2_jac = func(
-      std::array<std::reference_wrapper<const UnwrappedT>, sizeof...(Js)>{
-          {source_coords[Map1::dim + Js]...}},
-      map2);
-  tnsr::Ij<UnwrappedT, Size, Frame::NoFrame> jac{
-      make_with_value<UnwrappedT>(dereference_wrapper(source_coords[0]), 0.0)};
+  auto map2_jac =
+      func(std::array<T, sizeof...(Js)>{{CoordinateMap_detail::view_or_copy(
+               source_coords[Map1::dim + Js])...}},
+           map2);
+  tnsr::Ij<T, Size, Frame::NoFrame> jac{
+      make_with_value<T>(source_coords[0], 0.0)};
   for (size_t i = 0; i < Map1::dim; ++i) {
     for (size_t j = 0; j < Map1::dim; ++j) {
       jac.get(i, j) = std::move(map1_jac.get(i, j));
@@ -158,7 +151,7 @@ ProductOf2Maps<Map1, Map2>::ProductOf2Maps(Map1 map1, Map2 map2)
 
 template <typename Map1, typename Map2>
 template <typename T>
-std::array<tt::remove_cvref_wrap_t<T>, ProductOf2Maps<Map1, Map2>::dim>
+std::array<T, ProductOf2Maps<Map1, Map2>::dim>
 ProductOf2Maps<Map1, Map2>::operator()(
     const std::array<T, dim>& source_coords, const double time,
     const std::unordered_map<
@@ -189,8 +182,7 @@ auto ProductOf2Maps<Map1, Map2>::frame_velocity(
     const std::array<T, dim>& source_coords, const double time,
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-        functions_of_time) const
-    -> std::array<tt::remove_cvref_wrap_t<T>, dim> {
+        functions_of_time) const -> std::array<T, dim> {
   return product_detail::apply_frame_velocity(
       source_coords, map1_, map2_, time, functions_of_time,
       std::make_index_sequence<Map1::dim>{},
@@ -199,22 +191,19 @@ auto ProductOf2Maps<Map1, Map2>::frame_velocity(
 
 template <typename Map1, typename Map2>
 template <typename T>
-tnsr::Ij<tt::remove_cvref_wrap_t<T>, ProductOf2Maps<Map1, Map2>::dim,
-         Frame::NoFrame>
+tnsr::Ij<T, ProductOf2Maps<Map1, Map2>::dim, Frame::NoFrame>
 ProductOf2Maps<Map1, Map2>::inv_jacobian(
     const std::array<T, dim>& source_coords, const double time,
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
         functions_of_time) const {
-  using UnwrappedT = tt::remove_cvref_wrap_t<T>;
   return product_detail::apply_jac(
       source_coords, map1_, map2_,
       [&time, &functions_of_time](const auto& point, const auto& map) {
         return CoordinateMap_detail::apply_inverse_jacobian(
             map, point, time, functions_of_time,
-            domain::is_jacobian_time_dependent_t<
-                std::decay_t<decltype(map)>,
-                std::reference_wrapper<const UnwrappedT>>{});
+            domain::is_jacobian_time_dependent_t<std::decay_t<decltype(map)>,
+                                                 T>{});
       },
       std::make_index_sequence<Map1::dim>{},
       std::make_index_sequence<Map2::dim>{});
@@ -222,22 +211,19 @@ ProductOf2Maps<Map1, Map2>::inv_jacobian(
 
 template <typename Map1, typename Map2>
 template <typename T>
-tnsr::Ij<tt::remove_cvref_wrap_t<T>, ProductOf2Maps<Map1, Map2>::dim,
-         Frame::NoFrame>
+tnsr::Ij<T, ProductOf2Maps<Map1, Map2>::dim, Frame::NoFrame>
 ProductOf2Maps<Map1, Map2>::jacobian(
     const std::array<T, dim>& source_coords, const double time,
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
         functions_of_time) const {
-  using UnwrappedT = tt::remove_cvref_wrap_t<T>;
   return product_detail::apply_jac(
       source_coords, map1_, map2_,
       [&time, &functions_of_time](const auto& point, const auto& map) {
         return CoordinateMap_detail::apply_jacobian(
             map, point, time, functions_of_time,
-            domain::is_jacobian_time_dependent_t<
-                std::decay_t<decltype(map)>,
-                std::reference_wrapper<const UnwrappedT>>{});
+            domain::is_jacobian_time_dependent_t<std::decay_t<decltype(map)>,
+                                                 T>{});
       },
       std::make_index_sequence<Map1::dim>{},
       std::make_index_sequence<Map2::dim>{});
@@ -277,28 +263,27 @@ ProductOf3Maps<Map1, Map2, Map3>::ProductOf3Maps(Map1 map1, Map2 map2,
 
 template <typename Map1, typename Map2, typename Map3>
 template <typename T>
-std::array<tt::remove_cvref_wrap_t<T>, ProductOf3Maps<Map1, Map2, Map3>::dim>
+std::array<T, ProductOf3Maps<Map1, Map2, Map3>::dim>
 ProductOf3Maps<Map1, Map2, Map3>::operator()(
     const std::array<T, dim>& source_coords, const double time,
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
         functions_of_time) const {
-  using UnwrappedT = tt::remove_cvref_wrap_t<T>;
   return {
       {CoordinateMap_detail::apply_map(
            map1_,
-           std::array<std::reference_wrapper<const UnwrappedT>, 1>{
-               {source_coords[0]}},
+           std::array<T, 1>{
+               {CoordinateMap_detail::view_or_copy(source_coords[0])}},
            time, functions_of_time, domain::is_map_time_dependent_t<Map1>{})[0],
        CoordinateMap_detail::apply_map(
            map2_,
-           std::array<std::reference_wrapper<const UnwrappedT>, 1>{
-               {source_coords[1]}},
+           std::array<T, 1>{
+               {CoordinateMap_detail::view_or_copy(source_coords[1])}},
            time, functions_of_time, domain::is_map_time_dependent_t<Map2>{})[0],
        CoordinateMap_detail::apply_map(
            map3_,
-           std::array<std::reference_wrapper<const UnwrappedT>, 1>{
-               {source_coords[2]}},
+           std::array<T, 1>{
+               {CoordinateMap_detail::view_or_copy(source_coords[2])}},
            time, functions_of_time,
            domain::is_map_time_dependent_t<Map3>{})[0]}};
 }
@@ -332,102 +317,85 @@ auto ProductOf3Maps<Map1, Map2, Map3>::frame_velocity(
     const std::array<T, dim>& source_coords, const double time,
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
-        functions_of_time) const
-    -> std::array<tt::remove_cvref_wrap_t<T>, dim> {
-  using UnwrappedT = tt::remove_cvref_wrap_t<T>;
+        functions_of_time) const -> std::array<T, dim> {
   return {
       {CoordinateMap_detail::apply_frame_velocity(
            map1_,
-           std::array<std::reference_wrapper<const UnwrappedT>, 1>{
-               {source_coords[0]}},
+           std::array<T, 1>{
+               {CoordinateMap_detail::view_or_copy(source_coords[0])}},
            time, functions_of_time, domain::is_map_time_dependent_t<Map1>{})[0],
        CoordinateMap_detail::apply_frame_velocity(
            map2_,
-           std::array<std::reference_wrapper<const UnwrappedT>, 1>{
-               {source_coords[1]}},
+           std::array<T, 1>{
+               {CoordinateMap_detail::view_or_copy(source_coords[1])}},
            time, functions_of_time, domain::is_map_time_dependent_t<Map2>{})[0],
        CoordinateMap_detail::apply_frame_velocity(
            map3_,
-           std::array<std::reference_wrapper<const UnwrappedT>, 1>{
-               {source_coords[2]}},
+           std::array<T, 1>{
+               {CoordinateMap_detail::view_or_copy(source_coords[2])}},
            time, functions_of_time,
            domain::is_map_time_dependent_t<Map3>{})[0]}};
 }
 
 template <typename Map1, typename Map2, typename Map3>
 template <typename T>
-tnsr::Ij<tt::remove_cvref_wrap_t<T>, ProductOf3Maps<Map1, Map2, Map3>::dim,
-         Frame::NoFrame>
+tnsr::Ij<T, ProductOf3Maps<Map1, Map2, Map3>::dim, Frame::NoFrame>
 ProductOf3Maps<Map1, Map2, Map3>::inv_jacobian(
     const std::array<T, dim>& source_coords, const double time,
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
         functions_of_time) const {
-  using UnwrappedT = tt::remove_cvref_wrap_t<T>;
-  tnsr::Ij<UnwrappedT, dim, Frame::NoFrame> inv_jacobian_matrix{
-      make_with_value<UnwrappedT>(dereference_wrapper(source_coords[0]), 0.0)};
+  tnsr::Ij<T, dim, Frame::NoFrame> inv_jacobian_matrix{
+      make_with_value<T>(source_coords[0], 0.0)};
   get<0, 0>(inv_jacobian_matrix) =
       get<0, 0>(CoordinateMap_detail::apply_inverse_jacobian(
           map1_,
-          std::array<std::reference_wrapper<const UnwrappedT>, 1>{
-              {source_coords[0]}},
+          std::array<T, 1>{
+              {CoordinateMap_detail::view_or_copy(source_coords[0])}},
           time, functions_of_time,
-          domain::is_jacobian_time_dependent_t<
-              Map1, std::reference_wrapper<const UnwrappedT>>{}));
+          domain::is_jacobian_time_dependent_t<Map1, T>{}));
   get<1, 1>(inv_jacobian_matrix) =
       get<0, 0>(CoordinateMap_detail::apply_inverse_jacobian(
           map2_,
-          std::array<std::reference_wrapper<const UnwrappedT>, 1>{
-              {source_coords[1]}},
+          std::array<T, 1>{
+              {CoordinateMap_detail::view_or_copy(source_coords[1])}},
           time, functions_of_time,
-          domain::is_jacobian_time_dependent_t<
-              Map2, std::reference_wrapper<const UnwrappedT>>{}));
+          domain::is_jacobian_time_dependent_t<Map2, T>{}));
   get<2, 2>(inv_jacobian_matrix) =
       get<0, 0>(CoordinateMap_detail::apply_inverse_jacobian(
           map3_,
-          std::array<std::reference_wrapper<const UnwrappedT>, 1>{
-              {source_coords[2]}},
+          std::array<T, 1>{
+              {CoordinateMap_detail::view_or_copy(source_coords[2])}},
           time, functions_of_time,
-          domain::is_jacobian_time_dependent_t<
-              Map3, std::reference_wrapper<const UnwrappedT>>{}));
+          domain::is_jacobian_time_dependent_t<Map3, T>{}));
   return inv_jacobian_matrix;
 }
 
 template <typename Map1, typename Map2, typename Map3>
 template <typename T>
-tnsr::Ij<tt::remove_cvref_wrap_t<T>, ProductOf3Maps<Map1, Map2, Map3>::dim,
-         Frame::NoFrame>
+tnsr::Ij<T, ProductOf3Maps<Map1, Map2, Map3>::dim, Frame::NoFrame>
 ProductOf3Maps<Map1, Map2, Map3>::jacobian(
     const std::array<T, dim>& source_coords, const double time,
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
         functions_of_time) const {
-  using UnwrappedT = tt::remove_cvref_wrap_t<T>;
-  tnsr::Ij<UnwrappedT, dim, Frame::NoFrame> jacobian_matrix{
-      make_with_value<UnwrappedT>(dereference_wrapper(source_coords[0]), 0.0)};
+  tnsr::Ij<T, dim, Frame::NoFrame> jacobian_matrix{
+      make_with_value<T>(source_coords[0], 0.0)};
   get<0, 0>(jacobian_matrix) = get<0, 0>(CoordinateMap_detail::apply_jacobian(
       map1_,
-      std::array<std::reference_wrapper<const UnwrappedT>, 1>{
-          {source_coords[0]}},
+      std::array<T, 1>{{CoordinateMap_detail::view_or_copy(source_coords[0])}},
       time, functions_of_time,
-      domain::is_jacobian_time_dependent_t<
-          Map1, std::reference_wrapper<const UnwrappedT>>{}));
+      domain::is_jacobian_time_dependent_t<Map1, T>{}));
   get<1, 1>(jacobian_matrix) = get<0, 0>(CoordinateMap_detail::apply_jacobian(
       map2_,
-      std::array<std::reference_wrapper<const UnwrappedT>, 1>{
-          {source_coords[1]}},
+      std::array<T, 1>{{CoordinateMap_detail::view_or_copy(source_coords[1])}},
       time, functions_of_time,
-      domain::is_jacobian_time_dependent_t<
-          Map2, std::reference_wrapper<const UnwrappedT>>{}
-
-      ));
+      domain::is_jacobian_time_dependent_t<Map2, T>{}));
   get<2, 2>(jacobian_matrix) = get<0, 0>(CoordinateMap_detail::apply_jacobian(
       map3_,
-      std::array<std::reference_wrapper<const UnwrappedT>, 1>{
-          {source_coords[2]}},
+      std::array<T, 1>{{CoordinateMap_detail::view_or_copy(source_coords[2])}},
       time, functions_of_time,
-      domain::is_jacobian_time_dependent_t<
-          Map3, std::reference_wrapper<const UnwrappedT>>{}));
+      domain::is_jacobian_time_dependent_t<Map3, T>{}));
   return jacobian_matrix;
 }
 template <typename Map1, typename Map2, typename Map3>

--- a/tests/Unit/Helpers/Domain/CoordinateMaps/TestMapHelpers.hpp
+++ b/tests/Unit/Helpers/Domain/CoordinateMaps/TestMapHelpers.hpp
@@ -11,7 +11,6 @@
 #include <algorithm>
 #include <array>
 #include <cmath>
-#include <functional>
 #include <limits>
 #include <memory>
 #include <numeric>
@@ -449,29 +448,18 @@ void test_coordinate_map_argument_types(
                    });
     return result;
   };
-  const auto add_reference_wrapper = [](const auto& unwrapped_array) {
-    using Arg = std::decay_t<decltype(unwrapped_array)>;
-    return make_array<std::reference_wrapper<const typename Arg::value_type>,
-                      Map::dim>(unwrapped_array);
-  };
 
   {
     INFO("Test call-operator");
     const auto mapped_point = map(test_point, args...);
-    CHECK_ITERABLE_APPROX(map(add_reference_wrapper(test_point), args...),
-                          mapped_point);
     CHECK_ITERABLE_APPROX(map(make_array_data_vector(test_point), args...),
                           make_array_data_vector(mapped_point));
-    CHECK_ITERABLE_APPROX(
-        map(add_reference_wrapper(make_array_data_vector(test_point)), args...),
-        make_array_data_vector(mapped_point));
   }
 
   // Here, time_args is a const auto& not const Args& because time_args
   // is allowed to be different than Args (which was the reason for the
   // overloader below that calls this function).
-  const auto check_jac = [](const auto& make_arr_data_vec,
-                            const auto& add_ref_wrap, const Map& the_map,
+  const auto check_jac = [](const auto& make_arr_data_vec, const Map& the_map,
                             const std::array<double, Map::dim>& point,
                             const auto&... time_args) {
     const auto make_tensor_data_vector = [](const auto& double_tensor) {
@@ -488,14 +476,8 @@ void test_coordinate_map_argument_types(
     {
       INFO("Test Jacobian");
       const auto expected = the_map.jacobian(point, time_args...);
-      CHECK_ITERABLE_APPROX(the_map.jacobian(add_ref_wrap(point), time_args...),
-                            expected);
       CHECK_ITERABLE_APPROX(
           the_map.jacobian(make_arr_data_vec(point), time_args...),
-          make_tensor_data_vector(expected));
-      CHECK_ITERABLE_APPROX(
-          the_map.jacobian(add_ref_wrap(make_arr_data_vec(point)),
-                           time_args...),
           make_tensor_data_vector(expected));
     }
     {
@@ -511,14 +493,8 @@ void test_coordinate_map_argument_types(
                             using std::max;
                             return max(state, abs(element));
                           }));
-      CHECK_ITERABLE_APPROX(
-          the_map.inv_jacobian(add_ref_wrap(point), time_args...), expected);
       CHECK_ITERABLE_CUSTOM_APPROX(
           the_map.inv_jacobian(make_arr_data_vec(point), time_args...),
-          make_tensor_data_vector(expected), custom_approx);
-      CHECK_ITERABLE_CUSTOM_APPROX(
-          the_map.inv_jacobian(add_ref_wrap(make_arr_data_vec(point)),
-                               time_args...),
           make_tensor_data_vector(expected), custom_approx);
     }
 
@@ -526,10 +502,9 @@ void test_coordinate_map_argument_types(
   };
 
   if constexpr (domain::is_jacobian_time_dependent_t<decltype(map), double>{}) {
-    check_jac(make_array_data_vector, add_reference_wrapper, map, test_point,
-              args...);
+    check_jac(make_array_data_vector, map, test_point, args...);
   } else {
-    check_jac(make_array_data_vector, add_reference_wrapper, map, test_point);
+    check_jac(make_array_data_vector, map, test_point);
   }
 }
 


### PR DESCRIPTION
## Proposed changes
This PR removes the few usages we have for using reference_wrappers in the coordinate maps so these can be removed in a follow up PR.

- Pass coordinate subsets to product maps directly, using non-owning
  `DataVector` views to avoid copies.
- Simplify the `BulgedCube` Jacobian helper to take coordinates directly.
- Remove coordinate-map tests for `reference_wrapper` arguments in preparation
  for the follow-up cleanup, see #7461 

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent was used, have a co-author trailer of the form
      "Co-Authored-By: <agent name> <agent email>" as the last line of the
      commit, e.g. "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>".

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
