### PR TITLE
Support boundary evolution fields part 1-2

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/BoundaryEvolvedFields/CMakeLists.txt
+++ b/src/Evolution/DiscontinuousGalerkin/BoundaryEvolvedFields/CMakeLists.txt
@@ -1,0 +1,11 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  InitializeBoundaryEvolvedFields.hpp
+  NamespaceDocs.hpp
+  Tags.hpp
+  )

--- a/src/Evolution/DiscontinuousGalerkin/BoundaryEvolvedFields/InitializeBoundaryEvolvedFields.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/BoundaryEvolvedFields/InitializeBoundaryEvolvedFields.hpp
@@ -1,0 +1,169 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <typeinfo>
+#include <utility>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Creators/Tags/ExternalBoundaryConditions.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/DiscontinuousGalerkin/BoundaryEvolvedFields/Tags.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/ProjectToBoundary.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Parallel/AlgorithmExecution.hpp"
+#include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
+#include "Time/Tags/HistoryEvolvedVariables.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TypeTraits/CreateHasTypeAlias.hpp"
+
+/// \cond
+namespace Parallel {
+template <typename Metavariables>
+class GlobalCache;
+}  // namespace Parallel
+namespace tuples {
+template <class... Tags>
+class TaggedTuple;
+}  // namespace tuples
+/// \endcond
+
+namespace evolution::dg::BoundaryEvolvedFields {
+namespace detail {
+// A metavariables enables adaptive mesh refinement by declaring a nested `amr`
+// type (which holds the `amr::projectors` list read by `amr::AdjustDomain`).
+// Detect its presence to fail loud when the facility -- which stores per-face
+// value/history maps with no AMR projector -- would otherwise have those maps
+// silently emptied by an AMR event.
+CREATE_HAS_TYPE_ALIAS(amr)
+CREATE_HAS_TYPE_ALIAS_V(amr)
+}  // namespace detail
+
+/// \ingroup ActionsGroup
+/// \ingroup DiscontinuousGalerkinGroup
+/// \brief Allocates and initializes the per-face boundary-evolved
+/// field storage on each opting external face.
+///
+/// Iterates the element's external boundaries, resolves each face's applied
+/// boundary condition by `typeid` against `DerivedBoundaryConditionsList`, and,
+/// for each boundary condition that opts in (declares
+/// `boundary_evolved_variables`), allocates the face-sized per-face `Variables`
+/// entries in the value, dt-stash, and history maps. Each
+/// `Tags::BoundaryValue<Source>` is initialized by projecting its interior
+/// `Source` from the volume `variables_tag` to the face. Interior and
+/// non-opting faces get no entry.
+///
+/// Runs after the domain and initial data are set and after
+/// `Initialization::Mortars`, before the self-start phase.
+///
+/// \tparam Dim the spatial dimension
+/// \tparam System the evolution system (supplies `variables_tag`)
+/// \tparam DerivedBoundaryConditionsList the concrete boundary condition types
+template <size_t Dim, typename System, typename DerivedBoundaryConditionsList>
+struct InitializeBoundaryEvolvedFields {
+ private:
+  using field_tags_list =
+      boundary_evolved_field_tags<DerivedBoundaryConditionsList>;
+
+  static_assert(
+      boundary_evolved_fields_are_homogeneous_v<DerivedBoundaryConditionsList>,
+      "The boundary-evolved-fields facility requires every boundary condition "
+      "that opts in (declares `boundary_evolved_variables`) to declare the "
+      "identical field list. Heterogeneous per-face field sets are not yet "
+      "supported: a face would carry union components its own boundary "
+      "condition never initializes, which are still recorded and "
+      "time-integrated.");
+
+ public:
+  using values_tag = Tags::BoundaryEvolvedFieldsValues<Dim, field_tags_list>;
+  using dt_stash_tag = Tags::BoundaryEvolvedFieldsDtStash<Dim, field_tags_list>;
+  using history_tag = Tags::BoundaryEvolvedFieldsHistory<Dim, field_tags_list>;
+
+  using const_global_cache_tags =
+      tmpl::list<domain::Tags::ExternalBoundaryConditions<Dim>>;
+  using simple_tags_from_options = tmpl::list<>;
+  using simple_tags = tmpl::list<values_tag, dt_stash_tag, history_tag>;
+  using compute_tags = tmpl::list<>;
+
+  template <typename DbTagsList, typename... InboxTags, typename Metavariables,
+            typename ArrayIndex, typename ActionList,
+            typename ParallelComponent>
+  static Parallel::iterable_action_return_t apply(
+      db::DataBox<DbTagsList>& box,
+      const tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      const Parallel::GlobalCache<Metavariables>& /*cache*/,
+      const ArrayIndex& /*array_index*/, ActionList /*meta*/,
+      const ParallelComponent* const /*meta*/) {
+    static_assert(
+        tmpl::size<field_tags_list>::value == 0 or
+            not detail::has_amr_v<Metavariables>,
+        "Boundary-evolved fields do not yet support adaptive mesh refinement "
+        "(AMR): it requires adding a boundary-history projector to the "
+        "facility.");
+    const auto& element = db::get<::domain::Tags::Element<Dim>>(box);
+    const auto& mesh = db::get<::domain::Tags::Mesh<Dim>>(box);
+    const auto& volume_variables = db::get<typename System::variables_tag>(box);
+    const auto& external_boundary_conditions =
+        db::get<domain::Tags::ExternalBoundaryConditions<Dim>>(box).at(
+            element.id().block_id());
+
+    using volume_history_tags = ::Tags::get_all_history_tags<DbTagsList>;
+    const size_t initial_order =
+        db::get<tmpl::front<volume_history_tags>>(box).integration_order();
+
+    typename values_tag::type values{};
+    typename dt_stash_tag::type dt_stash{};
+    typename history_tag::type histories{};
+
+    for (const Direction<Dim>& direction : element.external_boundaries()) {
+      const auto& boundary_condition =
+          *external_boundary_conditions.at(direction);
+      tmpl::for_each<DerivedBoundaryConditionsList>([&boundary_condition,
+                                                     &direction, &mesh,
+                                                     &volume_variables, &values,
+                                                     &dt_stash, &histories,
+                                                     &initial_order](
+                                                        auto derived_bc_v) {
+        using DerivedBoundaryCondition =
+            tmpl::type_from<decltype(derived_bc_v)>;
+        using bc_field_tags =
+            boundary_evolved_variables_of<DerivedBoundaryCondition>;
+        if constexpr (bc_opts_in_v<DerivedBoundaryCondition>) {
+          if (typeid(boundary_condition) == typeid(DerivedBoundaryCondition)) {
+            const size_t number_of_face_grid_points =
+                mesh.slice_away(direction.dimension()).number_of_grid_points();
+            Variables<field_tags_list> face_values{number_of_face_grid_points};
+            tmpl::for_each<bc_field_tags>([&direction, &mesh, &volume_variables,
+                                           &face_values](auto tag_v) {
+              using boundary_tag = tmpl::type_from<decltype(tag_v)>;
+              using source_tag = typename boundary_tag::tag;
+              const auto& volume_field = get<source_tag>(volume_variables);
+              auto& face_field = get<boundary_tag>(face_values);
+              ::dg::project_tensor_to_boundary(make_not_null(&face_field),
+                                               volume_field, mesh, direction);
+            });
+            dt_stash.insert(
+                {direction, typename dt_stash_tag::type::mapped_type{
+                                number_of_face_grid_points}});
+            histories.insert(
+                {direction,
+                 typename history_tag::type::mapped_type{initial_order}});
+            values.insert({direction, std::move(face_values)});
+          }
+        }
+      });
+    }
+
+    ::Initialization::mutate_assign<simple_tags>(
+        make_not_null(&box), std::move(values), std::move(dt_stash),
+        std::move(histories));
+    return {Parallel::AlgorithmExecution::Continue, std::nullopt};
+  }
+};
+}  // namespace evolution::dg::BoundaryEvolvedFields

