### PR TITLE
Add SecondOrderWrapper to wrap ScalarWave's solutions

### DIFF
--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/CMakeLists.txt
@@ -10,6 +10,7 @@ spectre_target_sources(
   PRIVATE
   PlaneWave.cpp
   RegularSphericalWave.cpp
+  SecondOrderWrapper.cpp
   SemidiscretizedDg.cpp
   )
 
@@ -20,6 +21,8 @@ spectre_target_headers(
   Factory.hpp
   PlaneWave.hpp
   RegularSphericalWave.hpp
+  SecondOrderWrapper.hpp
+  SecondOrderWrapper.tpp
   SemidiscretizedDg.hpp
   Solutions.hpp
   )

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/Factory.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/Factory.hpp
@@ -5,6 +5,7 @@
 
 #include "PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/WaveEquation/RegularSphericalWave.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/WaveEquation/SecondOrderWrapper.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/WaveEquation/SemidiscretizedDg.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -17,3 +18,11 @@ using all_solutions = tmpl::append<
     tmpl::conditional_t<Dim == 3, tmpl::list<RegularSphericalWave>,
                         tmpl::list<>>>;
 }  // namespace ScalarWave::Solutions
+
+namespace SecondOrderScalarWave::Solutions {
+/// \brief List of all analytic solutions for the second-order in space scalar
+/// wave system
+template <size_t Dim>
+using all_solutions =
+    tmpl::list<SecondOrderWrapper<ScalarWave::Solutions::PlaneWave<Dim>>>;
+}  // namespace SecondOrderScalarWave::Solutions

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp
@@ -79,7 +79,7 @@ class PlaneWave : public evolution::initial_data::InitialData,
   static constexpr Options::String help = {
       "A plane wave solution of the Euclidean wave equation"};
   using tags =
