### PR TITLE
Return zero vector for zero horizon spin

### DIFF
--- a/src/PointwiseFunctions/GeneralRelativity/Surfaces/Spin.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Surfaces/Spin.cpp
@@ -526,6 +526,11 @@ void spin_vector(
          "spin_function size doesn't match ylm physical size: "
              << get(spin_function).size() << " vs " << ylm_physical_size);
 
+  if (spin_magnitude == 0.0) {
+    *result = make_array<3>(0.0);
+    return;
+  }
+
   // Compute very rough center of the measurement frame by simply
   // averaging measurement_frame_coords.  It is ok for this center to
   // be very rough, since it will be corrected below.

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Surfaces/Test_GrSurfaces.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Surfaces/Test_GrSurfaces.cpp
@@ -1170,6 +1170,23 @@ SPECTRE_TEST_CASE("Unit.GrSurfaces.DimensionfulSpinMagnitude",
 
 SPECTRE_TEST_CASE("Unit.GrSurfaces.SpinVector",
                   "[ApparentHorizonFinder][Unit]") {
+  {
+    const ylm::Strahlkorper<Frame::Inertial> sphere{4, 2.0, {0.0, 0.0, 0.0}};
+    const auto box = db::create<
+        db::AddSimpleTags<ylm::Tags::items_tags<Frame::Inertial>>,
+        db::AddComputeTags<ylm::Tags::compute_items_tags<Frame::Inertial>>>(
+        sphere);
+    const auto& cartesian_coords =
+        db::get<ylm::Tags::CartesianCoords<Frame::Inertial>>(box);
+    const size_t number_of_points = sphere.ylm_spherepack().physical_size();
+    const Scalar<DataVector> area_element{number_of_points, 1.0};
+    const Scalar<DataVector> ricci_scalar{number_of_points, 0.5};
+    const Scalar<DataVector> spin_function{number_of_points, 0.0};
+    CHECK(gr::surfaces::spin_vector(0.0, area_element, ricci_scalar,
+                                    spin_function, sphere, cartesian_coords) ==
+          std::array{0.0, 0.0, 0.0});
+  }
+
   // Set up Kerr horizon
   constexpr int l_max = 20;
   const double mass = 2.0;


### PR DESCRIPTION
## Proposed changes

This doesn't seem critical to me, but codex noticed that the spin direction code currently does not correctly handle the case where the spin is exactly 0, which might come up in the future in some test case where we deliberately are using Schwarzschild. This is a quick PR to fix that.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [x] If a coding agent was used, have a co-author trailer of the form
      "Co-Authored-By: <agent name> <agent email>" as the last line of the
      commit, e.g. "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>".

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
