### PR TITLE
Compactify the Scalar SF

### DIFF
--- a/src/Elliptic/Systems/SelfForce/Scalar/AnalyticData/CircularOrbit.cpp
+++ b/src/Elliptic/Systems/SelfForce/Scalar/AnalyticData/CircularOrbit.cpp
@@ -104,8 +104,6 @@ CircularOrbit::variables(
     // NOLINTNEXTLINE
     r.set_data_ref(const_cast<DataVector*>(&r_star_or_r));
     r_minus_r_plus = r - r_plus;
-    r_star = gr::tortoise_radius_from_boyer_lindquist_minus_r_plus(
-        r_minus_r_plus, M, black_hole_spin_);
   } else {
     // NOLINTNEXTLINE
     r_star.set_data_ref(const_cast<DataVector*>(&r_star_or_r));
@@ -125,6 +123,8 @@ CircularOrbit::variables(
   const DataVector r_sq_plus_a_sq = square(r) + square(a);
   const DataVector r_sq_plus_a_sq_sq = square(r_sq_plus_a_sq);
   const DataVector sin_theta_squared = 1. - cos_theta_sq;
+  const DataVector sigma_squared =
+      r_sq_plus_a_sq_sq - square(a) * delta * sin_theta_squared;
   tuples::TaggedTuple<Tags::Alpha, Tags::Beta, Tags::Gamma> result{};
   // Hyperboloidal slicing
   ComplexDataVector H;
@@ -144,12 +144,12 @@ CircularOrbit::variables(
   DataVector inv_r{};
   DataVector dsigma_dr{};
   if (in_u_region) {
-    // Inside u-region, x coordinate is defined as
-    // 2 r_u - r_u^2/r to compactify the wavezone.
-    // Elliptic PDEs will be re-written as a function of
-    // inv_r (1/r) instead of r.
-    inv_r = (2.0 * r_u - r) / (r_u * r_u);
-    dsigma_dr = square(r_u) * square(inv_r);
+  // sigma = 2*r_u - r_u^2/r  =>  1/r = (2*r_u - sigma) / r_u^2.
+  // The domain coordinate here is actually sigma, not the physical
+  // Boyer-Lindquist radius, in this region.
+  const DataVector& sigma = get<0>(x);
+  inv_r = (2.0 * r_u - sigma) / (r_u * r_u);
+  dsigma_dr = square(r_u) * square(inv_r);
   } else {
     inv_r = 1.0 / r;
     dsigma_dr = make_with_value<DataVector>(r_star_or_r, 1.0);
@@ -159,16 +159,14 @@ CircularOrbit::variables(
   auto& gamma = get<Tags::Gamma>(result);
   const DataVector one_plus_a_sq_inv_r_sq = 1.0 + square(a) * square(inv_r);
   const DataVector delta_over_r_sq = one_plus_a_sq_inv_r_sq - 2.0 * M * inv_r;
-  const DataVector one_over_r_sq_plus_a_sq =
-      square(inv_r) / one_plus_a_sq_inv_r_sq;
-  const DataVector r_over_r_sq_plus_a_sq = inv_r / one_plus_a_sq_inv_r_sq;
-  const DataVector sigma_sq_over_r_sq_plus_a_sq_sq =
-      1.0 - square(a) * square(inv_r) * delta_over_r_sq * sin_theta_squared /
-                square(one_plus_a_sq_inv_r_sq);
 
   if (penetrating_horizon_) {
     get<0>(alpha) = (delta_over_r_sq / one_plus_a_sq_inv_r_sq) * dsigma_dr;
-    get<1>(alpha) = (square(inv_r) / one_plus_a_sq_inv_r_sq) / dsigma_dr;
+    if (in_u_region){
+    get<1>(alpha) = 1.0 / (square(r_u) * one_plus_a_sq_inv_r_sq);
+    } else {
+    get<1>(alpha) = 1.0 / r_sq_plus_a_sq;
+    }
   } else {
     get<0>(alpha) = make_with_value<DataVector>(r_star_or_r, 1.0);
     get<1>(alpha) = delta / r_sq_plus_a_sq_sq;
@@ -180,12 +178,22 @@ CircularOrbit::variables(
       // division by zero.
       continue;
     }
+    if (in_u_region){
     get(beta)[p] =
-        square(k) * (square(H[p]) - sigma_sq_over_r_sq_plus_a_sq_sq[p]) +
+        (square(k) * square(a) * delta_over_r_sq[p] * sin_theta_squared[p] +
         2. * a * m_mode_number_ * k *
-            (2. * M * r_over_r_sq_plus_a_sq[p] + H[p]) *
-            one_over_r_sq_plus_a_sq[p];
-    get(beta)[p] /= get<0>(alpha)[p];
+            (2. * M * inv_r[p] + one_plus_a_sq_inv_r_sq[p])) /
+        (one_plus_a_sq_inv_r_sq[p] * delta_over_r_sq[p] * square(r_u));
+    } else {
+    get(beta)[p] =
+        square(k) *
+            (square(H[p]) - sigma_squared[p] / r_sq_plus_a_sq_sq[p]) +
+        2. * a * m_mode_number_ * k *
+            (2. * M * r[p] / r_sq_plus_a_sq[p] + H[p]) / r_sq_plus_a_sq[p];
+    if (penetrating_horizon_) {
+      get(beta)[p] /= get<0>(alpha)[p];
+    }
+    }
   }
 
   get(beta) +=
@@ -277,8 +285,6 @@ CircularOrbit::variables(
     // NOLINTNEXTLINE
     r.set_data_ref(const_cast<DataVector*>(&r_star_or_r));
     r_minus_r_plus = r - r_plus;
-    r_star = gr::tortoise_radius_from_boyer_lindquist_minus_r_plus(
-        r_minus_r_plus, M, black_hole_spin_);
   } else {
     // NOLINTNEXTLINE
     r_star.set_data_ref(const_cast<DataVector*>(&r_star_or_r));

--- a/src/Elliptic/Systems/SelfForce/Scalar/AnalyticData/CircularOrbit.cpp
+++ b/src/Elliptic/Systems/SelfForce/Scalar/AnalyticData/CircularOrbit.cpp
@@ -125,8 +125,6 @@ CircularOrbit::variables(
   const DataVector r_sq_plus_a_sq = square(r) + square(a);
   const DataVector r_sq_plus_a_sq_sq = square(r_sq_plus_a_sq);
   const DataVector sin_theta_squared = 1. - cos_theta_sq;
-  const DataVector sigma_squared =
-      r_sq_plus_a_sq_sq - square(a) * delta * sin_theta_squared;
   tuples::TaggedTuple<Tags::Alpha, Tags::Beta, Tags::Gamma> result{};
   // Hyperboloidal slicing
   ComplexDataVector H;
@@ -138,12 +136,39 @@ CircularOrbit::variables(
     H = make_with_value<ComplexDataVector>(r_star_or_r, 0.);
     dH = make_with_value<ComplexDataVector>(r_star_or_r, 0.);
   }
+  const bool in_u_region =
+      penetrating_horizon_ and r[0] > (*hyperboloidal_slicing_transitions_)[3];
+  const double r_u =
+      penetrating_horizon_ ? (*hyperboloidal_slicing_transitions_)[3] : 0.0;
+
+  DataVector inv_r{};
+  DataVector dsigma_dr{};
+  if (in_u_region) {
+    // Inside u-region, x coordinate is defined as
+    // 2 r_u - r_u^2/r to compactify the wavezone.
+    // Elliptic PDEs will be re-written as a function of
+    // inv_r (1/r) instead of r.
+    inv_r = (2.0 * r_u - r) / (r_u * r_u);
+    dsigma_dr = square(r_u) * square(inv_r);
+  } else {
+    inv_r = 1.0 / r;
+    dsigma_dr = make_with_value<DataVector>(r_star_or_r, 1.0);
+  }
   auto& alpha = get<Tags::Alpha>(result);
   auto& beta = get<Tags::Beta>(result);
   auto& gamma = get<Tags::Gamma>(result);
+  const DataVector one_plus_a_sq_inv_r_sq = 1.0 + square(a) * square(inv_r);
+  const DataVector delta_over_r_sq = one_plus_a_sq_inv_r_sq - 2.0 * M * inv_r;
+  const DataVector one_over_r_sq_plus_a_sq =
+      square(inv_r) / one_plus_a_sq_inv_r_sq;
+  const DataVector r_over_r_sq_plus_a_sq = inv_r / one_plus_a_sq_inv_r_sq;
+  const DataVector sigma_sq_over_r_sq_plus_a_sq_sq =
+      1.0 - square(a) * square(inv_r) * delta_over_r_sq * sin_theta_squared /
+                square(one_plus_a_sq_inv_r_sq);
+
   if (penetrating_horizon_) {
-    get<0>(alpha) = delta / r_sq_plus_a_sq;
-    get<1>(alpha) = 1.0 / r_sq_plus_a_sq;
+    get<0>(alpha) = (delta_over_r_sq / one_plus_a_sq_inv_r_sq) * dsigma_dr;
+    get<1>(alpha) = (square(inv_r) / one_plus_a_sq_inv_r_sq) / dsigma_dr;
   } else {
     get<0>(alpha) = make_with_value<DataVector>(r_star_or_r, 1.0);
     get<1>(alpha) = delta / r_sq_plus_a_sq_sq;
@@ -156,30 +181,31 @@ CircularOrbit::variables(
       continue;
     }
     get(beta)[p] =
-        square(k) *
-            (square(H[p]) - sigma_squared[p] / r_sq_plus_a_sq_sq[p]) +
+        square(k) * (square(H[p]) - sigma_sq_over_r_sq_plus_a_sq_sq[p]) +
         2. * a * m_mode_number_ * k *
-            (2. * M * r[p] / r_sq_plus_a_sq[p] + H[p]) / r_sq_plus_a_sq[p];
-    if (penetrating_horizon_) {
-      get(beta)[p] /= get<0>(alpha)[p];
-    }
+            (2. * M * r_over_r_sq_plus_a_sq[p] + H[p]) *
+            one_over_r_sq_plus_a_sq[p];
+    get(beta)[p] /= get<0>(alpha)[p];
   }
+
   get(beta) +=
       get<1>(alpha) * (m_mode_number_ * (m_mode_number_ + 1) +
-                       2. * M / r * (1. - square(a) / M / r) +
+                       2. * M * inv_r * (1. - square(a) / M * inv_r) +
                        std::complex<double>(0., 2. * a * m_mode_number_) *
-                           (1. + a * omega * H) / r) -
+                           (1. + a * omega * H) * inv_r) -
       std::complex<double>(0., k) * dH;
   get<0>(gamma) =
-      2. * square(a) * delta / (r * r_sq_plus_a_sq_sq) -
-      std::complex<double>(0., 2. * a * m_mode_number_) / r_sq_plus_a_sq -
-      std::complex<double>(0., 2. * k) * H;
+      2. * square(a) * cube(inv_r) * delta_over_r_sq /
+          square(one_plus_a_sq_inv_r_sq) -
+      std::complex<double>(0., 2. * a * m_mode_number_) * square(inv_r) /
+          (one_plus_a_sq_inv_r_sq)-std::complex<double>(0., 2. * k) * H;
   get<1>(gamma) = 2. * m_mode_number_ * cos_theta_or_sq * get<1>(alpha);
+
   if (impose_equatorial_symmetry_) {
     get<1>(gamma) += sin_theta_squared * get<1>(alpha);
     get<1>(gamma) *= 2.0;
   }
- get<1>(alpha) *= sin_theta_squared;
+  get<1>(alpha) *= sin_theta_squared;
   if (impose_equatorial_symmetry_) {
     get<1>(alpha) *= 4. * cos_theta_sq;
   }

--- a/src/Elliptic/Systems/SelfForce/Scalar/AnalyticData/CircularOrbit.cpp
+++ b/src/Elliptic/Systems/SelfForce/Scalar/AnalyticData/CircularOrbit.cpp
@@ -96,17 +96,27 @@ CircularOrbit::variables(
   const double k = m_mode_number_ * omega;
 
   // Resolve coordinates
-  const auto& r_star_or_r = get<0>(x);
+  const auto& r_star_or_r_or_sigma = get<0>(x);
+  const double r_u =
+      penetrating_horizon_ ? (*hyperboloidal_slicing_transitions_)[3] : 0.0;
+  const bool in_u_region =
+      penetrating_horizon_ and r_star_or_r_or_sigma[0] > r_u;
   DataVector r;
   DataVector r_star;
   DataVector r_minus_r_plus;
   if (penetrating_horizon_) {
-    // NOLINTNEXTLINE
-    r.set_data_ref(const_cast<DataVector*>(&r_star_or_r));
+    if (in_u_region) {
+      // The domain coordinate here is sigma = 2*r_u - r_u^2/r, not the
+      // physical Boyer-Lindquist radius. Invert to get the true r.
+      r = square(r_u) / (2.0 * r_u - r_star_or_r_or_sigma);
+    } else {
+      // NOLINTNEXTLINE
+      r.set_data_ref(const_cast<DataVector*>(&r_star_or_r_or_sigma));
+    }
     r_minus_r_plus = r - r_plus;
   } else {
     // NOLINTNEXTLINE
-    r_star.set_data_ref(const_cast<DataVector*>(&r_star_or_r));
+    r_star.set_data_ref(const_cast<DataVector*>(&r_star_or_r_or_sigma));
     r_minus_r_plus = gr::boyer_lindquist_radius_minus_r_plus_from_tortoise(
         r_star, M, black_hole_spin_);
     r = r_minus_r_plus + r_plus;
@@ -131,28 +141,17 @@ CircularOrbit::variables(
   ComplexDataVector dH;
   if (hyperboloidal_slicing_transitions_.has_value()) {
     std::tie(H, dH) = boost_function_and_deriv(
-        r_star_or_r, hyperboloidal_slicing_transitions_.value());
+        r_star_or_r_or_sigma, hyperboloidal_slicing_transitions_.value());
   } else {
-    H = make_with_value<ComplexDataVector>(r_star_or_r, 0.);
-    dH = make_with_value<ComplexDataVector>(r_star_or_r, 0.);
+    H = make_with_value<ComplexDataVector>(r_star_or_r_or_sigma, 0.);
+    dH = make_with_value<ComplexDataVector>(r_star_or_r_or_sigma, 0.);
   }
-  const bool in_u_region =
-      penetrating_horizon_ and r[0] > (*hyperboloidal_slicing_transitions_)[3];
-  const double r_u =
-      penetrating_horizon_ ? (*hyperboloidal_slicing_transitions_)[3] : 0.0;
-
-  DataVector inv_r{};
+  const DataVector inv_r = 1.0 / r;
   DataVector dsigma_dr{};
   if (in_u_region) {
-  // sigma = 2*r_u - r_u^2/r  =>  1/r = (2*r_u - sigma) / r_u^2.
-  // The domain coordinate here is actually sigma, not the physical
-  // Boyer-Lindquist radius, in this region.
-  const DataVector& sigma = get<0>(x);
-  inv_r = (2.0 * r_u - sigma) / (r_u * r_u);
-  dsigma_dr = square(r_u) * square(inv_r);
+    dsigma_dr = square(r_u) * square(inv_r);
   } else {
-    inv_r = 1.0 / r;
-    dsigma_dr = make_with_value<DataVector>(r_star_or_r, 1.0);
+    dsigma_dr = make_with_value<DataVector>(r_star_or_r_or_sigma, 1.0);
   }
   auto& alpha = get<Tags::Alpha>(result);
   auto& beta = get<Tags::Beta>(result);
@@ -162,37 +161,36 @@ CircularOrbit::variables(
 
   if (penetrating_horizon_) {
     get<0>(alpha) = (delta_over_r_sq / one_plus_a_sq_inv_r_sq) * dsigma_dr;
-    if (in_u_region){
-    get<1>(alpha) = 1.0 / (square(r_u) * one_plus_a_sq_inv_r_sq);
+    if (in_u_region) {
+      get<1>(alpha) = 1.0 / (square(r_u) * one_plus_a_sq_inv_r_sq);
     } else {
-    get<1>(alpha) = 1.0 / r_sq_plus_a_sq;
+      get<1>(alpha) = 1.0 / r_sq_plus_a_sq;
     }
   } else {
-    get<0>(alpha) = make_with_value<DataVector>(r_star_or_r, 1.0);
+    get<0>(alpha) = make_with_value<DataVector>(r_star_or_r_or_sigma, 1.0);
     get<1>(alpha) = delta / r_sq_plus_a_sq_sq;
   }
-  get(beta) = make_with_value<ComplexDataVector>(r_star_or_r, 0.);
+  get(beta) = make_with_value<ComplexDataVector>(r_star_or_r_or_sigma, 0.);
   for (size_t p = 0; p < get(beta).size(); ++p) {
     if (penetrating_horizon_ and equal_within_roundoff(r[p], r_plus)) {
       // The following terms are zero at the horizon. Skip them to avoid
       // division by zero.
       continue;
     }
-    if (in_u_region){
-    get(beta)[p] =
-        (square(k) * square(a) * delta_over_r_sq[p] * sin_theta_squared[p] +
-        2. * a * m_mode_number_ * k *
-            (2. * M * inv_r[p] + one_plus_a_sq_inv_r_sq[p])) /
-        (one_plus_a_sq_inv_r_sq[p] * delta_over_r_sq[p] * square(r_u));
+    if (in_u_region) {
+      get(beta)[p] =
+          (square(k) * square(a) * delta_over_r_sq[p] * sin_theta_squared[p] +
+           2. * a * m_mode_number_ * k *
+               (2. * M * inv_r[p] + one_plus_a_sq_inv_r_sq[p])) /
+          (one_plus_a_sq_inv_r_sq[p] * delta_over_r_sq[p] * square(r_u));
     } else {
-    get(beta)[p] =
-        square(k) *
-            (square(H[p]) - sigma_squared[p] / r_sq_plus_a_sq_sq[p]) +
-        2. * a * m_mode_number_ * k *
-            (2. * M * r[p] / r_sq_plus_a_sq[p] + H[p]) / r_sq_plus_a_sq[p];
-    if (penetrating_horizon_) {
-      get(beta)[p] /= get<0>(alpha)[p];
-    }
+      get(beta)[p] =
+          square(k) * (square(H[p]) - sigma_squared[p] / r_sq_plus_a_sq_sq[p]) +
+          2. * a * m_mode_number_ * k *
+              (2. * M * r[p] / r_sq_plus_a_sq[p] + H[p]) / r_sq_plus_a_sq[p];
+      if (penetrating_horizon_) {
+        get(beta)[p] /= get<0>(alpha)[p];
+      }
     }
   }
 
@@ -262,32 +260,32 @@ CircularOrbit::variables(
                                            2.0 * a * sqrt(M * r_0)));
     effsource_set_particle(&xp, e, l, 0.);
   }
-  const auto& r_star_or_r = get<0>(x);
+  const auto& r_star_or_r_or_sigma = get<0>(x);
   if (hyperboloidal_slicing_transitions_.has_value() and
-      ((min(r_star_or_r) < (*hyperboloidal_slicing_transitions_)[1] and
-        not equal_within_roundoff(min(r_star_or_r),
+      ((min(r_star_or_r_or_sigma) < (*hyperboloidal_slicing_transitions_)[1] and
+        not equal_within_roundoff(min(r_star_or_r_or_sigma),
                                   (*hyperboloidal_slicing_transitions_)[1])) or
-       (max(r_star_or_r) > (*hyperboloidal_slicing_transitions_)[2] and
-        not equal_within_roundoff(max(r_star_or_r),
+       (max(r_star_or_r_or_sigma) > (*hyperboloidal_slicing_transitions_)[2] and
+        not equal_within_roundoff(max(r_star_or_r_or_sigma),
                                   (*hyperboloidal_slicing_transitions_)[2])))) {
     ERROR(
         "The effective source is only valid where no hyperboloidal slicing is "
         "applied, which is in the radial range ["
         << (*hyperboloidal_slicing_transitions_)[1] << ", "
         << (*hyperboloidal_slicing_transitions_)[2]
-        << "], but was requested in the range [" << min(r_star_or_r) << ", "
-        << max(r_star_or_r) << "]");
+        << "], but was requested in the range [" << min(r_star_or_r_or_sigma)
+        << ", " << max(r_star_or_r_or_sigma) << "]");
   }
   DataVector r;
   DataVector r_star;
   DataVector r_minus_r_plus;
   if (penetrating_horizon_) {
     // NOLINTNEXTLINE
-    r.set_data_ref(const_cast<DataVector*>(&r_star_or_r));
+    r.set_data_ref(const_cast<DataVector*>(&r_star_or_r_or_sigma));
     r_minus_r_plus = r - r_plus;
   } else {
     // NOLINTNEXTLINE
-    r_star.set_data_ref(const_cast<DataVector*>(&r_star_or_r));
+    r_star.set_data_ref(const_cast<DataVector*>(&r_star_or_r_or_sigma));
     r_minus_r_plus = gr::boyer_lindquist_radius_minus_r_plus_from_tortoise(
         r_star, M, black_hole_spin_);
     r = r_minus_r_plus + r_plus;

--- a/src/Elliptic/Systems/SelfForce/Scalar/AnalyticData/CircularOrbit.hpp
+++ b/src/Elliptic/Systems/SelfForce/Scalar/AnalyticData/CircularOrbit.hpp
@@ -172,7 +172,7 @@ namespace ScalarSelfForce::AnalyticData {
  * Jacobian $J \equiv d\sigma/dr = r_u^2/r^2$ are continuous ($C^1$) at the
  * transition ($J=1$ there), so no coordinate jump condition is needed.
  *
- * Since $\partial_r = J \partial_\sigma$, the flux form must be rewritten
+ * Since $\partial_\sigma = J \partial_\r$, the flux form must be rewritten
  * in terms of $\sigma$-derivatives. Dividing the transformed equation by
  * $J$ to match the generic structure of first order flux form gives the
  * substitutions

--- a/src/Elliptic/Systems/SelfForce/Scalar/AnalyticData/CircularOrbit.hpp
+++ b/src/Elliptic/Systems/SelfForce/Scalar/AnalyticData/CircularOrbit.hpp
@@ -66,7 +66,7 @@ namespace ScalarSelfForce::AnalyticData {
  * - Use $r$ as the radial coordinate instead of $r_\star$. This has two
  *   advantages: first, the horizon is placed at a finite radius rather than
  *   $r_\star \rightarrow -\infty$; second, the flux component normal to the
- *   boundary vanishes at the horizon ($r=r_{\plus}$), which reduces to
+ *   boundary vanishes at the horizon ($r=r_+$), which reduces to
  *   simple regularity conditions.
 
  * Written this way, the equations are regular at the poles and converge
@@ -93,7 +93,7 @@ namespace ScalarSelfForce::AnalyticData {
  * decomposition used in \cite Vu:2026ypc Eq. (2.16) as:
  * \begin{align}
  *   \Psi_m^P &= \frac{r}{2 \pi \sin(\theta)^{|m|}}
- *     e^{i m \left( \varphi - \phi\right)} \Phi_m^\mathrm{Wardell} \\
+ *     e^{-i m \left( \varphi - \phi\right)} \Phi_m^\mathrm{Wardell} \\
  *   S_m^\mathrm{eff} &= \frac{r}{2 \pi \sin(\theta)^{|m|}}
  *     e^{-i m \left( \varphi - \phi\right)}
  *     \frac{\Delta\,(r^2 + a^2\cos^2\theta)}{(r^2 + a^2)^2}
@@ -158,6 +158,35 @@ namespace ScalarSelfForce::AnalyticData {
  *     \left.\frac{\partial \Psi_m}{\partial r_*}\right|_{r_*=(r_*^u)^-} =
  *     -im\Omega\Psi_m\big|_{r_*=r_*^u}
  * \end{align}
+ *
+ * \par Compactification
+ * To resolve the large wavezone without truncating the domain at a large
+ * but finite $R$, we compactify the $u$ region to $r=\infty$.
+ * With $r_u$ the radius at the $t$-$u$ transition, we redefine
+ * the domain coordinate as
+ * \begin{align}
+ *   \sigma = 2 r_u - \frac{r_u^2}{r} \text{,}
+ * \end{align}
+ * so $\sigma \rightarrow r_u$ as $r \rightarrow r_u$ and $\sigma
+ * \rightarrow 2 r_u$ as $r \rightarrow \infty$. Both $\sigma$ and its
+ * Jacobian $J \equiv d\sigma/dr = r_u^2/r^2$ are continuous ($C^1$) at the
+ * transition ($J=1$ there), so no coordinate jump condition is needed.
+ *
+ * Since $\partial_r = J \partial_\sigma$, the flux form must be rewritten
+ * in terms of $\sigma$-derivatives. Dividing the transformed equation by
+ * $J$ to match the generic structure of first order flux form gives the
+ * substitutions
+ * \begin{align}
+ *   &\alpha_r \rightarrow \alpha_r J, &&
+ *   \alpha_\theta \rightarrow \alpha_\theta / J, \\
+ *   &\beta \rightarrow \beta / J, &&
+ *   \gamma_\theta \rightarrow \gamma_\theta / J
+ * \end{align}
+ * with $S_m = 0$ in the $u$ region. As $r\rightarrow\infty$, $J\rightarrow
+ * 0$, so the radial flux vanishes, removing the need for the approximate
+ * (Bayliss-Turkel) outer boundary condition. To avoid $\infty/\infty$
+ * terms, all coefficients are written as functions of $1/r$ rather than
+ * $r$.
  */
 class CircularOrbit : public elliptic::analytic_data::Background,
                       public elliptic::analytic_data::InitialGuess {

--- a/src/Elliptic/Systems/SelfForce/Scalar/Tags.hpp
+++ b/src/Elliptic/Systems/SelfForce/Scalar/Tags.hpp
@@ -54,8 +54,8 @@ namespace Tags {
  *   \Psi_m(r,\theta) e^{im\Delta\phi(r)} e^{im(\phi - \Omega t)}
  * \end{equation}
  *
- * where $\Delta\phi(r) = \frac{a}{r_\plus - r_\minus}
- * \ln(\frac{r-r_\plus}{r-r_\minus})$.
+ * where $\Delta\phi(r) = \frac{a}{r_+ - r_-}
+ * \ln(\frac{r-r_+}{r-r_-})$.
  */
 struct MMode : db::SimpleTag {
   using type = Scalar<ComplexDataVector>;

--- a/tests/InputFiles/SelfForce/ScalarCircularOrbit.yaml
+++ b/tests/InputFiles/SelfForce/ScalarCircularOrbit.yaml
@@ -53,17 +53,18 @@ DomainCreator:
     BlockBounds:
       # Puncture position is at r = 10.
       - [1.866025403784, 5., 6., &worldtube_right 14,
-         25., &outer_radius 1e4] # r_*
+         25., &outer_radius 50] # r
+         # outer_radius = 2 * r_u
       - [-1., -0.5, 0.5, 1.]  # cos(theta)
     Distributions:
-      # r_*
-      - [Linear, Linear, Linear, Linear, &outer_shell_distribution Inverse]
+      # r
+      - [Linear, Linear, Linear, Linear, Linear]
       # cos(theta)
       - [Linear, Linear, Linear]
     SingularityPositions:
-      # r_*
+      # r
       - [-51., -51., -51., 0., 0.]
-      # os(theta)
+      # cos(theta)
       - [-2., -2., -2.]
     InitialGridPoints: [4, 4]
     InitialLevels: [0, 0]
@@ -121,14 +122,7 @@ DomainCreator:
     BoundaryConditions:
       # Radial boundary conditions
       - Lower: None
-        Upper:
-          Sommerfeld:
-            BlackHoleMass: *bh_mass
-            BlackHoleSpin: *bh_spin
-            OrbitalRadius: *orbital_radius
-            MModeNumber: *m_mode_number
-            HyperboloidalSlicing: True
-            Order: 2
+        Upper: None
       # Angular boundary conditions
       - None
 
@@ -216,10 +210,7 @@ EventsAndTriggersAtIterations:
           CoordinatesFloatingPointType: Double
           FloatingPointTypes: [Double]
 
-RadiallyCompressedCoordinates:
-  InnerRadius: *worldtube_right
-  OuterRadius: *outer_radius
-  Compression: *outer_shell_distribution
+RadiallyCompressedCoordinates: None
 
 BuildMatrix:
   MatrixSubfileName: None

--- a/tests/InputFiles/SelfForce/ScalarCircularOrbit.yaml
+++ b/tests/InputFiles/SelfForce/ScalarCircularOrbit.yaml
@@ -52,9 +52,9 @@ DomainCreator:
     # Order of dimensions is (r, cos(theta))
     BlockBounds:
       # Puncture position is at r = 10.
+      # outer_radius = 2 * r_u
       - [1.866025403784, 5., 6., &worldtube_right 14,
          25., &outer_radius 50] # r
-         # outer_radius = 2 * r_u
       - [-1., -0.5, 0.5, 1.]  # cos(theta)
     Distributions:
       # r

--- a/tests/Unit/Elliptic/Systems/SelfForce/Scalar/AnalyticData/Test_CircularOrbit.cpp
+++ b/tests/Unit/Elliptic/Systems/SelfForce/Scalar/AnalyticData/Test_CircularOrbit.cpp
@@ -114,4 +114,50 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.ScalarSelfForce.CircularOrbit",
     }
   }
 }
+
+SPECTRE_TEST_CASE(
+    "Unit.PointwiseFunctions.ScalarSelfForce.CircularOrbit.Compactification",
+    "[PointwiseFunctions][Unit]") {
+  // Check that Alpha in the compactified u-region (coordinate sigma) matches
+  // the original r-based Alpha formula, rescaled by the chain-rule Jacobian
+  // J = dsigma/dr = r_u^2/r^2, for sigma = 2*r_u - r_u^2/r.
+  const double black_hole_mass = 1.;
+  const double black_hole_spin = 0.9;
+  const double r_u = 25.;
+  const double r = 2. * r_u;
+  // sigma(r=2*r_u) = 2*r_u - r_u^2/(2*r_u) = 1.5*r_u
+  const double sigma = 1.5 * r_u;
+  const double cos_theta = 0.3;
+  const double sin_theta_squared = 1. - square(cos_theta);
+
+  const auto circular_orbit = CircularOrbit{black_hole_mass,
+                                            black_hole_spin,
+                                            6.,
+                                            1,
+                                            {{-10., -5., r_u, r_u}},
+                                            true,
+                                            false};
+
+  tnsr::I<DataVector, 2> x{};
+  get<0>(x) = DataVector{sigma};
+  get<1>(x) = DataVector{cos_theta};
+  const auto background =
+      circular_orbit.variables(x, CircularOrbit::background_tags{});
+  const auto& alpha = get<Tags::Alpha>(background);
+
+  // Independently compute the reference r-based Alpha and the Jacobian.
+  const double a = black_hole_spin * black_hole_mass;
+  const double M = black_hole_mass;
+  const double r_plus = M * (1. + sqrt(1. - square(black_hole_spin)));
+  const double r_minus = M * (1. - sqrt(1. - square(black_hole_spin)));
+  const double delta = (r - r_plus) * (r - r_minus);
+  const double r_sq_plus_a_sq = square(r) + square(a);
+  const double jacobian = square(r_u) / square(r);  // dsigma/dr at r=2*r_u
+  const double expected_alpha0 = (delta / r_sq_plus_a_sq) * jacobian;
+  const double expected_alpha1 =
+      (1. / r_sq_plus_a_sq) / jacobian * sin_theta_squared;
+
+  CHECK_ITERABLE_APPROX(get<0>(alpha)[0], expected_alpha0);
+  CHECK_ITERABLE_APPROX(get<1>(alpha)[0], expected_alpha1);
+}
 }  // namespace ScalarSelfForce::AnalyticData


### PR DESCRIPTION
## Proposed changes
- Compactify the radial domain for Circular Scalar SF 
- Inside the u-region, x coordinate is defined as $\sigma = 2 r_u - \frac{r_u^2}{r}$. 
- Details are in` CircularOrbit.hpp`
<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent was used, have a co-author trailer of the form
      "Co-Authored-By: <agent name> <agent email>" as the last line of the
      commit, e.g. "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>".

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
