### PR TITLE
CCE: make CauchySecondOrder angular-solve threshold an option

### DIFF
--- a/src/Evolution/Systems/Cce/Initialize/CauchySecondOrder.cpp
+++ b/src/Evolution/Systems/Cce/Initialize/CauchySecondOrder.cpp
@@ -28,10 +28,12 @@ namespace Cce::InitializeJ {
 CauchySecondOrder::CauchySecondOrder(const double angular_coordinate_tolerance,
                                      const size_t max_iterations,
                                      const bool require_convergence,
+                                     const double max_angular_solve_error,
                                      const double max_scri_second_derivative)
     : require_convergence_{require_convergence},
       angular_coordinate_tolerance_{angular_coordinate_tolerance},
       max_iterations_{max_iterations},
+      max_angular_solve_error_{max_angular_solve_error},
       max_scri_second_derivative_{max_scri_second_derivative} {}
 
 std::unique_ptr<InitializeJ<false>> CauchySecondOrder::get_clone() const {
@@ -180,22 +182,23 @@ void CauchySecondOrder::operator()(
   // alteration of the spherical mesh, so it tolerates only a small asymptotic
   // J. Guard against a large asymptotic initial J in Cauchy coordinates before
   // attempting the solve, which would otherwise fail less informatively.
-  const double max_angular_solve_error = 1.0e-2;
   const double max_asymptotic_j = max(abs(j_at_scri_view.data()));
-  if (max_asymptotic_j > max_angular_solve_error) {
+  if (max_asymptotic_j > max_angular_solve_error_) {
     ERROR(
         "The asymptotic value of the initial J in Cauchy coordinates has "
         "magnitude "
-        << max_asymptotic_j
-        << ", which is too large for the angular-coordinate solve to "
-           "eliminate. The worldtube data may be incorrect, or the worldtube "
-           "may be too close to the strong-field region. Consider using the "
+        << max_asymptotic_j << ", which exceeds the threshold "
+        << max_angular_solve_error_
+        << " set by the MaxAngularSolveError option, so the "
+           "angular-coordinate solve cannot eliminate it. The worldtube data "
+           "may be incorrect, or the worldtube may be too close to the "
+           "strong-field region. Consider raising the threshold or using the "
            "ConformalFactor initial-data generator instead.");
   }
 
   detail::iteratively_adapt_angular_coordinates(
       cartesian_cauchy_coordinates, angular_cauchy_coordinates, l_max,
-      angular_coordinate_tolerance_, max_iterations_, max_angular_solve_error,
+      angular_coordinate_tolerance_, max_iterations_, max_angular_solve_error_,
       iteration_function, require_convergence_, finalize_function);
 
   // Safeguard: the second-order construction forces the second radial
@@ -237,6 +240,7 @@ void CauchySecondOrder::pup(PUP::er& p) {
   p | require_convergence_;
   p | angular_coordinate_tolerance_;
   p | max_iterations_;
+  p | max_angular_solve_error_;
   p | max_scri_second_derivative_;
 }
 

--- a/src/Evolution/Systems/Cce/Initialize/CauchySecondOrder.hpp
+++ b/src/Evolution/Systems/Cce/Initialize/CauchySecondOrder.hpp
@@ -28,9 +28,13 @@ namespace Cce::InitializeJ {
  * \details The volume \f$J\f$ is built from the worldtube values of
  * \f$J\f$, \f$\partial_r J\f$, and \f$\partial_y^2 J\f$ computed from the
  * H hypersurface equation. The remaining angular coordinates are determined
- * iteratively to ensure asymptotic flatness. As a safeguard, the
- * initialization aborts if the second radial derivative of \f$J\f$ at scri+
- * of the final solution exceeds `MaxScriSecondDerivative`.
+ * iteratively to ensure asymptotic flatness. The angular solve can eliminate
+ * \f$J\f$ at scri+ only through a well-behaved alteration of the spherical
+ * mesh, so it tolerates only a small asymptotic \f$J\f$; the initialization
+ * aborts if the asymptotic \f$J\f$ in Cauchy coordinates, or the deviation at
+ * any iteration of the solve, exceeds `MaxAngularSolveError`. As a further
+ * safeguard, the initialization aborts if the second radial derivative of
+ * \f$J\f$ at scri+ of the final solution exceeds `MaxScriSecondDerivative`.
  */
 struct CauchySecondOrder : InitializeJ<false> {
   struct AngularCoordinateTolerance {
@@ -59,6 +63,20 @@ struct CauchySecondOrder : InitializeJ<false> {
     static type suggested_value() { return true; }
   };
 
+  struct MaxAngularSolveError {
+    using type = double;
+    static constexpr Options::String help = {
+        "Largest deviation of J from zero at scri+ that the iterative angular "
+        "solve is permitted to encounter. Initialization aborts if the "
+        "asymptotic J in Cauchy coordinates exceeds this value before the "
+        "solve, or if any iteration of the solve exceeds it. Raise this to "
+        "attempt initialization from worldtube data with a larger asymptotic "
+        "strain, at the risk of a poorly behaved angular coordinate map."};
+    static type lower_bound() { return 1.0e-14; }
+    static type upper_bound() { return 1.0e2; }
+    static type suggested_value() { return 1.0e-1; }
+  };
+
   struct MaxScriSecondDerivative {
     using type = double;
     static constexpr Options::String help = {
@@ -72,8 +90,9 @@ struct CauchySecondOrder : InitializeJ<false> {
     static type suggested_value() { return 1.0e-8; }
   };
 
-  using options = tmpl::list<AngularCoordinateTolerance, MaxIterations,
-                             RequireConvergence, MaxScriSecondDerivative>;
+  using options =
+      tmpl::list<AngularCoordinateTolerance, MaxIterations, RequireConvergence,
+                 MaxAngularSolveError, MaxScriSecondDerivative>;
   static constexpr Options::String help = {
       "Second-order initial data generator for the Cauchy CCE evolution."};
 
@@ -81,7 +100,7 @@ struct CauchySecondOrder : InitializeJ<false> {
   explicit CauchySecondOrder(CkMigrateMessage* /*unused*/) {}
 
   CauchySecondOrder(double angular_coordinate_tolerance, size_t max_iterations,
-                    bool require_convergence,
+                    bool require_convergence, double max_angular_solve_error,
                     double max_scri_second_derivative);
 
   CauchySecondOrder() = default;
@@ -130,6 +149,8 @@ struct CauchySecondOrder : InitializeJ<false> {
   double angular_coordinate_tolerance_ =
       std::numeric_limits<double>::signaling_NaN();
   size_t max_iterations_ = 0;
+  double max_angular_solve_error_ =
+      std::numeric_limits<double>::signaling_NaN();
   double max_scri_second_derivative_ =
       std::numeric_limits<double>::signaling_NaN();
 };

--- a/support/Pipelines/Bbh/Cce.yaml
+++ b/support/Pipelines/Bbh/Cce.yaml
@@ -130,6 +130,7 @@ Cce:
       AngularCoordTolerance: 1e-12
       MaxIterations: 1000
       RequireConvergence: True
+      MaxAngularSolveError: 1e-1
       MaxScriSecondDerivative: 1e-9
 
   StartTime: Auto # Start at the first time in file

--- a/tests/InputFiles/Cce/CharacteristicExtract.yaml
+++ b/tests/InputFiles/Cce/CharacteristicExtract.yaml
@@ -126,6 +126,7 @@ Cce:
       AngularCoordTolerance: 1e-12
       MaxIterations: 1000
       RequireConvergence: True
+      MaxAngularSolveError: 1e-1
       MaxScriSecondDerivative: 1e-9
 
   StartTime: Auto # Start at the first time in file

--- a/tests/Unit/Evolution/Systems/Cce/Test_InitializeCce.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_InitializeCce.cpp
@@ -299,7 +299,7 @@ void test_initialize_j_cauchy_second_order(
   // allow up to 1000 iterations (the option maximum) to reliably converge with
   // `require_convergence = true`.
   const auto initializer =
-      InitializeJ::CauchySecondOrder{1.0e-10, 1000, true, 1.0e-8};
+      InitializeJ::CauchySecondOrder{1.0e-10, 1000, true, 1.0e-1, 1.0e-8};
   db::mutate_apply<InitializeJ::CauchySecondOrder::return_tags,
                    InitializeJ::CauchySecondOrder::argument_tags>(
       initializer, box_to_initialize, make_not_null(&node_lock));
@@ -380,7 +380,21 @@ void test_cauchy_second_order_scri_derivative_error(
   auto node_lock = Parallel::NodeLock{};
   db::mutate_apply<InitializeJ::CauchySecondOrder::return_tags,
                    InitializeJ::CauchySecondOrder::argument_tags>(
-      InitializeJ::CauchySecondOrder{1.0e-10, 1000, true, 1.0e-30},
+      InitializeJ::CauchySecondOrder{1.0e-10, 1000, true, 1.0e-1, 1.0e-30},
+      box_to_initialize, make_not_null(&node_lock));
+}
+
+template <typename DbTags>
+void test_cauchy_second_order_angular_solve_threshold(
+    const gsl::not_null<db::DataBox<DbTags>*> box_to_initialize) {
+  // Before the angular solve the constructed J is generically nonzero at scri+
+  // at the scale of the strain, so an unachievably small `MaxAngularSolveError`
+  // trips the pre-solve guard even on uncorrupted worldtube data. This checks
+  // that the threshold is honored from the option rather than hard-coded.
+  auto node_lock = Parallel::NodeLock{};
+  db::mutate_apply<InitializeJ::CauchySecondOrder::return_tags,
+                   InitializeJ::CauchySecondOrder::argument_tags>(
+      InitializeJ::CauchySecondOrder{1.0e-10, 400, true, 1.0e-14, 1.0e-8},
       box_to_initialize, make_not_null(&node_lock));
 }
 
@@ -398,7 +412,7 @@ void test_cauchy_second_order_asymptotic_j_error(
   auto node_lock = Parallel::NodeLock{};
   db::mutate_apply<InitializeJ::CauchySecondOrder::return_tags,
                    InitializeJ::CauchySecondOrder::argument_tags>(
-      InitializeJ::CauchySecondOrder{1.0e-10, 400, true, 1.0e-8},
+      InitializeJ::CauchySecondOrder{1.0e-10, 400, true, 1.0e-1, 1.0e-8},
       box_to_initialize, make_not_null(&node_lock));
 }
 
@@ -806,6 +820,10 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.InitializeJ", "[Unit][Cce]") {
       Catch::Matchers::ContainsSubstring(
           "The initial J has a second radial derivative at scri+ of "
           "magnitude"));
+  CHECK_THROWS_WITH(test_cauchy_second_order_angular_solve_threshold(
+                        make_not_null(&box_to_initialize)),
+                    Catch::Matchers::ContainsSubstring(
+                        "set by the MaxAngularSolveError option"));
   CHECK_THROWS_WITH(
       test_cauchy_second_order_asymptotic_j_error(
           make_not_null(&box_to_initialize)),

--- a/tests/Unit/Evolution/Systems/Cce/Test_OptionTags.cpp
+++ b/tests/Unit/Evolution/Systems/Cce/Test_OptionTags.cpp
@@ -171,6 +171,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Cce.OptionTags", "[Unit][Cce]") {
       "  AngularCoordTolerance: 1e-10\n"
       "  MaxIterations: 300\n"
       "  RequireConvergence: false\n"
+      "  MaxAngularSolveError: 1e-3\n"
       "  MaxScriSecondDerivative: 1e-6");
   CHECK_FALSE(
       TestHelpers::test_option_tag<Cce::OptionTags::AnalyticInitializeJ>(


### PR DESCRIPTION
## Proposed changes

`CauchySecondOrder` had `error_threshold` of `iteratively_adapt_angular_coordinates` hardcoded to `1e-2`. Worldtube data with a larger asymptotic J in Cauchy coordinates could not be used to generate initial data.

Now it is exposed as a new `MaxAngularSolveError` option. The
suggested value is `1e-1` rather than `1e-2`. The other `InitializeJ` schemes keep their hardcoded
`1e-2`.

### Upgrade instructions

<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent is used, have one of
      "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>"
      as the last line of the commit, depending on the agent.

### Further comments