### PR TITLE
Update fetched Yaml-Cpp and XSIMD version

### DIFF
--- a/cmake/SetupXsimd.cmake
+++ b/cmake/SetupXsimd.cmake
@@ -20,12 +20,12 @@ if(USE_XSIMD)
     include(FetchContent)
     FetchContent_Declare(xsimd
         GIT_REPOSITORY https://github.com/xtensor-stack/xsimd
-        GIT_TAG 13.2.0
+        GIT_TAG 14.3.0
         ${SPECTRE_FETCHCONTENT_BASE_ARGS}
     )
     FetchContent_MakeAvailable(xsimd)
     set(xsimd_INCLUDE_DIRS ${xsimd_SOURCE_DIR}/include)
-    set(xsimd_VERSION "13.2.0")
+    set(xsimd_VERSION "14.3.0")
     if (NOT CMAKE_VERSION VERSION_GREATER_EQUAL 3.25)
       get_target_property(XSIMD_IID xsimd INTERFACE_INCLUDE_DIRECTORIES)
       set_target_properties(xsimd PROPERTIES INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${XSIMD_IID}")

--- a/cmake/SetupYamlCpp.cmake
+++ b/cmake/SetupYamlCpp.cmake
@@ -12,7 +12,7 @@ if (NOT YAML_CPP_FOUND)
   include(FetchContent)
   FetchContent_Declare(yaml-cpp
     GIT_REPOSITORY https://github.com/jbeder/yaml-cpp.git
-    GIT_TAG 0.8.0
+    GIT_TAG yaml-cpp-0.9.0
     GIT_SHALLOW TRUE
     ${SPECTRE_FETCHCONTENT_BASE_ARGS}
   )


### PR DESCRIPTION
## Proposed changes

Update the version for automatically fetched Yaml-Cpp and XSIMD.

### Upgrade instructions

Cmake will reconfigure automatically on the next build.

### Further comments

Newer CMake versions throw an error when pulling in the previous version of Yaml-Cpp because of its outdated CMake version.
For the previous XSIMD version it was giving a warning that support for its version will be removed.