-      tmpl::list<Tags::Psi, Tags::Pi, Tags::Phi<3>, ::Tags::dt<Tags::Psi>,
+      tmpl::list<Tags::Psi, Tags::Pi, Tags::Phi<Dim>, ::Tags::dt<Tags::Psi>,
                  ::Tags::dt<Tags::Pi>, ::Tags::dt<Tags::Phi<Dim>>>;
 
   PlaneWave() = default;

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/SecondOrderWrapper.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/SecondOrderWrapper.cpp
@@ -1,0 +1,13 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/AnalyticSolutions/WaveEquation/SecondOrderWrapper.hpp"
+
+#include "PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/WaveEquation/SecondOrderWrapper.tpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+GENERATE_INSTANTIATIONS(SECOND_ORDER_WRAPPER_INSTANTIATE,
+                        (ScalarWave::Solutions::PlaneWave<1>,
+                         ScalarWave::Solutions::PlaneWave<2>,
+                         ScalarWave::Solutions::PlaneWave<3>))

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/SecondOrderWrapper.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/SecondOrderWrapper.hpp
@@ -1,0 +1,154 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+#include "DataStructures/TaggedTuple.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Options/String.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/AnalyticSolution.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
+#include "Utilities/PrettyType.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+namespace SecondOrderScalarWave::Tags {
+struct Psi;
+struct Pi;
+template <size_t Dim>
+struct Phi;
+}  // namespace SecondOrderScalarWave::Tags
+namespace Tags {
+template <typename Tag>
+struct dt;
+}  // namespace Tags
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace SecondOrderScalarWave::Solutions {
+/*!
+ * \brief Adapts a `ScalarWave` analytic solution to an analytic solution of
+ * the `SecondOrderScalarWave` system.
+ *
+ * The wrapped `SolutionType` supplies the mathematics of the solution together
+ * with its variables and their time derivatives in the `ScalarWave` tag
+ * namespace. This adapter re-exposes those quantities through the
+ * `SecondOrderScalarWave` tags, adding the three `variables` interfaces the
+ * second-order-in-space system requires: the evolved and auxiliary variables
+ * \f$\{\Psi, \Pi, \Phi_i\}\f$, the evolved variables \f$\{\Psi, \Pi\}\f$, and
+ * the time derivatives of the evolved variables
+ * \f$\{\partial_t\Psi, \partial_t\Pi\}\f$. In the second-order-in-space system
+ * only \f$\Psi\f$ and \f$\Pi\f$ are evolved; \f$\Phi_i\f$ is auxiliary and is
+ * not evolved, so \f$\partial_t\Phi_i\f$ from the wrapped solution is
+ * discarded.
+ *
+ * The wrapped solution is held by composition, so only the second-order
+ * interface below is public; the `ScalarWave` interface of `SolutionType` is
+ * not exposed.
+ *
+ * \tparam SolutionType a `ScalarWave` analytic solution to adapt
+ */
+template <typename SolutionType>
+class SecondOrderWrapper : public evolution::initial_data::InitialData,
+                           public MarkAsAnalyticSolution {
+ private:
+  // Lifetime-safe backing storage for `help`, built on first use so it is
+  // constructed before `help` reads it.
+  static const std::string& help_storage() {
+    static const std::string storage =
+        "Adapts a ScalarWave analytic solution for SecondOrderScalarWave.\n" +
+        std::string{SolutionType::help};
+    return storage;
+  }
+
+ public:
+  SecondOrderWrapper() = default;
+  SecondOrderWrapper(const SecondOrderWrapper& /*rhs*/) = default;
+  SecondOrderWrapper& operator=(const SecondOrderWrapper& /*rhs*/) = default;
+  SecondOrderWrapper(SecondOrderWrapper&& /*rhs*/) = default;
+  SecondOrderWrapper& operator=(SecondOrderWrapper&& /*rhs*/) = default;
+  ~SecondOrderWrapper() override = default;
+
+  explicit SecondOrderWrapper(SolutionType solution)
+      : wrapped_solution_(std::move(solution)) {}
+
+  template <typename... Args>
+  requires std::is_constructible_v<SolutionType, Args&&...>
+  explicit SecondOrderWrapper(Args&&... args)
+      : wrapped_solution_(std::forward<Args>(args)...) {}
+
+  auto get_clone() const
+      -> std::unique_ptr<evolution::initial_data::InitialData> override;
+
+  /// \cond
+  explicit SecondOrderWrapper(CkMigrateMessage* msg);
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(SecondOrderWrapper);
+  /// \endcond
+
+  static constexpr size_t volume_dim = SolutionType::volume_dim;
+  using options = typename SolutionType::options;
+  inline static Options::String help = help_storage().c_str();
+  static std::string name() {
+    return "SecondOrder" + pretty_type::name<SolutionType>();
+  }
+
+  using tags = tmpl::list<SecondOrderScalarWave::Tags::Psi,
+                          SecondOrderScalarWave::Tags::Pi,
+                          SecondOrderScalarWave::Tags::Phi<volume_dim>,
+                          ::Tags::dt<SecondOrderScalarWave::Tags::Psi>,
+                          ::Tags::dt<SecondOrderScalarWave::Tags::Pi>>;
+
+  /// Retrieve the evolved and auxiliary variables (Psi, Pi, Phi) at time `t`
+  /// and spatial coordinates `x`
+  tuples::TaggedTuple<SecondOrderScalarWave::Tags::Psi,
+                      SecondOrderScalarWave::Tags::Pi,
+                      SecondOrderScalarWave::Tags::Phi<volume_dim>>
+  variables(const tnsr::I<DataVector, volume_dim>& x, double t,
+            tmpl::list<SecondOrderScalarWave::Tags::Psi,
+                       SecondOrderScalarWave::Tags::Pi,
+                       SecondOrderScalarWave::Tags::Phi<volume_dim>>
+            /*meta*/) const;
+
+  /// Retrieve the evolved variables (Psi, Pi)
+  tuples::TaggedTuple<SecondOrderScalarWave::Tags::Psi,
+                      SecondOrderScalarWave::Tags::Pi>
+  variables(const tnsr::I<DataVector, volume_dim>& x, double t,
+            tmpl::list<SecondOrderScalarWave::Tags::Psi,
+                       SecondOrderScalarWave::Tags::Pi> /*meta*/) const;
+
+  /// Retrieve the time derivatives of the evolved variables (dt(Psi), dt(Pi))
+  /// at time `t` and spatial coordinates `x`
+  tuples::TaggedTuple<::Tags::dt<SecondOrderScalarWave::Tags::Psi>,
+                      ::Tags::dt<SecondOrderScalarWave::Tags::Pi>>
+  variables(const tnsr::I<DataVector, volume_dim>& x, double t,
+            tmpl::list<::Tags::dt<SecondOrderScalarWave::Tags::Psi>,
+                       ::Tags::dt<SecondOrderScalarWave::Tags::Pi>>
+            /*meta*/) const;
+
+  // NOLINTNEXTLINE(google-runtime-references)
+  void pup(PUP::er& p) override;
+
+ private:
+  friend bool operator==(const SecondOrderWrapper& lhs,
+                         const SecondOrderWrapper& rhs) {
+    return lhs.wrapped_solution_ == rhs.wrapped_solution_;
+  }
+  friend bool operator!=(const SecondOrderWrapper& lhs,
+                         const SecondOrderWrapper& rhs) {
+    return not(lhs == rhs);
+  }
+
+  SolutionType wrapped_solution_{};
+};
+}  // namespace SecondOrderScalarWave::Solutions

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/SecondOrderWrapper.tpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/SecondOrderWrapper.tpp
@@ -1,0 +1,103 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include "PointwiseFunctions/AnalyticSolutions/WaveEquation/SecondOrderWrapper.hpp"
+
+#include <cstddef>
+#include <utility>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/TaggedTuple.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/ScalarWave/Tags.hpp"
+#include "Evolution/Systems/SecondOrderScalarWave/Tags.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+
+namespace SecondOrderScalarWave::Solutions {
+template <typename SolutionType>
+SecondOrderWrapper<SolutionType>::SecondOrderWrapper(CkMigrateMessage* msg)
+    : evolution::initial_data::InitialData(msg) {}
+
+template <typename SolutionType>
+std::unique_ptr<evolution::initial_data::InitialData>
+SecondOrderWrapper<SolutionType>::get_clone() const {
+  return std::make_unique<SecondOrderWrapper<SolutionType>>(*this);
+}
+
+template <typename SolutionType>
+tuples::TaggedTuple<SecondOrderScalarWave::Tags::Psi,
+                    SecondOrderScalarWave::Tags::Pi,
+                    SecondOrderScalarWave::Tags::Phi<
+                        SecondOrderWrapper<SolutionType>::volume_dim>>
+SecondOrderWrapper<SolutionType>::variables(
+    const tnsr::I<DataVector, SecondOrderWrapper<SolutionType>::volume_dim>& x,
+    const double t,
+    const tmpl::list<SecondOrderScalarWave::Tags::Psi,
+                     SecondOrderScalarWave::Tags::Pi,
+                     SecondOrderScalarWave::Tags::Phi<
+                         SecondOrderWrapper<SolutionType>::volume_dim>>
+    /*meta*/) const {
+  auto scalar_wave_vars = wrapped_solution_.variables(
+      x, t,
+      tmpl::list<ScalarWave::Tags::Psi, ScalarWave::Tags::Pi,
+                 ScalarWave::Tags::Phi<volume_dim>>{});
+  return {std::move(get<ScalarWave::Tags::Psi>(scalar_wave_vars)),
+          std::move(get<ScalarWave::Tags::Pi>(scalar_wave_vars)),
+          std::move(get<ScalarWave::Tags::Phi<volume_dim>>(scalar_wave_vars))};
+}
+
+template <typename SolutionType>
+tuples::TaggedTuple<SecondOrderScalarWave::Tags::Psi,
+                    SecondOrderScalarWave::Tags::Pi>
+SecondOrderWrapper<SolutionType>::variables(
+    const tnsr::I<DataVector, SecondOrderWrapper<SolutionType>::volume_dim>& x,
+    const double t,
+    const tmpl::list<SecondOrderScalarWave::Tags::Psi,
+                     SecondOrderScalarWave::Tags::Pi> /*meta*/) const {
+  auto scalar_wave_vars = wrapped_solution_.variables(
+      x, t,
+      tmpl::list<ScalarWave::Tags::Psi, ScalarWave::Tags::Pi,
+                 ScalarWave::Tags::Phi<volume_dim>>{});
+  return {std::move(get<ScalarWave::Tags::Psi>(scalar_wave_vars)),
+          std::move(get<ScalarWave::Tags::Pi>(scalar_wave_vars))};
+}
+
+template <typename SolutionType>
+tuples::TaggedTuple<::Tags::dt<SecondOrderScalarWave::Tags::Psi>,
+                    ::Tags::dt<SecondOrderScalarWave::Tags::Pi>>
+SecondOrderWrapper<SolutionType>::variables(
+    const tnsr::I<DataVector, SecondOrderWrapper<SolutionType>::volume_dim>& x,
+    const double t,
+    const tmpl::list<::Tags::dt<SecondOrderScalarWave::Tags::Psi>,
+                     ::Tags::dt<SecondOrderScalarWave::Tags::Pi>> /*meta*/)
+    const {
+  auto scalar_wave_dt_vars = wrapped_solution_.variables(
+      x, t,
+      tmpl::list<::Tags::dt<ScalarWave::Tags::Psi>,
+                 ::Tags::dt<ScalarWave::Tags::Pi>,
+                 ::Tags::dt<ScalarWave::Tags::Phi<volume_dim>>>{});
+  // The second-order-in-space system does not evolve Phi, so its time
+  // derivative from the wrapped solution is discarded.
+  return {
+      std::move(get<::Tags::dt<ScalarWave::Tags::Psi>>(scalar_wave_dt_vars)),
+      std::move(get<::Tags::dt<ScalarWave::Tags::Pi>>(scalar_wave_dt_vars))};
+}
+
+template <typename SolutionType>
+void SecondOrderWrapper<SolutionType>::pup(PUP::er& p) {
+  evolution::initial_data::InitialData::pup(p);
+  p | wrapped_solution_;
+}
+
+template <typename SolutionType>
+PUP::able::PUP_ID SecondOrderWrapper<SolutionType>::my_PUP_ID = 0;
+
+#define SECOND_ORDER_WRAPPER_SOLUTION_TYPE(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define SECOND_ORDER_WRAPPER_INSTANTIATE(_, data)                      \
+  template class SecondOrderScalarWave::Solutions::SecondOrderWrapper< \
+      SECOND_ORDER_WRAPPER_SOLUTION_TYPE(data)>;
+}  // namespace SecondOrderScalarWave::Solutions

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/Solutions.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/Solutions.hpp
@@ -2,15 +2,37 @@
 // See LICENSE.txt for details.
 
 /// \file
