### PR TITLE
Fix on_interface basis assumptions

### DIFF
--- a/src/NumericalAlgorithms/LinearOperators/Filters/FilledCylinder.tpp
+++ b/src/NumericalAlgorithms/LinearOperators/Filters/FilledCylinder.tpp
@@ -253,52 +253,62 @@ void FilledCylinder<TagList>::apply_on_boundary(
     /*inv_jac_grid_to_inertial*/,
     const std::optional<Jacobian<DataVector, 3, Frame::Grid, Frame::Inertial>>&
     /*jac_grid_to_inertial*/) const {
-  const bool zernike_0 = mesh.basis(0) == Spectral::Basis::ZernikeB2;
-  const bool zernike_1 = mesh.basis(1) == Spectral::Basis::ZernikeB2;
+  const bool is_disk_face =
+      mesh.basis() == make_array<2>(Spectral::Basis::ZernikeB2);
+  const bool is_mantle_face = (mesh.basis(0) == Spectral::Basis::Fourier and
+                               Filters::detail::is_legendre_or_chebyshev(
+                                   mesh.basis(1), mesh.quadrature(1))) or
+                              (Filters::detail::is_legendre_or_chebyshev(
+                                   mesh.basis(0), mesh.quadrature(0)) and
+                               mesh.basis(1) == Spectral::Basis::Fourier);
   // A filled-cylinder face drops one volume dimension while preserving the
   // order of the remaining two, so the basis (and quadrature) pattern of the
   // 2-D face mesh uniquely identifies which physical directions it spans:
-  //   (ZernikeB2, ZernikeB2)              -> (radial, angular)  [axial face]
-  //   (ZernikeB2/Equiangular, Legendre)   -> (angular, z)       [mantle face]
+  //   (ZernikeB2, ZernikeB2)        -> (radial, angular)  [axial face]
+  //   (Fourier, Legendre)           -> (angular, z)       [mantle face]
+  // Note that the mortar infrastructure converts ZernikeB2/Equiangular to
+  // Fourier/Equiangular
   // A (radial, z) face -- (ZernikeB2/GaussRadauUpper, Legendre) -- would be
   // obtained by slicing away the angular direction, but that direction is
   // periodic and so has no boundary faces; such a face cannot occur and is
   // treated as an error below.
-  if (zernike_0 and zernike_1) {
+  if (is_disk_face) {
     // Axial face: a full disk.
     Spectral::filtering::zernike_b2_disk_filter(
         vars, mesh, 36.0,
         FilledCylinder_detail::to_unsigned(radial_angular_half_power_),
         num_modes_to_kill_);
     return;
+  } else if (mesh.basis(0) == Spectral::Basis::ZernikeB2 or
+             mesh.basis(1) == Spectral::Basis::ZernikeB2) {
+    // The angular direction was sliced: angular direction is periodic and so
+    // has no boundary faces; such a face cannot occur.
+    ERROR(
+        "The FilledCylinder boundary filter was given a (radial, z) face "
+        "(face basis "
+        << mesh.basis(0) << ", " << mesh.basis(1) << " with dim-0 quadrature "
+        << mesh.quadrature(0)
+        << "). Such a face is obtained by slicing away the angular direction "
+           "of the volume mesh, but the angular direction is periodic and so "
+           "has no boundary faces. The boundary filter is only valid on the "
+           "axial face (radial, angular) and the mantle face (angular, z).");
   }
   std::array<std::reference_wrapper<const Matrix>, 2> filter{
       std::cref(empty_matrix_), std::cref(empty_matrix_)};
-  if (zernike_0 and not zernike_1) {
-    // dim 1 is z (Legendre/Chebyshev) and dim 0 is a lone ZernikeB2 direction.
-    if (mesh.quadrature(0) != Spectral::Quadrature::Equiangular) {
-      // dim 0 is the radial direction (GaussRadauUpper), so this is a
-      // (radial, z) face, obtained by slicing away the angular direction. The
-      // angular direction is periodic and so has no boundary faces; such a
-      // face cannot occur.
-      ERROR(
-          "The FilledCylinder boundary filter was given a (radial, z) face "
-          "(face basis "
-          << mesh.basis(0) << ", " << mesh.basis(1) << " with dim-0 quadrature "
-          << mesh.quadrature(0)
-          << "). Such a face is obtained by slicing away the angular direction "
-             "of the volume mesh, but the angular direction is periodic and so "
-             "has no boundary faces. The boundary filter is only valid on the "
-             "axial face (radial, angular) and the mantle face (angular, z).");
+  if (is_mantle_face) {
+    if (mesh.basis(0) == Spectral::Basis::Fourier) {
+      filter[0] = std::cref(angular_filter_matrix(
+          Mesh<1>{mesh.extents(0), Spectral::Basis::Fourier,
+                  Spectral::Quadrature::Equiangular}));
+      filter[1] = std::cref(exponential_filter_matrix(
+          z_half_power_, mesh.slice_through(1), cached_z_filter_));
+    } else {
+      filter[0] = std::cref(exponential_filter_matrix(
+          z_half_power_, mesh.slice_through(1), cached_z_filter_));
+      filter[1] = std::cref(angular_filter_matrix(
+          Mesh<1>{mesh.extents(0), Spectral::Basis::Fourier,
+                  Spectral::Quadrature::Equiangular}));
     }
-    // Mantle face: dim 0 is the angular direction. It is collocated on
-    // equiangular ZernikeB2 points, so it is filtered as Fourier via a matching
-    // Fourier/Equiangular 1-D mesh of the same extent.
-    filter[0] = std::cref(
-        angular_filter_matrix(Mesh<1>{mesh.extents(0), Spectral::Basis::Fourier,
-                                      Spectral::Quadrature::Equiangular}));
-    filter[1] = std::cref(exponential_filter_matrix(
-        z_half_power_, mesh.slice_through(1), cached_z_filter_));
   } else {
     ERROR(
         "FilledCylinder filter called on a face mesh with an unexpected basis "

--- a/src/NumericalAlgorithms/Spectral/Mesh.cpp
+++ b/src/NumericalAlgorithms/Spectral/Mesh.cpp
@@ -236,11 +236,10 @@ Mesh<Dim - 1> Mesh<Dim>::on_interface(const size_t d) const {
   // (Fourier) so that the face mesh has the correct basis for the boundary.
   if (basis(d) == Spectral::Basis::ZernikeB3) {
     ASSERT(Dim == 3, "ZernikeB3 should only be used on 3D meshes, got " << Dim);
-    // Can't test interface direction is upper, but that is also an assumption
-    ASSERT(d == 0 and quadrature(d) == Spectral::Quadrature::GaussRadauUpper,
-           "A mesh using B3 only has an interface when sliced in the first "
-           "dimension (not in angular directions), got "
-               << d);
+    ASSERT(quadrature(d) == Spectral::Quadrature::GaussRadauUpper,
+           "A B3 ball's outer boundary is at the upper end of the radial "
+           "dimension (GaussRadauUpper quadrature), but dimension "
+               << d << " has quadrature " << quadrature(d));
     ASSERT(basis() == make_array<Dim>(Spectral::Basis::ZernikeB3),
            "Mesh is using ZernikeB3 basis in a nonisotropic manner, got "
                << basis());
@@ -251,19 +250,18 @@ Mesh<Dim - 1> Mesh<Dim>::on_interface(const size_t d) const {
   if (basis(d) == Spectral::Basis::ZernikeB2) {
     ASSERT(Dim == 2 or Dim == 3,
            "ZernikeB2 should only be used on 2D or 3D meshes, got " << Dim);
-    // Can't test interface direction is upper, but that is also an assumption
-    ASSERT(d == 0 and quadrature(d) == Spectral::Quadrature::GaussRadauUpper,
-           "A mesh using B2 only has an interface when sliced in the first "
-           "dimension (not in angular direction), got "
-               << d);
-    ASSERT(basis(0) == Spectral::Basis::ZernikeB2 and
-               basis(1) == Spectral::Basis::ZernikeB2,
-           "Mesh does not have ZernikeB2 for the first two bases, got "
-               << basis());
+    ASSERT(quadrature(d) == Spectral::Quadrature::GaussRadauUpper,
+           "A B2 disk's outer boundary is at the upper end of the radial "
+           "dimension (GaussRadauUpper quadrature), but dimension "
+               << d << " has quadrature " << quadrature(d));
     auto bases = face.basis();
-    if constexpr (Dim > 1) {
-      bases[0] = Spectral::Basis::Fourier;
-    }
+    ASSERT(
+        std::count(bases.begin(), bases.end(), Spectral::Basis::ZernikeB2) == 1,
+        "Expected exactly one ZernikeB2 angular basis remaining in the "
+        "face after slicing a B2 mesh, got face bases "
+            << face.basis());
+    std::replace(bases.begin(), bases.end(), Spectral::Basis::ZernikeB2,
+                 Spectral::Basis::Fourier);
     return {face.extents().indices(), bases, face.quadrature()};
   }
   return face;

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Filters/Test_FilledCylinder.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Filters/Test_FilledCylinder.cpp
@@ -434,10 +434,11 @@ void test_apply_on_boundary() {
     CHECK_VARIABLES_CUSTOM_APPROX(vars, expected, custom_approx);
   }
 
-  // Mantle (radial) face: slice away dim 0 -> face dims (ZernikeB2/Equiangular
-  // angular, Legendre z). The angular direction is filtered as Fourier.
+  // Mantle face: slice away dim 0, then mortar-converted to Fourier/Equiangular
+  // in the angular direction -> face dims (Fourier/Equiangular angular,
+  // Legendre z).
   {
-    const Mesh<2> face = volume_mesh.slice_away(0);
+    const Mesh<2> face = volume_mesh.on_interface(0);
     const Mesh<1> fourier_angular{face.extents(0), Spectral::Basis::Fourier,
                                   Spectral::Quadrature::Equiangular};
     const auto initial = deterministic_vars<2>(face);
@@ -467,7 +468,13 @@ void test_apply_on_boundary() {
     const auto cutoff_filter =
         CylinderFilter(num_modes_to_kill, std::nullopt, z_half, true,
                        std::nullopt, false, false, std::nullopt, std::nullopt);
-    const Mesh<2> face = volume_mesh.slice_away(0);
+    const Mesh<2> face{
+        std::array<size_t, 2>{volume_mesh.extents(1), volume_mesh.extents(2)},
+        std::array<Spectral::Basis, 2>{Spectral::Basis::Fourier,
+                                       Spectral::Basis::Legendre},
+        std::array<Spectral::Quadrature, 2>{
+            Spectral::Quadrature::Equiangular,
+            Spectral::Quadrature::GaussLobatto}};
     const Mesh<1> fourier_angular{face.extents(0), Spectral::Basis::Fourier,
                                   Spectral::Quadrature::Equiangular};
     const auto initial = deterministic_vars<2>(face);
@@ -506,7 +513,13 @@ void test_apply_on_boundary() {
     const auto identity_filter =
         CylinderFilter(0, std::nullopt, std::nullopt, true, std::nullopt, false,
                        false, std::nullopt, std::nullopt);
-    const Mesh<2> face = volume_mesh.slice_away(0);
+    const Mesh<2> face{
+        std::array<size_t, 2>{volume_mesh.extents(1), volume_mesh.extents(2)},
+        std::array<Spectral::Basis, 2>{Spectral::Basis::Fourier,
+                                       Spectral::Basis::Legendre},
+        std::array<Spectral::Quadrature, 2>{
+            Spectral::Quadrature::Equiangular,
+            Spectral::Quadrature::GaussLobatto}};
     const auto initial = deterministic_vars<2>(face);
     auto vars = initial;
     identity_filter.apply_on_boundary(make_not_null(&vars), face, std::nullopt,

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_Mesh.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_Mesh.cpp
@@ -216,6 +216,20 @@ void test_interface_mesh() {
                 std::array{Spectral::Quadrature::Equiangular,
                            Spectral::Quadrature::GaussLobatto}));
 
+  // B2 cylinder (reoriented: radial is last dim). Arises in Pill blocks where
+  // the cylinder axis is not aligned with the block's first logical direction.
+  const Mesh<3> b2_cyl_rev_mesh{
+      {{5, 7, 3}},
+      {{Spectral::Basis::Legendre, Spectral::Basis::ZernikeB2,
+        Spectral::Basis::ZernikeB2}},
+      {{Spectral::Quadrature::GaussLobatto, Spectral::Quadrature::Equiangular,
+        Spectral::Quadrature::GaussRadauUpper}}};
+  CHECK(b2_cyl_rev_mesh.on_interface(2) ==
+        Mesh<2>({{5, 7}},
+                std::array{Spectral::Basis::Legendre, Spectral::Basis::Fourier},
+                std::array{Spectral::Quadrature::GaussLobatto,
+                           Spectral::Quadrature::Equiangular}));
+
 #ifdef SPECTRE_DEBUG
   // B3: wrong Dim
   CHECK_THROWS_WITH((Mesh<2>{{{3, 7}},
@@ -234,7 +248,7 @@ void test_interface_mesh() {
             Spectral::Quadrature::Equiangular}}}
            .on_interface(1)),
       Catch::Matchers::ContainsSubstring(
-          "A mesh using B3 only has an interface when sliced in the first "
+          "A B3 ball's outer boundary is at the upper end of the radial "
           "dimension"));
   // B3: radial dimension does not use GaussRadauUpper
   CHECK_THROWS_WITH(
@@ -244,7 +258,7 @@ void test_interface_mesh() {
                  Spectral::Quadrature::Equiangular}}}
            .on_interface(0)),
       Catch::Matchers::ContainsSubstring(
-          "A mesh using B3 only has an interface when sliced in the first "
+          "A B3 ball's outer boundary is at the upper end of the radial "
           "dimension"));
   // B3: non-isotropic bases
   CHECK_THROWS_WITH(
@@ -271,7 +285,7 @@ void test_interface_mesh() {
                  Spectral::Quadrature::Equiangular}}}
            .on_interface(1)),
       Catch::Matchers::ContainsSubstring(
-          "A mesh using B2 only has an interface when sliced in the first "
+          "A B2 disk's outer boundary is at the upper end of the radial "
           "dimension"));
   // B2: radial dimension does not use GaussRadauUpper
   CHECK_THROWS_WITH(
@@ -281,9 +295,9 @@ void test_interface_mesh() {
           {{Spectral::Quadrature::Gauss, Spectral::Quadrature::Equiangular}}}
            .on_interface(0)),
       Catch::Matchers::ContainsSubstring(
-          "A mesh using B2 only has an interface when sliced in the first "
+          "A B2 disk's outer boundary is at the upper end of the radial "
           "dimension"));
-  // B2: first two bases are not both ZernikeB2
+  // B2: no ZernikeB2 angular basis in face after slicing radial
   CHECK_THROWS_WITH(
       (Mesh<2>{{{3, 7}},
                {{Spectral::Basis::ZernikeB2, Spectral::Basis::Legendre}},
@@ -291,7 +305,8 @@ void test_interface_mesh() {
                  Spectral::Quadrature::Gauss}}}
            .on_interface(0)),
       Catch::Matchers::ContainsSubstring(
-          "Mesh does not have ZernikeB2 for the first two bases"));
+          "Expected exactly one ZernikeB2 angular basis remaining in the "
+          "face"));
 #endif  // SPECTRE_DEBUG
 }
 


### PR DESCRIPTION
## Proposed changes

First commit: no longer assume basis ordering for B2/B3 as orientation maps can shuffle things

Second commit: have FilledCylinder accept Fourier/Equiangular on boundary—which is what mortar code gives—as opposed to ZernikeB2/Equiangular

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent was used, have a co-author trailer of the form
      "Co-Authored-By: <agent name> <agent email>" as the last line of the
      commit, e.g. "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>".

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
