### PR TITLE
Bump CodingAgents container to NPM 24 for latest claude

### DIFF
--- a/containers/CodingAgents.def
+++ b/containers/CodingAgents.def
@@ -111,9 +111,9 @@ From: sxscollaboration/spectre:dev
     apt-get clean
     rm -rf /var/lib/apt/lists/*
 
-    # Install Node.js 20 from NodeSource (this will install node and npm)
-    echo "=== Installing Node.js 20 ==="
-    curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
+    # Install Node.js 24 from NodeSource (this will install node and npm).
+    echo "=== Installing Node.js 24 ==="
+    curl -fsSL https://deb.nodesource.com/setup_24.x | bash -
     apt-get install -y --no-install-recommends nodejs
     # Cleanup apt lists to reduce image size
     apt-get clean


### PR DESCRIPTION
## Proposed changes

Newest claude requires NPM 22 or newer. npm 22 is EOL in April 2027, so just bump right to 24.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent was used, have a co-author trailer of the form
      "Co-Authored-By: <agent name> <agent email>" as the last line of the
      commit, e.g. "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>".

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