-/// Defines ScalarWave::Solutions
+/// Defines ScalarWave::Solutions and SecondOrderScalarWave::Solutions
 
 #pragma once
 
 namespace ScalarWave {
 /*!
  * \ingroup AnalyticSolutionsGroup
- * \brief Holds classes implementing a solution to the Euclidean wave equation
- * \f$0 = \frac{\partial^2 \Psi}{\partial t^2} - \nabla^2 \Psi\f$.
+ * \brief Holds analytic solutions to the first-order reduction of the
+ * Euclidean wave equation.
+ *
+ * The first-order system evolves \f$\Psi\f$, \f$\Pi\f$, and \f$\Phi_j\f$:
+ * \f{align*}
+ * \partial_t \Psi &= -\Pi, \\
+ * \partial_t \Pi &= -\delta^{ij}\partial_i\Phi_j, \\
+ * \partial_t \Phi_j &= -\partial_j\Pi.
+ * \f}
  */
 namespace Solutions {}
 }  // namespace ScalarWave
+
+/*!
+ * \ingroup AnalyticSolutionsGroup
+ * \brief Holds analytic solutions to the second-order-in-space formulation of
+ * the Euclidean wave equation.
+ *
+ * The second-order-in-space system evolves \f$\Psi\f$ and \f$\Pi\f$, while
+ * \f$\Phi_j\f$ is auxiliary:
+ * \f{align*}
+ * \partial_t \Psi &= -\Pi, \\
+ * \partial_t \Pi &= -\delta^{ij}\partial_i\Phi_j, \\
+ * \Phi_j &= \partial_j\Psi.
+ * \f}
+ */
+namespace SecondOrderScalarWave::Solutions {}

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/CMakeLists.txt
@@ -13,6 +13,7 @@ set(LIBRARY "Test_WaveEquation")
 set(LIBRARY_SOURCES
   Test_PlaneWave.cpp
   Test_RegularSphericalWave.cpp
+  Test_SecondOrderWrapper.cpp
   # Test_SemidiscretizedDg.cpp
   )
 