--- a/src/Evolution/DiscontinuousGalerkin/BoundaryEvolvedFields/NamespaceDocs.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/BoundaryEvolvedFields/NamespaceDocs.hpp
@@ -1,0 +1,10 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+/// Storage and time integration for boundary-evolved fields: quantities held
+/// and time-integrated only on an element's external boundary faces (a
+/// per-face, pointwise ODE), driven by boundary
+/// conditions that opt in via a `boundary_evolved_variables` type alias.
+namespace evolution::dg::BoundaryEvolvedFields {}

--- a/src/Evolution/DiscontinuousGalerkin/BoundaryEvolvedFields/Tags.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/BoundaryEvolvedFields/Tags.hpp
@@ -1,0 +1,140 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <type_traits>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Time/History.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TypeTraits/CreateGetTypeAliasOrDefault.hpp"
+
+namespace evolution::dg {
+namespace Tags {
+/// \ingroup DiscontinuousGalerkinGroup
+/// \brief The boundary-evolved twin of an interior source field.
+///
+/// A boundary-evolved field is stored and time-integrated only on external
+/// boundary faces (a pointwise per-face-node ODE); it
+/// has no volume extent. This is a prefix tag wrapping the
+/// interior source, so its type matches the source, the
+/// initialization can be automatic, and its name disambiguates the
+/// source (`db::tag_name` gives e.g. "BoundaryValue(Psi)").
+///
+/// \note Boundary evolved fields cannot currently be used with AMR.
+template <typename Source>
+struct BoundaryValue : db::PrefixTag, db::SimpleTag {
+  using type = typename Source::type;
+  /// The interior source field this boundary field is the twin of.
+  using tag = Source;
+};
+
+/// \ingroup DiscontinuousGalerkinGroup
+/// \brief The current values of the boundary-evolved fields, one contiguous
+/// face-sized `Variables` per opting external face.
+///
+/// Keyed by external `Direction`; empty on interior elements and on non-opting
+/// faces. Per-face storage is required because a corner/edge node shared by
+/// several external faces carries a distinct boundary value per face (each
+/// face applies its boundary condition with its own normal, so the values
+/// differ even when two faces hold the same boundary condition).
+template <size_t Dim, typename FieldTagsList>
+struct BoundaryEvolvedFieldsValues : db::SimpleTag {
+  using type = DirectionMap<Dim, Variables<FieldTagsList>>;
+};
+
+/// \ingroup DiscontinuousGalerkinGroup
+/// \brief The per-face stash holding the time derivatives of the
+/// boundary-evolved fields, produced by the `boundary_field_time_derivatives`
+/// defined in a concrete boundary condition class and consumed when recording
+/// the time-stepper history.
+///
+/// The stored type is the time stepper's `DerivVars`
+/// (`db::prefix_variables<::Tags::dt, Variables<FieldTagsList>>`) so that it
+/// passes the type checks in `TimeSteppers::History::insert`.
+template <size_t Dim, typename FieldTagsList>
+struct BoundaryEvolvedFieldsDtStash : db::SimpleTag {
+  using type = DirectionMap<
+      Dim, typename TimeSteppers::History<Variables<FieldTagsList>>::DerivVars>;
+};
+
+/// \ingroup DiscontinuousGalerkinGroup
+/// \brief The per-face time-stepper history of the boundary-evolved fields.
+///
+/// A `DirectionMap` of one `TimeSteppers::History` per opting external face,
+/// deliberately a plain `db::SimpleTag` rather than a
+/// `Tags::HistoryEvolvedVariables`. The volume variables already own the
+/// element's single history; a *second* `HistoryEvolvedVariables` would break
+/// code that assumes exactly one history. A plain tag is invisible to
+/// `Tags::get_all_history_tags` (which filters that type), so
+/// the facility's update action instead syncs its order to the volume history.
+template <size_t Dim, typename FieldTagsList>
+struct BoundaryEvolvedFieldsHistory : db::SimpleTag {
+  using type =
+      DirectionMap<Dim, TimeSteppers::History<Variables<FieldTagsList>>>;
+};
+}  // namespace Tags
+
+namespace BoundaryEvolvedFields {
+namespace detail {
+CREATE_GET_TYPE_ALIAS_OR_DEFAULT(boundary_evolved_variables)
+}  // namespace detail
+
+/// \ingroup DiscontinuousGalerkinGroup
+/// \brief The boundary-evolved field tags declared by a boundary condition, or
+/// an empty list if it does not opt in.
+///
+/// A boundary condition opts in by declaring
+/// `using boundary_evolved_variables =
+/// tmpl::list<Tags::BoundaryValue<Source>...>;`.
+template <typename BoundaryCondition>
+using boundary_evolved_variables_of =
+    detail::get_boundary_evolved_variables_or_default_t<BoundaryCondition,
+                                                        tmpl::list<>>;
+
+/// \ingroup DiscontinuousGalerkinGroup
+/// \brief `true` if the boundary condition opts into boundary-evolved fields.
+template <typename BoundaryCondition>
+constexpr bool bc_opts_in_v =
+    not std::is_same_v<boundary_evolved_variables_of<BoundaryCondition>,
+                       tmpl::list<>>;
+
+namespace detail {
+// Each boundary condition's declared `boundary_evolved_variables`, in list
+// order; `tmpl::list<>` for non-opting conditions.
+template <typename DerivedBoundaryConditionsList>
+using declared_boundary_evolved_lists =
+    tmpl::transform<DerivedBoundaryConditionsList,
+                    tmpl::bind<boundary_evolved_variables_of, tmpl::_1>>;
+}  // namespace detail
+
+/// \ingroup DiscontinuousGalerkinGroup
+/// \brief The flat, duplicate-free union of the boundary-evolved field tags
+/// declared by all boundary conditions in `DerivedBoundaryConditionsList`.
+///
+/// This is the compile-time field set the facility stores and integrates. It is
+/// empty when no boundary condition opts in. An empty union is effectively a
+/// no-op for the boundary field facility.
+template <typename DerivedBoundaryConditionsList>
+using boundary_evolved_field_tags = tmpl::remove_duplicates<tmpl::flatten<
+    detail::declared_boundary_evolved_lists<DerivedBoundaryConditionsList>>>;
+
+/// \ingroup DiscontinuousGalerkinGroup
+/// \brief `true` if every boundary condition in `DerivedBoundaryConditionsList`
+/// that opts into the facility declares the identical
+/// `boundary_evolved_variables` list (ordering in each list must be the same).
+///
+/// At most one distinct non-empty declared list exists across
+/// the boundary conditions. Heterogeneous per-face field sets are not yet
+/// supported.
+template <typename DerivedBoundaryConditionsList>
+constexpr bool boundary_evolved_fields_are_homogeneous_v =
+    tmpl::size<tmpl::remove_duplicates<tmpl::remove<
+        detail::declared_boundary_evolved_lists<DerivedBoundaryConditionsList>,
+        tmpl::list<>>>>::value <= 1;
+}  // namespace BoundaryEvolvedFields
+}  // namespace evolution::dg

