### PR TITLE
Support boundary evolution fields part 1-1

### DIFF
--- a/src/Time/Actions/SelfStartActions.hpp
+++ b/src/Time/Actions/SelfStartActions.hpp
@@ -121,21 +121,24 @@ struct InitialValue : db::PrefixTag, db::SimpleTag {
 /// Self-start actions
 namespace Actions {
 namespace detail {
-template <typename System, bool HasPrimitives>
+template <typename System, typename AdditionalVarsToSave, bool HasPrimitives>
 struct vars_to_save_impl {
-  using type = tmpl::flatten<tmpl::list<typename System::variables_tag>>;
+  using type = tmpl::flatten<
+      tmpl::list<typename System::variables_tag, AdditionalVarsToSave>>;
 };
 
-template <typename System>
-struct vars_to_save_impl<System, true> {
+template <typename System, typename AdditionalVarsToSave>
+struct vars_to_save_impl<System, AdditionalVarsToSave, true> {
   using type =
       tmpl::flatten<tmpl::list<typename System::variables_tag,
-                               typename System::primitive_variables_tag>>;
+                               typename System::primitive_variables_tag,
+                               AdditionalVarsToSave>>;
 };
 
-template <typename System>
+template <typename System, typename AdditionalVarsToSave = tmpl::list<>>
 using vars_to_save = typename vars_to_save_impl<
-    System, System::has_primitive_and_conservative_vars>::type;
+    System, AdditionalVarsToSave,
+    System::has_primitive_and_conservative_vars>::type;
 }  // namespace detail
 
 /// \ingroup ActionsGroup
@@ -184,7 +187,8 @@ using vars_to_save = typename vars_to_save_impl<
 /// - Removes: nothing
 /// - Modifies: Tags::TimeStep
 template <typename System,
-          template <typename> typename CacheTagPrefix = std::type_identity_t>
+          template <typename> typename CacheTagPrefix = std::type_identity_t,
+          typename AdditionalVarsToSave = tmpl::list<>>
 struct Initialize {
  private:
   template <typename TagsToSave>
@@ -202,8 +206,9 @@ struct Initialize {
   };
 
  public:
-  using simple_tags = typename StoreInitialValues<tmpl::push_back<
-      detail::vars_to_save<System>, ::Tags::TimeStep>>::simple_tags;
+  using simple_tags = typename StoreInitialValues<
+      tmpl::push_back<detail::vars_to_save<System, AdditionalVarsToSave>,
+                      ::Tags::TimeStep>>::simple_tags;
 
   template <typename DbTags, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
@@ -237,8 +242,9 @@ struct Initialize {
     // first real step.
     const TimeDelta self_start_step = initial_step / (values_needed + 1);
 
-    StoreInitialValues<tmpl::push_back<detail::vars_to_save<System>,
-                                       ::Tags::TimeStep>>::apply(box);
+    StoreInitialValues<
+        tmpl::push_back<detail::vars_to_save<System, AdditionalVarsToSave>,
+                        ::Tags::TimeStep>>::apply(box);
     db::mutate<::Tags::TimeStep>(
         [&self_start_step](const gsl::not_null<::TimeDelta*> time_step) {
           *time_step = self_start_step;
@@ -263,7 +269,8 @@ struct Initialize {
 /// - Adds: nothing
 /// - Removes: nothing
 /// - Modifies: nothing
-template <typename ExitTag, typename System>
+template <typename ExitTag, typename System,
+          typename AdditionalVarsToSave = tmpl::list<>>
 struct CheckForCompletion {
   template <typename DbTags, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
@@ -278,15 +285,16 @@ struct CheckForCompletion {
         db::get<::Tags::Next<::Tags::TimeStepId>>(box).is_at_slab_boundary();
 
     if (done_with_order) {
-      tmpl::for_each<detail::vars_to_save<System>>([&box](auto tag) {
-        using Tag = tmpl::type_from<decltype(tag)>;
-        db::mutate<Tag>(
-            [](const gsl::not_null<typename Tag::type*> value,
-               const std::tuple<typename Tag::type>& initial_value) {
-              *value = get<0>(initial_value);
-            },
-            make_not_null(&box), db::get<Tags::InitialValue<Tag>>(box));
-      });
+      tmpl::for_each<detail::vars_to_save<System, AdditionalVarsToSave>>(
+          [&box](auto tag) {
+            using Tag = tmpl::type_from<decltype(tag)>;
+            db::mutate<Tag>(
+                [](const gsl::not_null<typename Tag::type*> value,
+                   const std::tuple<typename Tag::type>& initial_value) {
+                  *value = get<0>(initial_value);
+                },
+                make_not_null(&box), db::get<Tags::InitialValue<Tag>>(box));
+          });
     }
 
     // The self start procedure begins with slab number
@@ -451,15 +459,23 @@ struct PhaseEnd;
 /// \tparam StepActions List of actions computing and recording the
 /// system derivative and updating the evolved variables (but not the
 /// time).
+/// \tparam AdditionalVarsToSave List of extra tags to snapshot when
+/// self-start begins and to restore at each order-increase reset, in
+/// addition to the system's evolved (and primitive) variables. Used by
+/// facilities that keep their own time-integrated state, e.g. the
+/// boundary-evolved-fields facility passes its per-face value-map tag.
 ///
 /// \see SelfStart
 template <typename StepActions, typename System,
-          template <typename> typename CacheTagPrefix = std::type_identity_t>
+          template <typename> typename CacheTagPrefix = std::type_identity_t,
+          typename AdditionalVarsToSave = tmpl::list<>>
 using self_start_procedure = tmpl::flatten<tmpl::list<
-// clang-format off
-    SelfStart::Actions::Initialize<System, CacheTagPrefix>,
+    // clang-format off
+    SelfStart::Actions::Initialize<System, CacheTagPrefix,
+                                   AdditionalVarsToSave>,
     ::Actions::Label<detail::PhaseStart>,
-    SelfStart::Actions::CheckForCompletion<detail::PhaseEnd, System>,
+    SelfStart::Actions::CheckForCompletion<detail::PhaseEnd, System,
+                                           AdditionalVarsToSave>,
     ::Actions::MutateApply<AdvanceTime<CacheTagPrefix>>,
     SelfStart::Actions::CheckForOrderIncrease,
     StepActions,

--- a/tests/Unit/Time/Actions/Test_SelfStartActions.cpp
+++ b/tests/Unit/Time/Actions/Test_SelfStartActions.cpp
@@ -77,6 +77,10 @@ struct PrimitiveVar : db::SimpleTag {
   using type = double;
 };
 
+struct ExtraVar : db::SimpleTag {
+  using type = double;
+};
+
 struct ComputeTimeDerivative {
   template <typename DbTagsList, typename... InboxTags, typename Metavariables,
             typename ArrayIndex, typename ActionList,
@@ -88,11 +92,30 @@ struct ComputeTimeDerivative {
       const ArrayIndex& /*array_index*/, ActionList /*meta*/,
       const ParallelComponent* const /*meta*/) {
     using argument_tag = tmpl::conditional_t<
-        Metavariables::system::has_primitive_and_conservative_vars,
-        PrimitiveVar, Var>;
+        Metavariables::save_extra_var, ExtraVar,
+        tmpl::conditional_t<
+            Metavariables::system::has_primitive_and_conservative_vars,
+            PrimitiveVar, Var>>;
     db::mutate<Tags::dt<Var>>([](const gsl::not_null<double*> dt_var,
                                  const double var) { *dt_var = exp(var); },
                               make_not_null(&box), db::get<argument_tag>(box));
+    return {Parallel::AlgorithmExecution::Continue, std::nullopt};
+  }
+};
+
+struct UpdateExtraVar {
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static Parallel::iterable_action_return_t apply(
+      db::DataBox<DbTagsList>& box,
+      tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/, ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) {
+    db::mutate<ExtraVar>([](const gsl::not_null<double*> extra,
+                            const double var) { *extra = var; },
+                         make_not_null(&box), db::get<Var>(box));
     return {Parallel::AlgorithmExecution::Continue, std::nullopt};
   }
 };
@@ -131,10 +154,12 @@ using additional_history_tag = Tags::HistoryEvolvedVariables<ComplexVar>;
 template <typename Metavariables>
 struct Component;
 
-template <bool HasPrimitives = false, bool MultipleHistories = false>
+template <bool HasPrimitives = false, bool MultipleHistories = false,
+          bool SaveExtraVar = false>
 struct Metavariables {
   static constexpr bool has_primitives = HasPrimitives;
   static constexpr bool multiple_histories = MultipleHistories;
+  static constexpr bool save_extra_var = SaveExtraVar;
   using system = System<HasPrimitives>;
   using component_list = tmpl::list<Component<Metavariables>>;
   using ordered_list_of_primitive_recovery_schemes = tmpl::list<>;
@@ -158,8 +183,9 @@ struct Component {
       tmpl::conditional_t<Metavariables::multiple_histories,
                           additional_history_tag, tmpl::list<>>,
       Tags::TimeStepId, Tags::Next<Tags::TimeStepId>, Tags::TimeStep,
-      Tags::Time, Tags::StepNumberWithinSlab,
-      Tags::AdaptiveSteppingDiagnostics>>;
+      Tags::Time, Tags::StepNumberWithinSlab, Tags::AdaptiveSteppingDiagnostics,
+      tmpl::conditional_t<Metavariables::save_extra_var, tmpl::list<ExtraVar>,
+                          tmpl::list<>>>>;
   using compute_tags = time_stepper_ref_tags<TimeStepper>;
 
   static constexpr bool has_primitives = Metavariables::has_primitives;
@@ -171,11 +197,15 @@ struct Component {
       Actions::MutateApply<UpdateU<typename metavariables::system>>,
       Actions::MutateApply<CleanHistory<typename metavariables::system>>,
       tmpl::conditional_t<has_primitives, Actions::UpdatePrimitives,
+                          tmpl::list<>>,
+      tmpl::conditional_t<Metavariables::save_extra_var, UpdateExtraVar,
                           tmpl::list<>>>;
-  using action_list = tmpl::flatten<
-      tmpl::list<SelfStart::self_start_procedure<
-                     step_actions, typename metavariables::system>,
-                 step_actions>>;
+  using action_list = tmpl::flatten<tmpl::list<
+      SelfStart::self_start_procedure<
+          step_actions, typename metavariables::system, std::type_identity_t,
+          tmpl::conditional_t<Metavariables::save_extra_var,
+                              tmpl::list<ExtraVar>, tmpl::list<>>>,
+      step_actions>>;
   using phase_dependent_action_list = tmpl::list<
       Parallel::PhaseActions<Parallel::Phase::Initialization,
                              tmpl::list<ActionTesting::InitializeDataBox<
@@ -183,9 +213,10 @@ struct Component {
       Parallel::PhaseActions<Parallel::Phase::Testing, action_list>>;
 };
 
-template <bool HasPrimitives = false, bool MultipleHistories = false>
+template <bool HasPrimitives = false, bool MultipleHistories = false,
+          bool SaveExtraVar = false>
 using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<
-    Metavariables<HasPrimitives, MultipleHistories>>;
+    Metavariables<HasPrimitives, MultipleHistories, SaveExtraVar>>;
 
 template <bool HasPrimitives = false, bool MultipleHistories = false>
 void emplace_component_and_initialize(
@@ -258,8 +289,10 @@ void emplace_component_and_initialize<true, true>(
 template <typename T>
 struct is_initialize : std::false_type {};
 
-template <typename System, template <typename> typename CacheTagPrefix>
-struct is_initialize<SelfStart::Actions::Initialize<System, CacheTagPrefix>>
+template <typename System, template <typename> typename CacheTagPrefix,
+          typename AdditionalVarsToSave>
+struct is_initialize<SelfStart::Actions::Initialize<System, CacheTagPrefix,
+                                                    AdditionalVarsToSave>>
     : std::true_type {};
 
 using not_self_start_action = std::negation<std::disjunction<
@@ -273,17 +306,20 @@ using not_self_start_action = std::negation<std::disjunction<
 // is run first (as that would often lead to an infinite loop).
 // Returns true if the last action jumped.
 template <typename Stop, typename Whitelist, bool MultipleHistories,
-          bool HasPrimitives>
+          bool HasPrimitives, bool SaveExtraVar = false>
 bool run_past(
-    const gsl::not_null<MockRuntimeSystem<HasPrimitives, MultipleHistories>*>
+    const gsl::not_null<
+        MockRuntimeSystem<HasPrimitives, MultipleHistories, SaveExtraVar>*>
         runner) {
   for (;;) {
     bool done = false;
-    const size_t current_action = ActionTesting::get_next_action_index<
-        Component<Metavariables<HasPrimitives, MultipleHistories>>>(*runner, 0);
+    const size_t current_action =
+        ActionTesting::get_next_action_index<Component<
+            Metavariables<HasPrimitives, MultipleHistories, SaveExtraVar>>>(
+            *runner, 0);
     size_t action_to_check = current_action;
-    tmpl::for_each<typename Component<
-        Metavariables<HasPrimitives, MultipleHistories>>::action_list>(
+    tmpl::for_each<typename Component<Metavariables<
+        HasPrimitives, MultipleHistories, SaveExtraVar>>::action_list>(
         [&action_to_check, &done](const auto action) {
           using Action = tmpl::type_from<decltype(action)>;
           if (action_to_check-- == 0) {
@@ -292,16 +328,16 @@ bool run_past(
             REQUIRE((done or tmpl::apply<Whitelist, Action>::value));
           }
         });
-    ActionTesting::next_action<
-        Component<Metavariables<HasPrimitives, MultipleHistories>>>(runner, 0);
+    ActionTesting::next_action<Component<
+        Metavariables<HasPrimitives, MultipleHistories, SaveExtraVar>>>(runner,
+                                                                        0);
     // NOLINTNEXTLINE(clang-analyzer-core.uninitialized.Branch) false positive
     if (done) {
       // Self-start does not use the automatic algorithm looping, so
       // we don't have to check for the end.
       return current_action + 1 !=
-             ActionTesting::get_next_action_index<
-                 Component<Metavariables<HasPrimitives, MultipleHistories>>>(
-                 *runner, 0);
+             ActionTesting::get_next_action_index<Component<Metavariables<
+                 HasPrimitives, MultipleHistories, SaveExtraVar>>>(*runner, 0);
     }
   }
 }
@@ -421,7 +457,8 @@ void test_actions(const size_t order, const int step_denominator) {
   }
 }
 
-template <bool TestPrimitives, bool MultipleHistories>
+template <bool TestPrimitives, bool MultipleHistories,
+          bool SaveExtraVar = false>
 double error_in_step(const size_t order, const double step) {
   const bool forward_in_time = step > 0.;
   const auto slab = forward_in_time ? Slab::with_duration_from_start(1., step)
@@ -431,15 +468,38 @@ double error_in_step(const size_t order, const double step) {
   const Time initial_time = forward_in_time ? slab.start() : slab.end();
   const double initial_value = -1.;
 
-  using component = Component<Metavariables<TestPrimitives, MultipleHistories>>;
-  MockRuntimeSystem<TestPrimitives, MultipleHistories> runner{
+  using component =
+      Component<Metavariables<TestPrimitives, MultipleHistories, SaveExtraVar>>;
+  MockRuntimeSystem<TestPrimitives, MultipleHistories, SaveExtraVar> runner{
       {std::make_unique<TimeSteppers::AdamsBashforth>(order),
        EventsAndTriggers{},
        std::vector<std::unique_ptr<StepChooser<StepChooserUse::LtsStep>>>{},
        VariableOrderAlgorithm{order}}};
-  emplace_component_and_initialize<TestPrimitives, MultipleHistories>(
-      make_not_null(&runner), forward_in_time, initial_time, initial_time_step,
-      order, initial_value);
+  if constexpr (SaveExtraVar) {
+    // Test that ExtraVar is treated the same as primitive variables
+    // by the time stepper
+    const TimeStepId next_time_step_id(
+        forward_in_time, 1 - static_cast<int64_t>(order), initial_time);
+    const double nan = std::numeric_limits<double>::signaling_NaN();
+    if constexpr (MultipleHistories) {
+      ActionTesting::emplace_component_and_initialize<component>(
+          make_not_null(&runner), 0,
+          {initial_value, 0., typename history_tag::type{1},
+           typename additional_history_tag::type{1}, TimeStepId{},
+           next_time_step_id, initial_time_step, nan, uint64_t{0},
+           Tags::AdaptiveSteppingDiagnostics::type{}, initial_value});
+    } else {
+      ActionTesting::emplace_component_and_initialize<component>(
+          make_not_null(&runner), 0,
+          {initial_value, 0., typename history_tag::type{1}, TimeStepId{},
+           next_time_step_id, initial_time_step, nan, uint64_t{0},
+           Tags::AdaptiveSteppingDiagnostics::type{}, initial_value});
+    }
+  } else {
+    emplace_component_and_initialize<TestPrimitives, MultipleHistories>(
+        make_not_null(&runner), forward_in_time, initial_time,
+        initial_time_step, order, initial_value);
+  }
 
   ActionTesting::set_phase(make_not_null(&runner), Parallel::Phase::Testing);
 
@@ -454,13 +514,15 @@ double error_in_step(const size_t order, const double step) {
   return ActionTesting::get_databox_tag<component, Var>(runner, 0) - exact;
 }
 
-template <bool TestPrimitives, bool MultipleHistories>
+template <bool TestPrimitives, bool MultipleHistories,
+          bool SaveExtraVar = false>
 void test_convergence(const size_t order, const bool forward_in_time) {
   const double step = forward_in_time ? 0.1 : -0.1;
   const double convergence_rate =
-      (log(abs(error_in_step<TestPrimitives, MultipleHistories>(order, step))) -
-       log(abs(error_in_step<TestPrimitives, MultipleHistories>(order,
-                                                                0.5 * step)))) /
+      (log(abs(error_in_step<TestPrimitives, MultipleHistories, SaveExtraVar>(
+           order, step))) -
+       log(abs(error_in_step<TestPrimitives, MultipleHistories, SaveExtraVar>(
+           order, 0.5 * step)))) /
       log(2.);
   // This measures the local truncation error, so order + 1.  It
   // should be converging to an integer, so just check that it looks
@@ -489,6 +551,8 @@ SPECTRE_TEST_CASE("Unit.Time.Actions.SelfStart", "[Unit][Time][Actions]") {
       test_convergence<true, false>(order, forward_in_time);
       test_convergence<false, true>(order, forward_in_time);
       test_convergence<true, true>(order, forward_in_time);
+      test_convergence<false, false, true>(order, forward_in_time);
+      test_convergence<false, true, true>(order, forward_in_time);
     }
   }
 


### PR DESCRIPTION
Allow self-start to snapshot and restore additional variables alongside evolved and primitive variables. The additional variables will be used to store boundary evolution fields: variables that can be integrated along the boundary with no volume extent.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent was used, have a co-author trailer of the form
      "Co-Authored-By: <agent name> <agent email>" as the last line of the
      commit, e.g. "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>".

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