--- a/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_SecondOrderWrapper.cpp
+++ b/tests/Unit/PointwiseFunctions/AnalyticSolutions/WaveEquation/Test_SecondOrderWrapper.cpp
@@ -1,0 +1,237 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <iomanip>
+#include <limits>
+#include <memory>
+#include <random>
+#include <sstream>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/TaggedTuple.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/Systems/ScalarWave/Tags.hpp"
+#include "Evolution/Systems/SecondOrderScalarWave/Tags.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/WaveEquation/SecondOrderWrapper.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/InitialData.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/Tags/InitialData.hpp"
+#include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
+#include "PointwiseFunctions/MathFunctions/PowX.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/PrettyType.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
+#include "Utilities/Serialization/Serialize.hpp"
+#include "Utilities/TMPL.hpp"
+
+// Tests SecondOrderWrapper as an adapter around
+// ScalarWave::Solutions::PlaneWave. The wrapped solution's mathematics (psi,
+// dpsi_dt, ...) is exercised by Test_PlaneWave; here we only verify the adapter
+// contract: the second-order `variables` interfaces re-expose the wrapped
+// solution's values under the SecondOrderScalarWave tags.
+namespace {
+// Tag namespaces of the wrapped (first-order) solution and the second-order
+// system the adapter targets.
+namespace sw_tags = ScalarWave::Tags;
+namespace so_tags = SecondOrderScalarWave::Tags;
+
+template <size_t Dim>
+using Wrapper = SecondOrderScalarWave::Solutions::SecondOrderWrapper<
+    ScalarWave::Solutions::PlaneWave<Dim>>;
+
+template <size_t Dim>
+std::string yaml_sequence(const std::array<double, Dim>& values) {
+  std::stringstream result{};
+  result << std::setprecision(std::numeric_limits<double>::max_digits10) << "[";
+  for (size_t d = 0; d < Dim; ++d) {
+    if (d > 0) {
+      result << ", ";
+    }
+    result << gsl::at(values, d);
+  }
+  result << "]";
+  return result.str();
+}
+
+template <size_t Dim>
+struct Metavariables {
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes = tmpl::map<
+        tmpl::pair<MathFunction<1, Frame::Inertial>,
+                   tmpl::list<MathFunctions::PowX<1, Frame::Inertial>>>,
+        tmpl::pair<evolution::initial_data::InitialData,
+                   tmpl::list<Wrapper<Dim>>>>;
+  };
+};
+
+// Verifies the three second-order `variables` interfaces against the
+// independently supplied first-order PlaneWave. This establishes that the
+// plane-wave values are preserved under the mapping to the
+// SecondOrderScalarWave tags.
+template <size_t Dim>
+void check_adapter_contract(
+    const Wrapper<Dim>& second_order_plane_wave,
+    const ScalarWave::Solutions::PlaneWave<Dim>& plane_wave,
+    const tnsr::I<DataVector, Dim>& x, const double t) {
+  const auto plane_wave_vars = plane_wave.variables(
+      x, t, tmpl::list<sw_tags::Psi, sw_tags::Pi, sw_tags::Phi<Dim>>{});
+
+  // Evolved and auxiliary variables {Psi, Pi, Phi}: the values from the wrapped
+  // solution are preserved under the tag mapping.
+  const auto second_order_vars = second_order_plane_wave.variables(
+      x, t, tmpl::list<so_tags::Psi, so_tags::Pi, so_tags::Phi<Dim>>{});
+  CHECK(get<so_tags::Psi>(second_order_vars) ==
+        get<sw_tags::Psi>(plane_wave_vars));
+  CHECK(get<so_tags::Pi>(second_order_vars) ==
+        get<sw_tags::Pi>(plane_wave_vars));
+  CHECK(get<so_tags::Phi<Dim>>(second_order_vars) ==
+        get<sw_tags::Phi<Dim>>(plane_wave_vars));
+
+  // Evolved variables {Psi, Pi}.
+  const auto second_order_evolved_vars = second_order_plane_wave.variables(
+      x, t, tmpl::list<so_tags::Psi, so_tags::Pi>{});
+  static_assert(
+      std::is_same_v<std::decay_t<decltype(second_order_evolved_vars)>,
+                     tuples::TaggedTuple<so_tags::Psi, so_tags::Pi>>,
+      "The evolved-variables overload must return exactly {Psi, Pi}.");
+  CHECK(get<so_tags::Psi>(second_order_evolved_vars) ==
+        get<sw_tags::Psi>(plane_wave_vars));
+  CHECK(get<so_tags::Pi>(second_order_evolved_vars) ==
+        get<sw_tags::Pi>(plane_wave_vars));
+
+  // Time derivatives of the evolved variables {dt<Psi>, dt<Pi>}: the return
+  // type drops the wrapped solution's dt<Phi>.
+  const auto plane_wave_dt_vars = plane_wave.variables(
+      x, t,
+      tmpl::list<Tags::dt<sw_tags::Psi>, Tags::dt<sw_tags::Pi>,
+                 Tags::dt<sw_tags::Phi<Dim>>>{});
+  const auto second_order_dt_vars = second_order_plane_wave.variables(
+      x, t, tmpl::list<Tags::dt<so_tags::Psi>, Tags::dt<so_tags::Pi>>{});
+  static_assert(
+      std::is_same_v<
+          std::decay_t<decltype(second_order_dt_vars)>,
+          tuples::TaggedTuple<Tags::dt<so_tags::Psi>, Tags::dt<so_tags::Pi>>>,
+      "The second-order dt overload must drop dt<Phi>.");
+  CHECK(get<Tags::dt<so_tags::Psi>>(second_order_dt_vars) ==
+        get<Tags::dt<sw_tags::Psi>>(plane_wave_dt_vars));
+  CHECK(get<Tags::dt<so_tags::Pi>>(second_order_dt_vars) ==
+        get<Tags::dt<sw_tags::Pi>>(plane_wave_dt_vars));
+}
+
+template <size_t Dim>
+void test_wrapper(const gsl::not_null<std::mt19937*> generator) {
+  std::uniform_real_distribution<> wave_magnitude_distribution(0.5, 2.0);
+  std::uniform_real_distribution<> value_distribution(-2.0, 2.0);
+  auto wave_vector = make_with_random_values<std::array<double, Dim>>(
+      generator, make_not_null(&wave_magnitude_distribution),
+      std::array<double, Dim>{});
+  for (size_t d = 1; d < Dim; d += 2) {
+    gsl::at(wave_vector, d) *= -1.0;
+  }
+  const auto center = make_with_random_values<std::array<double, Dim>>(
+      generator, make_not_null(&value_distribution), std::array<double, Dim>{});
+  const auto make_profile = [](const int power) {
+    return std::make_unique<MathFunctions::PowX<1, Frame::Inertial>>(power);
+  };
+
+  const ScalarWave::Solutions::PlaneWave<Dim> plane_wave(wave_vector, center,
+                                                         make_profile(3));
+  const SecondOrderScalarWave::Solutions::SecondOrderWrapper
+      second_order_plane_wave(plane_wave);
+  static_assert(
+      std::is_same_v<std::remove_const_t<decltype(second_order_plane_wave)>,
+                     Wrapper<Dim>>,
+      "Class template argument deduction must yield Wrapper<Dim>.");
+  // The wrapper holds the ScalarWave solution by composition, not inheritance,
+  // so the wrapped interface stays hidden.
+  static_assert(not std::is_base_of_v<ScalarWave::Solutions::PlaneWave<Dim>,
+                                      Wrapper<Dim>>,
+                "The wrapper must not inherit the wrapped solution.");
+  // Differs only in the profile, exercising inequality through the wrapped
+  // solution's operator==.
+  const Wrapper<Dim> different_second_order_plane_wave(wave_vector, center,
+                                                       make_profile(2));
+
+  const auto x = make_with_random_values<tnsr::I<DataVector, Dim>>(
+      generator, make_not_null(&value_distribution), DataVector(5));
+  const auto t = make_with_random_values<double>(
+      generator, make_not_null(&value_distribution));
+
+  // The user-facing factory name of a wrapped PlaneWave is unchanged.
+  CHECK(pretty_type::name<Wrapper<Dim>>() == "SecondOrderPlaneWave");
+
+  // Equality and inequality.
+  CHECK(second_order_plane_wave == second_order_plane_wave);
+  CHECK_FALSE(second_order_plane_wave != second_order_plane_wave);
+  CHECK(second_order_plane_wave != different_second_order_plane_wave);
+  CHECK_FALSE(second_order_plane_wave == different_second_order_plane_wave);
+
+  // Copy and move semantics.
+  test_copy_semantics(second_order_plane_wave);
+  auto second_order_plane_wave_to_move = second_order_plane_wave;
+  test_move_semantics(std::move(second_order_plane_wave_to_move),
+                      second_order_plane_wave);
+
+  // The adapter contract for the three second-order `variables` interfaces,
+  // compared against the independently accessible wrapped solution.
+  check_adapter_contract(second_order_plane_wave, plane_wave, x, t);
+
+  // Serialization round-trip preserves equality and the adapter contract.
+  register_factory_classes_with_charm<Metavariables<Dim>>();
+  const auto deserialized_second_order_plane_wave =
+      serialize_and_deserialize(second_order_plane_wave);
+  CHECK(deserialized_second_order_plane_wave == second_order_plane_wave);
+  check_adapter_contract(deserialized_second_order_plane_wave, plane_wave, x,
+                         t);
+
+  // Clone behavior.
+  const auto cloned_initial_data = second_order_plane_wave.get_clone();
+  CHECK(dynamic_cast<const Wrapper<Dim>&>(*cloned_initial_data) ==
+        second_order_plane_wave);
+
+  // Factory creation from options through the SecondOrderPlaneWave name, and
+  // serialization of the option-created solution.
+  const std::string option_string =
+      "SecondOrderPlaneWave:\n"
+      "  WaveVector: " +
+      yaml_sequence(wave_vector) + "\n  Center: " + yaml_sequence(center) +
+      "\n  Profile:\n"
+      "    PowX:\n"
+      "      Power: 3";
+  const std::unique_ptr<evolution::initial_data::InitialData>
+      option_created_initial_data = TestHelpers::test_option_tag<
+          evolution::initial_data::OptionTags::InitialData, Metavariables<Dim>>(
+          option_string);
+  CHECK(dynamic_cast<const Wrapper<Dim>&>(*option_created_initial_data) ==
+        second_order_plane_wave);
+  const auto deserialized_option_created_initial_data =
+      serialize_and_deserialize(option_created_initial_data);
+  CHECK(dynamic_cast<const Wrapper<Dim>&>(
+            *deserialized_option_created_initial_data) ==
+        second_order_plane_wave);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.PointwiseFunctions.AnalyticSolutions.WaveEquation."
+    "SecondOrderWrapper",
+    "[PointwiseFunctions][Unit]") {
+  MAKE_GENERATOR(generator);
+  test_wrapper<1>(make_not_null(&generator));
+  test_wrapper<2>(make_not_null(&generator));
+  test_wrapper<3>(make_not_null(&generator));
+}


### PR DESCRIPTION
## Proposed changes

Add `SecondOrderWrapper` to wrap `ScalarWave`'s solutions for `SecondOrderScalarWave`.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent was used, have a co-author trailer of the form
      "Co-Authored-By: <agent name> <agent email>" as the last line of the
      commit, e.g. "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>".

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
