### PR TITLE
Apply skew transition factor to map parameter

### DIFF
--- a/src/ControlSystem/ControlErrors/Skew.hpp
+++ b/src/ControlSystem/ControlErrors/Skew.hpp
@@ -250,7 +250,7 @@ struct Skew : tt::ConformsTo<protocols::ControlError> {
                           (weight_a * inclination_angle_a_ +
                            weight_b * inclination_angle_b_) /
                           (weight_a + weight_b) -
-                      func;
+                      (1.0 - temporal_transition_function) * func;
     } else {
       control_error *= -1.0;
     }

--- a/tests/Unit/ControlSystem/ControlErrors/Test_Skew.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_Skew.cpp
@@ -133,6 +133,13 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.ControlErrors.Skew",
       function_of_time =
           std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
               initial_time, make_array<3>(DataVector{2, 0.0}), expiration_time);
+  const DataVector skew_value{0.1, -0.2};
+  const std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>
+      nonzero_function_of_time =
+          std::make_unique<domain::FunctionsOfTime::PiecewisePolynomial<2>>(
+              initial_time,
+              std::array{skew_value, DataVector{2, 0.0}, DataVector{2, 0.0}},
+              expiration_time);
 
   const std::array<double, 3> horizon_center_a{grid_x_coord, 0.0, 0.0};
   const std::array<double, 3> horizon_center_b{-grid_x_coord, 0.0, 0.0};
@@ -143,18 +150,23 @@ SPECTRE_TEST_CASE("Unit.ControlSystem.ControlErrors.Skew",
                                                   horizon_center_b);
 
     // Not activated
-    test_skew(initial_time, horizon_a, horizon_b, function_of_time,
-              DataVector{2, 0.0}, std::nullopt);
+    test_skew(initial_time, horizon_a, horizon_b, nonzero_function_of_time,
+              -skew_value, std::nullopt);
 
-    horizon_a = ylm::Strahlkorper<Frame::Distorted>(l_max, 5.0 * radius,
+    const double horizon_radius = 5.0 * radius;
+    horizon_a = ylm::Strahlkorper<Frame::Distorted>(l_max, horizon_radius,
                                                     horizon_center_a);
-    horizon_b = ylm::Strahlkorper<Frame::Distorted>(l_max, 5.0 * radius,
+    horizon_b = ylm::Strahlkorper<Frame::Distorted>(l_max, horizon_radius,
                                                     horizon_center_b);
 
-    // Activated, but error is still zero because the horizon isn't distorted.
-    // However, we do have a suggested timescale now
-    test_skew(initial_time, horizon_a, horizon_b, function_of_time,
-              DataVector{2, 0.0}, {6.0});
+    // Activated, but the horizon isn't distorted, so only the function of time
+    // contributes to the control error. We also have a suggested timescale now.
+    const double relative_delta_x =
+        (grid_x_coord - horizon_radius) / grid_x_coord;
+    const double transition_function =
+        0.5 * (1.0 - tanh(10.0 * relative_delta_x - 5.0));
+    test_skew(initial_time, horizon_a, horizon_b, nonzero_function_of_time,
+              -(1.0 - transition_function) * skew_value, {6.0});
   }
 
   // Create surface that is just a sphere that's shifted by a constant offset,


### PR DESCRIPTION
## Proposed changes

<!--
At a high level, describe what this PR does.
-->

There appears to be a bug in the skew map error function, which codex flagged for me to review. The help text says the error function subtracts (1-g)F_j, but the implementation only subtracts -F_j. This PR fixes this and adds a test that would have caught it.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [x] If a coding agent was used, have a co-author trailer of the form
      "Co-Authored-By: <agent name> <agent email>" as the last line of the
      commit, e.g. "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>".

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