--- a/src/Evolution/DiscontinuousGalerkin/CMakeLists.txt
+++ b/src/Evolution/DiscontinuousGalerkin/CMakeLists.txt
@@ -42,6 +42,7 @@ spectre_target_sources(
   )
 
 add_subdirectory(Actions)
+add_subdirectory(BoundaryEvolvedFields)
 add_subdirectory(EqualRateLts)
 add_subdirectory(Initialization)
 add_subdirectory(Limiters)

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/BoundaryEvolvedFields/CMakeLists.txt
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/BoundaryEvolvedFields/CMakeLists.txt
@@ -1,0 +1,25 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+set(LIBRARY "Test_BoundaryEvolvedFields")
+
+set(LIBRARY_SOURCES
+  Test_InitializeBoundaryEvolvedFields.cpp
+  Test_Tags.cpp
+  )
+
+add_test_library(${LIBRARY} "${LIBRARY_SOURCES}")
+
+target_link_libraries(
+  ${LIBRARY}
+  PRIVATE
+  DataStructures
+  DgSubcell
+  DiscontinuousGalerkin
+  Domain
+  DomainStructure
+  Evolution
+  Spectral
+  Time
+  Utilities
+  )

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/BoundaryEvolvedFields/Test_InitializeBoundaryEvolvedFields.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/BoundaryEvolvedFields/Test_InitializeBoundaryEvolvedFields.cpp
@@ -1,0 +1,291 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <pup.h>
+#include <type_traits>
+#include <vector>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "DataStructures/VariablesTag.hpp"
+#include "Domain/BoundaryConditions/BoundaryCondition.hpp"
+#include "Domain/Creators/Tags/ExternalBoundaryConditions.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/Neighbors.hpp"
+#include "Domain/Structure/OrientationMap.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/DiscontinuousGalerkin/BoundaryEvolvedFields/InitializeBoundaryEvolvedFields.hpp"
+#include "Evolution/DiscontinuousGalerkin/BoundaryEvolvedFields/Tags.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/ProjectToBoundary.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "Parallel/Phase.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "Time/Tags/HistoryEvolvedVariables.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+// Interior source fields whose boundary twins we evolve.
+struct Psi : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+struct Pi : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+using evolution::dg::Tags::BoundaryValue;
+
+struct MockSystem {
+  using variables_tag = ::Tags::Variables<tmpl::list<Psi, Pi>>;
+};
+
+// The volume history, keyed on the system's evolved variables as in
+// production. The initializer reads its `integration_order()` to seed each
+// face history; it needs no records.
+using volume_history_tag =
+    ::Tags::HistoryEvolvedVariables<typename MockSystem::variables_tag>;
+
+// A boundary condition that opts in with two fields, so the projection of
+// every union slot is checked.
+template <size_t Dim>
+class MockOptingBc : public domain::BoundaryConditions::BoundaryCondition {
+ public:
+  MockOptingBc() = default;
+  MockOptingBc(MockOptingBc&&) = default;
+  MockOptingBc& operator=(MockOptingBc&&) = default;
+  MockOptingBc(const MockOptingBc&) = default;
+  MockOptingBc& operator=(const MockOptingBc&) = default;
+  ~MockOptingBc() override = default;
+
+  explicit MockOptingBc(CkMigrateMessage* msg)
+      : domain::BoundaryConditions::BoundaryCondition(msg) {}
+
+  WRAPPED_PUPable_decl_base_template(
+      domain::BoundaryConditions::BoundaryCondition, MockOptingBc);
+
+  auto get_clone() const -> std::unique_ptr<
+      domain::BoundaryConditions::BoundaryCondition> override {
+    return std::make_unique<MockOptingBc<Dim>>(*this);
+  }
+
+  // NOLINTNEXTLINE
+  void pup(PUP::er& p) override {
+    domain::BoundaryConditions::BoundaryCondition::pup(p);
+  }
+
+  using boundary_evolved_variables =
+      tmpl::list<BoundaryValue<Psi>, BoundaryValue<Pi>>;
+};
+
+template <size_t Dim>
+// NOLINTNEXTLINE
+PUP::able::PUP_ID MockOptingBc<Dim>::my_PUP_ID = 0;
+
+template <size_t Dim>
+class MockNonOptingBc : public domain::BoundaryConditions::BoundaryCondition {
+ public:
+  MockNonOptingBc() = default;
+  MockNonOptingBc(MockNonOptingBc&&) = default;
+  MockNonOptingBc& operator=(MockNonOptingBc&&) = default;
+  MockNonOptingBc(const MockNonOptingBc&) = default;
+  MockNonOptingBc& operator=(const MockNonOptingBc&) = default;
+  ~MockNonOptingBc() override = default;
+
+  explicit MockNonOptingBc(CkMigrateMessage* msg)
+      : domain::BoundaryConditions::BoundaryCondition(msg) {}
+
+  WRAPPED_PUPable_decl_base_template(
+      domain::BoundaryConditions::BoundaryCondition, MockNonOptingBc);
+
+  auto get_clone() const -> std::unique_ptr<
+      domain::BoundaryConditions::BoundaryCondition> override {
+    return std::make_unique<MockNonOptingBc<Dim>>(*this);
+  }
+
+  // NOLINTNEXTLINE
+  void pup(PUP::er& p) override {
+    domain::BoundaryConditions::BoundaryCondition::pup(p);
+  }
+};
+
+template <size_t Dim>
+// NOLINTNEXTLINE
+PUP::able::PUP_ID MockNonOptingBc<Dim>::my_PUP_ID = 0;
+
+using mock_field_tags = tmpl::list<BoundaryValue<Psi>, BoundaryValue<Pi>>;
+
+template <typename Metavariables>
+struct MockComponent {
+  static constexpr size_t Dim = Metavariables::volume_dim;
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = int;
+  using simple_tags =
+      tmpl::list<domain::Tags::Element<Dim>, domain::Tags::Mesh<Dim>,
+                 typename MockSystem::variables_tag, volume_history_tag>;
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<Parallel::Phase::Initialization,
+                             tmpl::list<ActionTesting::InitializeDataBox<
+                                 simple_tags, tmpl::list<>>>>,
+      Parallel::PhaseActions<
+          Parallel::Phase::Testing,
+          tmpl::list<
+              evolution::dg::BoundaryEvolvedFields::
+                  InitializeBoundaryEvolvedFields<
+                      Dim, MockSystem,
+                      tmpl::list<MockOptingBc<Dim>, MockNonOptingBc<Dim>>>>>>;
+};
+struct MockMetavars {
+  static constexpr size_t volume_dim = 2;
+  using component_list = tmpl::list<MockComponent<MockMetavars>>;
+};
+
+void test_initialize_boundary_evolved_fields(
+    const Spectral::Quadrature quadrature) {
+  INFO("InitializeBoundaryEvolvedFields on a real element");
+  CAPTURE(quadrature);
+  constexpr size_t Dim = 2;
+  using component = MockComponent<MockMetavars>;
+  using values_tag =
+      evolution::dg::Tags::BoundaryEvolvedFieldsValues<Dim, mock_field_tags>;
+  using dt_stash_tag =
+      evolution::dg::Tags::BoundaryEvolvedFieldsDtStash<Dim, mock_field_tags>;
+  using history_tag =
+      evolution::dg::Tags::BoundaryEvolvedFieldsHistory<Dim, mock_field_tags>;
+
+  // The AMR guard's metavariables detector: a nested `amr` type is the
+  // AMR-enable signal.
+  struct MetavarsWithAmr {
+    struct amr {};
+  };
+  static_assert(
+      evolution::dg::BoundaryEvolvedFields::detail::has_amr_v<MetavarsWithAmr>);
+  static_assert(not evolution::dg::BoundaryEvolvedFields::detail::has_amr_v<
+                MockMetavars>);
+
+  // The mutator's stored tags are exactly the value, dt-stash, and history
+  // maps of the (homogeneous) boundary-evolved field-tag union.
+  using mutator =
+      evolution::dg::BoundaryEvolvedFields::InitializeBoundaryEvolvedFields<
+          Dim, MockSystem, tmpl::list<MockOptingBc<Dim>, MockNonOptingBc<Dim>>>;
+  static_assert(
+      std::is_same_v<typename mutator::simple_tags,
+                     tmpl::list<values_tag, dt_stash_tag, history_tag>>,
+      "The init mutator must store the value, dt-stash, and history maps of "
+      "the boundary-evolved field-tag union.");
+
+  const Mesh<Dim> mesh{{{3, 4}}, Spectral::Basis::Legendre, quadrature};
+
+  // The element spans its block in xi, so both xi faces and lower_eta are
+  // external; upper_eta has a neighbor, so it is interior. The two OPTING
+  // faces (lower_xi, lower_eta) slice different dimensions and have different
+  // face sizes on the mixed-extent mesh, so the per-face projection and
+  // allocation are checked through both sliced dimensions; upper_xi is the
+  // non-opting external face.
+  const ElementId<Dim> self_id{0, {{{0, 0}, {1, 0}}}};
+  const ElementId<Dim> neighbor_eta_id{0, {{{0, 0}, {1, 1}}}};
+  const OrientationMap<Dim> orientation = OrientationMap<Dim>::create_aligned();
+  typename Element<Dim>::Neighbors_t neighbors{};
+  neighbors[Direction<Dim>::upper_eta()] =
+      Neighbors<Dim>{{neighbor_eta_id}, orientation};
+  const Element<Dim> element{self_id, neighbors};
+  const std::array<Direction<Dim>, 2> opting_directions{
+      Direction<Dim>::lower_xi(), Direction<Dim>::lower_eta()};
+  const auto non_opting_direction = Direction<Dim>::upper_xi();
+
+  // Spatially-varying volume data, distinct per field, so the per-node
+  // projection check is meaningful for every union slot.
+  Variables<tmpl::list<Psi, Pi>> volume_vars{mesh.number_of_grid_points()};
+  for (size_t i = 0; i < mesh.number_of_grid_points(); ++i) {
+    get(get<Psi>(volume_vars))[i] = 1.0 + 0.75 * static_cast<double>(i);
+    get(get<Pi>(volume_vars))[i] =
+        -2.0 + 0.5 * static_cast<double>(i) * static_cast<double>(i);
+  }
+  const size_t volume_integration_order = 3;
+
+  std::vector<DirectionMap<
+      Dim, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
+      external_boundary_conditions{1};
+  for (const auto& direction : opting_directions) {
+    external_boundary_conditions[0][direction] =
+        std::make_unique<MockOptingBc<Dim>>();
+  }
+  external_boundary_conditions[0][non_opting_direction] =
+      std::make_unique<MockNonOptingBc<Dim>>();
+
+  ActionTesting::MockRuntimeSystem<MockMetavars> runner{
+      {std::move(external_boundary_conditions)}};
+  ActionTesting::emplace_component_and_initialize<component>(
+      make_not_null(&runner), 0,
+      {element, mesh, volume_vars,
+       typename volume_history_tag::type{volume_integration_order}});
+  ActionTesting::set_phase(make_not_null(&runner), Parallel::Phase::Testing);
+  ActionTesting::next_action<component>(make_not_null(&runner), 0);
+
+  // Face selection: one entry per map per opting external face, nothing else.
+  const auto& values =
+      ActionTesting::get_databox_tag<component, values_tag>(runner, 0);
+  const auto& dt_stash =
+      ActionTesting::get_databox_tag<component, dt_stash_tag>(runner, 0);
+  const auto& histories =
+      ActionTesting::get_databox_tag<component, history_tag>(runner, 0);
+  CHECK(values.size() == 2);
+  CHECK(dt_stash.size() == 2);
+  CHECK(histories.size() == 2);
+  CHECK(not values.contains(non_opting_direction));
+  CHECK(not values.contains(Direction<Dim>::upper_eta()));
+
+  for (const auto& direction : opting_directions) {
+    CAPTURE(direction);
+    REQUIRE(values.contains(direction));
+    REQUIRE(dt_stash.contains(direction));
+    REQUIRE(histories.contains(direction));
+    const size_t num_face_pts =
+        mesh.slice_away(direction.dimension()).number_of_grid_points();
+
+    // Every union slot is the volume source projected to this face.
+    const auto& face_values = values.at(direction);
+    REQUIRE(face_values.number_of_grid_points() == num_face_pts);
+    tmpl::for_each<tmpl::list<Psi, Pi>>([&face_values, &mesh, &direction,
+                                         &num_face_pts,
+                                         &volume_vars](auto source_tag_v) {
+      using source_tag = tmpl::type_from<decltype(source_tag_v)>;
+      Scalar<DataVector> expected{num_face_pts};
+      dg::project_tensor_to_boundary(make_not_null(&expected),
+                                     get<source_tag>(volume_vars), mesh,
+                                     direction);
+      CHECK(get(get<BoundaryValue<source_tag>>(face_values)) == get(expected));
+    });
+
+    // The dt-stash entry is allocated at face size; the history is empty and
+    // seeded at the volume history's integration order.
+    CHECK(dt_stash.at(direction).number_of_grid_points() == num_face_pts);
+    CHECK(histories.at(direction).integration_order() ==
+          volume_integration_order);
+    CHECK(histories.at(direction).size() == 0);
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Dg.BoundaryEvolvedFields.Initialize",
+                  "[Unit][Evolution]") {
+  register_classes_with_charm<MockNonOptingBc<2>, MockOptingBc<2>>();
+
+  test_initialize_boundary_evolved_fields(Spectral::Quadrature::Gauss);
+  test_initialize_boundary_evolved_fields(Spectral::Quadrature::GaussLobatto);
+}

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/BoundaryEvolvedFields/Test_Tags.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/BoundaryEvolvedFields/Test_Tags.cpp
@@ -1,0 +1,155 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <type_traits>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Evolution/DiscontinuousGalerkin/BoundaryEvolvedFields/Tags.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "Time/Slab.hpp"
+#include "Time/Time.hpp"
+#include "Time/TimeStepId.hpp"
+#include "Utilities/Serialization/Serialize.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+// Interior source fields whose boundary twins we evolve.
+struct Psi : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+struct Pi : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+using evolution::dg::BoundaryEvolvedFields::bc_opts_in_v;
+using evolution::dg::BoundaryEvolvedFields::boundary_evolved_field_tags;
+using evolution::dg::BoundaryEvolvedFields::
+    boundary_evolved_fields_are_homogeneous_v;
+using evolution::dg::BoundaryEvolvedFields::boundary_evolved_variables_of;
+using evolution::dg::Tags::BoundaryValue;
+
+using field_tags = tmpl::list<BoundaryValue<Psi>>;
+template <size_t Dim>
+using values_tag =
+    evolution::dg::Tags::BoundaryEvolvedFieldsValues<Dim, field_tags>;
+template <size_t Dim>
+using dt_stash_tag =
+    evolution::dg::Tags::BoundaryEvolvedFieldsDtStash<Dim, field_tags>;
+template <size_t Dim>
+using history_tag =
+    evolution::dg::Tags::BoundaryEvolvedFieldsHistory<Dim, field_tags>;
+
+void test_tag_names() {
+  // A prefix tag: the composed name disambiguates the wrapped source field.
+  TestHelpers::db::test_prefix_tag<BoundaryValue<Psi>>("BoundaryValue(Psi)");
+  TestHelpers::db::test_simple_tag<values_tag<1>>(
+      "BoundaryEvolvedFieldsValues");
+  TestHelpers::db::test_simple_tag<dt_stash_tag<1>>(
+      "BoundaryEvolvedFieldsDtStash");
+  TestHelpers::db::test_simple_tag<history_tag<1>>(
+      "BoundaryEvolvedFieldsHistory");
+}
+
+struct MockBcPsi {
+  using boundary_evolved_variables = tmpl::list<BoundaryValue<Psi>>;
+};
+// A second boundary condition declaring the identical field set, for the
+// homogeneous-multi-boundary-condition and de-duplicate checks.
+struct MockBcPsiAgain {
+  using boundary_evolved_variables = tmpl::list<BoundaryValue<Psi>>;
+};
+// A heterogeneous declaration (a different field set); forbidden by the
+// homogeneity contract, used only for the negative homogeneity check.
+struct MockBcPsiPi {
+  using boundary_evolved_variables =
+      tmpl::list<BoundaryValue<Psi>, BoundaryValue<Pi>>;
+};
+// Declares nothing: it must compile away (contribute no field tags).
+struct MockBcNonOpting {};
+
+void test_union_metafunction() {
+  INFO("boundary_evolved_field_tags union, opt-in trait, homogeneity guard");
+  static_assert(not bc_opts_in_v<MockBcNonOpting>,
+                "A boundary condition that declares nothing must not opt in.");
+  static_assert(bc_opts_in_v<MockBcPsi>);
+  static_assert(bc_opts_in_v<MockBcPsiPi>);
+  static_assert(std::is_same_v<boundary_evolved_variables_of<MockBcNonOpting>,
+                               tmpl::list<>>);
+
+  // The union is the flat, duplicate-free set over the derived boundary
+  // conditions: a multi-field condition keeps its fields, a non-opting one
+  // drops out, and two conditions declaring the same set collapse to one.
+  static_assert(
+      std::is_same_v<boundary_evolved_field_tags<
+                         tmpl::list<MockBcPsiPi, MockBcPsi, MockBcNonOpting>>,
+                     tmpl::list<BoundaryValue<Psi>, BoundaryValue<Pi>>>);
+  static_assert(std::is_same_v<boundary_evolved_field_tags<tmpl::list<
+                                   MockBcPsi, MockBcPsiAgain, MockBcNonOpting>>,
+                               tmpl::list<BoundaryValue<Psi>>>);
+  static_assert(
+      std::is_same_v<boundary_evolved_field_tags<tmpl::list<MockBcNonOpting>>,
+                     tmpl::list<>>);
+
+  // Homogeneity guard: every opting boundary condition must declare the
+  // identical field set; a heterogeneous pair is rejected.
+  static_assert(boundary_evolved_fields_are_homogeneous_v<
+                tmpl::list<MockBcPsi, MockBcPsiAgain, MockBcNonOpting>>);
+  static_assert(not boundary_evolved_fields_are_homogeneous_v<
+                tmpl::list<MockBcPsi, MockBcPsiPi>>);
+}
+
+// Checkpoint/restart: the per-face storage tags are ordinary mutable DataBox
+// SimpleTags (invisible to `get_all_history_tags`, but serialized by the
+// DataBox like any other), so the boundary state must round-trip through
+// serialization.
+void test_serialization() {
+  INFO("The facility storage tags round-trip through serialization");
+  constexpr size_t Dim = 1;
+  const auto direction = Direction<Dim>::lower_xi();
+  const size_t number_of_pts = 3;
+  const size_t order = 2;
+  const Slab slab(0., 1.);
+
+  Variables<field_tags> face_value{number_of_pts};
+  get(get<BoundaryValue<Psi>>(face_value)) = DataVector{number_of_pts, 1.5};
+  typename dt_stash_tag<Dim>::type::mapped_type face_deriv{number_of_pts};
+  get(get<Tags::dt<BoundaryValue<Psi>>>(face_deriv)) =
+      DataVector{number_of_pts, 2.5};
+
+  typename values_tag<Dim>::type values{};
+  values.insert({direction, face_value});
+  typename dt_stash_tag<Dim>::type dt_stash{};
+  dt_stash.insert({direction, face_deriv});
+  typename history_tag<Dim>::type histories{};
+  typename history_tag<Dim>::type::mapped_type history{order};
+  history.insert(TimeStepId(true, 0, slab.start()), face_value, face_deriv);
+  histories.insert({direction, std::move(history)});
+
+  CHECK(serialize_and_deserialize(values) == values);
+  CHECK(serialize_and_deserialize(dt_stash) == dt_stash);
+  // `TimeSteppers::History` has no `operator==`; verify the round-tripped
+  // per-face history keeps its order, its records, and their contents.
+  const auto histories2 = serialize_and_deserialize(histories);
+  const auto& h = histories2.at(direction);
+  CHECK(h.integration_order() == order);
+  CHECK(h.size() == 1);
+  CHECK(h.back().time_step_id == TimeStepId(true, 0, slab.start()));
+  CHECK(get(get<BoundaryValue<Psi>>(*h.back().value)) ==
+        get(get<BoundaryValue<Psi>>(face_value)));
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Evolution.Dg.BoundaryEvolvedFields.Tags",
+                  "[Unit][Evolution]") {
+  test_tag_names();
+  test_union_metafunction();
+  test_serialization();
+}

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/CMakeLists.txt
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/CMakeLists.txt
@@ -30,6 +30,7 @@ set(LIBRARY_SOURCES
   Test_UsingSubcell.cpp
   )
 
+add_subdirectory(BoundaryEvolvedFields)
 add_subdirectory(EqualRateLts)
 add_subdirectory(Limiters)
 add_subdirectory(Messages)


### PR DESCRIPTION
Add metafunctions to detect boundary evolved fields and custom actions to initialize them.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent was used, have a co-author trailer of the form
      "Co-Authored-By: <agent name> <agent email>" as the last line of the
      commit, e.g. "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>".

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
