### PR TITLE
Preserve inward-drift state when copying Size

### DIFF
--- a/src/ControlSystem/ControlErrors/Size.cpp
+++ b/src/ControlSystem/ControlErrors/Size.cpp
@@ -107,10 +107,13 @@ Size<DerivOrder, Horizon>& Size<DerivOrder, Horizon>::operator=(
   char_speed_predictor_ = rhs.char_speed_predictor_;
   comoving_char_speed_predictor_ = rhs.comoving_char_speed_predictor_;
   delta_radius_predictor_ = rhs.delta_radius_predictor_;
+  drift_limit_char_speed_predictor_ = rhs.drift_limit_char_speed_predictor_;
+  drift_limit_delta_radius_predictor_ = rhs.drift_limit_delta_radius_predictor_;
   state_history_ = rhs.state_history_;
   legend_ = rhs.legend_;
   subfile_name_ = rhs.subfile_name_;
   delta_r_drift_outward_options_ = rhs.delta_r_drift_outward_options_;
+  delta_r_drift_inward_options_ = rhs.delta_r_drift_inward_options_;
 
   return *this;
 }

--- a/src/ControlSystem/ControlErrors/Size.hpp
+++ b/src/ControlSystem/ControlErrors/Size.hpp
@@ -233,6 +233,19 @@ struct Size : tt::ConformsTo<protocols::ControlError> {
     double max_allowed_radial_distance{};
     double outward_drift_velocity{};
     double outward_drift_timescale{};
+
+    friend bool operator==(const DeltaRDriftOutwardOptions& lhs,
+                           const DeltaRDriftOutwardOptions& rhs) {
+      return lhs.max_allowed_radial_distance ==
+                 rhs.max_allowed_radial_distance and
+             lhs.outward_drift_velocity == rhs.outward_drift_velocity and
+             lhs.outward_drift_timescale == rhs.outward_drift_timescale;
+    }
+
+    friend bool operator!=(const DeltaRDriftOutwardOptions& lhs,
+                           const DeltaRDriftOutwardOptions& rhs) {
+      return not(lhs == rhs);
+    }
   };
 
   struct DeltaRDriftInwardOptions {
@@ -270,6 +283,19 @@ struct Size : tt::ConformsTo<protocols::ControlError> {
     double min_allowed_radial_distance{};
     double min_allowed_char_speed{};
     double inward_drift_velocity{};
+
+    friend bool operator==(const DeltaRDriftInwardOptions& lhs,
+                           const DeltaRDriftInwardOptions& rhs) {
+      return lhs.min_allowed_radial_distance ==
+                 rhs.min_allowed_radial_distance and
+             lhs.min_allowed_char_speed == rhs.min_allowed_char_speed and
+             lhs.inward_drift_velocity == rhs.inward_drift_velocity;
+    }
+
+    friend bool operator!=(const DeltaRDriftInwardOptions& lhs,
+                           const DeltaRDriftInwardOptions& rhs) {
+      return not(lhs == rhs);
+    }
   };
 
   using options =
@@ -333,6 +359,31 @@ struct Size : tt::ConformsTo<protocols::ControlError> {
   std::deque<std::pair<double, double>> control_error_history() const;
 
   void pup(PUP::er& p);
+
+  friend bool operator==(const Size& lhs, const Size& rhs) {
+    return lhs.smoother_tuner_ == rhs.smoother_tuner_ and
+           lhs.horizon_coef_averager_ == rhs.horizon_coef_averager_ and
+           lhs.info_ == rhs.info_ and
+           lhs.char_speed_predictor_ == rhs.char_speed_predictor_ and
+           lhs.comoving_char_speed_predictor_ ==
+               rhs.comoving_char_speed_predictor_ and
+           lhs.delta_radius_predictor_ == rhs.delta_radius_predictor_ and
+           lhs.drift_limit_char_speed_predictor_ ==
+               rhs.drift_limit_char_speed_predictor_ and
+           lhs.drift_limit_delta_radius_predictor_ ==
+               rhs.drift_limit_delta_radius_predictor_ and
+           lhs.state_history_ == rhs.state_history_ and
+           lhs.legend_ == rhs.legend_ and
+           lhs.subfile_name_ == rhs.subfile_name_ and
+           lhs.delta_r_drift_outward_options_ ==
+               rhs.delta_r_drift_outward_options_ and
+           lhs.delta_r_drift_inward_options_ ==
+               rhs.delta_r_drift_inward_options_;
+  }
+
+  friend bool operator!=(const Size& lhs, const Size& rhs) {
+    return not(lhs == rhs);
+  }
 
   /*!
    * \brief Actually computes the control error.

--- a/src/ControlSystem/ControlErrors/Size/Info.cpp
+++ b/src/ControlSystem/ControlErrors/Size/Info.cpp
@@ -53,6 +53,21 @@ void Info::reset() {
   // target_drift_velocity = 0.0;
 }
 
+bool operator==(const Info& lhs, const Info& rhs) {
+  const bool states_are_equal =
+      (lhs.state == nullptr and rhs.state == nullptr) or
+      (lhs.state != nullptr and rhs.state != nullptr and
+       lhs.state->number() == rhs.state->number());
+  return states_are_equal and lhs.damping_time == rhs.damping_time and
+         lhs.target_char_speed == rhs.target_char_speed and
+         lhs.target_drift_velocity == rhs.target_drift_velocity and
+         lhs.suggested_time_scale == rhs.suggested_time_scale and
+         lhs.discontinuous_change_has_occurred ==
+             rhs.discontinuous_change_has_occurred;
+}
+
+bool operator!=(const Info& lhs, const Info& rhs) { return not(lhs == rhs); }
+
 void Info::set_all_but_state(const Info& info) {
   damping_time = info.damping_time;
   target_char_speed = info.target_char_speed;

--- a/src/ControlSystem/ControlErrors/Size/Info.hpp
+++ b/src/ControlSystem/ControlErrors/Size/Info.hpp
@@ -55,6 +55,9 @@ struct Info {
   /// Reset `discontinuous_change_has_occurred` and `suggested_time_scale`
   void reset();
 
+  friend bool operator==(const Info& lhs, const Info& rhs);
+  friend bool operator!=(const Info& lhs, const Info& rhs);
+
  private:
   void set_all_but_state(const Info& info);
 };

--- a/src/ControlSystem/ControlErrors/Size/StateHistory.cpp
+++ b/src/ControlSystem/ControlErrors/Size/StateHistory.cpp
@@ -67,4 +67,13 @@ void StateHistory::pup(PUP::er& p) {
   p | num_times_to_store_;
   p | stored_control_errors_;
 }
+
+bool operator==(const StateHistory& lhs, const StateHistory& rhs) {
+  return lhs.num_times_to_store_ == rhs.num_times_to_store_ and
+         lhs.stored_control_errors_ == rhs.stored_control_errors_;
+}
+
+bool operator!=(const StateHistory& lhs, const StateHistory& rhs) {
+  return not(lhs == rhs);
+}
 }  // namespace control_system::size

--- a/src/ControlSystem/ControlErrors/Size/StateHistory.hpp
+++ b/src/ControlSystem/ControlErrors/Size/StateHistory.hpp
@@ -50,6 +50,9 @@ struct StateHistory {
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& p);
 
+  friend bool operator==(const StateHistory& lhs, const StateHistory& rhs);
+  friend bool operator!=(const StateHistory& lhs, const StateHistory& rhs);
+
  private:
   void initialize_stored_control_errors();
 

--- a/tests/Unit/ControlSystem/ControlErrors/Test_SizeError.cpp
+++ b/tests/Unit/ControlSystem/ControlErrors/Test_SizeError.cpp
@@ -47,6 +47,7 @@
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/Serialization/Serialize.hpp"
 #include "Utilities/TMPL.hpp"
 
 namespace Frame {
@@ -88,6 +89,35 @@ void test_control_error_delta_r() {
                                                   grid_frame_excision_radius);
 
   CHECK(control_error_delta_r == approx(-2.5));
+}
+
+void test_size_error_copy() {
+  using SizeError =
+      control_system::ControlErrors::Size<2, domain::ObjectLabel::A>;
+  const auto original = TestHelpers::test_creation<SizeError, Metavars>(
+      "MaxNumTimesForZeroCrossingPredictor: 4\n"
+      "SmoothAvgTimescaleFraction: 0.25\n"
+      "DeltaRDriftOutwardOptions: None\n"
+      "DeltaRDriftInwardOptions:\n"
+      "  MinAllowedRadialDistance: 0.1\n"
+      "  MinAllowedCharSpeed: 0.2\n"
+      "  InwardDriftVelocity: 0.3\n"
+      "InitialState: Initial\n"
+      "SmootherTuner:\n"
+      "  InitialTimescales: 0.2\n"
+      "  MinTimescale: 1.0e-4\n"
+      "  MaxTimescale: 20.0\n"
+      "  IncreaseThreshold: 2.5e-4\n"
+      "  DecreaseThreshold: 1.0e-3\n"
+      "  IncreaseFactor: 1.01\n"
+      "  DecreaseFactor: 0.98\n");
+  // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
+  const SizeError copy_constructed{original};
+  SizeError copy_assigned{};
+  copy_assigned = original;
+  CHECK(original == copy_constructed);
+  CHECK(original == copy_assigned);
+  CHECK(original == serialize_and_deserialize(original));
 }
 
 void test_size_error_horizon_higher_res_than_excision() {
@@ -475,6 +505,7 @@ void test_size_error(const double grid_excision_boundary_radius,
 SPECTRE_TEST_CASE("Unit.ControlSystem.SizeError", "[Domain][Unit]") {
   control_system::size::register_derived_with_charm();
   test_control_error_delta_r();
+  test_size_error_copy();
   test_size_error_horizon_higher_res_than_excision();
   // Should go to DeltaR state with error of zero, since ComovingMinCharSpeed
   // will be positive.


### PR DESCRIPTION
## Proposed changes

Codex noticed that some private member variables of Size error control are not copied by the copy constructor. This PR adds this missing private member variables to the copy constructor, to ensure the copy has the same state as the original.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [x] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [x] If a coding agent was used, have a co-author trailer of the form
      "Co-Authored-By: <agent name> <agent email>" as the last line of the
      commit, e.g. "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>".

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
