### PR TITLE
Handle mixed AhC l_max in ringdown transition

### DIFF
--- a/src/Evolution/Ringdown/Python/ComputeRingdownShapeAndTranslationFoT.py
+++ b/src/Evolution/Ringdown/Python/ComputeRingdownShapeAndTranslationFoT.py
@@ -14,6 +14,7 @@ from rich.pretty import pretty_repr
 import spectre.Evolution.Ringdown as Ringdown
 import spectre.IO.H5 as spectre_h5
 from spectre.DataStructures import ModalVector
+from spectre.SphericalHarmonics import Spherepack
 from spectre.Strahlkorper import (
     Frame,
     Strahlkorper,
@@ -110,12 +111,10 @@ def compute_ringdown_shape_and_translation_fot(
     """
 
     ahc_times = []
-    ahc_lmax = 0
     with spectre_h5.H5File(ahc_reductions_path, "r") as h5file:
         datfile = h5file.get_dat(ahc_subfile)
         datfile_np = np.array(datfile.get_data())
         ahc_times = datfile_np[:, 0]
-        ahc_lmax = int(datfile_np[0][4])
 
     # Transform AhC coefs to ringdown distorted frame and get other data
     # needed to start a ringdown, such as initial values for functions of time
@@ -135,15 +134,35 @@ def compute_ringdown_shape_and_translation_fot(
         trans_func_and_2_derivs=evaluated_fot_dict["Translation"],
     )
 
-    shape_coefs_at_different_times_for_fit = np.array(
-        shape_and_translation_coefs[0]
-    )
-    ahc_inertial_centers_for_fit = np.array(shape_and_translation_coefs[1])
     ahc_times_for_fit_list = []
-    for i, time in enumerate(ahc_times[-number_of_ahc_finds_for_fit:]):
+    ahc_lmax_for_fit_list = []
+    for row in datfile_np[-number_of_ahc_finds_for_fit:]:
+        time = row[0]
         if time <= match_time:
             ahc_times_for_fit_list.append(time)
+            ahc_lmax_for_fit_list.append(int(row[4]))
+
+    if len(shape_and_translation_coefs[0]) != len(ahc_lmax_for_fit_list):
+        raise ValueError(
+            "The number of AhC coefficient sets does not match the number "
+            "of AhC L values selected for the ringdown fit."
+        )
+
     ahc_times_for_fit = np.array(ahc_times_for_fit_list)
+    fit_lmax = min(ahc_lmax_for_fit_list)
+
+    target_spherepack = Spherepack(fit_lmax, fit_lmax)
+    shape_coefs_for_fit_list = []
+    for coefs, lmax in zip(
+        shape_and_translation_coefs[0], ahc_lmax_for_fit_list
+    ):
+        source_spherepack = Spherepack(lmax, lmax)
+        shape_coefs_for_fit_list.append(
+            source_spherepack.prolong_or_restrict(coefs, target_spherepack)
+        )
+
+    shape_coefs_at_different_times_for_fit = np.array(shape_coefs_for_fit_list)
+    ahc_inertial_centers_for_fit = np.array(shape_and_translation_coefs[1])
 
     logger.debug("AhC times available: " + str(ahc_times.shape[0]))
     logger.debug(
@@ -182,25 +201,25 @@ def compute_ringdown_shape_and_translation_fot(
     fit_ahc_dt_coef_mv = ModalVector(fit_ahc_dt_coefs)
     fit_ahc_dt2_coef_mv = ModalVector(fit_ahc_dt2_coefs)
     fit_ahc_strahlkorper = Strahlkorper[Frame.Inertial](
-        ahc_lmax, ahc_lmax, fit_ahc_coef_mv, ahc_inertial_centers_for_fit[-1]
+        fit_lmax, fit_lmax, fit_ahc_coef_mv, ahc_inertial_centers_for_fit[-1]
     )
     fit_ahc_dt_strahlkorper = Strahlkorper[Frame.Inertial](
-        ahc_lmax, ahc_lmax, fit_ahc_dt_coef_mv, ahc_inertial_centers_for_fit[-1]
+        fit_lmax, fit_lmax, fit_ahc_dt_coef_mv, ahc_inertial_centers_for_fit[-1]
     )
     fit_ahc_dt2_strahlkorper = Strahlkorper[Frame.Inertial](
-        ahc_lmax,
-        ahc_lmax,
+        fit_lmax,
+        fit_lmax,
         fit_ahc_dt2_coef_mv,
         ahc_inertial_centers_for_fit[-1],
     )
     legend_ahc, fit_ahc_ylm_coefs_to_write = ylm_legend_and_data(
-        fit_ahc_strahlkorper, match_time, ahc_lmax
+        fit_ahc_strahlkorper, match_time, fit_lmax
     )
     legend_ahc_dt, fit_ahc_dt_ylm_coefs_to_write = ylm_legend_and_data(
-        fit_ahc_dt_strahlkorper, match_time, ahc_lmax
+        fit_ahc_dt_strahlkorper, match_time, fit_lmax
     )
     legend_ahc_dt2, fit_ahc_dt2_ylm_coefs_to_write = ylm_legend_and_data(
-        fit_ahc_dt2_strahlkorper, match_time, ahc_lmax
+        fit_ahc_dt2_strahlkorper, match_time, fit_lmax
     )
 
     ringdown_ylm_coefs = [

--- a/src/NumericalAlgorithms/SphericalHarmonics/Python/Spherepack.cpp
+++ b/src/NumericalAlgorithms/SphericalHarmonics/Python/Spherepack.cpp
@@ -47,6 +47,11 @@ void bind_spherepack(pybind11::module& m) {  // NOLINT
                &ylm::Spherepack::spec_to_phys),
            py::arg("spectral_coefs"), py::arg("spectral_stride") = 1,
            py::arg("spectral_offset") = 0)
+      .def("prolong_or_restrict",
+           static_cast<DataVector (ylm::Spherepack::*)(
+               const DataVector&, const ylm::Spherepack&) const>(
+               &ylm::Spherepack::prolong_or_restrict),
+           py::arg("spectral_coefs"), py::arg("target"))
       // NOLINTNEXTLINE(misc-redundant-expression)
       .def(py::self == py::self)
       // NOLINTNEXTLINE(misc-redundant-expression)

--- a/tests/Unit/Evolution/Ringdown/Python/Test_ComputeRingdownShapeAndTranslationFoT.py
+++ b/tests/Unit/Evolution/Ringdown/Python/Test_ComputeRingdownShapeAndTranslationFoT.py
@@ -341,6 +341,227 @@ class TestComputeAhCCoefs(unittest.TestCase):
         self.assertEqual(expected_legends_ahc, ringdown_ylm_legend[1])
         self.assertEqual(expected_legends_ahc, ringdown_ylm_legend[2])
 
+    def test_compute_ringdown_shape_and_translation_fot_mixed_lmax(self):
+        # Building a fake directory to hold fake reduction data
+        self.test_dir = Path(
+            unit_test_build_path(), "Unit/Evolution/Ringdown/Python/Ringdown"
+        )
+        shutil.rmtree(self.test_dir, ignore_errors=True)
+        self.test_dir.mkdir(parents=True, exist_ok=True)
+        self.inspiral_reduction_data = self.test_dir / "BbhReductions.h5"
+        shape_coefs = [5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
+        times = [4990.0, 4992.0, 4994.0, 4996.0, 4998.0, 5000.0]
+        time_to_match = 5000.0
+        ahc_center = [0.0, 0.0, 0.0]
+        ahc_lmaxs = [3, 3, 3, 2, 2]
+        with spectre_h5.H5File(
+            str(self.inspiral_reduction_data.resolve()), "a"
+        ) as reduction_file:
+            legend = [
+                "Time",
+                "InertialExpansionCenter_x",
+                "InertialExpansionCenter_y",
+                "InertialExpansionCenter_z",
+                "Lmax",
+                "coef(0,0)",
+                "coef(1,-1)",
+                "coef(1,0)",
+                "coef(1,1)",
+                "coef(2,-2)",
+                "coef(2,-1)",
+                "coef(2,0)",
+                "coef(2,1)",
+                "coef(2,2)",
+                "coef(3,-3)",
+                "coef(3,-2)",
+                "coef(3,-1)",
+                "coef(3,0)",
+                "coef(3,1)",
+                "coef(3,2)",
+                "coef(3,3)",
+            ]
+            reduction_dat = reduction_file.try_insert_dat(
+                "ObservationAhC_Ylm.dat", legend, 0
+            )
+            for x in range(0, 5):
+                reduction_dat.append(
+                    [
+                        [
+                            times[x],
+                            ahc_center[0],
+                            ahc_center[1],
+                            ahc_center[2],
+                            ahc_lmaxs[x],
+                            shape_coefs[x],
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                        ]
+                    ]
+                )
+            reduction_file.close_current_object()
+
+        fot_dict = {}
+        fot_dict["Expansion"] = [1.0, 0.0, 0.0]
+        fot_dict["ExpansionOuterBoundary"] = [1.0, -1e-6, 0.0]
+        fot_dict["Rotation"] = [
+            [0.0, 0.0, 0.0, 1.0],
+            [0.15, 0.0, 0.0, 0.02],
+            [0.06, 0.0, 0.0, 0.03],
+        ]
+        fot_dict["Translation"] = [
+            [0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0],
+        ]
+
+        # Making volume data for functions of time to be extracted
+        rotation_fot = QuaternionFunctionOfTime(
+            time=times[0],
+            initial_quat_func=[DataVector(size=4, fill=1.0)],
+            initial_angle_func=4 * [DataVector(size=3, fill=0.0)],
+            expiration_time=math.inf,
+        )
+        expansion_fot = PiecewisePolynomial3(
+            times[0], 4 * [DataVector(size=1, fill=1.0)], math.inf
+        )
+        expansion_outer_fot = PiecewisePolynomial3(
+            times[0], 4 * [DataVector(size=1, fill=1.0)], math.inf
+        )
+        translation_fot = PiecewisePolynomial2(
+            times[0],
+            [
+                DataVector([1.0, -1.0, 0.5]),
+                DataVector([0.2, 0.1, 0.0]),
+                DataVector([0.0, 0.0, 0.0]),
+            ],
+            math.inf,
+        )
+        serialized_fots = serialize_functions_of_time(
+            {
+                "Expansion": expansion_fot,
+                "ExpansionOuterBoundary": expansion_outer_fot,
+                "Rotation": rotation_fot,
+                "Translation": translation_fot,
+            }
+        )
+
+        expansion_map = ExpansionMapOptions([1.0, 1e-4, 0.0], 100.0, 1e-6)
+        rotation_map = RotationMapOptions([[0.0, 0.0, 0.0, 1.0]], 100.0)
+        translation_map = TranslationMapOptions(
+            [[1.0, -1.0, 0.5], [0.2, 0.1, 0.0], [0.0, 0.0, 0.0]]
+        )
+        bco_time_dependent_options = BinaryCompactObjectTimeDependentOptions(
+            times[0],
+            expansion_map,
+            rotation_map,
+            translation_map,
+            None,
+            None,
+            None,
+            None,
+        )
+
+        binary_domain = BinaryCompactObject(
+            inner_radius_a=0.5,
+            outer_radius_a=2.0,
+            x_coord_a=5.0,
+            excise_a=True,
+            use_logarithmic_map_a=True,
+            inner_radius_b=0.5,
+            outer_radius_b=2.0,
+            x_coord_b=-5.0,
+            excise_b=True,
+            use_logarithmic_map_b=True,
+            center_of_mass_offset=[0.1, 0.2],
+            envelope_radius=50.0,
+            outer_radius=600.0,
+            cube_scale=1.2,
+            initial_refinement=1,
+            initial_number_of_grid_points=5,
+            use_equiangular_map=True,
+            radial_partitioning_outer_shell=[],
+            opening_angle_in_degrees=120.0,
+            time_dependent_options=bco_time_dependent_options,
+        ).create_domain()
+
+        serialized_binary_domain = serialize_domain(binary_domain)
+        self.inspiral_volume_data = self.test_dir / "BbhVolume0.h5"
+        with spectre_h5.H5File(self.inspiral_volume_data, "w") as volume_file:
+            volfile = volume_file.insert_vol("ForContinuation", version=0)
+            for x in range(0, 6):
+                volfile.write_volume_data(
+                    observation_id=x,
+                    observation_value=times[x],
+                    elements=[
+                        ElementVolumeData(
+                            element_name="WhatTheFreak",
+                            components=[
+                                TensorComponent(
+                                    "IsGoingOnHere",
+                                    np.random.rand(3),
+                                ),
+                            ],
+                            extents=[3],
+                            basis=[Spectral.Basis.Legendre],
+                            quadrature=[Spectral.Quadrature.GaussLobatto],
+                        )
+                    ],
+                    serialized_domain=serialized_binary_domain,
+                    serialized_observation_functions_of_time=serialized_fots,
+                )
+        volume_file.close_current_object()
+
+        ringdown_ylm_coefs, ringdown_ylm_legend, _ = (
+            compute_ringdown_shape_and_translation_fot(
+                path_to_volume_data=str(self.inspiral_volume_data),
+                volume_subfile_name="ForContinuation",
+                ahc_reductions_path=str(self.inspiral_reduction_data),
+                ahc_subfile="ObservationAhC_Ylm.dat",
+                evaluated_fot_dict=fot_dict,
+                number_of_ahc_finds_for_fit=5,
+                match_time=time_to_match,
+                settling_timescale=10.0,
+                zero_coefs_eps=None,
+            )
+        )
+        self.assertEqual(ringdown_ylm_coefs[0][4], 2.0)
+        self.assertEqual(ringdown_ylm_coefs[1][4], 2.0)
+        self.assertEqual(ringdown_ylm_coefs[2][4], 2.0)
+
+        expected_legends_ahc = [
+            "Time",
+            "DistortedExpansionCenter_x",
+            "DistortedExpansionCenter_y",
+            "DistortedExpansionCenter_z",
+            "Lmax",
+            "coef(0,0)",
+            "coef(1,-1)",
+            "coef(1,0)",
+            "coef(1,1)",
+            "coef(2,-2)",
+            "coef(2,-1)",
+            "coef(2,0)",
+            "coef(2,1)",
+            "coef(2,2)",
+        ]
+
+        self.assertEqual(expected_legends_ahc, ringdown_ylm_legend[0])
+        self.assertEqual(expected_legends_ahc, ringdown_ylm_legend[1])
+        self.assertEqual(expected_legends_ahc, ringdown_ylm_legend[2])
+
 
 if __name__ == "__main__":
     configure_logging(log_level=logging.DEBUG)


### PR DESCRIPTION
Restrict AhC coefficients to the minimum l_max over the ringdown fit window before fitting the shape and translation functions of time.

Add a regression test for mixed-l_max AhC input in the ringdown shape/translation FoT helper.

## Proposed changes

- expose `Spherepack.prolong_or_restrict` to Python
- restrict AhC coefficient vectors to the minimum `l_max` in the fit window before fitting the ringdown shape and translation functions of time
- use the fitted common `l_max` when constructing the fitted Strahlkorpers and writing the ringdown Ylm data
- add a regression test for mixed-`l_max` AhC input

 ### Upgrade instructions

<!-- UPGRADE INSTRUCTIONS -->

No upgrade instructions.

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [x] If a coding agent was used, have a co-author trailer of the form
      "Co-Authored-By: <agent name> <agent email>" as the last line of the
      commit, e.g. "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>".

### Further comments

This fixes a ringdown transition failure that occurs when the common horizon uses adaptive spherical-harmonic resolution during inspiral and the AhC coefficient vectors in the ringdown fit window therefore have different sizes. 

I reproduced the previous failure on an old inspiral run, verified that `start-ringdown` no longer raises the mixed-size failure, and verified that the generated ringdown YAML and `RingdownShapeCoefs.h5` use the expected truncated `LMax`.

This PR is related to a separate draft PR enabling adaptive `AhC` resolution for users. That change can produce mixed-`l_max` AhC data in the ringdown fit window, so this PR makes the ringdown transition robust to that case. 
Related PR is #7372

Testing: 
- `ctest -R Evolution.Ringdown.ComputeShapeAndTranslationFoT --output-on-failure`
- `ctest -R Ringdown --output-on-failure`
