### PR TITLE
Use cylinders instead of cubed cylinders in CBCO

### DIFF
--- a/src/Domain/Creators/BinaryCompactObject.cpp
+++ b/src/Domain/Creators/BinaryCompactObject.cpp
@@ -80,7 +80,8 @@ void validate_initial_grid_points(
     const Options::Context& context,
     const BinaryCompactObject::InitialGridPoints::type&
         initial_number_of_grid_points,
-    const std::unordered_set<std::string>& spherical_harmonic_shell_names) {
+    const std::unordered_set<std::string>& spherical_harmonic_shell_names,
+    const std::unordered_set<std::string>& filled_cylinder_names) {
   if (std::holds_alternative<
           std::unordered_map<std::string, std::variant<std::array<size_t, 3>,
                                                        std::array<size_t, 2>>>>(
@@ -89,31 +90,56 @@ void validate_initial_grid_points(
         std::unordered_map<std::string, std::variant<std::array<size_t, 3>,
                                                      std::array<size_t, 2>>>>(
         initial_number_of_grid_points);
-    for (const auto& [block_name, extents] : grid_points_map) {
-      const bool is_spherical_harmonic_block =
-          spherical_harmonic_shell_names.contains(block_name);
-      if (is_spherical_harmonic_block) {
+    for (const auto& [name, extents] : grid_points_map) {
+      const bool is_spherical_harmonic =
+          spherical_harmonic_shell_names.contains(name);
+      const bool is_filled_cylinder = filled_cylinder_names.contains(name);
+      ASSERT(not(is_spherical_harmonic and is_filled_cylinder),
+             "Block or group '"
+                 << name
+                 << "' cannot be both a spherical-harmonic shell block/group "
+                    "and a cylinder block/group. ");
+      if (is_spherical_harmonic) {
         if (std::holds_alternative<std::array<size_t, 3>>(extents)) {
-          PARSE_ERROR(context, "Block '"
-                                   << block_name
-                                   << "' is a spherical-harmonic shell block. "
-                                      "Specify its grid points as "
-                                      "[radial_points, L_max], not array<3>.");
+          PARSE_ERROR(context,
+                      "Block or group '"
+                          << name
+                          << "' is a spherical-harmonic shell block/group. "
+                             "Specify its grid points as "
+                             "[radial_points, L_max], not array<3>.");
+        }
+      } else if (is_filled_cylinder) {
+        if (std::holds_alternative<std::array<size_t, 3>>(extents)) {
+          PARSE_ERROR(
+              context,
+              "Block or group '"
+                  << name
+                  << "' is a filled cylinder block or group containing one. "
+                     "Specify its grid points as "
+                     "[radial_points, z_points], not array<3>.");
         }
       } else {
         if (std::holds_alternative<std::array<size_t, 2>>(extents)) {
-          if (not spherical_harmonic_shell_names.empty()) {
-            PARSE_ERROR(context,
-                        "Specifying 2 grid points for block '"
-                            << block_name
-                            << "' is only valid for spherical-harmonic "
-                               "shell blocks (OuterShell0, etc.).");
-          } else {
+          if (not spherical_harmonic_shell_names.empty() or
+              not filled_cylinder_names.empty()) {
             PARSE_ERROR(
                 context,
-                "Specifying 2 grid points (block '"
-                    << block_name
-                    << "') is only valid for spherical-harmonic shell blocks.");
+                "Specifying 2 grid points for block or group '"
+                    << name
+                    << "' is only valid for spherical-harmonic "
+                       "shell blocks (OuterShell0, etc.), "
+                       "spherical-harmonic block groups "
+                       "(OuterSphere, etc.), filled cylinder "
+                       "blocks (CAFilledCylinder, etc.), or block groups "
+                       "containing filled cylinder blocks (InnerA, etc.).");
+          } else {
+            PARSE_ERROR(context,
+                        "Specifying 2 grid points (block or group '"
+                            << name
+                            << "') is only valid for spherical-harmonic shell "
+                               "blocks, spherical-harmonic block groups, "
+                               "filled cylinder blocks, or block groups "
+                               "containing filled cylinder blocks.");
           }
         }
       }
@@ -124,40 +150,66 @@ void validate_initial_grid_points(
 void validate_initial_refinement(
     const Options::Context& context,
     const BinaryCompactObject::InitialRefinement::type& initial_refinement,
-    const std::unordered_set<std::string>& spherical_harmonic_shell_names) {
+    const std::unordered_set<std::string>& spherical_harmonic_shell_names,
+    const std::unordered_set<std::string>& cylinder_names) {
   if (std::holds_alternative<std::unordered_map<
           std::string, std::variant<std::array<size_t, 3>, size_t>>>(
           initial_refinement)) {
     const auto& refinement_map = std::get<std::unordered_map<
         std::string, std::variant<std::array<size_t, 3>, size_t>>>(
         initial_refinement);
-    for (const auto& [block_name, ref] : refinement_map) {
-      const bool is_spherical_harmonic_block =
-          spherical_harmonic_shell_names.contains(block_name);
-      if (is_spherical_harmonic_block) {
+    for (const auto& [name, ref] : refinement_map) {
+      const bool is_spherical_harmonic =
+          spherical_harmonic_shell_names.contains(name);
+      const bool is_cylinder = cylinder_names.contains(name);
+      ASSERT(not(is_spherical_harmonic and is_cylinder),
+             "Block or group '"
+                 << name
+                 << "' cannot be both a spherical-harmonic shell block/group "
+                    "and a cylinder block/group. ");
+      if (is_spherical_harmonic) {
         if (std::holds_alternative<std::array<size_t, 3>>(ref)) {
           PARSE_ERROR(context,
-                      "Block '"
-                          << block_name
-                          << "' is a spherical-harmonic shell block. "
+                      "Block or group '"
+                          << name
+                          << "' is a spherical-harmonic shell block/group. "
                              "Specify its refinement as a single number "
                              "(radial only), not array<3>. Angular "
                              "h-refinement is not supported for these blocks.");
         }
+      } else if (is_cylinder) {
+        if (std::holds_alternative<std::array<size_t, 3>>(ref)) {
+          PARSE_ERROR(
+              context,
+              "Block or group '"
+                  << name
+                  << "' is a cylinder block/group. "
+                     "Specify its refinement as a single number "
+                     "(z only), not array<3>. Radial and angular "
+                     "h-refinement are not supported for these blocks.");
+        }
       } else {
         if (std::holds_alternative<size_t>(ref)) {
-          if (not spherical_harmonic_shell_names.empty()) {
-            PARSE_ERROR(context,
-                        "Per-block single-number refinement for block '"
-                            << block_name
-                            << "' is only valid for spherical-harmonic "
-                               "shell blocks (OuterShell0, etc.).");
-          } else {
+          if (not spherical_harmonic_shell_names.empty() or
+              not cylinder_names.empty()) {
             PARSE_ERROR(
                 context,
-                "Per-block single-number refinement in map syntax (block '"
-                    << block_name
-                    << "') is only valid for spherical-harmonic shell blocks.");
+                "Per-block single-number refinement for block or group '"
+                    << name
+                    << "' is only valid for spherical-harmonic "
+                       "shell blocks (OuterShell0, etc.), "
+                       "spherical-harmonic shell block groups "
+                       "(OuterSphere, etc.), cylinder blocks "
+                       "(CAFilledCylinder, etc.), or cylinder block "
+                       "groups (InnerA, etc.).");
+          } else {
+            PARSE_ERROR(context,
+                        "Per-block single-number refinement in map syntax "
+                        "(block or group '"
+                            << name
+                            << "') is only valid for spherical-harmonic shell "
+                               "blocks/groups "
+                               "or cylinder blocks/groups.");
           }
         }
       }
@@ -167,21 +219,30 @@ void validate_initial_refinement(
 
 std::vector<std::array<size_t, 3>> set_initial_refinement(
     const ExpandOverBlocks<std::array<size_t, 3>>& expand_over_blocks,
-    const BinaryCompactObject::InitialRefinement::type& initial_refinement) {
+    const BinaryCompactObject::InitialRefinement::type& initial_refinement,
+    const std::unordered_set<std::string>& spherical_harmonic_shell_names,
+    const std::unordered_set<std::string>& cylinder_names) {
   return std::visit(
-      [&expand_over_blocks]<typename V>(
+      [&expand_over_blocks, &spherical_harmonic_shell_names,
+       &cylinder_names]<typename V>(
           const V& v) -> std::vector<std::array<size_t, 3>> {
         if constexpr (std::is_same_v<
                           V,
                           std::unordered_map<
                               std::string,
                               std::variant<std::array<size_t, 3>, size_t>>>) {
-          const auto converted = [&v]() {
+          const auto converted = [&v, &spherical_harmonic_shell_names,
+                                  &cylinder_names]() {
             std::unordered_map<std::string, std::array<size_t, 3>> result;
             for (const auto& [name, val] : v) {
-              if (std::holds_alternative<size_t>(val)) {
+              if (std::holds_alternative<size_t>(val) and
+                  spherical_harmonic_shell_names.contains(name)) {
                 const size_t r = std::get<size_t>(val);
                 result[name] = {r, 0, 0};
+              } else if (std::holds_alternative<size_t>(val) and
+                         cylinder_names.contains(name)) {
+                const size_t z = std::get<size_t>(val);
+                result[name] = {0, 0, z};
               } else {
                 result[name] = std::get<std::array<size_t, 3>>(val);
               }
@@ -198,21 +259,43 @@ std::vector<std::array<size_t, 3>> set_initial_refinement(
 
 std::vector<std::array<size_t, 3>> set_initial_grid_points(
     const ExpandOverBlocks<std::array<size_t, 3>>& expand_over_blocks,
-    const BinaryCompactObject::InitialGridPoints::type& initial_grid_points) {
+    const BinaryCompactObject::InitialGridPoints::type& initial_grid_points,
+    const std::unordered_set<std::string>& spherical_harmonic_shell_names,
+    const std::unordered_set<std::string>& filled_cylinder_names) {
   return std::visit(
-      [&expand_over_blocks]<typename V>(
+      [&expand_over_blocks, &spherical_harmonic_shell_names,
+       &filled_cylinder_names]<typename V>(
           const V& v) -> std::vector<std::array<size_t, 3>> {
         if constexpr (std::is_same_v<
                           V, std::unordered_map<
                                  std::string,
                                  std::variant<std::array<size_t, 3>,
                                               std::array<size_t, 2>>>>) {
-          const auto converted = [&v]() {
+          const auto converted = [&v, &spherical_harmonic_shell_names,
+                                  &filled_cylinder_names]() {
             std::unordered_map<std::string, std::array<size_t, 3>> result;
             for (const auto& [name, val] : v) {
-              if (std::holds_alternative<std::array<size_t, 2>>(val)) {
+              if (std::holds_alternative<std::array<size_t, 2>>(val) and
+                  spherical_harmonic_shell_names.contains(name)) {
                 const auto& a2 = std::get<std::array<size_t, 2>>(val);
                 result[name] = {a2[0], a2[1], a2[1]};
+              } else if (std::holds_alternative<std::array<size_t, 2>>(val) and
+                         filled_cylinder_names.contains(name)) {
+                const auto& a2 = std::get<std::array<size_t, 2>>(val);
+                // note:
+                // radial_points = (theta_modes / 2) + 1 + (theta_modes % 2), so
+                // one could have odd or even theta_modes for the same
+                // radial_points. Choosing the even theta_modes for the same
+                // radial_points means:
+                //   theta_modes = 2 * (radial_points - 1)
+                //   theta_points = 2 * theta_modes + 1 = 4 * radial_modes - 3
+                // Choosing the odd theta_modes for the same radial_points
+                // means:
+                //   theta_modes = 2 * (radial_points - 2) + 1
+                //   theta_points = 2 * theta_modes + 1 = 4 * radial_modes - 5
+                // Here, we choose the even case to get one extra theta_mode out
+                // of radial_points.
+                result[name] = {a2[0], 4 * a2[0] - 3, a2[1]};
               } else {
                 result[name] = std::get<std::array<size_t, 3>>(val);
               }
@@ -581,14 +664,15 @@ BinaryCompactObject::BinaryCompactObject(
       block_names_, block_groups_};
 
   try {
-    initial_refinement_ =
-        bco::set_initial_refinement(expand_over_blocks, initial_refinement);
+    initial_refinement_ = bco::set_initial_refinement(
+        expand_over_blocks, initial_refinement, spherical_harmonic_shell_names);
   } catch (const std::exception& error) {
     PARSE_ERROR(context, "Invalid 'InitialRefinement': " << error.what());
   }
   try {
     initial_number_of_grid_points_ = bco::set_initial_grid_points(
-        expand_over_blocks, initial_number_of_grid_points);
+        expand_over_blocks, initial_number_of_grid_points,
+        spherical_harmonic_shell_names);
   } catch (const std::exception& error) {
     PARSE_ERROR(context, "Invalid 'InitialGridPoints': " << error.what());
   }

--- a/src/Domain/Creators/BinaryCompactObject.hpp
+++ b/src/Domain/Creators/BinaryCompactObject.hpp
@@ -672,12 +672,14 @@ create_grid_anchors(const std::array<double, 3>& center_a,
  * \param context options context
  * \param initial_refinement the initial refinement from options
  * \param spherical_harmonic_shell_names the names of spherical shell blocks
- * that use spherical harmonics
+ * or groups that use spherical harmonics
+ * \param cylinder_names the names of cylindrical blocks or groups
  */
 void validate_initial_refinement(
     const Options::Context& context,
     const BinaryCompactObject::InitialRefinement::type& initial_refinement,
-    const std::unordered_set<std::string>& spherical_harmonic_shell_names);
+    const std::unordered_set<std::string>& spherical_harmonic_shell_names,
+    const std::unordered_set<std::string>& cylinder_names = {});
 
 /*!
  * \brief Validate `InitialGridPoints` map entries.
@@ -688,13 +690,16 @@ void validate_initial_refinement(
  * \param context options context
  * \param initial_number_of_grid_points the initial grid points from options
  * \param spherical_harmonic_shell_names the names of spherical shell blocks
- * that use spherical harmonics
+ * or groups that use spherical harmonics
+ * \param filled_cylinder_names the names of filled cylindrical blocks or groups
+ * containing them
  */
 void validate_initial_grid_points(
     const Options::Context& context,
     const BinaryCompactObject::InitialGridPoints::type&
         initial_number_of_grid_points,
-    const std::unordered_set<std::string>& spherical_harmonic_shell_names);
+    const std::unordered_set<std::string>& spherical_harmonic_shell_names,
+    const std::unordered_set<std::string>& filled_cylinder_names = {});
 
 /*!
  * \brief Convert `size_t` radial h refinement entries for spherical harmonic
@@ -705,12 +710,17 @@ void validate_initial_grid_points(
  * \param expand_over_blocks `ExpandOverBlocks` containing the block names and
  * block groups
  * \param initial_refinement the initial refinement from options
+ * \param spherical_harmonic_shell_names the names of spherical shell blocks
+ * or groups that use spherical harmonics
+ * \param cylinder_names the names of cylindrical blocks or groups
  *
  * \return converted refinement
  */
 std::vector<std::array<size_t, 3>> set_initial_refinement(
     const ExpandOverBlocks<std::array<size_t, 3>>& expand_over_blocks,
-    const BinaryCompactObject::InitialRefinement::type& initial_refinement);
+    const BinaryCompactObject::InitialRefinement::type& initial_refinement,
+    const std::unordered_set<std::string>& spherical_harmonic_shell_names,
+    const std::unordered_set<std::string>& cylinder_names = {});
 
 /*!
  * \brief Convert `array<2>{r, l_max}` entries for spherical harmonic blocks to
@@ -725,11 +735,17 @@ std::vector<std::array<size_t, 3>> set_initial_refinement(
  * \param expand_over_blocks `ExpandOverBlocks` containing the block names and
  * block groups
  * \param initial_grid_points the initial grid points from options
+ * \param spherical_harmonic_shell_names the names of spherical shell blocks
+ * or groups that use spherical harmonics
+ * \param filled_cylinder_names the names of filled cylindrical blocks or groups
+ * containing them
  *
  * \return converted grid points
  */
 std::vector<std::array<size_t, 3>> set_initial_grid_points(
     const ExpandOverBlocks<std::array<size_t, 3>>& expand_over_blocks,
-    const BinaryCompactObject::InitialGridPoints::type& initial_grid_points);
+    const BinaryCompactObject::InitialGridPoints::type& initial_grid_points,
+    const std::unordered_set<std::string>& spherical_harmonic_shell_names,
+    const std::unordered_set<std::string>& filled_cylinder_names = {});
 }  // namespace bco
 }  // namespace domain::creators

--- a/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
+++ b/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
@@ -16,6 +16,7 @@
 #include "Domain/CoordinateMaps/DiscreteRotation.hpp"
 #include "Domain/CoordinateMaps/Identity.hpp"
 #include "Domain/CoordinateMaps/Interval.hpp"
+#include "Domain/CoordinateMaps/PolarToCartesian.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/CoordinateMaps/SphericalToCartesianPfaffian.hpp"
@@ -65,7 +66,7 @@ namespace domain::creators {
 CylindricalBinaryCompactObject::CylindricalBinaryCompactObject(
     std::array<double, 3> center_A, std::array<double, 3> center_B,
     double radius_A, double radius_B, bool include_inner_sphere_A,
-    bool include_inner_sphere_B, double outer_radius, bool use_equiangular_map,
+    bool include_inner_sphere_B, double outer_radius,
     const typename InitialRefinement::type& initial_refinement,
     const typename InitialGridPoints::type& initial_grid_points,
     std::optional<bco::TimeDependentMapOptions<true>> time_dependent_options,
@@ -81,7 +82,6 @@ CylindricalBinaryCompactObject::CylindricalBinaryCompactObject(
       include_inner_sphere_A_(include_inner_sphere_A),
       include_inner_sphere_B_(include_inner_sphere_B),
       outer_radius_(outer_radius),
-      use_equiangular_map_(use_equiangular_map),
       inner_boundary_condition_(std::move(inner_boundary_condition)),
       outer_boundary_condition_(std::move(outer_boundary_condition)),
       time_dependent_options_(std::move(time_dependent_options)) {
@@ -130,25 +130,6 @@ CylindricalBinaryCompactObject::CylindricalBinaryCompactObject(
         context,
         "Cannot have periodic boundary conditions with a binary domain");
   }
-
-  // Build the set of spherical-harmonic shell block groups and block names so
-  // the validation below can distinguish spherical-harmonic blocks from other
-  // blocks and block groups.
-  std::unordered_set<std::string> spherical_harmonic_shell_names{"OuterSphere",
-                                                                 "OuterShell0"};
-  if (include_inner_sphere_A) {
-    spherical_harmonic_shell_names.insert("InnerSphereA");
-    spherical_harmonic_shell_names.insert("InnerAShell0");
-  }
-  if (include_inner_sphere_B) {
-    spherical_harmonic_shell_names.insert("InnerSphereB");
-    spherical_harmonic_shell_names.insert("InnerBShell0");
-  }
-
-  bco::validate_initial_refinement(context, initial_refinement,
-                                   spherical_harmonic_shell_names);
-  bco::validate_initial_grid_points(context, initial_grid_points,
-                                    spherical_harmonic_shell_names);
 
   // The choices made below for the quantities xi, z_cutting_plane_,
   // and xi_min_sphere_e are the ones made in SpEC, and in the
@@ -208,16 +189,6 @@ CylindricalBinaryCompactObject::CylindricalBinaryCompactObject(
                 0.5 * (std::abs(z_cutting_plane_ - center_B_[2]) - radius_B_)
           : radius_B_;
 
-  number_of_blocks_ = 46;
-  if (include_inner_sphere_A) {
-    number_of_blocks_ += 1;
-  }
-  if (include_inner_sphere_B) {
-    number_of_blocks_ += 1;
-  }
-  // Outer sphere
-  number_of_blocks_ += 1;
-
   // Add SphereE blocks if necessary.  Note that
   // https://arxiv.org/abs/1206.3015 has a mistake just above
   // Eq. (A.11) and the same mistake above Eq. (A.20), where it lists
@@ -240,250 +211,270 @@ CylindricalBinaryCompactObject::CylindricalBinaryCompactObject(
   // Create grid anchors in x direction from unrotated input centers
   grid_anchors_ = bco::create_grid_anchors(center_A, center_B);
 
-  // Create block names and groups
-  auto add_filled_cylinder_name = [this](const std::string& prefix,
-                                         const std::string& group_name) {
-    for (const std::string& where :
-         {"Center"s, "East"s, "North"s, "West"s, "South"s}) {
-      const std::string name =
-          std::string(prefix).append("FilledCylinder").append(where);
-      block_names_.push_back(name);
-      block_groups_[group_name].insert(name);
-    }
+  // Build the set of cylindrical block groups and block names so the
+  // validation below can distinguish spherical-harmonic blocks from other
+  // blocks and block groups.
+  std::unordered_set<std::string> filled_cylinder_names{};
+  std::unordered_set<std::string> hollow_cylinder_names{};
+
+  // Create cylinder block names and groups
+  auto add_filled_cylinder_name = [this, &filled_cylinder_names](
+                                      const std::string& prefix,
+                                      const std::string& group_name) {
+    const std::string name = std::string(prefix).append("FilledCylinder");
+    block_names_.push_back(name);
+    block_groups_[group_name].insert(name);
+    block_positions_[name] = block_names_.size() - 1;
+    filled_cylinder_names.insert(name);
+    filled_cylinder_names.insert(group_name);
   };
-  auto add_cylinder_name = [this](const std::string& prefix,
-                                  const std::string& group_name) {
-    for (const std::string& where : {"East"s, "North"s, "West"s, "South"s}) {
-      const std::string name =
-          std::string(prefix).append("Cylinder").append(where);
-      block_names_.push_back(name);
-      block_groups_[group_name].insert(name);
-    }
+  auto add_cylinder_name = [this, &hollow_cylinder_names](
+                               const std::string& prefix,
+                               const std::string& group_name) {
+    const std::string name = std::string(prefix).append("Cylinder");
+    block_names_.push_back(name);
+    block_groups_[group_name].insert(name);
+    block_positions_[name] = block_names_.size() - 1;
+    hollow_cylinder_names.insert(name);
+    hollow_cylinder_names.insert(group_name);
   };
 
   // CA Filled Cylinder
-  // 5 blocks: 0 thru 4
   add_filled_cylinder_name("CA", "Outer");
 
   // CA Cylinder
-  // 4 blocks: 5 thru 8
   add_cylinder_name("CA", "Outer");
 
   // EA Filled Cylinder
-  // 5 blocks: 9 thru 13
   add_filled_cylinder_name("EA", "InnerA");
 
   // EA Cylinder
-  // 4 blocks: 14 thru 17
   add_cylinder_name("EA", "InnerA");
 
   // EB Filled Cylinder
-  // 5 blocks: 18 thru 22
   add_filled_cylinder_name("EB", "InnerB");
 
   // EB Cylinder
-  // 4 blocks: 23 thru 26
   add_cylinder_name("EB", "InnerB");
 
   // MA Filled Cylinder
-  // 5 blocks: 27 thru 31
   add_filled_cylinder_name("MA", "InnerA");
 
   // MB Filled Cylinder
-  // 5 blocks: 32 thru 36
   add_filled_cylinder_name("MB", "InnerB");
 
   // CB Filled Cylinder
-  // 5 blocks: 37 thru 41
   add_filled_cylinder_name("CB", "Outer");
 
   // CB Cylinder
-  // 4 blocks: 42 thru 45
   add_cylinder_name("CB", "Outer");
 
+  // combine filled and hollow cylinder blocks and groups into one set
+  std::unordered_set<std::string> all_cylinder_names;
+  all_cylinder_names.insert(std::begin(filled_cylinder_names),
+                            std::end(filled_cylinder_names));
+  all_cylinder_names.insert(std::begin(hollow_cylinder_names),
+                            std::end(hollow_cylinder_names));
+
+  // Build the set of spherical-harmonic shell block groups and block names so
+  // the validation below can distinguish spherical-harmonic blocks from other
+  // blocks and block groups.
+  std::unordered_set<std::string> spherical_harmonic_shell_names{};
+
   // Create block names and groups
-  auto add_spherical_shell_name = [this](const std::string& prefix,
-                                         const std::string& group_name,
-                                         const size_t shell_number) {
+  auto add_spherical_shell_name = [this, &spherical_harmonic_shell_names](
+                                      const std::string& prefix,
+                                      const std::string& group_name,
+                                      const size_t shell_number) {
     const std::string name = std::string(prefix).append("Shell").append(
         std::to_string(shell_number));
     block_names_.push_back(name);
     block_groups_[group_name].insert(name);
+    block_positions_[name] = block_names_.size() - 1;
+    spherical_harmonic_shell_names.insert(name);
+    spherical_harmonic_shell_names.insert(group_name);
   };
-
-  const size_t first_inner_shell_A_block = 46;
-  size_t first_inner_shell_B_block = first_inner_shell_A_block;
-  first_outer_shell_block = first_inner_shell_A_block;
 
   if (include_inner_sphere_A) {
     add_spherical_shell_name("InnerA", "InnerSphereA", 0);
-
-    first_inner_shell_B_block += 1;
-    first_outer_shell_block += 1;
   }
   if (include_inner_sphere_B) {
     add_spherical_shell_name("InnerB", "InnerSphereB", 0);
-
-    first_outer_shell_block += 1;
   }
   add_spherical_shell_name("Outer", "OuterSphere", 0);
+
+  number_of_blocks_ = block_names_.size();
+  ASSERT(number_of_blocks_ == block_positions_.size(),
+         "Size of block_positions_ map should be equal to the number of blocks "
+         "in the domain.");
+
+  // Since BinaryCompactObject::InitialGridPoints type differs from
+  // CylindricalBinaryCompactObject::InitialGridPoints type, need to first
+  // create the BCO-compatible type with the CBCO data to be able to reuse the
+  // functionality of bco::validate_initial_grid_points() and
+  // bco::set_initial_grid_points().
+  const auto bco_initial_grid_points = std::visit(
+      [](const auto& value) {
+        return BinaryCompactObject::InitialGridPoints::type{value};
+      },
+      initial_grid_points);
+  // Validate that the input file has the correct format for
+  // InitialGridPoints. No need to validate the format for InitialRefinement
+  // because it does not accept a map of strings to possibly
+  // differently-sized arrays for refinement. If a map is provided, it already
+  // only accepts a map of size_t keys.
+  bco::validate_initial_grid_points(context, bco_initial_grid_points,
+                                    spherical_harmonic_shell_names,
+                                    filled_cylinder_names);
 
   // For expanding initial refinement and grid points over all blocks
   const ExpandOverBlocks<std::array<size_t, 3>> expand_over_blocks{
       block_names_, block_groups_};
   try {
-    initial_refinement_ =
-        bco::set_initial_refinement(expand_over_blocks, initial_refinement);
-    // If a global single-number refinement was used, post-process the spherical
-    // shell entries to make the angular directions have h refinement = 0.
+    // Since BinaryCompactObject::InitialRefinement map type differs from
+    // CylindricalBinaryCompactObject::InitialRefinement map type, need to first
+    // create the BCO-compatible type with the CBCO data to be able to reuse the
+    // functionality of bco::set_initial_refinement().
+    using bco_ref_map_type =
+        std::unordered_map<std::string,
+                           std::variant<std::array<size_t, 3>, size_t>>;
+    using cbco_ref_map_type = std::unordered_map<std::string, size_t>;
+    const auto bco_initial_refinement =
+        std::holds_alternative<size_t>(initial_refinement)
+            ? BinaryCompactObject::InitialRefinement::type{std::get<size_t>(
+                  initial_refinement)}
+            : BinaryCompactObject::InitialRefinement::type{bco_ref_map_type{
+                  std::get<cbco_ref_map_type>(initial_refinement).begin(),
+                  std::get<cbco_ref_map_type>(initial_refinement).end()}};
+    initial_refinement_ = bco::set_initial_refinement(
+        expand_over_blocks, bco_initial_refinement,
+        spherical_harmonic_shell_names, all_cylinder_names);
+    // If a global single-number h-refinement was used, post-process the
+    // expanded cylinder and spherical shell blocks to make the angular
+    // directions have h refinement = 0.
     if (std::holds_alternative<size_t>(initial_refinement)) {
-      if (include_inner_sphere_A) {
-        // InnerAShell0
-        initial_refinement_[first_inner_shell_A_block][1] = 0;
-        initial_refinement_[first_inner_shell_A_block][2] = 0;
+      for (const auto& [name, position] : block_positions_) {
+        if (name.find("Cylinder") != std::string::npos) {
+          // Set cylinder h refinement to {0, 0, z}
+          initial_refinement_[position][0] = 0;
+          initial_refinement_[position][1] = 0;
+        } else if (name.find("Shell") != std::string::npos) {
+          // Set spherical shell h refinement to {r, 0, 0}
+          initial_refinement_[position][1] = 0;
+          initial_refinement_[position][2] = 0;
+        }
       }
-      if (include_inner_sphere_B) {
-        // InnerBShell0
-        initial_refinement_[first_inner_shell_B_block][1] = 0;
-        initial_refinement_[first_inner_shell_B_block][2] = 0;
-      }
-      // OuterShell0
-      initial_refinement_[first_outer_shell_block][1] = 0;
-      initial_refinement_[first_outer_shell_block][2] = 0;
     }
   } catch (const std::exception& error) {
     PARSE_ERROR(context, "Invalid 'InitialRefinement': " << error.what());
   }
-  // Validate angular h-refinement == 0 in spherical shell blocks
-  if (include_inner_sphere_A_) {
-    if (gsl::at(initial_refinement_, first_inner_shell_A_block)[1] != 0 or
-        gsl::at(initial_refinement_, first_inner_shell_A_block)[2] != 0) {
-      PARSE_ERROR(context,
-                  "Angular h-refinement is not supported for "
-                  "spherical-harmonic inner-shell blocks. Specify refinement "
-                  "for InnerSphereA as a single number.");
+
+  // Validate angular h-refinement == 0 in cylinder and spherical shell blocks
+  for (const auto& [name, position] : block_positions_) {
+    if (name.find("Cylinder") != std::string::npos) {
+      if (gsl::at(gsl::at(initial_refinement_, position), 0) != 0 or
+          gsl::at(gsl::at(initial_refinement_, position), 1) != 0) {
+        PARSE_ERROR(context,
+                    "Angular h-refinement is not supported for cylindrical "
+                    "blocks. Specify refinement for "
+                        << name << " as a single number.");
+      }
+    } else if (name.find("Shell") != std::string::npos) {
+      if (gsl::at(gsl::at(initial_refinement_, position), 1) != 0 or
+          gsl::at(gsl::at(initial_refinement_, position), 2) != 0) {
+        PARSE_ERROR(context,
+                    "Angular h-refinement is not supported for "
+                    "spherical-harmonic shell blocks. Specify refinement for "
+                        << name << " as a single number.");
+      }
     }
-  }
-  if (include_inner_sphere_B_) {
-    if (gsl::at(initial_refinement_, first_inner_shell_B_block)[1] != 0 or
-        gsl::at(initial_refinement_, first_inner_shell_B_block)[2] != 0) {
-      PARSE_ERROR(context,
-                  "Angular h-refinement is not supported for "
-                  "spherical-harmonic inner-shell blocks. Specify refinement "
-                  "for InnerSphereB as a single number.");
-    }
-  }
-  if (gsl::at(initial_refinement_, first_outer_shell_block)[1] != 0 or
-      gsl::at(initial_refinement_, first_outer_shell_block)[2] != 0) {
-    PARSE_ERROR(context,
-                "Angular h-refinement is not supported for "
-                "spherical-harmonic outer-shell blocks. Specify refinement "
-                "for OuterSphere as a single number.");
   }
 
   try {
-    initial_grid_points_ =
-        bco::set_initial_grid_points(expand_over_blocks, initial_grid_points);
+    initial_grid_points_ = bco::set_initial_grid_points(
+        expand_over_blocks, bco_initial_grid_points,
+        spherical_harmonic_shell_names, filled_cylinder_names);
+    // If a global single-number p-refinement was used, post-process the
+    // expanded filled cylinder blocks to make the angular directions have the
+    // correct number of spectral points for ZernikeB2.
+    if (std::holds_alternative<size_t>(initial_grid_points)) {
+      for (const auto& [name, position] : block_positions_) {
+        if (name.find("FilledCylinder") != std::string::npos) {
+          // note for ZernikeB2:
+          // radial_points = (theta_modes / 2) + 1 + (theta_modes % 2), so one
+          // could have odd or even theta_modes for the same radial_points.
+          // Choosing the even theta_modes for the same radial_points means:
+          //   theta_modes = 2 * (radial_points - 1)
+          //   theta_points = 2 * theta_modes + 1 = 4 * radial_modes - 3
+          // Choosing the odd theta_modes for the same radial_points means:
+          //   theta_modes = 2 * (radial_points - 2) + 1
+          //   theta_points = 2 * theta_modes + 1 = 4 * radial_modes - 5
+          // Here, we choose the even case to get one extra theta_mode out of
+          // radial_points.
+          initial_grid_points_[position][1] =
+              4 * gsl::at(gsl::at(initial_grid_points_, position), 0) - 3;
+        }
+      }
+    }
   } catch (const std::exception& error) {
     PARSE_ERROR(context, "Invalid 'InitialGridPoints': " << error.what());
   }
-  // Validate angular grid points in spherical shell blocks. A
-  // spherical-harmonic shell is fully specified by a single ell, so l_max must
-  // equal m_max.
-  if (include_inner_sphere_A_) {
-    if (initial_grid_points_[first_inner_shell_A_block][1] !=
-        initial_grid_points_[first_inner_shell_A_block][2]) {
-      PARSE_ERROR(
-          context,
-          "Spherical-harmonic inner-shell blocks must have L_max = M_max. "
-          "Specify grid points for InnerSphereA as [radial_points, L_max].");
+
+  // Validate p-refinement values in cylinder and spherical shell blocks
+  for (const auto& [name, position] : block_positions_) {
+    if (name.find("FilledCylinder") != std::string::npos) {
+      // Validate number of radial points for filled cylinders is > 2
+      if (gsl::at(gsl::at(initial_grid_points_, position), 0) <= 2) {
+        PARSE_ERROR(context,
+                    "Filled cylindrical block "
+                        << name
+                        << " must have more than 2 radial grid points.");
+      }
+
+      // Validate number of angular grid points in filled cylinder blocks is
+      // what is expected by ZernikeB2. The Zernike disk is fully specified by
+      // either the number of radial points or the number of theta points, so
+      // check that they relate as expected.
+      const size_t num_theta_modes =
+          gsl::at(gsl::at(initial_grid_points_, position), 1) / 2;
+      const size_t expected_num_r_points =
+          (num_theta_modes / 2) + 1 + (num_theta_modes % 2);
+      if (gsl::at(gsl::at(initial_grid_points_, position), 0) !=
+          expected_num_r_points) {
+        PARSE_ERROR(context,
+                    "Filled cylinder blocks must have "
+                    "num_r_points = ((num_theta_points / 2) / 2) + 1 + "
+                    "((num_theta_points / 2) % 2). Specify grid points for "
+                        << name << " as [num_radial_points, num_z_points].");
+      }
     }
-    // For spherical-harmonic outer-shell blocks, initial_number_of_grid_points_
-    // stores {n_radial, l_max, m_max}. Convert (l_max, m_max) to the number of
-    // collocation points the spherical-harmonic basis uses in each angular
-    // direction.
-    initial_grid_points_[first_inner_shell_A_block][1] =
-        ylm::Spherepack::n_theta_points(
-            gsl::at(initial_grid_points_, first_inner_shell_A_block)[1]);
-    initial_grid_points_[first_inner_shell_A_block][2] =
-        ylm::Spherepack::n_phi_points(
-            gsl::at(initial_grid_points_, first_inner_shell_A_block)[2]);
-  }
-  if (include_inner_sphere_B_) {
-    if (initial_grid_points_[first_inner_shell_B_block][1] !=
-        initial_grid_points_[first_inner_shell_B_block][2]) {
-      PARSE_ERROR(
-          context,
-          "Spherical-harmonic inner-shell blocks must have L_max = M_max. "
-          "Specify grid points for InnerSphereB as [radial_points, L_max].");
+    if (name.find("Cylinder") != std::string::npos) {
+      // Validate number of angular grid points in all cylindrical blocks are
+      // odd.
+      if (gsl::at(gsl::at(initial_grid_points_, position), 1) % 2 == 0) {
+        PARSE_ERROR(context,
+                    "Cylindrical block "
+                        << name
+                        << " must have an odd number of angular grid points.");
+      }
+    } else if (name.find("Shell") != std::string::npos) {
+      // For spherical-harmonic shell blocks, initial_number_of_grid_points_
+      // stores {n_radial, l_max, m_max}. First validate that l_max == m_max,
+      // then convert (l_max, m_max) to the number of collocation points the
+      // spherical-harmonic basis uses in each angular direction.
+      const size_t l_max = gsl::at(gsl::at(initial_grid_points_, position), 1);
+      const size_t m_max = gsl::at(gsl::at(initial_grid_points_, position), 2);
+      if (l_max != m_max) {
+        PARSE_ERROR(context,
+                    "Spherical-harmonic shell blocks must have L_max = M_max. "
+                    "Specify grid points for "
+                        << name << " as [radial_points, L_max].");
+      }
+      initial_grid_points_[position][1] = ylm::Spherepack::n_theta_points(
+          gsl::at(gsl::at(initial_grid_points_, position), 1));
+      initial_grid_points_[position][2] = ylm::Spherepack::n_phi_points(
+          gsl::at(gsl::at(initial_grid_points_, position), 2));
     }
-    initial_grid_points_[first_inner_shell_B_block][1] =
-        ylm::Spherepack::n_theta_points(
-            gsl::at(initial_grid_points_, first_inner_shell_B_block)[1]);
-    initial_grid_points_[first_inner_shell_B_block][2] =
-        ylm::Spherepack::n_phi_points(
-            gsl::at(initial_grid_points_, first_inner_shell_B_block)[2]);
-  }
-  if (initial_grid_points_[first_outer_shell_block][1] !=
-      initial_grid_points_[first_outer_shell_block][2]) {
-    PARSE_ERROR(
-        context,
-        "Spherical-harmonic outer-shell blocks must have L_max = M_max. "
-        "Specify grid points for OuterSphere as [radial_points, L_max].");
-  }
-
-  initial_grid_points_[first_outer_shell_block][1] =
-      ylm::Spherepack::n_theta_points(
-          gsl::at(initial_grid_points_, first_outer_shell_block)[1]);
-  initial_grid_points_[first_outer_shell_block][2] =
-      ylm::Spherepack::n_phi_points(
-          gsl::at(initial_grid_points_, first_outer_shell_block)[2]);
-
-  // Now we must change the initial refinement and initial grid points
-  // for certain blocks, because the [r, theta, perp] directions do
-  // not always correspond to [xi, eta, zeta].  The values in
-  // initial_refinement_ must correspond to [xi, eta, zeta].
-  //
-  // In particular, for cylinders: [xi, eta, zeta] = [r, theta, perp]
-  // but for filled cylinders: [xi, eta, zeta] = [perp, theta, r].
-
-  auto swap_refinement_and_grid_points_xi_zeta = [this](const size_t block_id) {
-    size_t val = gsl::at(initial_refinement_[block_id], 0);
-    gsl::at(initial_refinement_[block_id], 0) =
-        gsl::at(initial_refinement_[block_id], 2);
-    gsl::at(initial_refinement_[block_id], 2) = val;
-    val = gsl::at(initial_grid_points_[block_id], 0);
-    gsl::at(initial_grid_points_[block_id], 0) =
-        gsl::at(initial_grid_points_[block_id], 2);
-    gsl::at(initial_grid_points_[block_id], 2) = val;
-  };
-
-  // CA Filled Cylinder
-  // 5 blocks: 0 thru 4
-  for (size_t block = 0; block < 5; ++block) {
-    swap_refinement_and_grid_points_xi_zeta(block);
-  }
-
-  // EA Filled Cylinder
-  // 5 blocks: 9 thru 13
-  for (size_t block = 9; block < 14; ++block) {
-    swap_refinement_and_grid_points_xi_zeta(block);
-  }
-
-  // EB Filled Cylinder
-  // 5 blocks: 18 thru 22
-  for (size_t block = 18; block < 23; ++block) {
-    swap_refinement_and_grid_points_xi_zeta(block);
-  }
-
-  // MA Filled Cylinder
-  // 5 blocks: 27 thru 31
-  // MB Filled Cylinder
-  // 5 blocks: 32 thru 36
-  // CB Filled Cylinder
-  // 5 blocks: 37 thru 41
-  for (size_t block = 27; block < 42; ++block) {
-    swap_refinement_and_grid_points_xi_zeta(block);
   }
 
   // Build time-dependent maps
@@ -529,6 +520,12 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const {
       Direction<3>::lower_zeta(), Direction<3>::upper_eta(),
       Direction<3>::upper_xi()}};
 
+  const OrientationMap<3> rotate_to_minus_z_axis{std::array<Direction<3>, 3>{
+      Direction<3>::lower_xi(), Direction<3>::upper_eta(),
+      Direction<3>::lower_zeta()}};
+
+  const OrientationMap<3> aligned = OrientationMap<3>::create_aligned();
+
   const std::array<double, 3> center_cutting_plane = {0.0, 0.0,
                                                       z_cutting_plane_};
 
@@ -555,120 +552,75 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const {
   const double radius_EB =
       sqrt(2.0) * std::abs(center_EB[2] - z_cutting_plane_);
 
-  // Construct vector<CoordMap>s that go from logical coordinates to
-  // various blocks making up a unit right cylinder.  These blocks are
-  // either the central square blocks, or the surrounding wedge
-  // blocks. The radii and bounds are what are expected by the
-  // UniformCylindricalEndcap maps, (except cylinder_inner_radius, which
-  // determines the internal block boundaries inside the cylinder, and
-  // which the UniformCylindricalEndcap maps don't care about).
-  const double cylinder_inner_radius = 0.5;
+  // Construct a coordinate map that goes from logical coordinates to a unit
+  // right cylinder block. The radii and bounds are what are expected by the
+  // UniformCylindricalEndCap and UniformCylindricalFlatEndCap maps.
+  const double cylinder_inner_radius = 0.0;
   const double cylinder_outer_radius = 1.0;
   const double cylinder_lower_bound_z = -1.0;
   const double cylinder_upper_bound_z = 1.0;
-  const auto logical_to_cylinder_center_maps =
-      cyl_wedge_coord_map_center_blocks(
-          cylinder_inner_radius, cylinder_lower_bound_z, cylinder_upper_bound_z,
-          use_equiangular_map_);
-  const auto logical_to_cylinder_surrounding_maps =
-      cyl_wedge_coord_map_surrounding_blocks(
-          cylinder_inner_radius, cylinder_outer_radius, cylinder_lower_bound_z,
-          cylinder_upper_bound_z, use_equiangular_map_, 0.0);
 
-  // Lambda that takes a UniformCylindricalEndcap map and a
-  // DiscreteRotation map, composes it with the logical-to-cylinder
-  // maps, and adds it to the list of coordinate maps. Also adds
-  // boundary conditions if requested.
+  const auto logical_to_cylinder_map =
+      cyl_coordinate_map(cylinder_inner_radius, cylinder_outer_radius,
+                         cylinder_lower_bound_z, cylinder_upper_bound_z);
+
+  // Lambda that takes a pre-rotation map, a UniformCylindricalEndcap or a
+  // UniformCylindricalFlatEndcap map and a DiscreteRotation map, composes it
+  // with the logical-to-cylinder map, and adds it to the list of
+  // coordinate maps. Also adds boundary conditions if requested. The
+  // pre-rotation map is used by blocks at the cutting plane to achieve nodal
+  // alignment with their block neighbor on the other side of the plane.
   auto add_endcap_to_list_of_maps =
-      [&coordinate_maps, &logical_to_cylinder_center_maps,
-       &logical_to_cylinder_surrounding_maps](
-          const CoordinateMaps::UniformCylindricalEndcap& endcap_map,
+      [&coordinate_maps, &logical_to_cylinder_map](
+          const CoordinateMaps::DiscreteRotation<3>& pre_rotation_map,
+          const auto& endcap_map,
           const CoordinateMaps::DiscreteRotation<3>& rotation_map) {
-        auto new_logical_to_cylinder_center_maps =
-            domain::make_vector_coordinate_map_base<Frame::BlockLogical,
-                                                    Frame::Inertial, 3>(
-                logical_to_cylinder_center_maps, endcap_map, rotation_map);
-        coordinate_maps.insert(
-            coordinate_maps.end(),
-            std::make_move_iterator(
-                new_logical_to_cylinder_center_maps.begin()),
-            std::make_move_iterator(new_logical_to_cylinder_center_maps.end()));
-        auto new_logical_to_cylinder_surrounding_maps =
-            domain::make_vector_coordinate_map_base<Frame::BlockLogical,
-                                                    Frame::Inertial, 3>(
-                logical_to_cylinder_surrounding_maps, endcap_map, rotation_map);
-        coordinate_maps.insert(
-            coordinate_maps.end(),
-            std::make_move_iterator(
-                new_logical_to_cylinder_surrounding_maps.begin()),
-            std::make_move_iterator(
-                new_logical_to_cylinder_surrounding_maps.end()));
+        auto new_logical_to_cylinder_map = ::domain::push_back(
+            ::domain::push_back(
+                ::domain::push_back(logical_to_cylinder_map, pre_rotation_map),
+                endcap_map),
+            rotation_map);
+
+        coordinate_maps.emplace_back(
+            std::make_unique<
+                std::decay_t<decltype(new_logical_to_cylinder_map)>>(
+                std::move(new_logical_to_cylinder_map)));
       };
 
-  // Lambda that takes a UniformCylindricalFlatEndcap map and a
-  // DiscreteRotation map, composes it with the logical-to-cylinder
-  // maps, and adds it to the list of coordinate maps. Also adds
-  // boundary conditions if requested.
-  auto add_flat_endcap_to_list_of_maps =
-      [&coordinate_maps, &logical_to_cylinder_center_maps,
-       &logical_to_cylinder_surrounding_maps](
-          const CoordinateMaps::UniformCylindricalFlatEndcap& endcap_map,
-          const CoordinateMaps::DiscreteRotation<3>& rotation_map) {
-        auto new_logical_to_cylinder_center_maps =
-            domain::make_vector_coordinate_map_base<Frame::BlockLogical,
-                                                    Frame::Inertial, 3>(
-                logical_to_cylinder_center_maps, endcap_map, rotation_map);
-        coordinate_maps.insert(
-            coordinate_maps.end(),
-            std::make_move_iterator(
-                new_logical_to_cylinder_center_maps.begin()),
-            std::make_move_iterator(new_logical_to_cylinder_center_maps.end()));
-        auto new_logical_to_cylinder_surrounding_maps =
-            domain::make_vector_coordinate_map_base<Frame::BlockLogical,
-                                                    Frame::Inertial, 3>(
-                logical_to_cylinder_surrounding_maps, endcap_map, rotation_map);
-        coordinate_maps.insert(
-            coordinate_maps.end(),
-            std::make_move_iterator(
-                new_logical_to_cylinder_surrounding_maps.begin()),
-            std::make_move_iterator(
-                new_logical_to_cylinder_surrounding_maps.end()));
-      };
-
-  // Construct vector<CoordMap>s that go from logical coordinates to
-  // various blocks making up a right cylindrical shell of inner radius 1,
-  // outer radius 2, and z-extents from -1 to +1.  These blocks are
-  // either the central square blocks, or the surrounding wedge
-  // blocks. The radii and bounds are what are expected by the
-  // UniformCylindricalEndcap maps.
+  // Construct a coordinate map that goes from logical coordinates to a unit
+  // right cylindrical shell block. The radii and bounds are what are expected
+  // by the UniformCylindricalSide map.
   const double cylindrical_shell_inner_radius = 1.0;
   const double cylindrical_shell_outer_radius = 2.0;
   const double cylindrical_shell_lower_bound_z = -1.0;
   const double cylindrical_shell_upper_bound_z = 1.0;
-  const auto logical_to_cylindrical_shell_maps =
-      cyl_wedge_coord_map_surrounding_blocks(
-          cylindrical_shell_inner_radius, cylindrical_shell_outer_radius,
-          cylindrical_shell_lower_bound_z, cylindrical_shell_upper_bound_z,
-          use_equiangular_map_, 1.0);
 
-  // Lambda that takes a UniformCylindricalSide map and a DiscreteRotation
-  // map, composes it with the logical-to-cylinder maps, and adds it
-  // to the list of coordinate maps.  Also adds boundary conditions if
-  // requested.
+  const auto logical_to_cylindrical_shell_map = cyl_coordinate_map(
+      cylindrical_shell_inner_radius, cylindrical_shell_outer_radius,
+      cylindrical_shell_lower_bound_z, cylindrical_shell_upper_bound_z);
+
+  // Lambda that takes a pre-rotation map, a UniformCylindricalSide map, and a
+  // DiscreteRotation map, composes it with the logical-to-cylinder maps, and
+  // adds it to the list of coordinate maps.  Also adds boundary conditions if
+  // requested.  The pre-rotation map is used by blocks at the cutting plane to
+  // achieve nodal alignment with their block neighbor on the other side of the
+  // plane.
   auto add_side_to_list_of_maps =
-      [&coordinate_maps, &logical_to_cylindrical_shell_maps](
+      [&coordinate_maps, &logical_to_cylindrical_shell_map](
+          const CoordinateMaps::DiscreteRotation<3>& pre_rotation_map,
           const CoordinateMaps::UniformCylindricalSide& side_map,
           const CoordinateMaps::DiscreteRotation<3>& rotation_map) {
-        auto new_logical_to_cylindrical_shell_maps =
-            domain::make_vector_coordinate_map_base<Frame::BlockLogical,
-                                                    Frame::Inertial, 3>(
-                logical_to_cylindrical_shell_maps, side_map, rotation_map);
-        coordinate_maps.insert(
-            coordinate_maps.end(),
-            std::make_move_iterator(
-                new_logical_to_cylindrical_shell_maps.begin()),
-            std::make_move_iterator(
-                new_logical_to_cylindrical_shell_maps.end()));
+        auto new_logical_to_cylindrical_shell_map = ::domain::push_back(
+            ::domain::push_back(
+                ::domain::push_back(logical_to_cylindrical_shell_map,
+                                    pre_rotation_map),
+                side_map),
+            rotation_map);
+
+        coordinate_maps.emplace_back(
+            std::make_unique<
+                std::decay_t<decltype(new_logical_to_cylindrical_shell_map)>>(
+                std::move(new_logical_to_cylindrical_shell_map)));
       };
 
   // Inner radius of the outer C shell.
@@ -698,16 +650,16 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const {
   const double z_cut_EA_lower = center_A_[2] - 0.7 * outer_radius_A_;
 
   // CA Filled Cylinder
-  // 5 blocks: 0 thru 4
   add_endcap_to_list_of_maps(
+      CoordinateMaps::DiscreteRotation<3>(aligned),
       CoordinateMaps::UniformCylindricalEndcap(center_EA, make_array<3>(0.0),
                                                radius_EA, inner_radius_C,
                                                z_cut_CA_lower, z_cut_CA_upper),
       CoordinateMaps::DiscreteRotation<3>(rotate_to_x_axis));
 
   // CA Cylinder
-  // 4 blocks: 5 thru 8
   add_side_to_list_of_maps(
+      CoordinateMaps::DiscreteRotation<3>(aligned),
       CoordinateMaps::UniformCylindricalSide(
           // codecov complains about the next line being untested.
           // No idea why, since this entire function is called.
@@ -718,16 +670,16 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const {
       CoordinateMaps::DiscreteRotation<3>(rotate_to_x_axis));
 
   // EA Filled Cylinder
-  // 5 blocks: 9 thru 13
   add_endcap_to_list_of_maps(
+      CoordinateMaps::DiscreteRotation<3>(aligned),
       CoordinateMaps::UniformCylindricalEndcap(center_A_, center_EA,
                                                outer_radius_A_, radius_EA,
                                                z_cut_EA_upper, z_cut_CA_lower),
       CoordinateMaps::DiscreteRotation<3>(rotate_to_x_axis));
 
   // EA Cylinder
-  // 4 blocks: 14 thru 17
   add_side_to_list_of_maps(
+      CoordinateMaps::DiscreteRotation<3>(aligned),
       // For some reason codecov complains about the next line.
       CoordinateMaps::UniformCylindricalSide(  // LCOV_EXCL_LINE
           center_A_, center_EA, outer_radius_A_, radius_EA, z_cut_EA_upper,
@@ -763,16 +715,16 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const {
   const double z_cut_EB_lower = center_B_[2] + 0.7 * outer_radius_B_;
 
   // EB Filled Cylinder
-  // 5 blocks: 18 thru 22
   add_endcap_to_list_of_maps(
+      CoordinateMaps::DiscreteRotation<3>(rotate_to_minus_z_axis),
       CoordinateMaps::UniformCylindricalEndcap(
           flip_about_xy_plane(center_B_), flip_about_xy_plane(center_EB),
           outer_radius_B_, radius_EB, -z_cut_EB_upper, -z_cut_CB_lower),
       CoordinateMaps::DiscreteRotation<3>(rotate_to_minus_x_axis));
 
   // EB Cylinder
-  // 4 blocks: 23 thru 26
   add_side_to_list_of_maps(
+      CoordinateMaps::DiscreteRotation<3>(rotate_to_minus_z_axis),
       CoordinateMaps::UniformCylindricalSide(
           flip_about_xy_plane(center_B_), flip_about_xy_plane(center_EB),
           outer_radius_B_, radius_EB, -z_cut_EB_upper, -z_cut_EB_lower,
@@ -780,16 +732,16 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const {
       CoordinateMaps::DiscreteRotation<3>(rotate_to_minus_x_axis));
 
   // MA Filled Cylinder
-  // 5 blocks: 27 thru 31
-  add_flat_endcap_to_list_of_maps(
+  add_endcap_to_list_of_maps(
+      CoordinateMaps::DiscreteRotation<3>(rotate_to_minus_z_axis),
       CoordinateMaps::UniformCylindricalFlatEndcap(
           flip_about_xy_plane(center_A_),
           flip_about_xy_plane(center_cutting_plane), outer_radius_A_, radius_MB,
           -z_cut_EA_lower),
       CoordinateMaps::DiscreteRotation<3>(rotate_to_minus_x_axis));
   // MB Filled Cylinder
-  // 5 blocks: 32 thru 36
-  add_flat_endcap_to_list_of_maps(
+  add_endcap_to_list_of_maps(
+      CoordinateMaps::DiscreteRotation<3>(aligned),
       // For some reason codecov complains about the next line.
       CoordinateMaps::UniformCylindricalFlatEndcap(  // LCOV_EXCL_LINE
           center_B_, center_cutting_plane, outer_radius_B_, radius_MB,
@@ -797,45 +749,52 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const {
       CoordinateMaps::DiscreteRotation<3>(rotate_to_x_axis));
 
   // CB Filled Cylinder
-  // 5 blocks: 37 thru 41
   add_endcap_to_list_of_maps(
+      CoordinateMaps::DiscreteRotation<3>(rotate_to_minus_z_axis),
       CoordinateMaps::UniformCylindricalEndcap(
           flip_about_xy_plane(center_EB), make_array<3>(0.0), radius_EB,
           inner_radius_C, -z_cut_CB_lower, -z_cut_CB_upper),
       CoordinateMaps::DiscreteRotation<3>(rotate_to_minus_x_axis));
 
   // CB Cylinder
-  // 4 blocks: 42 thru 45
   add_side_to_list_of_maps(
+      CoordinateMaps::DiscreteRotation<3>(rotate_to_minus_z_axis),
       CoordinateMaps::UniformCylindricalSide(
           flip_about_xy_plane(center_EB), make_array<3>(0.0), radius_EB,
           inner_radius_C, -z_cut_CB_lower, -z_cutting_plane_, -z_cut_CB_upper,
           -z_cutting_plane_),
       CoordinateMaps::DiscreteRotation<3>(rotate_to_minus_x_axis));
 
+  const size_t ea_endcap_block = block_positions_.at("EAFilledCylinder");
+  const size_t ea_side_block = block_positions_.at("EACylinder");
+  const size_t ma_endcap_block = block_positions_.at("MAFilledCylinder");
+  const size_t eb_endcap_block = block_positions_.at("EBFilledCylinder");
+  const size_t eb_side_block = block_positions_.at("EBCylinder");
+  const size_t mb_endcap_block = block_positions_.at("MBFilledCylinder");
+  const size_t ca_endcap_block = block_positions_.at("CAFilledCylinder");
+  const size_t ca_side_block = block_positions_.at("CACylinder");
+  const size_t cb_endcap_block = block_positions_.at("CBFilledCylinder");
+  const size_t cb_side_block = block_positions_.at("CBCylinder");
+
   // Excision spheres
   std::unordered_map<std::string, ExcisionSphere<3>> excision_spheres{};
 
   std::unordered_map<size_t, Direction<3>> abutting_directions_A;
-  const size_t first_inner_shell_A_block = 46;
-  size_t first_inner_shell_B_block = first_inner_shell_A_block;
+  const size_t inner_shell_A_block = 10;
+  size_t inner_shell_B_block = inner_shell_A_block;
   if (include_inner_sphere_A_) {
     // LCOV_EXCL_START
-    abutting_directions_A.emplace(first_inner_shell_A_block,
+    abutting_directions_A.emplace(inner_shell_A_block,
                                   Direction<3>::lower_xi());
     // LCOV_EXCL_STOP
 
     // Block numbers of sphereB might depend on whether there is an inner
     // sphereA layer, so increment here to get that right.
-    first_inner_shell_B_block += 1;
+    inner_shell_B_block += 1;
   } else {
-    for (size_t i = 0; i < 5; ++i) {
-      abutting_directions_A.emplace(9 + i, Direction<3>::lower_zeta());
-      abutting_directions_A.emplace(27 + i, Direction<3>::lower_zeta());
-    }
-    for (size_t i = 0; i < 4; ++i) {
-      abutting_directions_A.emplace(14 + i, Direction<3>::lower_xi());
-    }
+    abutting_directions_A.emplace(ea_endcap_block, Direction<3>::lower_zeta());
+    abutting_directions_A.emplace(ma_endcap_block, Direction<3>::upper_zeta());
+    abutting_directions_A.emplace(ea_side_block, Direction<3>::lower_xi());
   }
   excision_spheres.emplace(
       "ExcisionSphereA",
@@ -847,17 +806,13 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const {
   std::unordered_map<size_t, Direction<3>> abutting_directions_B;
   if (include_inner_sphere_B_) {
     // LCOV_EXCL_START
-    abutting_directions_B.emplace(first_inner_shell_B_block,
+    abutting_directions_B.emplace(inner_shell_B_block,
                                   Direction<3>::lower_xi());
     // LCOV_EXCL_STOP
   } else {
-    for (size_t i = 0; i < 5; ++i) {
-      abutting_directions_B.emplace(18 + i, Direction<3>::lower_zeta());
-      abutting_directions_B.emplace(32 + i, Direction<3>::lower_zeta());
-    }
-    for (size_t i = 0; i < 4; ++i) {
-      abutting_directions_B.emplace(23 + i, Direction<3>::lower_xi());
-    }
+    abutting_directions_B.emplace(eb_endcap_block, Direction<3>::upper_zeta());
+    abutting_directions_B.emplace(mb_endcap_block, Direction<3>::lower_zeta());
+    abutting_directions_B.emplace(eb_side_block, Direction<3>::lower_xi());
   }
   excision_spheres.emplace(
       "ExcisionSphereB",
@@ -867,175 +822,223 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const {
           abutting_directions_B});
 
   Domain<3> domain;
-  // `coordinate_maps` at this point contains the inner non-shell maps.
-  // Total =  num_shells + n_interior_cubes entries
-  // We determine auto-topology neighbors for these inner maps
-  std::vector<DirectionMap<3, BlockNeighbors<3>>> inner_neighbors;
-  set_internal_boundaries<3>(make_not_null(&inner_neighbors), coordinate_maps);
+  // non-shell maps
+  std::vector<DirectionMap<3, BlockNeighbors<3>>> inner_neighbors{
+      coordinate_maps.size()};
+
+  // Add a block as a neighbor to a host block
+  auto add_block_neighbor =
+      [](std::vector<DirectionMap<3, BlockNeighbors<3>>>& neighbors,
+         const size_t this_block_number, const size_t neighbor_block_number,
+         const Direction<3>& direction,
+         const OrientationMap<3>& orientation_map,
+         const bool are_conforming = true) {
+        neighbors[this_block_number].emplace(
+            direction,
+            BlockNeighbors<3>{{neighbor_block_number},
+                              {{neighbor_block_number, orientation_map}},
+                              are_conforming});
+      };
+
+  // EA Filled Cylinder
+  add_block_neighbor(
+      inner_neighbors, ea_endcap_block, ea_side_block, Direction<3>::upper_xi(),
+      OrientationMap<3>{{{Direction<3>::lower_zeta(), Direction<3>::upper_eta(),
+                          Direction<3>::upper_xi()}}});
+  add_block_neighbor(inner_neighbors, ea_endcap_block, ca_endcap_block,
+                     Direction<3>::upper_zeta(), aligned);
+
+  // EA Cylinder
+  add_block_neighbor(
+      inner_neighbors, ea_side_block, ea_endcap_block,
+      Direction<3>::upper_zeta(),
+      OrientationMap<3>{{{Direction<3>::upper_zeta(), Direction<3>::upper_eta(),
+                          Direction<3>::lower_xi()}}});
+  add_block_neighbor(
+      inner_neighbors, ea_side_block, ma_endcap_block,
+      Direction<3>::lower_zeta(),
+      OrientationMap<3>{{{Direction<3>::lower_zeta(), Direction<3>::upper_eta(),
+                          Direction<3>::upper_xi()}}});
+  add_block_neighbor(inner_neighbors, ea_side_block, ca_side_block,
+                     Direction<3>::upper_xi(), aligned);
+
+  // MA Filled Cylinder
+  add_block_neighbor(
+      inner_neighbors, ma_endcap_block, ea_side_block, Direction<3>::upper_xi(),
+      OrientationMap<3>{{{Direction<3>::upper_zeta(), Direction<3>::upper_eta(),
+                          Direction<3>::lower_xi()}}});
+  add_block_neighbor(inner_neighbors, ma_endcap_block, mb_endcap_block,
+                     Direction<3>::lower_zeta(), aligned);
+
+  // CA Filled Cylinder
+  add_block_neighbor(
+      inner_neighbors, ca_endcap_block, ca_side_block, Direction<3>::upper_xi(),
+      OrientationMap<3>{{{Direction<3>::lower_zeta(), Direction<3>::upper_eta(),
+                          Direction<3>::upper_xi()}}});
+  add_block_neighbor(inner_neighbors, ca_endcap_block, ea_endcap_block,
+                     Direction<3>::lower_zeta(), aligned);
+
+  // CA Cylinder
+  add_block_neighbor(
+      inner_neighbors, ca_side_block, ca_endcap_block,
+      Direction<3>::upper_zeta(),
+      OrientationMap<3>{{{Direction<3>::upper_zeta(), Direction<3>::upper_eta(),
+                          Direction<3>::lower_xi()}}});
+  add_block_neighbor(inner_neighbors, ca_side_block, cb_side_block,
+                     Direction<3>::lower_zeta(), aligned);
+  add_block_neighbor(inner_neighbors, ca_side_block, ea_side_block,
+                     Direction<3>::lower_xi(), aligned);
+
+  // EB Filled Cylinder
+  add_block_neighbor(
+      inner_neighbors, eb_endcap_block, eb_side_block, Direction<3>::upper_xi(),
+      OrientationMap<3>{{{Direction<3>::upper_zeta(), Direction<3>::upper_eta(),
+                          Direction<3>::lower_xi()}}});
+  add_block_neighbor(inner_neighbors, eb_endcap_block, cb_endcap_block,
+                     Direction<3>::lower_zeta(), aligned);
+
+  // EB Cylinder
+  add_block_neighbor(
+      inner_neighbors, eb_side_block, eb_endcap_block,
+      Direction<3>::lower_zeta(),
+      OrientationMap<3>{{{Direction<3>::lower_zeta(), Direction<3>::upper_eta(),
+                          Direction<3>::upper_xi()}}});
+  add_block_neighbor(
+      inner_neighbors, eb_side_block, mb_endcap_block,
+      Direction<3>::upper_zeta(),
+      OrientationMap<3>{{{Direction<3>::upper_zeta(), Direction<3>::upper_eta(),
+                          Direction<3>::lower_xi()}}});
+  add_block_neighbor(inner_neighbors, eb_side_block, cb_side_block,
+                     Direction<3>::upper_xi(), aligned);
+
+  // MB Filled Cylinder
+  add_block_neighbor(
+      inner_neighbors, mb_endcap_block, eb_side_block, Direction<3>::upper_xi(),
+      OrientationMap<3>{{{Direction<3>::lower_zeta(), Direction<3>::upper_eta(),
+                          Direction<3>::upper_xi()}}});
+  add_block_neighbor(inner_neighbors, mb_endcap_block, ma_endcap_block,
+                     Direction<3>::upper_zeta(), aligned);
+
+  // CB Filled Cylinder
+  add_block_neighbor(
+      inner_neighbors, cb_endcap_block, cb_side_block, Direction<3>::upper_xi(),
+      OrientationMap<3>{{{Direction<3>::upper_zeta(), Direction<3>::upper_eta(),
+                          Direction<3>::lower_xi()}}});
+  add_block_neighbor(inner_neighbors, cb_endcap_block, eb_endcap_block,
+                     Direction<3>::upper_zeta(), aligned);
+
+  // CB Cylinder
+  add_block_neighbor(
+      inner_neighbors, cb_side_block, cb_endcap_block,
+      Direction<3>::lower_zeta(),
+      OrientationMap<3>{{{Direction<3>::lower_zeta(), Direction<3>::upper_eta(),
+                          Direction<3>::upper_xi()}}});
+  add_block_neighbor(inner_neighbors, cb_side_block, ca_side_block,
+                     Direction<3>::upper_zeta(), aligned);
+  add_block_neighbor(inner_neighbors, cb_side_block, eb_side_block,
+                     Direction<3>::lower_xi(), aligned);
 
   // Connect the E sphere cylinder blocks to the outermost inner shells and
   // connect the C sphere cylinder blocks to the innermost outer shell
-  const OrientationMap<3> shell_to_cyl_endcap_center{
+  const OrientationMap<3> upper_shell_to_lower_cyl_endcap{
       {{Direction<3>::upper_zeta(), Direction<3>::self(),
         Direction<3>::self()}}};
-  const auto cyl_endcap_center_to_shell =
-      shell_to_cyl_endcap_center.inverse_map();
-  const OrientationMap<3> shell_to_cyl_endcap_wedge{
+  const auto lower_cyl_endcap_to_upper_shell =
+      upper_shell_to_lower_cyl_endcap.inverse_map();
+
+  const OrientationMap<3> upper_shell_to_upper_cyl_endcap{
+      {{Direction<3>::lower_zeta(), Direction<3>::self(),
+        Direction<3>::self()}}};
+  const auto upper_cyl_endcap_to_upper_shell =
+      upper_shell_to_upper_cyl_endcap.inverse_map();
+
+  const OrientationMap<3> lower_shell_to_upper_cyl_endcap{
       {{Direction<3>::upper_zeta(), Direction<3>::self(),
         Direction<3>::self()}}};
-  const auto cyl_endcap_wedge_to_shell =
-      shell_to_cyl_endcap_wedge.inverse_map();
+  const auto upper_cyl_endcap_to_lower_shell =
+      lower_shell_to_upper_cyl_endcap.inverse_map();
+
+  const OrientationMap<3> lower_shell_to_lower_cyl_endcap{
+      {{Direction<3>::lower_zeta(), Direction<3>::self(),
+        Direction<3>::self()}}};
+  const auto lower_cyl_endcap_to_lower_shell =
+      lower_shell_to_lower_cyl_endcap.inverse_map();
+
   const OrientationMap<3> shell_to_cyl_side{
       {{Direction<3>::upper_xi(), Direction<3>::self(), Direction<3>::self()}}};
   const auto cyl_side_to_shell = shell_to_cyl_side.inverse_map();
 
-  // Add a shell as a neighor of one of the blocks making up a cylinder
-  auto add_cyl_shell_block_neighbor =
-      [](std::vector<DirectionMap<3, BlockNeighbors<3>>>& neighbors,
-         const bool cyl_is_filled, const bool shell_is_outside_cyl,
-         const size_t cyl_block_number, const size_t shell_block_number,
-         const OrientationMap<3>& orientation_map) {
-        const Direction<3> direction =
-            cyl_is_filled ? (shell_is_outside_cyl ? Direction<3>::upper_zeta()
-                                                  : Direction<3>::lower_zeta())
-                          : (shell_is_outside_cyl ? Direction<3>::upper_xi()
-                                                  : Direction<3>::lower_xi());
-
-        neighbors[cyl_block_number].emplace(
-            direction,
-            BlockNeighbors<3>{{shell_block_number},
-                              {{shell_block_number, orientation_map}},
-                              /*are_conforming=*/false});
-      };
-
-  // Add a shell as a neighor of each of the blocks making up a cylindrical
-  // endcap
-  auto add_cyl_endcap_shell_neighbors =
-      [&add_cyl_shell_block_neighbor, &cyl_endcap_center_to_shell,
-       &cyl_endcap_wedge_to_shell](
-          std::vector<DirectionMap<3, BlockNeighbors<3>>>& neighbors,
-          const bool shell_is_outside_cyl, const size_t first_cyl_block_number,
-          const size_t shell_block_number) {
-        const bool cyl_is_filled = true;
-        add_cyl_shell_block_neighbor(neighbors, cyl_is_filled,
-                                     shell_is_outside_cyl,
-                                     first_cyl_block_number, shell_block_number,
-                                     cyl_endcap_center_to_shell);
-        for (size_t j = first_cyl_block_number + 1;
-             j < first_cyl_block_number + 5; j++) {
-          add_cyl_shell_block_neighbor(
-              neighbors, cyl_is_filled, shell_is_outside_cyl, j,
-              shell_block_number, cyl_endcap_wedge_to_shell);
-        }
-      };
-
-  // Add a shell as a neighor of each of the blocks making up a cylindrical side
-  auto add_cyl_side_shell_neighbors =
-      [&add_cyl_shell_block_neighbor, &cyl_side_to_shell](
-          std::vector<DirectionMap<3, BlockNeighbors<3>>>& neighbors,
-          const bool shell_is_outside_cyl, const size_t first_cyl_block_number,
-          const size_t shell_block_number) {
-        const bool cyl_is_filled = false;
-        for (size_t j = first_cyl_block_number; j < first_cyl_block_number + 4;
-             j++) {
-          add_cyl_shell_block_neighbor(neighbors, cyl_is_filled,
-                                       shell_is_outside_cyl, j,
-                                       shell_block_number, cyl_side_to_shell);
-        }
-      };
-
-  const size_t first_ea_endcap_block = 9;
-  const size_t first_ea_side_block = 14;
-  const size_t first_ma_endcap_block = 27;
-
   if (include_inner_sphere_A_) {
     // EA Filled Cylinder
-    add_cyl_endcap_shell_neighbors(inner_neighbors, false,
-                                   first_ea_endcap_block,
-                                   first_inner_shell_A_block);
+    add_block_neighbor(inner_neighbors, ea_endcap_block, inner_shell_A_block,
+                       Direction<3>::lower_zeta(),
+                       lower_cyl_endcap_to_upper_shell, false);
     // EA Cylinder
-    add_cyl_side_shell_neighbors(inner_neighbors, false, first_ea_side_block,
-                                 first_inner_shell_A_block);
+    add_block_neighbor(inner_neighbors, ea_side_block, inner_shell_A_block,
+                       Direction<3>::lower_xi(), cyl_side_to_shell, false);
     // MA Filled Cylinder
-    add_cyl_endcap_shell_neighbors(inner_neighbors, false,
-                                   first_ma_endcap_block,
-                                   first_inner_shell_A_block);
+    add_block_neighbor(inner_neighbors, ma_endcap_block, inner_shell_A_block,
+                       Direction<3>::upper_zeta(),
+                       upper_cyl_endcap_to_upper_shell, false);
   }
-
-  const size_t first_eb_endcap_block = 18;
-  const size_t first_eb_side_block = 23;
-  const size_t first_mb_endcap_block = 32;
 
   if (include_inner_sphere_B_) {
     // EB Filled Cylinder
-    add_cyl_endcap_shell_neighbors(inner_neighbors, false,
-                                   first_eb_endcap_block,
-                                   first_inner_shell_B_block);
+    add_block_neighbor(inner_neighbors, eb_endcap_block, inner_shell_B_block,
+                       Direction<3>::upper_zeta(),
+                       upper_cyl_endcap_to_upper_shell, false);
     // EB Cylinder
-    add_cyl_side_shell_neighbors(inner_neighbors, false, first_eb_side_block,
-                                 first_inner_shell_B_block);
+    add_block_neighbor(inner_neighbors, eb_side_block, inner_shell_B_block,
+                       Direction<3>::lower_xi(), cyl_side_to_shell, false);
     // MB Filled Cylinder
-    add_cyl_endcap_shell_neighbors(inner_neighbors, false,
-                                   first_mb_endcap_block,
-                                   first_inner_shell_B_block);
+    add_block_neighbor(inner_neighbors, mb_endcap_block, inner_shell_B_block,
+                       Direction<3>::lower_zeta(),
+                       lower_cyl_endcap_to_upper_shell, false);
   }
 
-  const size_t first_ca_endcap_block = 0;
-  const size_t first_ca_side_block = 5;
-  const size_t first_cb_endcap_block = 37;
-  const size_t first_cb_side_block = 42;
+  const size_t outer_shell_block = block_positions_.at("OuterShell0");
 
   // CA Filled Cylinder
-  add_cyl_endcap_shell_neighbors(inner_neighbors, true, first_ca_endcap_block,
-                                 first_outer_shell_block);
+  add_block_neighbor(inner_neighbors, ca_endcap_block, outer_shell_block,
+                     Direction<3>::upper_zeta(),
+                     upper_cyl_endcap_to_lower_shell, false);
   // CA Cylinder
-  add_cyl_side_shell_neighbors(inner_neighbors, true, first_ca_side_block,
-                               first_outer_shell_block);
+  add_block_neighbor(inner_neighbors, ca_side_block, outer_shell_block,
+                     Direction<3>::upper_xi(), cyl_side_to_shell, false);
+
   // CB Filled Cylinder
-  add_cyl_endcap_shell_neighbors(inner_neighbors, true, first_cb_endcap_block,
-                                 first_outer_shell_block);
+  add_block_neighbor(inner_neighbors, cb_endcap_block, outer_shell_block,
+                     Direction<3>::lower_zeta(),
+                     lower_cyl_endcap_to_lower_shell, false);
   // CB Cylinder
-  add_cyl_side_shell_neighbors(inner_neighbors, true, first_cb_side_block,
-                               first_outer_shell_block);
+  add_block_neighbor(inner_neighbors, cb_side_block, outer_shell_block,
+                     Direction<3>::upper_xi(), cyl_side_to_shell, false);
 
   // Build blocks in final order.
   std::vector<Block<3>> blocks;
   blocks.reserve(number_of_blocks_);
 
   // (a) Inner blocks before SH shells.
-  for (size_t j = 0; j < first_inner_shell_A_block; ++j) {
+  for (size_t j = 0; j < inner_shell_A_block; ++j) {
+    const std::string& block_name = gsl::at(block_names_, j);
+    ASSERT(block_name.find("Cylinder") != std::string::npos,
+           "Expected block to be a cylindrical block with the substring "
+           "'Cylinder'.");
+
+    const auto cyl_topology = block_name.find("Filled") != std::string::npos ?
+        domain::topologies::full_cylinder :
+        domain::topologies::cylindrical_shell;
     blocks.emplace_back(std::move(coordinate_maps[j]), j,
-                        std::move(inner_neighbors[j]), block_names_[j]);
+                        std::move(inner_neighbors[j]), block_name,
+                        cyl_topology);
   }
 
-  // Add one of the blocks making up a cylindeical endcap as a neighbor of a
-  // shell
-  auto add_shell_cyl_endcap_neighbors =
-      [&shell_to_cyl_endcap_center, &shell_to_cyl_endcap_wedge](
-          std::unordered_set<size_t>& cyl_ids,
-          std::unordered_map<size_t, OrientationMap<3>>& cyl_orientations,
-          const size_t first_cyl_block_number) {
-        cyl_ids.insert(first_cyl_block_number);
-        cyl_orientations.emplace(first_cyl_block_number,
-                                 shell_to_cyl_endcap_center);
-        for (size_t j = first_cyl_block_number + 1;
-             j < first_cyl_block_number + 5; ++j) {
-          cyl_ids.insert(j);
-          cyl_orientations.emplace(j, shell_to_cyl_endcap_wedge);
-        }
-      };
-
-  // Add one of the blocks making up a cylindrical side as a neighbor of a shell
-  auto add_shell_cyl_side_neighbors =
-      [&shell_to_cyl_side](
-          std::unordered_set<size_t>& cyl_ids,
-          std::unordered_map<size_t, OrientationMap<3>>& cyl_orientations,
-          const size_t first_cyl_block_number) {
-        for (size_t j = first_cyl_block_number; j < first_cyl_block_number + 4;
-             ++j) {
-          cyl_ids.insert(j);
-          cyl_orientations.emplace(j, shell_to_cyl_side);
-        }
+  auto add_block_id_and_orientation_to_sets =
+      [](std::unordered_set<size_t>& ids,
+         std::unordered_map<size_t, OrientationMap<3>>& orientations,
+         const size_t block_number, const OrientationMap<3>& orientation) {
+        ids.insert(block_number);
+        orientations.emplace(block_number, orientation);
       };
 
   using Affine = CoordinateMaps::Affine;
@@ -1065,19 +1068,23 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const {
 
   // (b) SH inner shell blocks for InnerSphereA.
   if (include_inner_sphere_A_) {
-    // lower_xi → all 18 CA, CB blocks (non-conforming, multi-neighbor).
+    // upper_xi → EA endcap, EA side, and MA blocks
+    // (non-conforming, multi-neighbor).
     std::unordered_set<size_t> inner_a_cyl_ids;
     std::unordered_map<size_t, OrientationMap<3>> inner_a_cyl_orientations;
 
     // EA Filled Cylinder
-    add_shell_cyl_endcap_neighbors(inner_a_cyl_ids, inner_a_cyl_orientations,
-                                   first_ea_endcap_block);
+    add_block_id_and_orientation_to_sets(
+        inner_a_cyl_ids, inner_a_cyl_orientations, ea_endcap_block,
+        upper_shell_to_lower_cyl_endcap);
     // EA Cylinder
-    add_shell_cyl_side_neighbors(inner_a_cyl_ids, inner_a_cyl_orientations,
-                                 first_ea_side_block);
+    add_block_id_and_orientation_to_sets(inner_a_cyl_ids,
+                                         inner_a_cyl_orientations,
+                                         ea_side_block, shell_to_cyl_side);
     // MA Filled Cylinder
-    add_shell_cyl_endcap_neighbors(inner_a_cyl_ids, inner_a_cyl_orientations,
-                                   first_ma_endcap_block);
+    add_block_id_and_orientation_to_sets(
+        inner_a_cyl_ids, inner_a_cyl_orientations, ma_endcap_block,
+        upper_shell_to_upper_cyl_endcap);
 
     auto inner_a_sh_map = make_spherical_shell_coord_map(
         radius_A_, outer_radius_A_, rotate_from_z_to_x_axis(center_A_));
@@ -1088,27 +1095,31 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const {
         BlockNeighbors<3>{std::move(inner_a_cyl_ids),
                           std::move(inner_a_cyl_orientations),
                           /*are_conforming=*/false});
-    blocks.emplace_back(std::move(inner_a_sh_map), first_inner_shell_A_block,
+    blocks.emplace_back(std::move(inner_a_sh_map), inner_shell_A_block,
                         std::move(inner_a_sh_neighbors),
-                        block_names_[first_inner_shell_A_block],
+                        block_names_[inner_shell_A_block],
                         domain::topologies::spherical_shell);
   }
 
   // (c) SH inner shell blocks for InnerSphereB.
   if (include_inner_sphere_B_) {
-    // lower_xi → all 18 CA, CB blocks (non-conforming, multi-neighbor).
+    // upper_xi → EB endcap, EB side, and MB blocks
+    // (non-conforming, multi-neighbor).
     std::unordered_set<size_t> inner_b_cyl_ids;
     std::unordered_map<size_t, OrientationMap<3>> inner_b_cyl_orientations;
 
     // EB Filled Cylinder
-    add_shell_cyl_endcap_neighbors(inner_b_cyl_ids, inner_b_cyl_orientations,
-                                   first_eb_endcap_block);
+    add_block_id_and_orientation_to_sets(
+        inner_b_cyl_ids, inner_b_cyl_orientations, eb_endcap_block,
+        upper_shell_to_upper_cyl_endcap);
     // EB Cylinder
-    add_shell_cyl_side_neighbors(inner_b_cyl_ids, inner_b_cyl_orientations,
-                                 first_eb_side_block);
+    add_block_id_and_orientation_to_sets(inner_b_cyl_ids,
+                                         inner_b_cyl_orientations,
+                                         eb_side_block, shell_to_cyl_side);
     // MB Filled Cylinder
-    add_shell_cyl_endcap_neighbors(inner_b_cyl_ids, inner_b_cyl_orientations,
-                                   first_mb_endcap_block);
+    add_block_id_and_orientation_to_sets(
+        inner_b_cyl_ids, inner_b_cyl_orientations, mb_endcap_block,
+        upper_shell_to_lower_cyl_endcap);
 
     auto inner_b_sh_map = make_spherical_shell_coord_map(
         radius_B_, outer_radius_B_, rotate_from_z_to_x_axis(center_B_));
@@ -1120,29 +1131,31 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const {
                           std::move(inner_b_cyl_orientations),
                           /*are_conforming=*/false});
 
-    blocks.emplace_back(std::move(inner_b_sh_map), first_inner_shell_B_block,
+    blocks.emplace_back(std::move(inner_b_sh_map), inner_shell_B_block,
                         std::move(inner_b_sh_neighbors),
-                        block_names_[first_inner_shell_B_block],
+                        block_names_[inner_shell_B_block],
                         domain::topologies::spherical_shell);
   }
 
   // (d) SH outer shell blocks for OuterSphere.
-  // lower_xi → all 18 CA, CB blocks (non-conforming, multi-neighbor).
+  // lower_xi → all 4 CA, CB blocks (non-conforming, multi-neighbor).
   std::unordered_set<size_t> outer_cyl_ids;
   std::unordered_map<size_t, OrientationMap<3>> outer_cyl_orientations;
 
   // CA Filled Cylinder
-  add_shell_cyl_endcap_neighbors(outer_cyl_ids, outer_cyl_orientations,
-                                 first_ca_endcap_block);
+  add_block_id_and_orientation_to_sets(outer_cyl_ids, outer_cyl_orientations,
+                                       ca_endcap_block,
+                                       lower_shell_to_upper_cyl_endcap);
   // CA Cylinder
-  add_shell_cyl_side_neighbors(outer_cyl_ids, outer_cyl_orientations,
-                               first_ca_side_block);
+  add_block_id_and_orientation_to_sets(outer_cyl_ids, outer_cyl_orientations,
+                                       ca_side_block, shell_to_cyl_side);
   // CB Filled Cylinder
-  add_shell_cyl_endcap_neighbors(outer_cyl_ids, outer_cyl_orientations,
-                                 first_cb_endcap_block);
+  add_block_id_and_orientation_to_sets(outer_cyl_ids, outer_cyl_orientations,
+                                       cb_endcap_block,
+                                       lower_shell_to_lower_cyl_endcap);
   // CB Cylinder
-  add_shell_cyl_side_neighbors(outer_cyl_ids, outer_cyl_orientations,
-                               first_cb_side_block);
+  add_block_id_and_orientation_to_sets(outer_cyl_ids, outer_cyl_orientations,
+                                       cb_side_block, shell_to_cyl_side);
 
   auto outer_sh_map = make_spherical_shell_coord_map(
       inner_radius_C, outer_radius_, make_array<3>(0.0));
@@ -1154,10 +1167,9 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const {
                         std::move(outer_cyl_orientations),
                         /*are_conforming=*/false});
 
-  blocks.emplace_back(std::move(outer_sh_map), first_outer_shell_block,
-                      std::move(outer_sh_neighbors),
-                      block_names_[first_outer_shell_block],
-                      domain::topologies::spherical_shell);
+  blocks.emplace_back(
+      std::move(outer_sh_map), outer_shell_block, std::move(outer_sh_neighbors),
+      block_names_[outer_shell_block], domain::topologies::spherical_shell);
 
   domain =
       Domain<3>{std::move(blocks), std::move(excision_spheres), block_groups_};
@@ -1188,7 +1200,7 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const {
     // The first block in the outer shell needs the transition expansion +
     // rotation + translation map from the grid to inertial frame. No maps to
     // the distorted frame
-    grid_to_inertial_block_maps[first_outer_shell_block] =
+    grid_to_inertial_block_maps[outer_shell_block] =
         time_dependent_options_
             ->grid_to_inertial_map<domain::ObjectLabel::None>(false, false);
 
@@ -1206,64 +1218,29 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const {
 
     // The `true` being passed to the functions specifies that the size map
     // *should* be included in the distorted frame.
-    grid_to_inertial_block_maps[first_inner_shell_A_block] =
+    grid_to_inertial_block_maps[inner_shell_A_block] =
         time_dependent_options_->grid_to_inertial_map<domain::ObjectLabel::A>(
             true, true);
-    grid_to_distorted_block_maps[first_inner_shell_A_block] =
+    grid_to_distorted_block_maps[inner_shell_A_block] =
         time_dependent_options_->grid_to_distorted_map<domain::ObjectLabel::A>(
             true);
-    distorted_to_inertial_block_maps[first_inner_shell_A_block] =
+    distorted_to_inertial_block_maps[inner_shell_A_block] =
         time_dependent_options_
             ->distorted_to_inertial_map<domain::ObjectLabel::A>(true, true);
 
-    grid_to_inertial_block_maps[first_inner_shell_B_block] =
+    grid_to_inertial_block_maps[inner_shell_B_block] =
         time_dependent_options_->grid_to_inertial_map<domain::ObjectLabel::B>(
             true, true);
-    grid_to_distorted_block_maps[first_inner_shell_B_block] =
+    grid_to_distorted_block_maps[inner_shell_B_block] =
         time_dependent_options_->grid_to_distorted_map<domain::ObjectLabel::B>(
             true);
-    distorted_to_inertial_block_maps[first_inner_shell_B_block] =
+    distorted_to_inertial_block_maps[inner_shell_B_block] =
         time_dependent_options_
             ->distorted_to_inertial_map<domain::ObjectLabel::B>(true, true);
 
-    for (size_t block = 1; block < number_of_blocks_; ++block) {
-      if (block == first_inner_shell_A_block or
-          block == first_inner_shell_B_block or
-          block == first_outer_shell_block) {
-        continue;  // Already initialized
-      } else if (block > first_inner_shell_A_block and
-                 block < first_inner_shell_B_block) {
-        grid_to_inertial_block_maps[block] =
-            grid_to_inertial_block_maps[first_inner_shell_A_block]->get_clone();
-        if (grid_to_distorted_block_maps[first_inner_shell_A_block] !=
-            nullptr) {
-          grid_to_distorted_block_maps[block] =
-              grid_to_distorted_block_maps[first_inner_shell_A_block]
-                  ->get_clone();
-          distorted_to_inertial_block_maps[block] =
-              distorted_to_inertial_block_maps[first_inner_shell_A_block]
-                  ->get_clone();
-        }
-      } else if (block > first_inner_shell_B_block and
-                 block < first_outer_shell_block) {
-        grid_to_inertial_block_maps[block] =
-            grid_to_inertial_block_maps[first_inner_shell_B_block]->get_clone();
-        if (grid_to_distorted_block_maps[first_inner_shell_B_block] !=
-            nullptr) {
-          grid_to_distorted_block_maps[block] =
-              grid_to_distorted_block_maps[first_inner_shell_B_block]
-                  ->get_clone();
-          distorted_to_inertial_block_maps[block] =
-              distorted_to_inertial_block_maps[first_inner_shell_B_block]
-                  ->get_clone();
-        }
-      } else if (block > first_outer_shell_block) {
-        grid_to_inertial_block_maps[block] =
-            grid_to_inertial_block_maps[first_outer_shell_block]->get_clone();
-      } else {
-        grid_to_inertial_block_maps[block] =
-            grid_to_inertial_block_maps[0]->get_clone();
-      }
+    for (size_t block = 1; block < inner_shell_A_block; ++block) {
+      grid_to_inertial_block_maps[block] =
+          grid_to_inertial_block_maps[0]->get_clone();
     }
 
     for (size_t block = 0; block < number_of_blocks_; ++block) {
@@ -1286,49 +1263,45 @@ CylindricalBinaryCompactObject::external_boundary_conditions() const {
   std::vector<DirectionMap<
       3, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
       boundary_conditions{number_of_blocks_};
-  for (size_t i = 0; i < 5; ++i) {
-    if (not include_inner_sphere_A_) {
+  const size_t ea_endcap_block = block_positions_.at("EAFilledCylinder");
+  const size_t ea_side_block = block_positions_.at("EACylinder");
+  const size_t ma_endcap_block = block_positions_.at("MAFilledCylinder");
+  const size_t eb_endcap_block = block_positions_.at("EBFilledCylinder");
+  const size_t eb_side_block = block_positions_.at("EBCylinder");
+  const size_t mb_endcap_block = block_positions_.at("MBFilledCylinder");
+  const size_t outer_shell_block = block_positions_.at("OuterShell0");
+
+  if (not include_inner_sphere_A_) {
       // EA Filled Cylinder
-      boundary_conditions[i + 9][Direction<3>::lower_zeta()] =
+      boundary_conditions[ea_endcap_block][Direction<3>::lower_zeta()] =
           inner_boundary_condition_->get_clone();
       // MA Filled Cylinder
-      boundary_conditions[i + 27][Direction<3>::lower_zeta()] =
+      boundary_conditions[ma_endcap_block][Direction<3>::upper_zeta()] =
           inner_boundary_condition_->get_clone();
-    }
-    if (not include_inner_sphere_B_) {
+      // EA Cylinder
+      boundary_conditions[ea_side_block][Direction<3>::lower_xi()] =
+          inner_boundary_condition_->get_clone();
+  } else {
+    boundary_conditions[block_positions_.at("InnerAShell0")]
+                       [Direction<3>::lower_xi()] =
+                           inner_boundary_condition_->get_clone();
+  }
+  if (not include_inner_sphere_B_) {
       // EB Filled Cylinder
-      boundary_conditions[i + 18][Direction<3>::lower_zeta()] =
+      boundary_conditions[eb_endcap_block][Direction<3>::upper_zeta()] =
           inner_boundary_condition_->get_clone();
       // MB Filled Cylinder
-      boundary_conditions[i + 32][Direction<3>::lower_zeta()] =
+      boundary_conditions[mb_endcap_block][Direction<3>::lower_zeta()] =
           inner_boundary_condition_->get_clone();
-    }
-  }
-  for (size_t i = 0; i < 4; ++i) {
-    if (not include_inner_sphere_A_) {
-      // EA Cylinder
-      boundary_conditions[i + 14][Direction<3>::lower_xi()] =
-          inner_boundary_condition_->get_clone();
-    }
-    if (not include_inner_sphere_B_) {
       // EB Cylinder
-      boundary_conditions[i + 23][Direction<3>::lower_xi()] =
+      boundary_conditions[eb_side_block][Direction<3>::lower_xi()] =
           inner_boundary_condition_->get_clone();
-    }
+  } else {
+    boundary_conditions[block_positions_.at("InnerBShell0")]
+                       [Direction<3>::lower_xi()] =
+                           inner_boundary_condition_->get_clone();
   }
-
-  size_t last_block = 46;
-  if (include_inner_sphere_A_) {
-    boundary_conditions[last_block][Direction<3>::lower_xi()] =
-        inner_boundary_condition_->get_clone();
-    last_block += 1;
-  }
-  if (include_inner_sphere_B_) {
-    boundary_conditions[last_block][Direction<3>::lower_xi()] =
-        inner_boundary_condition_->get_clone();
-    last_block += 1;
-  }
-  boundary_conditions[last_block][Direction<3>::upper_xi()] =
+  boundary_conditions[outer_shell_block][Direction<3>::upper_xi()] =
       outer_boundary_condition_->get_clone();
 
   return boundary_conditions;

--- a/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
+++ b/src/Domain/Creators/CylindricalBinaryCompactObject.cpp
@@ -16,6 +16,7 @@
 #include "Domain/CoordinateMaps/DiscreteRotation.hpp"
 #include "Domain/CoordinateMaps/Identity.hpp"
 #include "Domain/CoordinateMaps/Interval.hpp"
+#include "Domain/CoordinateMaps/PolarToCartesian.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/CoordinateMaps/SphericalToCartesianPfaffian.hpp"
@@ -65,7 +66,7 @@ namespace domain::creators {
 CylindricalBinaryCompactObject::CylindricalBinaryCompactObject(
     std::array<double, 3> center_A, std::array<double, 3> center_B,
     double radius_A, double radius_B, bool include_inner_sphere_A,
-    bool include_inner_sphere_B, double outer_radius, bool use_equiangular_map,
+    bool include_inner_sphere_B, double outer_radius,
     const typename InitialRefinement::type& initial_refinement,
     const typename InitialGridPoints::type& initial_grid_points,
     std::optional<bco::TimeDependentMapOptions<true>> time_dependent_options,
@@ -81,7 +82,6 @@ CylindricalBinaryCompactObject::CylindricalBinaryCompactObject(
       include_inner_sphere_A_(include_inner_sphere_A),
       include_inner_sphere_B_(include_inner_sphere_B),
       outer_radius_(outer_radius),
-      use_equiangular_map_(use_equiangular_map),
       inner_boundary_condition_(std::move(inner_boundary_condition)),
       outer_boundary_condition_(std::move(outer_boundary_condition)),
       time_dependent_options_(std::move(time_dependent_options)) {
@@ -130,25 +130,6 @@ CylindricalBinaryCompactObject::CylindricalBinaryCompactObject(
         context,
         "Cannot have periodic boundary conditions with a binary domain");
   }
-
-  // Build the set of spherical-harmonic shell block groups and block names so
-  // the validation below can distinguish spherical-harmonic blocks from other
-  // blocks and block groups.
-  std::unordered_set<std::string> spherical_harmonic_shell_names{"OuterSphere",
-                                                                 "OuterShell0"};
-  if (include_inner_sphere_A) {
-    spherical_harmonic_shell_names.insert("InnerSphereA");
-    spherical_harmonic_shell_names.insert("InnerAShell0");
-  }
-  if (include_inner_sphere_B) {
-    spherical_harmonic_shell_names.insert("InnerSphereB");
-    spherical_harmonic_shell_names.insert("InnerBShell0");
-  }
-
-  bco::validate_initial_refinement(context, initial_refinement,
-                                   spherical_harmonic_shell_names);
-  bco::validate_initial_grid_points(context, initial_grid_points,
-                                    spherical_harmonic_shell_names);
 
   // The choices made below for the quantities xi, z_cutting_plane_,
   // and xi_min_sphere_e are the ones made in SpEC, and in the
@@ -208,16 +189,6 @@ CylindricalBinaryCompactObject::CylindricalBinaryCompactObject(
                 0.5 * (std::abs(z_cutting_plane_ - center_B_[2]) - radius_B_)
           : radius_B_;
 
-  number_of_blocks_ = 46;
-  if (include_inner_sphere_A) {
-    number_of_blocks_ += 1;
-  }
-  if (include_inner_sphere_B) {
-    number_of_blocks_ += 1;
-  }
-  // Outer sphere
-  number_of_blocks_ += 1;
-
   // Add SphereE blocks if necessary.  Note that
   // https://arxiv.org/abs/1206.3015 has a mistake just above
   // Eq. (A.11) and the same mistake above Eq. (A.20), where it lists
@@ -240,250 +211,270 @@ CylindricalBinaryCompactObject::CylindricalBinaryCompactObject(
   // Create grid anchors in x direction from unrotated input centers
   grid_anchors_ = bco::create_grid_anchors(center_A, center_B);
 
-  // Create block names and groups
-  auto add_filled_cylinder_name = [this](const std::string& prefix,
-                                         const std::string& group_name) {
-    for (const std::string& where :
-         {"Center"s, "East"s, "North"s, "West"s, "South"s}) {
-      const std::string name =
-          std::string(prefix).append("FilledCylinder").append(where);
-      block_names_.push_back(name);
-      block_groups_[group_name].insert(name);
-    }
+  // Build the set of cylindrical block groups and block names so the
+  // validation below can distinguish spherical-harmonic blocks from other
+  // blocks and block groups.
+  std::unordered_set<std::string> filled_cylinder_names{};
+  std::unordered_set<std::string> hollow_cylinder_names{};
+
+  // Create cylinder block names and groups
+  auto add_filled_cylinder_name = [this, &filled_cylinder_names](
+                                      const std::string& prefix,
+                                      const std::string& group_name) {
+    const std::string name = std::string(prefix).append("FilledCylinder");
+    block_names_.push_back(name);
+    block_groups_[group_name].insert(name);
+    block_positions_[name] = block_names_.size() - 1;
+    filled_cylinder_names.insert(name);
+    filled_cylinder_names.insert(group_name);
   };
-  auto add_cylinder_name = [this](const std::string& prefix,
-                                  const std::string& group_name) {
-    for (const std::string& where : {"East"s, "North"s, "West"s, "South"s}) {
-      const std::string name =
-          std::string(prefix).append("Cylinder").append(where);
-      block_names_.push_back(name);
-      block_groups_[group_name].insert(name);
-    }
+  auto add_cylinder_name = [this, &hollow_cylinder_names](
+                               const std::string& prefix,
+                               const std::string& group_name) {
+    const std::string name = std::string(prefix).append("Cylinder");
+    block_names_.push_back(name);
+    block_groups_[group_name].insert(name);
+    block_positions_[name] = block_names_.size() - 1;
+    hollow_cylinder_names.insert(name);
+    hollow_cylinder_names.insert(group_name);
   };
 
   // CA Filled Cylinder
-  // 5 blocks: 0 thru 4
   add_filled_cylinder_name("CA", "Outer");
 
   // CA Cylinder
-  // 4 blocks: 5 thru 8
   add_cylinder_name("CA", "Outer");
 
   // EA Filled Cylinder
-  // 5 blocks: 9 thru 13
   add_filled_cylinder_name("EA", "InnerA");
 
   // EA Cylinder
-  // 4 blocks: 14 thru 17
   add_cylinder_name("EA", "InnerA");
 
   // EB Filled Cylinder
-  // 5 blocks: 18 thru 22
   add_filled_cylinder_name("EB", "InnerB");
 
   // EB Cylinder
-  // 4 blocks: 23 thru 26
   add_cylinder_name("EB", "InnerB");
 
   // MA Filled Cylinder
-  // 5 blocks: 27 thru 31
   add_filled_cylinder_name("MA", "InnerA");
 
   // MB Filled Cylinder
-  // 5 blocks: 32 thru 36
   add_filled_cylinder_name("MB", "InnerB");
 
   // CB Filled Cylinder
-  // 5 blocks: 37 thru 41
   add_filled_cylinder_name("CB", "Outer");
 
   // CB Cylinder
-  // 4 blocks: 42 thru 45
   add_cylinder_name("CB", "Outer");
 
+  // combine filled and hollow cylinder blocks and groups into one set
+  std::unordered_set<std::string> all_cylinder_names;
+  std::set_union(
+      std::begin(filled_cylinder_names), std::end(filled_cylinder_names),
+      std::begin(hollow_cylinder_names), std::end(hollow_cylinder_names),
+      std::inserter(all_cylinder_names, std::begin(all_cylinder_names)));
+
+  // Build the set of spherical-harmonic shell block groups and block names so
+  // the validation below can distinguish spherical-harmonic blocks from other
+  // blocks and block groups.
+  std::unordered_set<std::string> spherical_harmonic_shell_names{};
+
   // Create block names and groups
-  auto add_spherical_shell_name = [this](const std::string& prefix,
-                                         const std::string& group_name,
-                                         const size_t shell_number) {
+  auto add_spherical_shell_name = [this, &spherical_harmonic_shell_names](
+                                      const std::string& prefix,
+                                      const std::string& group_name,
+                                      const size_t shell_number) {
     const std::string name = std::string(prefix).append("Shell").append(
         std::to_string(shell_number));
     block_names_.push_back(name);
     block_groups_[group_name].insert(name);
+    block_positions_[name] = block_names_.size() - 1;
+    spherical_harmonic_shell_names.insert(name);
+    spherical_harmonic_shell_names.insert(group_name);
   };
-
-  const size_t first_inner_shell_A_block = 46;
-  size_t first_inner_shell_B_block = first_inner_shell_A_block;
-  first_outer_shell_block = first_inner_shell_A_block;
 
   if (include_inner_sphere_A) {
     add_spherical_shell_name("InnerA", "InnerSphereA", 0);
-
-    first_inner_shell_B_block += 1;
-    first_outer_shell_block += 1;
   }
   if (include_inner_sphere_B) {
     add_spherical_shell_name("InnerB", "InnerSphereB", 0);
-
-    first_outer_shell_block += 1;
   }
   add_spherical_shell_name("Outer", "OuterSphere", 0);
+
+  number_of_blocks_ = block_names_.size();
+  ASSERT(number_of_blocks_ == block_positions_.size(),
+         "Size of block_positions_ map should be equal to the number of blocks "
+         "in the domain.");
+
+  // Since BinaryCompactObject::InitialGridPoints type differs from
+  // CylindricalBinaryCompactObject::InitialGridPoints type, need to first
+  // create the BCO-compatible type with the CBCO data to be able to reuse the
+  // functionality of bco::validate_initial_grid_points() and
+  // bco::set_initial_grid_points().
+  const auto bco_initial_grid_points = std::visit(
+      [](const auto& value) {
+        return BinaryCompactObject::InitialGridPoints::type{value};
+      },
+      initial_grid_points);
+  // Validate that the input file has the correct format for
+  // InitialGridPoints. No need to validate the format for InitialRefinement
+  // because it does not accept a map of strings to possibly
+  // differently-sized arrays for refinement. If a map is provided, it already
+  // only accepts a map of size_t keys.
+  bco::validate_initial_grid_points(context, bco_initial_grid_points,
+                                    spherical_harmonic_shell_names,
+                                    filled_cylinder_names);
 
   // For expanding initial refinement and grid points over all blocks
   const ExpandOverBlocks<std::array<size_t, 3>> expand_over_blocks{
       block_names_, block_groups_};
   try {
-    initial_refinement_ =
-        bco::set_initial_refinement(expand_over_blocks, initial_refinement);
-    // If a global single-number refinement was used, post-process the spherical
-    // shell entries to make the angular directions have h refinement = 0.
+    // Since BinaryCompactObject::InitialRefinement map type differs from
+    // CylindricalBinaryCompactObject::InitialRefinement map type, need to first
+    // create the BCO-compatible type with the CBCO data to be able to reuse the
+    // functionality of bco::set_initial_refinement().
+    using bco_ref_map_type =
+        std::unordered_map<std::string,
+                           std::variant<std::array<size_t, 3>, size_t>>;
+    using cbco_ref_map_type = std::unordered_map<std::string, size_t>;
+    const auto bco_initial_refinement =
+        std::holds_alternative<size_t>(initial_refinement)
+            ? BinaryCompactObject::InitialRefinement::type{std::get<size_t>(
+                  initial_refinement)}
+            : BinaryCompactObject::InitialRefinement::type{bco_ref_map_type{
+                  std::get<cbco_ref_map_type>(initial_refinement).begin(),
+                  std::get<cbco_ref_map_type>(initial_refinement).end()}};
+    initial_refinement_ = bco::set_initial_refinement(
+        expand_over_blocks, bco_initial_refinement,
+        spherical_harmonic_shell_names, all_cylinder_names);
+    // If a global single-number h-refinement was used, post-process the
+    // expanded cylinder and spherical shell blocks to make the angular
+    // directions have h refinement = 0.
     if (std::holds_alternative<size_t>(initial_refinement)) {
-      if (include_inner_sphere_A) {
-        // InnerAShell0
-        initial_refinement_[first_inner_shell_A_block][1] = 0;
-        initial_refinement_[first_inner_shell_A_block][2] = 0;
+      for (const auto& [name, position] : block_positions_) {
+        if (name.find("Cylinder") != std::string::npos) {
+          // Set cylinder h refinement to {0, 0, z}
+          initial_refinement_[position][0] = 0;
+          initial_refinement_[position][1] = 0;
+        } else if (name.find("Shell") != std::string::npos) {
+          // Set spherical shell h refinement to {r, 0, 0}
+          initial_refinement_[position][1] = 0;
+          initial_refinement_[position][2] = 0;
+        }
       }
-      if (include_inner_sphere_B) {
-        // InnerBShell0
-        initial_refinement_[first_inner_shell_B_block][1] = 0;
-        initial_refinement_[first_inner_shell_B_block][2] = 0;
-      }
-      // OuterShell0
-      initial_refinement_[first_outer_shell_block][1] = 0;
-      initial_refinement_[first_outer_shell_block][2] = 0;
     }
   } catch (const std::exception& error) {
     PARSE_ERROR(context, "Invalid 'InitialRefinement': " << error.what());
   }
-  // Validate angular h-refinement == 0 in spherical shell blocks
-  if (include_inner_sphere_A_) {
-    if (gsl::at(initial_refinement_, first_inner_shell_A_block)[1] != 0 or
-        gsl::at(initial_refinement_, first_inner_shell_A_block)[2] != 0) {
-      PARSE_ERROR(context,
-                  "Angular h-refinement is not supported for "
-                  "spherical-harmonic inner-shell blocks. Specify refinement "
-                  "for InnerSphereA as a single number.");
+
+  // Validate angular h-refinement == 0 in cylinder and spherical shell blocks
+  for (const auto& [name, position] : block_positions_) {
+    if (name.find("Cylinder") != std::string::npos) {
+      if (gsl::at(gsl::at(initial_refinement_, position), 0) != 0 or
+          gsl::at(gsl::at(initial_refinement_, position), 1) != 0) {
+        PARSE_ERROR(context,
+                    "Angular h-refinement is not supported for cylindrical "
+                    "blocks. Specify refinement for "
+                        << name << " as a single number.");
+      }
+    } else if (name.find("Shell") != std::string::npos) {
+      if (gsl::at(gsl::at(initial_refinement_, position), 1) != 0 or
+          gsl::at(gsl::at(initial_refinement_, position), 2) != 0) {
+        PARSE_ERROR(context,
+                    "Angular h-refinement is not supported for "
+                    "spherical-harmonic shell blocks. Specify refinement for "
+                        << name << " as a single number.");
+      }
     }
-  }
-  if (include_inner_sphere_B_) {
-    if (gsl::at(initial_refinement_, first_inner_shell_B_block)[1] != 0 or
-        gsl::at(initial_refinement_, first_inner_shell_B_block)[2] != 0) {
-      PARSE_ERROR(context,
-                  "Angular h-refinement is not supported for "
-                  "spherical-harmonic inner-shell blocks. Specify refinement "
-                  "for InnerSphereB as a single number.");
-    }
-  }
-  if (gsl::at(initial_refinement_, first_outer_shell_block)[1] != 0 or
-      gsl::at(initial_refinement_, first_outer_shell_block)[2] != 0) {
-    PARSE_ERROR(context,
-                "Angular h-refinement is not supported for "
-                "spherical-harmonic outer-shell blocks. Specify refinement "
-                "for OuterSphere as a single number.");
   }
 
   try {
-    initial_grid_points_ =
-        bco::set_initial_grid_points(expand_over_blocks, initial_grid_points);
+    initial_grid_points_ = bco::set_initial_grid_points(
+        expand_over_blocks, bco_initial_grid_points,
+        spherical_harmonic_shell_names, filled_cylinder_names);
+    // If a global single-number p-refinement was used, post-process the
+    // expanded filled cylinder blocks to make the angular directions have the
+    // correct number of spectral points for ZernikeB2.
+    if (std::holds_alternative<size_t>(initial_grid_points)) {
+      for (const auto& [name, position] : block_positions_) {
+        if (name.find("FilledCylinder") != std::string::npos) {
+          // note for ZernikeB2:
+          // radial_points = (theta_modes / 2) + 1 + (theta_modes % 2), so one
+          // could have odd or even theta_modes for the same radial_points.
+          // Choosing the even theta_modes for the same radial_points means:
+          //   theta_modes = 2 * (radial_points - 1)
+          //   theta_points = 2 * theta_modes + 1 = 4 * radial_modes - 3
+          // Choosing the odd theta_modes for the same radial_points means:
+          //   theta_modes = 2 * (radial_points - 2) + 1
+          //   theta_points = 2 * theta_modes + 1 = 4 * radial_modes - 5
+          // Here, we choose the even case to get one extra theta_mode out of
+          // radial_points.
+          initial_grid_points_[position][1] =
+              4 * gsl::at(gsl::at(initial_grid_points_, position), 0) - 3;
+        }
+      }
+    }
   } catch (const std::exception& error) {
     PARSE_ERROR(context, "Invalid 'InitialGridPoints': " << error.what());
   }
-  // Validate angular grid points in spherical shell blocks. A
-  // spherical-harmonic shell is fully specified by a single ell, so l_max must
-  // equal m_max.
-  if (include_inner_sphere_A_) {
-    if (initial_grid_points_[first_inner_shell_A_block][1] !=
-        initial_grid_points_[first_inner_shell_A_block][2]) {
-      PARSE_ERROR(
-          context,
-          "Spherical-harmonic inner-shell blocks must have L_max = M_max. "
-          "Specify grid points for InnerSphereA as [radial_points, L_max].");
+
+  // Validate p-refinement values in cylinder and spherical shell blocks
+  for (const auto& [name, position] : block_positions_) {
+    if (name.find("FilledCylinder") != std::string::npos) {
+      // Validate number of radial points for filled cylinders is > 2
+      if (gsl::at(gsl::at(initial_grid_points_, position), 0) <= 2) {
+        PARSE_ERROR(context,
+                    "Filled cylindrical block "
+                        << name
+                        << " must have more than 2 radial grid points.");
+      }
+
+      // Validate number of angular grid points in filled cylinder blocks is
+      // what is expected by ZernikeB2. The Zernike disk is fully specified by
+      // either the number of radial points or the number of theta points, so
+      // check that they relate as expected.
+      const size_t num_theta_modes =
+          gsl::at(gsl::at(initial_grid_points_, position), 1) / 2;
+      const size_t expected_num_r_points =
+          (num_theta_modes / 2) + 1 + (num_theta_modes % 2);
+      if (gsl::at(gsl::at(initial_grid_points_, position), 0) !=
+          expected_num_r_points) {
+        PARSE_ERROR(context,
+                    "Filled cylinder blocks must have "
+                    "num_r_points = ((num_theta_points / 2) / 2) + 1 + "
+                    "((num_theta_points / 2) % 2). Specify grid points for "
+                        << name << " as [num_radial_points, num_z_points].");
+      }
     }
-    // For spherical-harmonic outer-shell blocks, initial_number_of_grid_points_
-    // stores {n_radial, l_max, m_max}. Convert (l_max, m_max) to the number of
-    // collocation points the spherical-harmonic basis uses in each angular
-    // direction.
-    initial_grid_points_[first_inner_shell_A_block][1] =
-        ylm::Spherepack::n_theta_points(
-            gsl::at(initial_grid_points_, first_inner_shell_A_block)[1]);
-    initial_grid_points_[first_inner_shell_A_block][2] =
-        ylm::Spherepack::n_phi_points(
-            gsl::at(initial_grid_points_, first_inner_shell_A_block)[2]);
-  }
-  if (include_inner_sphere_B_) {
-    if (initial_grid_points_[first_inner_shell_B_block][1] !=
-        initial_grid_points_[first_inner_shell_B_block][2]) {
-      PARSE_ERROR(
-          context,
-          "Spherical-harmonic inner-shell blocks must have L_max = M_max. "
-          "Specify grid points for InnerSphereB as [radial_points, L_max].");
+    if (name.find("Cylinder") != std::string::npos) {
+      // Validate number of angular grid points in all cylindrical blocks are
+      // odd.
+      if (gsl::at(gsl::at(initial_grid_points_, position), 1) % 2 == 0) {
+        PARSE_ERROR(context,
+                    "Cylindrical block "
+                        << name
+                        << " must have an odd number of angular grid points.");
+      }
+    } else if (name.find("Shell") != std::string::npos) {
+      // For spherical-harmonic shell blocks, initial_number_of_grid_points_
+      // stores {n_radial, l_max, m_max}. First validate that l_max == m_max,
+      // then convert (l_max, m_max) to the number of collocation points the
+      // spherical-harmonic basis uses in each angular direction.
+      const size_t l_max = gsl::at(gsl::at(initial_grid_points_, position), 1);
+      const size_t m_max = gsl::at(gsl::at(initial_grid_points_, position), 2);
+      if (l_max != m_max) {
+        PARSE_ERROR(context,
+                    "Spherical-harmonic shell blocks must have L_max = M_max. "
+                    "Specify grid points for "
+                        << name << " as [radial_points, L_max].");
+      }
+      initial_grid_points_[position][1] = ylm::Spherepack::n_theta_points(
+          gsl::at(gsl::at(initial_grid_points_, position), 1));
+      initial_grid_points_[position][2] = ylm::Spherepack::n_phi_points(
+          gsl::at(gsl::at(initial_grid_points_, position), 2));
     }
-    initial_grid_points_[first_inner_shell_B_block][1] =
-        ylm::Spherepack::n_theta_points(
-            gsl::at(initial_grid_points_, first_inner_shell_B_block)[1]);
-    initial_grid_points_[first_inner_shell_B_block][2] =
-        ylm::Spherepack::n_phi_points(
-            gsl::at(initial_grid_points_, first_inner_shell_B_block)[2]);
-  }
-  if (initial_grid_points_[first_outer_shell_block][1] !=
-      initial_grid_points_[first_outer_shell_block][2]) {
-    PARSE_ERROR(
-        context,
-        "Spherical-harmonic outer-shell blocks must have L_max = M_max. "
-        "Specify grid points for OuterSphere as [radial_points, L_max].");
-  }
-
-  initial_grid_points_[first_outer_shell_block][1] =
-      ylm::Spherepack::n_theta_points(
-          gsl::at(initial_grid_points_, first_outer_shell_block)[1]);
-  initial_grid_points_[first_outer_shell_block][2] =
-      ylm::Spherepack::n_phi_points(
-          gsl::at(initial_grid_points_, first_outer_shell_block)[2]);
-
-  // Now we must change the initial refinement and initial grid points
-  // for certain blocks, because the [r, theta, perp] directions do
-  // not always correspond to [xi, eta, zeta].  The values in
-  // initial_refinement_ must correspond to [xi, eta, zeta].
-  //
-  // In particular, for cylinders: [xi, eta, zeta] = [r, theta, perp]
-  // but for filled cylinders: [xi, eta, zeta] = [perp, theta, r].
-
-  auto swap_refinement_and_grid_points_xi_zeta = [this](const size_t block_id) {
-    size_t val = gsl::at(initial_refinement_[block_id], 0);
-    gsl::at(initial_refinement_[block_id], 0) =
-        gsl::at(initial_refinement_[block_id], 2);
-    gsl::at(initial_refinement_[block_id], 2) = val;
-    val = gsl::at(initial_grid_points_[block_id], 0);
-    gsl::at(initial_grid_points_[block_id], 0) =
-        gsl::at(initial_grid_points_[block_id], 2);
-    gsl::at(initial_grid_points_[block_id], 2) = val;
-  };
-
-  // CA Filled Cylinder
-  // 5 blocks: 0 thru 4
-  for (size_t block = 0; block < 5; ++block) {
-    swap_refinement_and_grid_points_xi_zeta(block);
-  }
-
-  // EA Filled Cylinder
-  // 5 blocks: 9 thru 13
-  for (size_t block = 9; block < 14; ++block) {
-    swap_refinement_and_grid_points_xi_zeta(block);
-  }
-
-  // EB Filled Cylinder
-  // 5 blocks: 18 thru 22
-  for (size_t block = 18; block < 23; ++block) {
-    swap_refinement_and_grid_points_xi_zeta(block);
-  }
-
-  // MA Filled Cylinder
-  // 5 blocks: 27 thru 31
-  // MB Filled Cylinder
-  // 5 blocks: 32 thru 36
-  // CB Filled Cylinder
-  // 5 blocks: 37 thru 41
-  for (size_t block = 27; block < 42; ++block) {
-    swap_refinement_and_grid_points_xi_zeta(block);
   }
 
   // Build time-dependent maps
@@ -529,6 +520,13 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const {
       Direction<3>::lower_zeta(), Direction<3>::upper_eta(),
       Direction<3>::upper_xi()}};
 
+  // 180 degree rotation about a cylinder's axis
+  const OrientationMap<3> half_turn_about_zeta{std::array<Direction<3>, 3>{
+      Direction<3>::lower_xi(), Direction<3>::lower_eta(),
+      Direction<3>::upper_zeta()}};
+
+  const OrientationMap<3> aligned = OrientationMap<3>::create_aligned();
+
   const std::array<double, 3> center_cutting_plane = {0.0, 0.0,
                                                       z_cutting_plane_};
 
@@ -555,120 +553,75 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const {
   const double radius_EB =
       sqrt(2.0) * std::abs(center_EB[2] - z_cutting_plane_);
 
-  // Construct vector<CoordMap>s that go from logical coordinates to
-  // various blocks making up a unit right cylinder.  These blocks are
-  // either the central square blocks, or the surrounding wedge
-  // blocks. The radii and bounds are what are expected by the
-  // UniformCylindricalEndcap maps, (except cylinder_inner_radius, which
-  // determines the internal block boundaries inside the cylinder, and
-  // which the UniformCylindricalEndcap maps don't care about).
-  const double cylinder_inner_radius = 0.5;
+  // Construct a coordinate map that goes from logical coordinates to a unit
+  // right cylinder block. The radii and bounds are what are expected by the
+  // UniformCylindricalEndCap and UniformCylindricalFlatEndCap maps.
+  const double cylinder_inner_radius = 0.0;
   const double cylinder_outer_radius = 1.0;
   const double cylinder_lower_bound_z = -1.0;
   const double cylinder_upper_bound_z = 1.0;
-  const auto logical_to_cylinder_center_maps =
-      cyl_wedge_coord_map_center_blocks(
-          cylinder_inner_radius, cylinder_lower_bound_z, cylinder_upper_bound_z,
-          use_equiangular_map_);
-  const auto logical_to_cylinder_surrounding_maps =
-      cyl_wedge_coord_map_surrounding_blocks(
-          cylinder_inner_radius, cylinder_outer_radius, cylinder_lower_bound_z,
-          cylinder_upper_bound_z, use_equiangular_map_, 0.0);
 
-  // Lambda that takes a UniformCylindricalEndcap map and a
-  // DiscreteRotation map, composes it with the logical-to-cylinder
-  // maps, and adds it to the list of coordinate maps. Also adds
-  // boundary conditions if requested.
+  const auto logical_to_cylinder_map =
+      cyl_coordinate_map(cylinder_inner_radius, cylinder_outer_radius,
+                         cylinder_lower_bound_z, cylinder_upper_bound_z);
+
+  // Lambda that takes a pre-rotation map, a UniformCylindricalEndcap or a
+  // UniformCylindricalFlatEndcap map and a DiscreteRotation map, composes it
+  // with the logical-to-cylinder map, and adds it to the list of
+  // coordinate maps. Also adds boundary conditions if requested. The
+  // pre-rotation map is used by blocks at the cutting plane to achieve nodal
+  // alignment with their block neighbor on the other side of the plane.
   auto add_endcap_to_list_of_maps =
-      [&coordinate_maps, &logical_to_cylinder_center_maps,
-       &logical_to_cylinder_surrounding_maps](
-          const CoordinateMaps::UniformCylindricalEndcap& endcap_map,
+      [&coordinate_maps, &logical_to_cylinder_map](
+          const CoordinateMaps::DiscreteRotation<3>& pre_rotation_map,
+          const auto& endcap_map,
           const CoordinateMaps::DiscreteRotation<3>& rotation_map) {
-        auto new_logical_to_cylinder_center_maps =
-            domain::make_vector_coordinate_map_base<Frame::BlockLogical,
-                                                    Frame::Inertial, 3>(
-                logical_to_cylinder_center_maps, endcap_map, rotation_map);
-        coordinate_maps.insert(
-            coordinate_maps.end(),
-            std::make_move_iterator(
-                new_logical_to_cylinder_center_maps.begin()),
-            std::make_move_iterator(new_logical_to_cylinder_center_maps.end()));
-        auto new_logical_to_cylinder_surrounding_maps =
-            domain::make_vector_coordinate_map_base<Frame::BlockLogical,
-                                                    Frame::Inertial, 3>(
-                logical_to_cylinder_surrounding_maps, endcap_map, rotation_map);
-        coordinate_maps.insert(
-            coordinate_maps.end(),
-            std::make_move_iterator(
-                new_logical_to_cylinder_surrounding_maps.begin()),
-            std::make_move_iterator(
-                new_logical_to_cylinder_surrounding_maps.end()));
+        auto new_logical_to_cylinder_map = ::domain::push_back(
+            ::domain::push_back(
+                ::domain::push_back(logical_to_cylinder_map, pre_rotation_map),
+                endcap_map),
+            rotation_map);
+
+        coordinate_maps.emplace_back(
+            std::make_unique<
+                std::decay_t<decltype(new_logical_to_cylinder_map)>>(
+                std::move(new_logical_to_cylinder_map)));
       };
 
-  // Lambda that takes a UniformCylindricalFlatEndcap map and a
-  // DiscreteRotation map, composes it with the logical-to-cylinder
-  // maps, and adds it to the list of coordinate maps. Also adds
-  // boundary conditions if requested.
-  auto add_flat_endcap_to_list_of_maps =
-      [&coordinate_maps, &logical_to_cylinder_center_maps,
-       &logical_to_cylinder_surrounding_maps](
-          const CoordinateMaps::UniformCylindricalFlatEndcap& endcap_map,
-          const CoordinateMaps::DiscreteRotation<3>& rotation_map) {
-        auto new_logical_to_cylinder_center_maps =
-            domain::make_vector_coordinate_map_base<Frame::BlockLogical,
-                                                    Frame::Inertial, 3>(
-                logical_to_cylinder_center_maps, endcap_map, rotation_map);
-        coordinate_maps.insert(
-            coordinate_maps.end(),
-            std::make_move_iterator(
-                new_logical_to_cylinder_center_maps.begin()),
-            std::make_move_iterator(new_logical_to_cylinder_center_maps.end()));
-        auto new_logical_to_cylinder_surrounding_maps =
-            domain::make_vector_coordinate_map_base<Frame::BlockLogical,
-                                                    Frame::Inertial, 3>(
-                logical_to_cylinder_surrounding_maps, endcap_map, rotation_map);
-        coordinate_maps.insert(
-            coordinate_maps.end(),
-            std::make_move_iterator(
-                new_logical_to_cylinder_surrounding_maps.begin()),
-            std::make_move_iterator(
-                new_logical_to_cylinder_surrounding_maps.end()));
-      };
-
-  // Construct vector<CoordMap>s that go from logical coordinates to
-  // various blocks making up a right cylindrical shell of inner radius 1,
-  // outer radius 2, and z-extents from -1 to +1.  These blocks are
-  // either the central square blocks, or the surrounding wedge
-  // blocks. The radii and bounds are what are expected by the
-  // UniformCylindricalEndcap maps.
+  // Construct a coordinate map that goes from logical coordinates to a unit
+  // right cylindrical shell block. The radii and bounds are what are expected
+  // by the UniformCylindricalSide map.
   const double cylindrical_shell_inner_radius = 1.0;
   const double cylindrical_shell_outer_radius = 2.0;
   const double cylindrical_shell_lower_bound_z = -1.0;
   const double cylindrical_shell_upper_bound_z = 1.0;
-  const auto logical_to_cylindrical_shell_maps =
-      cyl_wedge_coord_map_surrounding_blocks(
-          cylindrical_shell_inner_radius, cylindrical_shell_outer_radius,
-          cylindrical_shell_lower_bound_z, cylindrical_shell_upper_bound_z,
-          use_equiangular_map_, 1.0);
 
-  // Lambda that takes a UniformCylindricalSide map and a DiscreteRotation
-  // map, composes it with the logical-to-cylinder maps, and adds it
-  // to the list of coordinate maps.  Also adds boundary conditions if
-  // requested.
+  const auto logical_to_cylindrical_shell_map = cyl_coordinate_map(
+      cylindrical_shell_inner_radius, cylindrical_shell_outer_radius,
+      cylindrical_shell_lower_bound_z, cylindrical_shell_upper_bound_z);
+
+  // Lambda that takes a pre-rotation map, a UniformCylindricalSide map, and a
+  // DiscreteRotation map, composes it with the logical-to-cylinder maps, and
+  // adds it to the list of coordinate maps.  Also adds boundary conditions if
+  // requested.  The pre-rotation map is used by blocks at the cutting plane to
+  // achieve nodal alignment with their block neighbor on the other side of the
+  // plane.
   auto add_side_to_list_of_maps =
-      [&coordinate_maps, &logical_to_cylindrical_shell_maps](
+      [&coordinate_maps, &logical_to_cylindrical_shell_map](
+          const CoordinateMaps::DiscreteRotation<3>& pre_rotation_map,
           const CoordinateMaps::UniformCylindricalSide& side_map,
           const CoordinateMaps::DiscreteRotation<3>& rotation_map) {
-        auto new_logical_to_cylindrical_shell_maps =
-            domain::make_vector_coordinate_map_base<Frame::BlockLogical,
-                                                    Frame::Inertial, 3>(
-                logical_to_cylindrical_shell_maps, side_map, rotation_map);
-        coordinate_maps.insert(
-            coordinate_maps.end(),
-            std::make_move_iterator(
-                new_logical_to_cylindrical_shell_maps.begin()),
-            std::make_move_iterator(
-                new_logical_to_cylindrical_shell_maps.end()));
+        auto new_logical_to_cylindrical_shell_map = ::domain::push_back(
+            ::domain::push_back(
+                ::domain::push_back(logical_to_cylindrical_shell_map,
+                                    pre_rotation_map),
+                side_map),
+            rotation_map);
+
+        coordinate_maps.emplace_back(
+            std::make_unique<
+                std::decay_t<decltype(new_logical_to_cylindrical_shell_map)>>(
+                std::move(new_logical_to_cylindrical_shell_map)));
       };
 
   // Inner radius of the outer C shell.
@@ -698,16 +651,16 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const {
   const double z_cut_EA_lower = center_A_[2] - 0.7 * outer_radius_A_;
 
   // CA Filled Cylinder
-  // 5 blocks: 0 thru 4
   add_endcap_to_list_of_maps(
+      CoordinateMaps::DiscreteRotation<3>(aligned),
       CoordinateMaps::UniformCylindricalEndcap(center_EA, make_array<3>(0.0),
                                                radius_EA, inner_radius_C,
                                                z_cut_CA_lower, z_cut_CA_upper),
       CoordinateMaps::DiscreteRotation<3>(rotate_to_x_axis));
 
   // CA Cylinder
-  // 4 blocks: 5 thru 8
   add_side_to_list_of_maps(
+      CoordinateMaps::DiscreteRotation<3>(aligned),
       CoordinateMaps::UniformCylindricalSide(
           // codecov complains about the next line being untested.
           // No idea why, since this entire function is called.
@@ -718,16 +671,16 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const {
       CoordinateMaps::DiscreteRotation<3>(rotate_to_x_axis));
 
   // EA Filled Cylinder
-  // 5 blocks: 9 thru 13
   add_endcap_to_list_of_maps(
+      CoordinateMaps::DiscreteRotation<3>(aligned),
       CoordinateMaps::UniformCylindricalEndcap(center_A_, center_EA,
                                                outer_radius_A_, radius_EA,
                                                z_cut_EA_upper, z_cut_CA_lower),
       CoordinateMaps::DiscreteRotation<3>(rotate_to_x_axis));
 
   // EA Cylinder
-  // 4 blocks: 14 thru 17
   add_side_to_list_of_maps(
+      CoordinateMaps::DiscreteRotation<3>(aligned),
       // For some reason codecov complains about the next line.
       CoordinateMaps::UniformCylindricalSide(  // LCOV_EXCL_LINE
           center_A_, center_EA, outer_radius_A_, radius_EA, z_cut_EA_upper,
@@ -763,16 +716,16 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const {
   const double z_cut_EB_lower = center_B_[2] + 0.7 * outer_radius_B_;
 
   // EB Filled Cylinder
-  // 5 blocks: 18 thru 22
   add_endcap_to_list_of_maps(
+      CoordinateMaps::DiscreteRotation<3>(half_turn_about_zeta),
       CoordinateMaps::UniformCylindricalEndcap(
           flip_about_xy_plane(center_B_), flip_about_xy_plane(center_EB),
           outer_radius_B_, radius_EB, -z_cut_EB_upper, -z_cut_CB_lower),
       CoordinateMaps::DiscreteRotation<3>(rotate_to_minus_x_axis));
 
   // EB Cylinder
-  // 4 blocks: 23 thru 26
   add_side_to_list_of_maps(
+      CoordinateMaps::DiscreteRotation<3>(half_turn_about_zeta),
       CoordinateMaps::UniformCylindricalSide(
           flip_about_xy_plane(center_B_), flip_about_xy_plane(center_EB),
           outer_radius_B_, radius_EB, -z_cut_EB_upper, -z_cut_EB_lower,
@@ -780,16 +733,16 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const {
       CoordinateMaps::DiscreteRotation<3>(rotate_to_minus_x_axis));
 
   // MA Filled Cylinder
-  // 5 blocks: 27 thru 31
-  add_flat_endcap_to_list_of_maps(
+  add_endcap_to_list_of_maps(
+      CoordinateMaps::DiscreteRotation<3>(half_turn_about_zeta),
       CoordinateMaps::UniformCylindricalFlatEndcap(
           flip_about_xy_plane(center_A_),
           flip_about_xy_plane(center_cutting_plane), outer_radius_A_, radius_MB,
           -z_cut_EA_lower),
       CoordinateMaps::DiscreteRotation<3>(rotate_to_minus_x_axis));
   // MB Filled Cylinder
-  // 5 blocks: 32 thru 36
-  add_flat_endcap_to_list_of_maps(
+  add_endcap_to_list_of_maps(
+      CoordinateMaps::DiscreteRotation<3>(aligned),
       // For some reason codecov complains about the next line.
       CoordinateMaps::UniformCylindricalFlatEndcap(  // LCOV_EXCL_LINE
           center_B_, center_cutting_plane, outer_radius_B_, radius_MB,
@@ -797,45 +750,52 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const {
       CoordinateMaps::DiscreteRotation<3>(rotate_to_x_axis));
 
   // CB Filled Cylinder
-  // 5 blocks: 37 thru 41
   add_endcap_to_list_of_maps(
+      CoordinateMaps::DiscreteRotation<3>(half_turn_about_zeta),
       CoordinateMaps::UniformCylindricalEndcap(
           flip_about_xy_plane(center_EB), make_array<3>(0.0), radius_EB,
           inner_radius_C, -z_cut_CB_lower, -z_cut_CB_upper),
       CoordinateMaps::DiscreteRotation<3>(rotate_to_minus_x_axis));
 
   // CB Cylinder
-  // 4 blocks: 42 thru 45
   add_side_to_list_of_maps(
+      CoordinateMaps::DiscreteRotation<3>(half_turn_about_zeta),
       CoordinateMaps::UniformCylindricalSide(
           flip_about_xy_plane(center_EB), make_array<3>(0.0), radius_EB,
           inner_radius_C, -z_cut_CB_lower, -z_cutting_plane_, -z_cut_CB_upper,
           -z_cutting_plane_),
       CoordinateMaps::DiscreteRotation<3>(rotate_to_minus_x_axis));
 
+  const size_t ea_endcap_block = block_positions_.at("EAFilledCylinder");
+  const size_t ea_side_block = block_positions_.at("EACylinder");
+  const size_t ma_endcap_block = block_positions_.at("MAFilledCylinder");
+  const size_t eb_endcap_block = block_positions_.at("EBFilledCylinder");
+  const size_t eb_side_block = block_positions_.at("EBCylinder");
+  const size_t mb_endcap_block = block_positions_.at("MBFilledCylinder");
+  const size_t ca_endcap_block = block_positions_.at("CAFilledCylinder");
+  const size_t ca_side_block = block_positions_.at("CACylinder");
+  const size_t cb_endcap_block = block_positions_.at("CBFilledCylinder");
+  const size_t cb_side_block = block_positions_.at("CBCylinder");
+
   // Excision spheres
   std::unordered_map<std::string, ExcisionSphere<3>> excision_spheres{};
 
   std::unordered_map<size_t, Direction<3>> abutting_directions_A;
-  const size_t first_inner_shell_A_block = 46;
-  size_t first_inner_shell_B_block = first_inner_shell_A_block;
+  const size_t inner_shell_A_block = 10;  // 46;
+  size_t inner_shell_B_block = inner_shell_A_block;
   if (include_inner_sphere_A_) {
     // LCOV_EXCL_START
-    abutting_directions_A.emplace(first_inner_shell_A_block,
+    abutting_directions_A.emplace(inner_shell_A_block,
                                   Direction<3>::lower_xi());
     // LCOV_EXCL_STOP
 
     // Block numbers of sphereB might depend on whether there is an inner
     // sphereA layer, so increment here to get that right.
-    first_inner_shell_B_block += 1;
+    inner_shell_B_block += 1;
   } else {
-    for (size_t i = 0; i < 5; ++i) {
-      abutting_directions_A.emplace(9 + i, Direction<3>::lower_zeta());
-      abutting_directions_A.emplace(27 + i, Direction<3>::lower_zeta());
-    }
-    for (size_t i = 0; i < 4; ++i) {
-      abutting_directions_A.emplace(14 + i, Direction<3>::lower_xi());
-    }
+    abutting_directions_A.emplace(ea_endcap_block, Direction<3>::lower_zeta());
+    abutting_directions_A.emplace(ma_endcap_block, Direction<3>::lower_zeta());
+    abutting_directions_A.emplace(ea_side_block, Direction<3>::lower_xi());
   }
   excision_spheres.emplace(
       "ExcisionSphereA",
@@ -847,17 +807,13 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const {
   std::unordered_map<size_t, Direction<3>> abutting_directions_B;
   if (include_inner_sphere_B_) {
     // LCOV_EXCL_START
-    abutting_directions_B.emplace(first_inner_shell_B_block,
+    abutting_directions_B.emplace(inner_shell_B_block,
                                   Direction<3>::lower_xi());
     // LCOV_EXCL_STOP
   } else {
-    for (size_t i = 0; i < 5; ++i) {
-      abutting_directions_B.emplace(18 + i, Direction<3>::lower_zeta());
-      abutting_directions_B.emplace(32 + i, Direction<3>::lower_zeta());
-    }
-    for (size_t i = 0; i < 4; ++i) {
-      abutting_directions_B.emplace(23 + i, Direction<3>::lower_xi());
-    }
+    abutting_directions_B.emplace(eb_endcap_block, Direction<3>::lower_zeta());
+    abutting_directions_B.emplace(mb_endcap_block, Direction<3>::lower_zeta());
+    abutting_directions_B.emplace(eb_side_block, Direction<3>::lower_xi());
   }
   excision_spheres.emplace(
       "ExcisionSphereB",
@@ -867,29 +823,143 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const {
           abutting_directions_B});
 
   Domain<3> domain;
-  // `coordinate_maps` at this point contains the inner non-shell maps.
-  // Total =  num_shells + n_interior_cubes entries
-  // We determine auto-topology neighbors for these inner maps
-  std::vector<DirectionMap<3, BlockNeighbors<3>>> inner_neighbors;
-  set_internal_boundaries<3>(make_not_null(&inner_neighbors), coordinate_maps);
+  // non-shell maps
+  std::vector<DirectionMap<3, BlockNeighbors<3>>> inner_neighbors{
+      coordinate_maps.size()};
+
+  // Add a cylinder as a neighor of a cylinder
+  auto add_cyl_cyl_block_neighbor =
+      [](std::vector<DirectionMap<3, BlockNeighbors<3>>>& neighbors,
+         const size_t this_block_number, const size_t neighbor_block_number,
+         const Direction<3>& direction,
+         const OrientationMap<3>& orientation_map) {
+        neighbors[this_block_number].emplace(
+            direction,
+            BlockNeighbors<3>{{neighbor_block_number},
+                              {{neighbor_block_number, orientation_map}},
+                              /*are_conforming=*/true});
+      };
+
+  // EA Filled Cylinder
+  add_cyl_cyl_block_neighbor(
+      inner_neighbors, ea_endcap_block, ea_side_block, Direction<3>::upper_xi(),
+      OrientationMap<3>{{{Direction<3>::lower_zeta(), Direction<3>::upper_eta(),
+                          Direction<3>::upper_xi()}}});
+  add_cyl_cyl_block_neighbor(inner_neighbors, ea_endcap_block, ca_endcap_block,
+                             Direction<3>::upper_zeta(), aligned);
+
+  // EA Cylinder
+  add_cyl_cyl_block_neighbor(
+      inner_neighbors, ea_side_block, ea_endcap_block,
+      Direction<3>::upper_zeta(),
+      OrientationMap<3>{{{Direction<3>::upper_zeta(), Direction<3>::upper_eta(),
+                          Direction<3>::lower_xi()}}});
+  add_cyl_cyl_block_neighbor(
+      inner_neighbors, ea_side_block, ma_endcap_block,
+      Direction<3>::lower_zeta(),
+      OrientationMap<3>{{{Direction<3>::upper_zeta(), Direction<3>::lower_eta(),
+                          Direction<3>::upper_xi()}}});
+  add_cyl_cyl_block_neighbor(inner_neighbors, ea_side_block, ca_side_block,
+                             Direction<3>::upper_xi(), aligned);
+
+  // MA Filled Cylinder
+  add_cyl_cyl_block_neighbor(
+      inner_neighbors, ma_endcap_block, ea_side_block, Direction<3>::upper_xi(),
+      OrientationMap<3>{{{Direction<3>::upper_zeta(), Direction<3>::lower_eta(),
+                          Direction<3>::upper_xi()}}});
+  add_cyl_cyl_block_neighbor(
+      inner_neighbors, ma_endcap_block, mb_endcap_block,
+      Direction<3>::upper_zeta(),
+      OrientationMap<3>{{{Direction<3>::upper_xi(), Direction<3>::lower_eta(),
+                          Direction<3>::lower_zeta()}}});
+
+  // CA Filled Cylinder
+  add_cyl_cyl_block_neighbor(
+      inner_neighbors, ca_endcap_block, ca_side_block, Direction<3>::upper_xi(),
+      OrientationMap<3>{{{Direction<3>::lower_zeta(), Direction<3>::upper_eta(),
+                          Direction<3>::upper_xi()}}});
+  add_cyl_cyl_block_neighbor(inner_neighbors, ca_endcap_block, ea_endcap_block,
+                             Direction<3>::lower_zeta(), aligned);
+
+  // CA Cylinder
+  add_cyl_cyl_block_neighbor(
+      inner_neighbors, ca_side_block, ca_endcap_block,
+      Direction<3>::upper_zeta(),
+      OrientationMap<3>{{{Direction<3>::upper_zeta(), Direction<3>::upper_eta(),
+                          Direction<3>::lower_xi()}}});
+  add_cyl_cyl_block_neighbor(
+      inner_neighbors, ca_side_block, cb_side_block, Direction<3>::lower_zeta(),
+      OrientationMap<3>{{{Direction<3>::upper_xi(), Direction<3>::lower_eta(),
+                          Direction<3>::lower_zeta()}}});
+  add_cyl_cyl_block_neighbor(inner_neighbors, ca_side_block, ea_side_block,
+                             Direction<3>::lower_xi(), aligned);
+
+  // EB Filled Cylinder
+  add_cyl_cyl_block_neighbor(
+      inner_neighbors, eb_endcap_block, eb_side_block, Direction<3>::upper_xi(),
+      OrientationMap<3>{{{Direction<3>::lower_zeta(), Direction<3>::upper_eta(),
+                          Direction<3>::upper_xi()}}});
+  add_cyl_cyl_block_neighbor(inner_neighbors, eb_endcap_block, cb_endcap_block,
+                             Direction<3>::upper_zeta(), aligned);
+
+  // EB Cylinder
+  add_cyl_cyl_block_neighbor(
+      inner_neighbors, eb_side_block, eb_endcap_block,
+      Direction<3>::upper_zeta(),
+      OrientationMap<3>{{{Direction<3>::upper_zeta(), Direction<3>::upper_eta(),
+                          Direction<3>::lower_xi()}}});
+  add_cyl_cyl_block_neighbor(
+      inner_neighbors, eb_side_block, mb_endcap_block,
+      Direction<3>::lower_zeta(),
+      OrientationMap<3>{{{Direction<3>::upper_zeta(), Direction<3>::lower_eta(),
+                          Direction<3>::upper_xi()}}});
+  add_cyl_cyl_block_neighbor(inner_neighbors, eb_side_block, cb_side_block,
+                             Direction<3>::upper_xi(), aligned);
+
+  // MB Filled Cylinder
+  add_cyl_cyl_block_neighbor(
+      inner_neighbors, mb_endcap_block, eb_side_block, Direction<3>::upper_xi(),
+      OrientationMap<3>{{{Direction<3>::upper_zeta(), Direction<3>::lower_eta(),
+                          Direction<3>::upper_xi()}}});
+  add_cyl_cyl_block_neighbor(
+      inner_neighbors, mb_endcap_block, ma_endcap_block,
+      Direction<3>::upper_zeta(),
+      OrientationMap<3>{{{Direction<3>::upper_xi(), Direction<3>::lower_eta(),
+                          Direction<3>::lower_zeta()}}});
+
+  // CB Filled Cylinder
+  add_cyl_cyl_block_neighbor(
+      inner_neighbors, cb_endcap_block, cb_side_block, Direction<3>::upper_xi(),
+      OrientationMap<3>{{{Direction<3>::lower_zeta(), Direction<3>::upper_eta(),
+                          Direction<3>::upper_xi()}}});
+  add_cyl_cyl_block_neighbor(inner_neighbors, cb_endcap_block, eb_endcap_block,
+                             Direction<3>::lower_zeta(), aligned);
+
+  // CB Cylinder
+  add_cyl_cyl_block_neighbor(
+      inner_neighbors, cb_side_block, cb_endcap_block,
+      Direction<3>::upper_zeta(),
+      OrientationMap<3>{{{Direction<3>::upper_zeta(), Direction<3>::upper_eta(),
+                          Direction<3>::lower_xi()}}});
+  add_cyl_cyl_block_neighbor(
+      inner_neighbors, cb_side_block, ca_side_block, Direction<3>::lower_zeta(),
+      OrientationMap<3>{{{Direction<3>::upper_xi(), Direction<3>::lower_eta(),
+                          Direction<3>::lower_zeta()}}});
+  add_cyl_cyl_block_neighbor(inner_neighbors, cb_side_block, eb_side_block,
+                             Direction<3>::lower_xi(), aligned);
 
   // Connect the E sphere cylinder blocks to the outermost inner shells and
   // connect the C sphere cylinder blocks to the innermost outer shell
-  const OrientationMap<3> shell_to_cyl_endcap_center{
+  const OrientationMap<3> shell_to_cyl_endcap{
       {{Direction<3>::upper_zeta(), Direction<3>::self(),
         Direction<3>::self()}}};
-  const auto cyl_endcap_center_to_shell =
-      shell_to_cyl_endcap_center.inverse_map();
-  const OrientationMap<3> shell_to_cyl_endcap_wedge{
-      {{Direction<3>::upper_zeta(), Direction<3>::self(),
-        Direction<3>::self()}}};
-  const auto cyl_endcap_wedge_to_shell =
-      shell_to_cyl_endcap_wedge.inverse_map();
+  const auto cyl_endcap_to_shell =
+      shell_to_cyl_endcap.inverse_map();
   const OrientationMap<3> shell_to_cyl_side{
       {{Direction<3>::upper_xi(), Direction<3>::self(), Direction<3>::self()}}};
   const auto cyl_side_to_shell = shell_to_cyl_side.inverse_map();
 
-  // Add a shell as a neighor of one of the blocks making up a cylinder
+  // Add a spherical shell as a neighor of one of a cylinder
   auto add_cyl_shell_block_neighbor =
       [](std::vector<DirectionMap<3, BlockNeighbors<3>>>& neighbors,
          const bool cyl_is_filled, const bool shell_is_outside_cyl,
@@ -908,134 +978,83 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const {
                               /*are_conforming=*/false});
       };
 
-  // Add a shell as a neighor of each of the blocks making up a cylindrical
-  // endcap
-  auto add_cyl_endcap_shell_neighbors =
-      [&add_cyl_shell_block_neighbor, &cyl_endcap_center_to_shell,
-       &cyl_endcap_wedge_to_shell](
-          std::vector<DirectionMap<3, BlockNeighbors<3>>>& neighbors,
-          const bool shell_is_outside_cyl, const size_t first_cyl_block_number,
-          const size_t shell_block_number) {
-        const bool cyl_is_filled = true;
-        add_cyl_shell_block_neighbor(neighbors, cyl_is_filled,
-                                     shell_is_outside_cyl,
-                                     first_cyl_block_number, shell_block_number,
-                                     cyl_endcap_center_to_shell);
-        for (size_t j = first_cyl_block_number + 1;
-             j < first_cyl_block_number + 5; j++) {
-          add_cyl_shell_block_neighbor(
-              neighbors, cyl_is_filled, shell_is_outside_cyl, j,
-              shell_block_number, cyl_endcap_wedge_to_shell);
-        }
-      };
-
-  // Add a shell as a neighor of each of the blocks making up a cylindrical side
-  auto add_cyl_side_shell_neighbors =
-      [&add_cyl_shell_block_neighbor, &cyl_side_to_shell](
-          std::vector<DirectionMap<3, BlockNeighbors<3>>>& neighbors,
-          const bool shell_is_outside_cyl, const size_t first_cyl_block_number,
-          const size_t shell_block_number) {
-        const bool cyl_is_filled = false;
-        for (size_t j = first_cyl_block_number; j < first_cyl_block_number + 4;
-             j++) {
-          add_cyl_shell_block_neighbor(neighbors, cyl_is_filled,
-                                       shell_is_outside_cyl, j,
-                                       shell_block_number, cyl_side_to_shell);
-        }
-      };
-
-  const size_t first_ea_endcap_block = 9;
-  const size_t first_ea_side_block = 14;
-  const size_t first_ma_endcap_block = 27;
-
   if (include_inner_sphere_A_) {
     // EA Filled Cylinder
-    add_cyl_endcap_shell_neighbors(inner_neighbors, false,
-                                   first_ea_endcap_block,
-                                   first_inner_shell_A_block);
+    add_cyl_shell_block_neighbor(inner_neighbors, true, false, ea_endcap_block,
+                                 inner_shell_A_block, cyl_endcap_to_shell);
     // EA Cylinder
-    add_cyl_side_shell_neighbors(inner_neighbors, false, first_ea_side_block,
-                                 first_inner_shell_A_block);
+    add_cyl_shell_block_neighbor(inner_neighbors, false, false, ea_side_block,
+                                 inner_shell_A_block, cyl_side_to_shell);
     // MA Filled Cylinder
-    add_cyl_endcap_shell_neighbors(inner_neighbors, false,
-                                   first_ma_endcap_block,
-                                   first_inner_shell_A_block);
+    add_cyl_shell_block_neighbor(inner_neighbors, true, false, ma_endcap_block,
+                                 inner_shell_A_block, cyl_endcap_to_shell);
   }
-
-  const size_t first_eb_endcap_block = 18;
-  const size_t first_eb_side_block = 23;
-  const size_t first_mb_endcap_block = 32;
 
   if (include_inner_sphere_B_) {
     // EB Filled Cylinder
-    add_cyl_endcap_shell_neighbors(inner_neighbors, false,
-                                   first_eb_endcap_block,
-                                   first_inner_shell_B_block);
+    add_cyl_shell_block_neighbor(inner_neighbors, true, false, eb_endcap_block,
+                                 inner_shell_B_block, cyl_endcap_to_shell);
     // EB Cylinder
-    add_cyl_side_shell_neighbors(inner_neighbors, false, first_eb_side_block,
-                                 first_inner_shell_B_block);
+    add_cyl_shell_block_neighbor(inner_neighbors, false, false, eb_side_block,
+                                 inner_shell_B_block, cyl_side_to_shell);
     // MB Filled Cylinder
-    add_cyl_endcap_shell_neighbors(inner_neighbors, false,
-                                   first_mb_endcap_block,
-                                   first_inner_shell_B_block);
+    add_cyl_shell_block_neighbor(inner_neighbors, true, false, mb_endcap_block,
+                                 inner_shell_B_block, cyl_endcap_to_shell);
   }
 
-  const size_t first_ca_endcap_block = 0;
-  const size_t first_ca_side_block = 5;
-  const size_t first_cb_endcap_block = 37;
-  const size_t first_cb_side_block = 42;
+  const size_t outer_shell_block = block_positions_.at("OuterShell0");
 
   // CA Filled Cylinder
-  add_cyl_endcap_shell_neighbors(inner_neighbors, true, first_ca_endcap_block,
-                                 first_outer_shell_block);
+  add_cyl_shell_block_neighbor(inner_neighbors, true, true, ca_endcap_block,
+                               outer_shell_block, cyl_endcap_to_shell);
   // CA Cylinder
-  add_cyl_side_shell_neighbors(inner_neighbors, true, first_ca_side_block,
-                               first_outer_shell_block);
+  add_cyl_shell_block_neighbor(inner_neighbors, false, true, ca_side_block,
+                               outer_shell_block, cyl_side_to_shell);
+
   // CB Filled Cylinder
-  add_cyl_endcap_shell_neighbors(inner_neighbors, true, first_cb_endcap_block,
-                                 first_outer_shell_block);
+  add_cyl_shell_block_neighbor(inner_neighbors, true, true, cb_endcap_block,
+                               outer_shell_block, cyl_endcap_to_shell);
   // CB Cylinder
-  add_cyl_side_shell_neighbors(inner_neighbors, true, first_cb_side_block,
-                               first_outer_shell_block);
+  add_cyl_shell_block_neighbor(inner_neighbors, false, true, cb_side_block,
+                               outer_shell_block, cyl_side_to_shell);
 
   // Build blocks in final order.
   std::vector<Block<3>> blocks;
   blocks.reserve(number_of_blocks_);
 
   // (a) Inner blocks before SH shells.
-  for (size_t j = 0; j < first_inner_shell_A_block; ++j) {
+  for (size_t j = 0; j < inner_shell_A_block; ++j) {
+    const std::string block_name = gsl::at(block_names_, j);
+    ASSERT(block_name.find("Cylinder") != std::string::npos,
+           "Expected block to be a cylindrical block with the substring "
+           "'Cylinder'.");
+
+    const auto cyl_topology = block_name.find("Filled") != std::string::npos ?
+        domain::topologies::full_cylinder :
+        domain::topologies::cylindrical_shell;
     blocks.emplace_back(std::move(coordinate_maps[j]), j,
-                        std::move(inner_neighbors[j]), block_names_[j]);
+                        std::move(inner_neighbors[j]), block_name,
+                        cyl_topology);
   }
 
-  // Add one of the blocks making up a cylindeical endcap as a neighbor of a
-  // shell
-  auto add_shell_cyl_endcap_neighbors =
-      [&shell_to_cyl_endcap_center, &shell_to_cyl_endcap_wedge](
+  // Add a cylindrical endcap as a neighbor of a spherical shell
+  auto add_shell_cyl_endcap_neighbor =
+      [&shell_to_cyl_endcap](
           std::unordered_set<size_t>& cyl_ids,
           std::unordered_map<size_t, OrientationMap<3>>& cyl_orientations,
-          const size_t first_cyl_block_number) {
-        cyl_ids.insert(first_cyl_block_number);
-        cyl_orientations.emplace(first_cyl_block_number,
-                                 shell_to_cyl_endcap_center);
-        for (size_t j = first_cyl_block_number + 1;
-             j < first_cyl_block_number + 5; ++j) {
-          cyl_ids.insert(j);
-          cyl_orientations.emplace(j, shell_to_cyl_endcap_wedge);
-        }
+          const size_t cyl_block_number) {
+        cyl_ids.insert(cyl_block_number);
+        cyl_orientations.emplace(cyl_block_number, shell_to_cyl_endcap);
       };
 
-  // Add one of the blocks making up a cylindrical side as a neighbor of a shell
-  auto add_shell_cyl_side_neighbors =
+  // Add a cylindrical side as a neighbor of a spherical shell
+  auto add_shell_cyl_side_neighbor =
       [&shell_to_cyl_side](
           std::unordered_set<size_t>& cyl_ids,
           std::unordered_map<size_t, OrientationMap<3>>& cyl_orientations,
-          const size_t first_cyl_block_number) {
-        for (size_t j = first_cyl_block_number; j < first_cyl_block_number + 4;
-             ++j) {
-          cyl_ids.insert(j);
-          cyl_orientations.emplace(j, shell_to_cyl_side);
-        }
+          const size_t cyl_block_number) {
+        cyl_ids.insert(cyl_block_number);
+        cyl_orientations.emplace(cyl_block_number, shell_to_cyl_side);
       };
 
   using Affine = CoordinateMaps::Affine;
@@ -1065,19 +1084,20 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const {
 
   // (b) SH inner shell blocks for InnerSphereA.
   if (include_inner_sphere_A_) {
-    // lower_xi → all 18 CA, CB blocks (non-conforming, multi-neighbor).
+    // upper_xi → EA endcap, EA side, and MA blocks
+    // (non-conforming, multi-neighbor).
     std::unordered_set<size_t> inner_a_cyl_ids;
     std::unordered_map<size_t, OrientationMap<3>> inner_a_cyl_orientations;
 
     // EA Filled Cylinder
-    add_shell_cyl_endcap_neighbors(inner_a_cyl_ids, inner_a_cyl_orientations,
-                                   first_ea_endcap_block);
+    add_shell_cyl_endcap_neighbor(inner_a_cyl_ids, inner_a_cyl_orientations,
+                                  ea_endcap_block);
     // EA Cylinder
-    add_shell_cyl_side_neighbors(inner_a_cyl_ids, inner_a_cyl_orientations,
-                                 first_ea_side_block);
+    add_shell_cyl_side_neighbor(inner_a_cyl_ids, inner_a_cyl_orientations,
+                                ea_side_block);
     // MA Filled Cylinder
-    add_shell_cyl_endcap_neighbors(inner_a_cyl_ids, inner_a_cyl_orientations,
-                                   first_ma_endcap_block);
+    add_shell_cyl_endcap_neighbor(inner_a_cyl_ids, inner_a_cyl_orientations,
+                                  ma_endcap_block);
 
     auto inner_a_sh_map = make_spherical_shell_coord_map(
         radius_A_, outer_radius_A_, rotate_from_z_to_x_axis(center_A_));
@@ -1088,27 +1108,28 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const {
         BlockNeighbors<3>{std::move(inner_a_cyl_ids),
                           std::move(inner_a_cyl_orientations),
                           /*are_conforming=*/false});
-    blocks.emplace_back(std::move(inner_a_sh_map), first_inner_shell_A_block,
+    blocks.emplace_back(std::move(inner_a_sh_map), inner_shell_A_block,
                         std::move(inner_a_sh_neighbors),
-                        block_names_[first_inner_shell_A_block],
+                        block_names_[inner_shell_A_block],
                         domain::topologies::spherical_shell);
   }
 
   // (c) SH inner shell blocks for InnerSphereB.
   if (include_inner_sphere_B_) {
-    // lower_xi → all 18 CA, CB blocks (non-conforming, multi-neighbor).
+    // upper_xi → EB endcap, EB side, and MB blocks
+    // (non-conforming, multi-neighbor).
     std::unordered_set<size_t> inner_b_cyl_ids;
     std::unordered_map<size_t, OrientationMap<3>> inner_b_cyl_orientations;
 
     // EB Filled Cylinder
-    add_shell_cyl_endcap_neighbors(inner_b_cyl_ids, inner_b_cyl_orientations,
-                                   first_eb_endcap_block);
+    add_shell_cyl_endcap_neighbor(inner_b_cyl_ids, inner_b_cyl_orientations,
+                                  eb_endcap_block);
     // EB Cylinder
-    add_shell_cyl_side_neighbors(inner_b_cyl_ids, inner_b_cyl_orientations,
-                                 first_eb_side_block);
+    add_shell_cyl_side_neighbor(inner_b_cyl_ids, inner_b_cyl_orientations,
+                                eb_side_block);
     // MB Filled Cylinder
-    add_shell_cyl_endcap_neighbors(inner_b_cyl_ids, inner_b_cyl_orientations,
-                                   first_mb_endcap_block);
+    add_shell_cyl_endcap_neighbor(inner_b_cyl_ids, inner_b_cyl_orientations,
+                                  mb_endcap_block);
 
     auto inner_b_sh_map = make_spherical_shell_coord_map(
         radius_B_, outer_radius_B_, rotate_from_z_to_x_axis(center_B_));
@@ -1120,29 +1141,29 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const {
                           std::move(inner_b_cyl_orientations),
                           /*are_conforming=*/false});
 
-    blocks.emplace_back(std::move(inner_b_sh_map), first_inner_shell_B_block,
+    blocks.emplace_back(std::move(inner_b_sh_map), inner_shell_B_block,
                         std::move(inner_b_sh_neighbors),
-                        block_names_[first_inner_shell_B_block],
+                        block_names_[inner_shell_B_block],
                         domain::topologies::spherical_shell);
   }
 
   // (d) SH outer shell blocks for OuterSphere.
-  // lower_xi → all 18 CA, CB blocks (non-conforming, multi-neighbor).
+  // lower_xi → all 4 CA, CB blocks (non-conforming, multi-neighbor).
   std::unordered_set<size_t> outer_cyl_ids;
   std::unordered_map<size_t, OrientationMap<3>> outer_cyl_orientations;
 
   // CA Filled Cylinder
-  add_shell_cyl_endcap_neighbors(outer_cyl_ids, outer_cyl_orientations,
-                                 first_ca_endcap_block);
+  add_shell_cyl_endcap_neighbor(outer_cyl_ids, outer_cyl_orientations,
+                                ca_endcap_block);
   // CA Cylinder
-  add_shell_cyl_side_neighbors(outer_cyl_ids, outer_cyl_orientations,
-                               first_ca_side_block);
+  add_shell_cyl_side_neighbor(outer_cyl_ids, outer_cyl_orientations,
+                              ca_side_block);
   // CB Filled Cylinder
-  add_shell_cyl_endcap_neighbors(outer_cyl_ids, outer_cyl_orientations,
-                                 first_cb_endcap_block);
+  add_shell_cyl_endcap_neighbor(outer_cyl_ids, outer_cyl_orientations,
+                                cb_endcap_block);
   // CB Cylinder
-  add_shell_cyl_side_neighbors(outer_cyl_ids, outer_cyl_orientations,
-                               first_cb_side_block);
+  add_shell_cyl_side_neighbor(outer_cyl_ids, outer_cyl_orientations,
+                              cb_side_block);
 
   auto outer_sh_map = make_spherical_shell_coord_map(
       inner_radius_C, outer_radius_, make_array<3>(0.0));
@@ -1154,10 +1175,9 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const {
                         std::move(outer_cyl_orientations),
                         /*are_conforming=*/false});
 
-  blocks.emplace_back(std::move(outer_sh_map), first_outer_shell_block,
-                      std::move(outer_sh_neighbors),
-                      block_names_[first_outer_shell_block],
-                      domain::topologies::spherical_shell);
+  blocks.emplace_back(
+      std::move(outer_sh_map), outer_shell_block, std::move(outer_sh_neighbors),
+      block_names_[outer_shell_block], domain::topologies::spherical_shell);
 
   domain =
       Domain<3>{std::move(blocks), std::move(excision_spheres), block_groups_};
@@ -1188,7 +1208,7 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const {
     // The first block in the outer shell needs the transition expansion +
     // rotation + translation map from the grid to inertial frame. No maps to
     // the distorted frame
-    grid_to_inertial_block_maps[first_outer_shell_block] =
+    grid_to_inertial_block_maps[outer_shell_block] =
         time_dependent_options_
             ->grid_to_inertial_map<domain::ObjectLabel::None>(false, false);
 
@@ -1206,60 +1226,53 @@ Domain<3> CylindricalBinaryCompactObject::create_domain() const {
 
     // The `true` being passed to the functions specifies that the size map
     // *should* be included in the distorted frame.
-    grid_to_inertial_block_maps[first_inner_shell_A_block] =
+    grid_to_inertial_block_maps[inner_shell_A_block] =
         time_dependent_options_->grid_to_inertial_map<domain::ObjectLabel::A>(
             true, true);
-    grid_to_distorted_block_maps[first_inner_shell_A_block] =
+    grid_to_distorted_block_maps[inner_shell_A_block] =
         time_dependent_options_->grid_to_distorted_map<domain::ObjectLabel::A>(
             true);
-    distorted_to_inertial_block_maps[first_inner_shell_A_block] =
+    distorted_to_inertial_block_maps[inner_shell_A_block] =
         time_dependent_options_
             ->distorted_to_inertial_map<domain::ObjectLabel::A>(true, true);
 
-    grid_to_inertial_block_maps[first_inner_shell_B_block] =
+    grid_to_inertial_block_maps[inner_shell_B_block] =
         time_dependent_options_->grid_to_inertial_map<domain::ObjectLabel::B>(
             true, true);
-    grid_to_distorted_block_maps[first_inner_shell_B_block] =
+    grid_to_distorted_block_maps[inner_shell_B_block] =
         time_dependent_options_->grid_to_distorted_map<domain::ObjectLabel::B>(
             true);
-    distorted_to_inertial_block_maps[first_inner_shell_B_block] =
+    distorted_to_inertial_block_maps[inner_shell_B_block] =
         time_dependent_options_
             ->distorted_to_inertial_map<domain::ObjectLabel::B>(true, true);
 
     for (size_t block = 1; block < number_of_blocks_; ++block) {
-      if (block == first_inner_shell_A_block or
-          block == first_inner_shell_B_block or
-          block == first_outer_shell_block) {
+      if (block == inner_shell_A_block or block == inner_shell_B_block or
+          block == outer_shell_block) {
         continue;  // Already initialized
-      } else if (block > first_inner_shell_A_block and
-                 block < first_inner_shell_B_block) {
+      } else if (block > inner_shell_A_block and block < inner_shell_B_block) {
         grid_to_inertial_block_maps[block] =
-            grid_to_inertial_block_maps[first_inner_shell_A_block]->get_clone();
-        if (grid_to_distorted_block_maps[first_inner_shell_A_block] !=
-            nullptr) {
+            grid_to_inertial_block_maps[inner_shell_A_block]->get_clone();
+        if (grid_to_distorted_block_maps[inner_shell_A_block] != nullptr) {
           grid_to_distorted_block_maps[block] =
-              grid_to_distorted_block_maps[first_inner_shell_A_block]
-                  ->get_clone();
+              grid_to_distorted_block_maps[inner_shell_A_block]->get_clone();
           distorted_to_inertial_block_maps[block] =
-              distorted_to_inertial_block_maps[first_inner_shell_A_block]
+              distorted_to_inertial_block_maps[inner_shell_A_block]
                   ->get_clone();
         }
-      } else if (block > first_inner_shell_B_block and
-                 block < first_outer_shell_block) {
+      } else if (block > inner_shell_B_block and block < outer_shell_block) {
         grid_to_inertial_block_maps[block] =
-            grid_to_inertial_block_maps[first_inner_shell_B_block]->get_clone();
-        if (grid_to_distorted_block_maps[first_inner_shell_B_block] !=
-            nullptr) {
+            grid_to_inertial_block_maps[inner_shell_B_block]->get_clone();
+        if (grid_to_distorted_block_maps[inner_shell_B_block] != nullptr) {
           grid_to_distorted_block_maps[block] =
-              grid_to_distorted_block_maps[first_inner_shell_B_block]
-                  ->get_clone();
+              grid_to_distorted_block_maps[inner_shell_B_block]->get_clone();
           distorted_to_inertial_block_maps[block] =
-              distorted_to_inertial_block_maps[first_inner_shell_B_block]
+              distorted_to_inertial_block_maps[inner_shell_B_block]
                   ->get_clone();
         }
-      } else if (block > first_outer_shell_block) {
+      } else if (block > outer_shell_block) {
         grid_to_inertial_block_maps[block] =
-            grid_to_inertial_block_maps[first_outer_shell_block]->get_clone();
+            grid_to_inertial_block_maps[outer_shell_block]->get_clone();
       } else {
         grid_to_inertial_block_maps[block] =
             grid_to_inertial_block_maps[0]->get_clone();
@@ -1286,49 +1299,45 @@ CylindricalBinaryCompactObject::external_boundary_conditions() const {
   std::vector<DirectionMap<
       3, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
       boundary_conditions{number_of_blocks_};
-  for (size_t i = 0; i < 5; ++i) {
-    if (not include_inner_sphere_A_) {
+  const size_t ea_endcap_block = block_positions_.at("EAFilledCylinder");
+  const size_t ea_side_block = block_positions_.at("EACylinder");
+  const size_t ma_endcap_block = block_positions_.at("MAFilledCylinder");
+  const size_t eb_endcap_block = block_positions_.at("EBFilledCylinder");
+  const size_t eb_side_block = block_positions_.at("EBCylinder");
+  const size_t mb_endcap_block = block_positions_.at("MBFilledCylinder");
+  const size_t outer_shell_block = block_positions_.at("OuterShell0");
+
+  if (not include_inner_sphere_A_) {
       // EA Filled Cylinder
-      boundary_conditions[i + 9][Direction<3>::lower_zeta()] =
+      boundary_conditions[ea_endcap_block][Direction<3>::lower_zeta()] =
           inner_boundary_condition_->get_clone();
       // MA Filled Cylinder
-      boundary_conditions[i + 27][Direction<3>::lower_zeta()] =
+      boundary_conditions[ma_endcap_block][Direction<3>::lower_zeta()] =
           inner_boundary_condition_->get_clone();
-    }
-    if (not include_inner_sphere_B_) {
+      // EA Cylinder
+      boundary_conditions[ea_side_block][Direction<3>::lower_xi()] =
+          inner_boundary_condition_->get_clone();
+  } else {
+    boundary_conditions[block_positions_.at("InnerAShell0")]
+                       [Direction<3>::lower_xi()] =
+                           inner_boundary_condition_->get_clone();
+  }
+  if (not include_inner_sphere_B_) {
       // EB Filled Cylinder
-      boundary_conditions[i + 18][Direction<3>::lower_zeta()] =
+      boundary_conditions[eb_endcap_block][Direction<3>::lower_zeta()] =
           inner_boundary_condition_->get_clone();
       // MB Filled Cylinder
-      boundary_conditions[i + 32][Direction<3>::lower_zeta()] =
+      boundary_conditions[mb_endcap_block][Direction<3>::lower_zeta()] =
           inner_boundary_condition_->get_clone();
-    }
-  }
-  for (size_t i = 0; i < 4; ++i) {
-    if (not include_inner_sphere_A_) {
-      // EA Cylinder
-      boundary_conditions[i + 14][Direction<3>::lower_xi()] =
-          inner_boundary_condition_->get_clone();
-    }
-    if (not include_inner_sphere_B_) {
       // EB Cylinder
-      boundary_conditions[i + 23][Direction<3>::lower_xi()] =
+      boundary_conditions[eb_side_block][Direction<3>::lower_xi()] =
           inner_boundary_condition_->get_clone();
-    }
+  } else {
+    boundary_conditions[block_positions_.at("InnerBShell0")]
+                       [Direction<3>::lower_xi()] =
+                           inner_boundary_condition_->get_clone();
   }
-
-  size_t last_block = 46;
-  if (include_inner_sphere_A_) {
-    boundary_conditions[last_block][Direction<3>::lower_xi()] =
-        inner_boundary_condition_->get_clone();
-    last_block += 1;
-  }
-  if (include_inner_sphere_B_) {
-    boundary_conditions[last_block][Direction<3>::lower_xi()] =
-        inner_boundary_condition_->get_clone();
-    last_block += 1;
-  }
-  boundary_conditions[last_block][Direction<3>::upper_xi()] =
+  boundary_conditions[outer_shell_block][Direction<3>::upper_xi()] =
       outer_boundary_condition_->get_clone();
 
   return boundary_conditions;

--- a/src/Domain/Creators/CylindricalBinaryCompactObject.hpp
+++ b/src/Domain/Creators/CylindricalBinaryCompactObject.hpp
@@ -32,7 +32,10 @@
 namespace domain {
 namespace CoordinateMaps {
 class Affine;
+template <size_t Dim>
+class Identity;
 class Interval;
+class PolarToCartesian;
 template <typename Map1, typename Map2>
 class ProductOf2Maps;
 template <typename Map1, typename Map2, typename Map3>
@@ -101,13 +104,10 @@ namespace domain::creators {
  *
  * The Blocks are named as follows:
  * - Each of CAFilledCylinder, EAFilledCylinder, EBFilledCylinder,
- *   MAFilledCylinder, MBFilledCylinder, and CBFilledCylinder consists
- *   of 5 blocks, named 'Center', 'East', 'North', 'West', and
- *   'South', so an example of a valid block name is
- *   'CAFilledCylinderCenter'.
- * - Each of CACylinder, EACylinder, EBCylinder, and CBCylinder
- *   consists of 4 blocks, named 'East', 'North', 'West', and 'South',
- *   so an example of a valid block name is 'CACylinderEast'.
+ *   MAFilledCylinder, MBFilledCylinder, and CBFilledCylinder are filled
+ *   cylindrical endcaps made of a single cylindrical block.
+ * - Each of CACylinder, EACylinder, EBCylinder, and CBCylinder are hollow
+ *   ylindrical shells made of a single cylindrical block.
  * - The Block group called "Outer" consists of all the CA and CB blocks.
  * - OuterShell0 is the single shell in a Block group called "OuterSphere" and
  *   it borders the outer boundary.
@@ -149,48 +149,39 @@ namespace domain::creators {
  */
 class CylindricalBinaryCompactObject : public DomainCreator<3> {
  public:
-  using maps_list = tmpl::flatten<
-      tmpl::list<domain::CoordinateMap<
-                     Frame::BlockLogical, Frame::Inertial,
-                     CoordinateMaps::ProductOf3Maps<CoordinateMaps::Interval,
-                                                    CoordinateMaps::Interval,
-                                                    CoordinateMaps::Interval>,
-                     CoordinateMaps::UniformCylindricalEndcap,
-                     CoordinateMaps::DiscreteRotation<3>>,
-                 domain::CoordinateMap<
-                     Frame::BlockLogical, Frame::Inertial,
-                     CoordinateMaps::ProductOf2Maps<CoordinateMaps::Wedge<2>,
-                                                    CoordinateMaps::Interval>,
-                     CoordinateMaps::UniformCylindricalEndcap,
-                     CoordinateMaps::DiscreteRotation<3>>,
-                 domain::CoordinateMap<
-                     Frame::BlockLogical, Frame::Inertial,
-                     CoordinateMaps::ProductOf3Maps<CoordinateMaps::Interval,
-                                                    CoordinateMaps::Interval,
-                                                    CoordinateMaps::Interval>,
-                     CoordinateMaps::UniformCylindricalFlatEndcap,
-                     CoordinateMaps::DiscreteRotation<3>>,
-                 domain::CoordinateMap<
-                     Frame::BlockLogical, Frame::Inertial,
-                     CoordinateMaps::ProductOf2Maps<CoordinateMaps::Wedge<2>,
-                                                    CoordinateMaps::Interval>,
-                     CoordinateMaps::UniformCylindricalFlatEndcap,
-                     CoordinateMaps::DiscreteRotation<3>>,
-                 domain::CoordinateMap<
-                     Frame::BlockLogical, Frame::Inertial,
-                     CoordinateMaps::ProductOf2Maps<CoordinateMaps::Wedge<2>,
-                                                    CoordinateMaps::Interval>,
-                     CoordinateMaps::UniformCylindricalSide,
-                     CoordinateMaps::DiscreteRotation<3>>,
-                 domain::CoordinateMap<
-                     Frame::BlockLogical, Frame::Inertial,
-                     domain::CoordinateMaps::ProductOf2Maps<
-                         CoordinateMaps::Interval, CoordinateMaps::Identity<2>>,
-                     domain::CoordinateMaps::SphericalToCartesianPfaffian,
-                     CoordinateMaps::ProductOf3Maps<CoordinateMaps::Affine,
-                                                    CoordinateMaps::Affine,
-                                                    CoordinateMaps::Affine>>,
-                 bco::TimeDependentMapOptions<true>::maps_list>>;
+  using unit_cylinder_map =
+      CoordinateMaps::ProductOf3Maps<CoordinateMaps::Affine,
+                                     CoordinateMaps::Identity<1>,
+                                     CoordinateMaps::Interval>;
+  using polar_to_cartesian_map =
+      CoordinateMaps::ProductOf2Maps<CoordinateMaps::PolarToCartesian,
+                                     CoordinateMaps::Identity<1>>;
+
+  using maps_list = tmpl::flatten<tmpl::list<
+      domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial,
+                            unit_cylinder_map, polar_to_cartesian_map,
+                            CoordinateMaps::DiscreteRotation<3>,
+                            CoordinateMaps::UniformCylindricalEndcap,
+                            CoordinateMaps::DiscreteRotation<3>>,
+      domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial,
+                            unit_cylinder_map, polar_to_cartesian_map,
+                            CoordinateMaps::DiscreteRotation<3>,
+                            CoordinateMaps::UniformCylindricalFlatEndcap,
+                            CoordinateMaps::DiscreteRotation<3>>,
+      domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial,
+                            unit_cylinder_map, polar_to_cartesian_map,
+                            CoordinateMaps::DiscreteRotation<3>,
+                            CoordinateMaps::UniformCylindricalSide,
+                            CoordinateMaps::DiscreteRotation<3>>,
+      domain::CoordinateMap<
+          Frame::BlockLogical, Frame::Inertial,
+          domain::CoordinateMaps::ProductOf2Maps<CoordinateMaps::Interval,
+                                                 CoordinateMaps::Identity<2>>,
+          domain::CoordinateMaps::SphericalToCartesianPfaffian,
+          CoordinateMaps::ProductOf3Maps<CoordinateMaps::Affine,
+                                         CoordinateMaps::Affine,
+                                         CoordinateMaps::Affine>>,
+      bco::TimeDependentMapOptions<true>::maps_list>>;
 
   struct CenterA {
     using type = std::array<double, 3>;
@@ -227,44 +218,57 @@ class CylindricalBinaryCompactObject : public DomainCreator<3> {
     static constexpr Options::String help = {
         "Grid-coordinate radius of outer boundary."};
   };
-  struct UseEquiangularMap {
-    using type = bool;
-    static constexpr Options::String help = {
-        "Distribute grid points equiangularly in 2d wedges."};
-    static bool suggested_value() { return false; }
-  };
 
   struct InitialRefinement {
-    using type = std::variant<
-        size_t, std::array<size_t, 3>, std::vector<std::array<size_t, 3>>,
-        std::unordered_map<std::string, std::array<size_t, 3>>,
-        std::unordered_map<std::string,
-                           std::variant<std::array<size_t, 3>, size_t>>>;
+    using type = std::variant<size_t, std::unordered_map<std::string, size_t>>;
     static constexpr Options::String help = {
-        "Initial refinement level. Specify one of: a single number, a list "
-        "representing [r, theta, perp], or such a list for every block in the "
-        "domain. Here 'r' is the radial direction normal to the inner and "
-        "outer boundaries, 'theta' is the periodic direction, and 'perp' is "
-        "the third direction. Note that for spherical shell block groups "
-        "('InnerSphereA', 'InnerSphereB', and 'OuterSphere'), you must instead "
-        "specify refinement as a single value representing radial refinement."};
+        "Initial refinement level. Specify one of: a single number or a list "
+        "of single numbers for every block group in the domain, every block "
+        "name in the domain, or a mix of block groups and blocks. Each single "
+        "number represents the radial refinement for spherical shell blocks "
+        "and z refinement for cylindrical blocks.\n\nNote that the z direction "
+        "in cylinder blocks will roughly correspond to refinement in a "
+        "direction parallel to the axis of separation between the two objects. "
+        "Because filled cylinder blocks lie along the axis of separation but "
+        "hollow cylinder blocks wrap around it, refinement in leads to "
+        "refinement in different spherical coordinate directions in the "
+        "global spherical coordinates. More specifically, z refinement in "
+        "filled cylinders (e.g. EAFilledCylinder) will roughly correspond to "
+        "radial refinement in global spherical coordinates, but in hollow "
+        "cylinders, it will behave more like angular refinement in global "
+        "spherical coordinates that is perpendicular to the cylinder's local "
+        "angular direction."};
   };
+
   struct InitialGridPoints {
     using type = std::variant<
-        size_t, std::array<size_t, 3>, std::vector<std::array<size_t, 3>>,
-        std::unordered_map<std::string, std::array<size_t, 3>>,
+        size_t,
         std::unordered_map<std::string, std::variant<std::array<size_t, 3>,
                                                      std::array<size_t, 2>>>>;
     static constexpr Options::String help = {
-        "Initial number of grid points. Specify one of: a single number, a "
-        "list representing [r, theta, perp], or such a list for every block in "
-        "the domain. Here 'r' is the radial direction normal to the inner and "
-        "outer boundaries, 'theta' is the periodic direction, and 'perp' is "
-        "the third direction. The exception to this is that for spherical "
-        "shell blocks groups ('InnerSphereA', 'InnerSphereB', 'OuterSphere'),"
-        "you must instead specify grid points as [r, L_max]. The exception to "
-        "this is if a single number is specified for global initial grid "
-        "points."};
+        "Initial number of grid points. Specify one of the following:"
+        "\n\t- a single number"
+        "\n\t- lists for blocks and/or block groups as follows:"
+        "\n\t\t- [r, l_max] for spherical shell blocks and groups"
+        "\n\t\t- [r, z] for filled cylinder blocks and groups containing them, "
+        "\n\t\t  where r must be > 2"
+        "\n\t\t- [r, theta, z] for hollow cylinder blocks, where theta must be "
+        "\n\t\t  odd\n\n"
+        "While the most verbose, the best choice for a production run is "
+        "likely to specify a list for each cylindrical block instead of each "
+        "cylindrical block group. If you set a whole group (e.g. InnerA) using "
+        "[r, z], the interfaces between its filled cylinders "
+        "(e.g. EAFilledCylinder) and its hollow cylinders (e.g. EACylinder) "
+        "may not have similar resolution on each side unless r and z are "
+        "close. This is because at these interfaces, the z direction in filled "
+        "cylinders lines up with the radial direction in hollow cylinders. To "
+        "get the resolution on either side of these interfaces to match well, "
+        "you either want to set a cylindrical block group with r and z close "
+        "in value or set the individual cylindrical blocks for more freedom. "
+        "Also note that any h refinement in these cylindrical blocks will also "
+        "be in similarly different directions at the interface, which affects "
+        "this picture of trying to match the p refinement at the interface of "
+        "hollow and filled cylinders."};
   };
 
   struct BoundaryConditions {
@@ -298,7 +302,7 @@ class CylindricalBinaryCompactObject : public DomainCreator<3> {
   template <typename Metavariables>
   using options = tmpl::append<
       tmpl::list<CenterA, CenterB, RadiusA, RadiusB, IncludeInnerSphereA,
-                 IncludeInnerSphereB, OuterRadius, UseEquiangularMap,
+                 IncludeInnerSphereB, OuterRadius,
                  InitialRefinement, InitialGridPoints, TimeDependentMaps>,
       tmpl::conditional_t<
           domain::BoundaryConditions::has_boundary_conditions_base_v<
@@ -322,7 +326,6 @@ class CylindricalBinaryCompactObject : public DomainCreator<3> {
       std::array<double, 3> center_A, std::array<double, 3> center_B,
       double radius_A, double radius_B, bool include_inner_sphere_A,
       bool include_inner_sphere_B, double outer_radius,
-      bool use_equiangular_map,
       const typename InitialRefinement::type& initial_refinement,
       const typename InitialGridPoints::type& initial_grid_points,
       std::optional<bco::TimeDependentMapOptions<true>> time_dependent_options =
@@ -386,7 +389,6 @@ class CylindricalBinaryCompactObject : public DomainCreator<3> {
   bool include_inner_sphere_A_{};
   bool include_inner_sphere_B_{};
   double outer_radius_{};
-  bool use_equiangular_map_{false};
   typename std::vector<std::array<size_t, 3>> initial_refinement_{};
   typename std::vector<std::array<size_t, 3>> initial_grid_points_{};
   // cut_spheres_offset_factor_ is eta in Eq. (A.9) of
@@ -399,7 +401,7 @@ class CylindricalBinaryCompactObject : public DomainCreator<3> {
   // https://arxiv.org/abs/1206.3015 (but rotated to the z-axis).
   double z_cutting_plane_{};
   size_t number_of_blocks_{};
-  size_t first_outer_shell_block{};
+  std::unordered_map<std::string, size_t> block_positions_{};
   std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
       inner_boundary_condition_;
   std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>

--- a/src/Domain/Creators/CylindricalBinaryCompactObject.hpp
+++ b/src/Domain/Creators/CylindricalBinaryCompactObject.hpp
@@ -32,7 +32,10 @@
 namespace domain {
 namespace CoordinateMaps {
 class Affine;
+template <size_t Dim>
+class Identity;
 class Interval;
+class PolarToCartesian;
 template <typename Map1, typename Map2>
 class ProductOf2Maps;
 template <typename Map1, typename Map2, typename Map3>
@@ -101,13 +104,10 @@ namespace domain::creators {
  *
  * The Blocks are named as follows:
  * - Each of CAFilledCylinder, EAFilledCylinder, EBFilledCylinder,
- *   MAFilledCylinder, MBFilledCylinder, and CBFilledCylinder consists
- *   of 5 blocks, named 'Center', 'East', 'North', 'West', and
- *   'South', so an example of a valid block name is
- *   'CAFilledCylinderCenter'.
- * - Each of CACylinder, EACylinder, EBCylinder, and CBCylinder
- *   consists of 4 blocks, named 'East', 'North', 'West', and 'South',
- *   so an example of a valid block name is 'CACylinderEast'.
+ *   MAFilledCylinder, MBFilledCylinder, and CBFilledCylinder are filled
+ *   cylindrical endcaps made of a single cylindrical block.
+ * - Each of CACylinder, EACylinder, EBCylinder, and CBCylinder are hollow
+ *   ylindrical shells made of a single cylindrical block.
  * - The Block group called "Outer" consists of all the CA and CB blocks.
  * - OuterShell0 is the single shell in a Block group called "OuterSphere" and
  *   it borders the outer boundary.
@@ -149,48 +149,39 @@ namespace domain::creators {
  */
 class CylindricalBinaryCompactObject : public DomainCreator<3> {
  public:
-  using maps_list = tmpl::flatten<
-      tmpl::list<domain::CoordinateMap<
-                     Frame::BlockLogical, Frame::Inertial,
-                     CoordinateMaps::ProductOf3Maps<CoordinateMaps::Interval,
-                                                    CoordinateMaps::Interval,
-                                                    CoordinateMaps::Interval>,
-                     CoordinateMaps::UniformCylindricalEndcap,
-                     CoordinateMaps::DiscreteRotation<3>>,
-                 domain::CoordinateMap<
-                     Frame::BlockLogical, Frame::Inertial,
-                     CoordinateMaps::ProductOf2Maps<CoordinateMaps::Wedge<2>,
-                                                    CoordinateMaps::Interval>,
-                     CoordinateMaps::UniformCylindricalEndcap,
-                     CoordinateMaps::DiscreteRotation<3>>,
-                 domain::CoordinateMap<
-                     Frame::BlockLogical, Frame::Inertial,
-                     CoordinateMaps::ProductOf3Maps<CoordinateMaps::Interval,
-                                                    CoordinateMaps::Interval,
-                                                    CoordinateMaps::Interval>,
-                     CoordinateMaps::UniformCylindricalFlatEndcap,
-                     CoordinateMaps::DiscreteRotation<3>>,
-                 domain::CoordinateMap<
-                     Frame::BlockLogical, Frame::Inertial,
-                     CoordinateMaps::ProductOf2Maps<CoordinateMaps::Wedge<2>,
-                                                    CoordinateMaps::Interval>,
-                     CoordinateMaps::UniformCylindricalFlatEndcap,
-                     CoordinateMaps::DiscreteRotation<3>>,
-                 domain::CoordinateMap<
-                     Frame::BlockLogical, Frame::Inertial,
-                     CoordinateMaps::ProductOf2Maps<CoordinateMaps::Wedge<2>,
-                                                    CoordinateMaps::Interval>,
-                     CoordinateMaps::UniformCylindricalSide,
-                     CoordinateMaps::DiscreteRotation<3>>,
-                 domain::CoordinateMap<
-                     Frame::BlockLogical, Frame::Inertial,
-                     domain::CoordinateMaps::ProductOf2Maps<
-                         CoordinateMaps::Interval, CoordinateMaps::Identity<2>>,
-                     domain::CoordinateMaps::SphericalToCartesianPfaffian,
-                     CoordinateMaps::ProductOf3Maps<CoordinateMaps::Affine,
-                                                    CoordinateMaps::Affine,
-                                                    CoordinateMaps::Affine>>,
-                 bco::TimeDependentMapOptions<true>::maps_list>>;
+  using unit_cylinder_map =
+      CoordinateMaps::ProductOf3Maps<CoordinateMaps::Affine,
+                                     CoordinateMaps::Identity<1>,
+                                     CoordinateMaps::Interval>;
+  using polar_to_cartesian_map =
+      CoordinateMaps::ProductOf2Maps<CoordinateMaps::PolarToCartesian,
+                                     CoordinateMaps::Identity<1>>;
+
+  using maps_list = tmpl::flatten<tmpl::list<
+      domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial,
+                            unit_cylinder_map, polar_to_cartesian_map,
+                            CoordinateMaps::DiscreteRotation<3>,
+                            CoordinateMaps::UniformCylindricalEndcap,
+                            CoordinateMaps::DiscreteRotation<3>>,
+      domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial,
+                            unit_cylinder_map, polar_to_cartesian_map,
+                            CoordinateMaps::DiscreteRotation<3>,
+                            CoordinateMaps::UniformCylindricalFlatEndcap,
+                            CoordinateMaps::DiscreteRotation<3>>,
+      domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial,
+                            unit_cylinder_map, polar_to_cartesian_map,
+                            CoordinateMaps::DiscreteRotation<3>,
+                            CoordinateMaps::UniformCylindricalSide,
+                            CoordinateMaps::DiscreteRotation<3>>,
+      domain::CoordinateMap<
+          Frame::BlockLogical, Frame::Inertial,
+          domain::CoordinateMaps::ProductOf2Maps<CoordinateMaps::Interval,
+                                                 CoordinateMaps::Identity<2>>,
+          domain::CoordinateMaps::SphericalToCartesianPfaffian,
+          CoordinateMaps::ProductOf3Maps<CoordinateMaps::Affine,
+                                         CoordinateMaps::Affine,
+                                         CoordinateMaps::Affine>>,
+      bco::TimeDependentMapOptions<true>::maps_list>>;
 
   struct CenterA {
     using type = std::array<double, 3>;
@@ -227,44 +218,57 @@ class CylindricalBinaryCompactObject : public DomainCreator<3> {
     static constexpr Options::String help = {
         "Grid-coordinate radius of outer boundary."};
   };
-  struct UseEquiangularMap {
-    using type = bool;
-    static constexpr Options::String help = {
-        "Distribute grid points equiangularly in 2d wedges."};
-    static bool suggested_value() { return false; }
-  };
 
   struct InitialRefinement {
-    using type = std::variant<
-        size_t, std::array<size_t, 3>, std::vector<std::array<size_t, 3>>,
-        std::unordered_map<std::string, std::array<size_t, 3>>,
-        std::unordered_map<std::string,
-                           std::variant<std::array<size_t, 3>, size_t>>>;
+    using type = std::variant<size_t, std::unordered_map<std::string, size_t>>;
     static constexpr Options::String help = {
-        "Initial refinement level. Specify one of: a single number, a list "
-        "representing [r, theta, perp], or such a list for every block in the "
-        "domain. Here 'r' is the radial direction normal to the inner and "
-        "outer boundaries, 'theta' is the periodic direction, and 'perp' is "
-        "the third direction. Note that for spherical shell block groups "
-        "('InnerSphereA', 'InnerSphereB', and 'OuterSphere'), you must instead "
-        "specify refinement as a single value representing radial refinement."};
+        "Initial refinement level. Specify one of: a single number or a list "
+        "of single numbers for every block group in the domain, every block "
+        "name in the domain, or a mix of block groups and blocks. Each single "
+        "number represents the radial refinement for spherical shell blocks "
+        "and z refinement for cylindrical blocks.\n\nNote that the z direction "
+        "in cylinder blocks will roughly correspond to refinement in a "
+        "direction parallel to the axis of separation between the two objects. "
+        "Because filled cylinder blocks lie along the axis of separation but "
+        "hollow cylinder blocks wrap around it, refinement in z leads to "
+        "refinement in different spherical coordinate directions in the "
+        "global spherical coordinates. More specifically, z refinement in "
+        "filled cylinders (e.g. EAFilledCylinder) will roughly correspond to "
+        "radial refinement in global spherical coordinates, but in hollow "
+        "cylinders, it will behave more like angular refinement in global "
+        "spherical coordinates that is perpendicular to the cylinder's local "
+        "angular direction."};
   };
+
   struct InitialGridPoints {
     using type = std::variant<
-        size_t, std::array<size_t, 3>, std::vector<std::array<size_t, 3>>,
-        std::unordered_map<std::string, std::array<size_t, 3>>,
+        size_t,
         std::unordered_map<std::string, std::variant<std::array<size_t, 3>,
                                                      std::array<size_t, 2>>>>;
     static constexpr Options::String help = {
-        "Initial number of grid points. Specify one of: a single number, a "
-        "list representing [r, theta, perp], or such a list for every block in "
-        "the domain. Here 'r' is the radial direction normal to the inner and "
-        "outer boundaries, 'theta' is the periodic direction, and 'perp' is "
-        "the third direction. The exception to this is that for spherical "
-        "shell blocks groups ('InnerSphereA', 'InnerSphereB', 'OuterSphere'),"
-        "you must instead specify grid points as [r, L_max]. The exception to "
-        "this is if a single number is specified for global initial grid "
-        "points."};
+        "Initial number of grid points. Specify one of the following:"
+        "\n\t- a single number"
+        "\n\t- lists for blocks and/or block groups as follows:"
+        "\n\t\t- [r, l_max] for spherical shell blocks and groups"
+        "\n\t\t- [r, z] for filled cylinder blocks and groups containing them, "
+        "\n\t\t  where r must be > 2"
+        "\n\t\t- [r, theta, z] for hollow cylinder blocks, where theta must be "
+        "\n\t\t  odd\n\n"
+        "While the most verbose, the best choice for a production run is "
+        "likely to specify a list for each cylindrical block instead of each "
+        "cylindrical block group. If you set a whole group (e.g. InnerA) using "
+        "[r, z], the interfaces between its filled cylinders "
+        "(e.g. EAFilledCylinder) and its hollow cylinders (e.g. EACylinder) "
+        "may not have similar resolution on each side unless r and z are "
+        "close. This is because at these interfaces, the z direction in filled "
+        "cylinders lines up with the radial direction in hollow cylinders. To "
+        "get the resolution on either side of these interfaces to match well, "
+        "you either want to set a cylindrical block group with r and z close "
+        "in value or set the individual cylindrical blocks for more freedom. "
+        "Also note that any h refinement in these cylindrical blocks will also "
+        "be in similarly different directions at the interface, which affects "
+        "this picture of trying to match the p refinement at the interface of "
+        "hollow and filled cylinders."};
   };
 
   struct BoundaryConditions {
@@ -298,7 +302,7 @@ class CylindricalBinaryCompactObject : public DomainCreator<3> {
   template <typename Metavariables>
   using options = tmpl::append<
       tmpl::list<CenterA, CenterB, RadiusA, RadiusB, IncludeInnerSphereA,
-                 IncludeInnerSphereB, OuterRadius, UseEquiangularMap,
+                 IncludeInnerSphereB, OuterRadius,
                  InitialRefinement, InitialGridPoints, TimeDependentMaps>,
       tmpl::conditional_t<
           domain::BoundaryConditions::has_boundary_conditions_base_v<
@@ -322,7 +326,6 @@ class CylindricalBinaryCompactObject : public DomainCreator<3> {
       std::array<double, 3> center_A, std::array<double, 3> center_B,
       double radius_A, double radius_B, bool include_inner_sphere_A,
       bool include_inner_sphere_B, double outer_radius,
-      bool use_equiangular_map,
       const typename InitialRefinement::type& initial_refinement,
       const typename InitialGridPoints::type& initial_grid_points,
       std::optional<bco::TimeDependentMapOptions<true>> time_dependent_options =
@@ -386,7 +389,6 @@ class CylindricalBinaryCompactObject : public DomainCreator<3> {
   bool include_inner_sphere_A_{};
   bool include_inner_sphere_B_{};
   double outer_radius_{};
-  bool use_equiangular_map_{false};
   typename std::vector<std::array<size_t, 3>> initial_refinement_{};
   typename std::vector<std::array<size_t, 3>> initial_grid_points_{};
   // cut_spheres_offset_factor_ is eta in Eq. (A.9) of
@@ -399,7 +401,7 @@ class CylindricalBinaryCompactObject : public DomainCreator<3> {
   // https://arxiv.org/abs/1206.3015 (but rotated to the z-axis).
   double z_cutting_plane_{};
   size_t number_of_blocks_{};
-  size_t first_outer_shell_block{};
+  std::unordered_map<std::string, size_t> block_positions_{};
   std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
       inner_boundary_condition_;
   std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>

--- a/src/Domain/DomainHelpers.cpp
+++ b/src/Domain/DomainHelpers.cpp
@@ -24,6 +24,7 @@
 #include "Domain/CoordinateMaps/Identity.hpp"
 #include "Domain/CoordinateMaps/Interval.hpp"
 #include "Domain/CoordinateMaps/MapInstantiationMacros.hpp"
+#include "Domain/CoordinateMaps/PolarToCartesian.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.tpp"
 #include "Domain/CoordinateMaps/Wedge.hpp"
@@ -1183,6 +1184,35 @@ cyl_wedge_coordinate_maps(
       inner_radius, lower_z_bound, upper_z_bound, use_equiangular_map,
       partitioning_in_z, distribution_in_z, CylindricalDomainParityFlip::none));
   return cylinder_mapping;
+}
+
+domain::CoordinateMap<
+    Frame::BlockLogical, Frame::Inertial,
+    domain::CoordinateMaps::ProductOf3Maps<
+        ::domain::CoordinateMaps::Affine, ::domain::CoordinateMaps::Identity<1>,
+        ::domain::CoordinateMaps::Interval>,
+    domain::CoordinateMaps::ProductOf2Maps<
+        ::domain::CoordinateMaps::PolarToCartesian,
+        ::domain::CoordinateMaps::Identity<1>>>
+cyl_coordinate_map(const double inner_radius, const double outer_radius,
+                   const double lower_z_bound, const double upper_z_bound) {
+  using Affine = domain::CoordinateMaps::Affine;
+  using Identity1D = domain::CoordinateMaps::Identity<1>;
+  using Interval = domain::CoordinateMaps::Interval;
+  using PolarToCartesian = domain::CoordinateMaps::PolarToCartesian;
+  const auto linear = domain::CoordinateMaps::Distribution::Linear;
+
+  // Map: (xi, eta, zeta) in [-1,1] x [0, 2pi] x [-1, 1]
+  //   xi -> r in [inner_r, outer_r]  (Affine)
+  //   eta -> phi in [0, 2pi)         (Identity<1>, passes through)
+  //   zeta -> z in [z_lower, z_upper] (Interval)
+  // Then PolarToCartesian x Identity<1> maps (r, phi, z) -> (x, y, z)
+  return domain::make_coordinate_map<Frame::BlockLogical, Frame::Inertial>(
+      domain::CoordinateMaps::ProductOf3Maps<Affine, Identity1D, Interval>{
+          Affine{-1.0, 1.0, inner_radius, outer_radius}, Identity1D{},
+          Interval{-1.0, 1.0, lower_z_bound, upper_z_bound, linear}},
+      domain::CoordinateMaps::ProductOf2Maps<PolarToCartesian, Identity1D>{
+          PolarToCartesian{}, Identity1D{}});
 }
 
 std::vector<std::array<size_t, 8>> corners_for_cylindrical_layered_domains(

--- a/src/Domain/DomainHelpers.hpp
+++ b/src/Domain/DomainHelpers.hpp
@@ -15,6 +15,7 @@
 
 #include "DataStructures/Index.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/Distribution.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/Side.hpp"
@@ -45,7 +46,11 @@ template <typename Map1, typename Map2>
 class ProductOf2Maps;
 template <typename Map1, typename Map2, typename Map3>
 class ProductOf3Maps;
+class Affine;
+template <size_t Dim>
+class Identity;
 class Interval;
+class PolarToCartesian;
 template <size_t Dim>
 class Wedge;
 class Frustum;
@@ -274,7 +279,8 @@ std::vector<std::array<size_t, 8>> corners_for_biradially_layered_domains(
         {1, 2, 3, 4, 5, 6, 7, 8}});
 
 /// \ingroup ComputationalDomainGroup
-/// These are the CoordinateMaps used in the Cylinder DomainCreator.
+/// These are the CoordinateMaps used in the Cylinder DomainCreator for when
+/// cylinders are built using cubes instead of a single cylindrical block.
 ///
 /// The `radial_partitioning` specifies the radial boundaries of sub-shells
 /// between `inner_radius` and `outer_radius`, while `partitioning_in_z`
@@ -352,6 +358,26 @@ auto cyl_wedge_coord_map_surrounding_blocks(
     CylindricalDomainParityFlip parity_flip = CylindricalDomainParityFlip::none)
     -> std::vector<domain::CoordinateMaps::ProductOf2Maps<
         domain::CoordinateMaps::Wedge<2>, domain::CoordinateMaps::Interval>>;
+
+/// \ingroup ComputationalDomainGroup
+/// This is the CoordinateMap used in the Cylinder DomainCreator for when
+/// cylinders are built using a single cylindrical block instead of cubes.
+///
+/// Returns a unit cylinder with the given `inner_radius`, `outer_radius`,
+/// `lower_z_bound`, and `upper_z_bound`. The returned unit cylinder's
+/// intended use is to compose it with `UniformCylindricalEndCap`,
+/// `UniformCylindricalFlatEndCap`, or `UniformCylindricalSide` to create the
+/// different cylinders needed by `domain::CylindricalBinaryCompactObject`.
+::domain::CoordinateMap<
+    Frame::BlockLogical, Frame::Inertial,
+    ::domain::CoordinateMaps::ProductOf3Maps<
+        ::domain::CoordinateMaps::Affine, ::domain::CoordinateMaps::Identity<1>,
+        ::domain::CoordinateMaps::Interval>,
+    ::domain::CoordinateMaps::ProductOf2Maps<
+        ::domain::CoordinateMaps::PolarToCartesian,
+        ::domain::CoordinateMaps::Identity<1>>>
+cyl_coordinate_map(double inner_radius, double outer_radius,
+                   double lower_z_bound, double upper_z_bound);
 
 /// \ingroup ComputationalDomainGroup
 /// \brief The corners for a cylindrical domain split into discs with radial

--- a/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
@@ -48,10 +48,37 @@ DomainCreator:
     RadiusB: &RadiusB 0.45825
     IncludeInnerSphereA: true
     IncludeInnerSphereB: true
-    UseEquiangularMap: true
     OuterRadius: 300.0
-    InitialRefinement: 2
-    InitialGridPoints: 7
+    InitialRefinement:
+      # z refinement for cylindrical block groups
+      InnerA: 1
+      InnerB: 1
+      Outer: 1
+      # radial refinement for spherical shell block groups
+      InnerSphereA: 1
+      InnerSphereB: 1
+      OuterSphere: 1
+    InitialGridPoints:
+      # [radial_points, z_points] for filled cylinders
+      # - theta_points will be set to 4 * radial_points - 3 = 21
+      CAFilledCylinder: [6, 9]
+      CBFilledCylinder: [6, 9]
+      EAFilledCylinder: [6, 9]
+      EBFilledCylinder: [6, 9]
+      MAFilledCylinder: [6, 9]
+      MBFilledCylinder: [6, 9]
+      # [radial_points, theta_points, z_points] for hollow cylinders
+      # - setiing radial_points = 2 * fllled cylinders' z_points because
+      #   filled cylinders' z refinement = 1
+      # - setting theta_points = filled cylinders' theta_points above
+      CACylinder: [18, 21, 7]
+      CBCylinder: [18, 21, 7]
+      EACylinder: [18, 21, 7]
+      EBCylinder: [18, 21, 7]
+      # [radial_points, L_max] for spherical shell block groups
+      InnerSphereA: [12, 20]
+      InnerSphereB: [12, 20]
+      OuterSphere: [20, 13]
     BoundaryConditions:
       InnerBoundary:
         DemandOutgoingCharSpeeds:

--- a/tests/Unit/Domain/Creators/Test_CylindricalBinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_CylindricalBinaryCompactObject.cpp
@@ -52,6 +52,9 @@ namespace {
 using ExpirationTimeMap = std::unordered_map<std::string, double>;
 using CylBCO = ::domain::creators::CylindricalBinaryCompactObject;
 using TimeDepOptions = domain::creators::bco::TimeDependentMapOptions<true>;
+using RefinementMap = std::unordered_map<std::string, size_t>;
+using GridPointsMap = std::unordered_map<
+    std::string, std::variant<std::array<size_t, 3>, std::array<size_t, 2>>>;
 
 std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
 create_inner_boundary_condition() {
@@ -88,51 +91,14 @@ std::pair<std::vector<std::string>,
 block_names_and_groups(const bool include_inner_sphere_A,
                        const bool include_inner_sphere_B) {
   std::vector<std::string> block_names{
-      "CAFilledCylinderCenter", "CAFilledCylinderEast",
-      "CAFilledCylinderNorth",  "CAFilledCylinderWest",
-      "CAFilledCylinderSouth",  "CACylinderEast",
-      "CACylinderNorth",        "CACylinderWest",
-      "CACylinderSouth",        "EAFilledCylinderCenter",
-      "EAFilledCylinderEast",   "EAFilledCylinderNorth",
-      "EAFilledCylinderWest",   "EAFilledCylinderSouth",
-      "EACylinderEast",         "EACylinderNorth",
-      "EACylinderWest",         "EACylinderSouth",
-      "EBFilledCylinderCenter", "EBFilledCylinderEast",
-      "EBFilledCylinderNorth",  "EBFilledCylinderWest",
-      "EBFilledCylinderSouth",  "EBCylinderEast",
-      "EBCylinderNorth",        "EBCylinderWest",
-      "EBCylinderSouth",        "MAFilledCylinderCenter",
-      "MAFilledCylinderEast",   "MAFilledCylinderNorth",
-      "MAFilledCylinderWest",   "MAFilledCylinderSouth",
-      "MBFilledCylinderCenter", "MBFilledCylinderEast",
-      "MBFilledCylinderNorth",  "MBFilledCylinderWest",
-      "MBFilledCylinderSouth",  "CBFilledCylinderCenter",
-      "CBFilledCylinderEast",   "CBFilledCylinderNorth",
-      "CBFilledCylinderWest",   "CBFilledCylinderSouth",
-      "CBCylinderEast",         "CBCylinderNorth",
-      "CBCylinderWest",         "CBCylinderSouth"};
+      "CAFilledCylinder", "CACylinder", "EAFilledCylinder", "EACylinder",
+      "EBFilledCylinder", "EBCylinder", "MAFilledCylinder", "MBFilledCylinder",
+      "CBFilledCylinder", "CBCylinder"};
   std::unordered_map<std::string, std::unordered_set<std::string>> block_groups{
       {"Outer",
-       {{"CAFilledCylinderCenter", "CBCylinderEast", "CAFilledCylinderEast",
-         "CAFilledCylinderNorth", "CBFilledCylinderNorth", "CACylinderEast",
-         "CBFilledCylinderEast", "CAFilledCylinderSouth", "CACylinderNorth",
-         "CAFilledCylinderWest", "CACylinderWest", "CACylinderSouth",
-         "CBFilledCylinderCenter", "CBFilledCylinderWest",
-         "CBFilledCylinderSouth", "CBCylinderNorth", "CBCylinderWest",
-         "CBCylinderSouth"}}},
-      {"InnerA",
-       {"EAFilledCylinderCenter", "MAFilledCylinderNorth", "EACylinderSouth",
-        "EAFilledCylinderSouth", "EACylinderNorth", "EACylinderWest",
-        "MAFilledCylinderCenter", "EAFilledCylinderNorth",
-        "EAFilledCylinderWest", "MAFilledCylinderSouth", "EACylinderEast",
-        "MAFilledCylinderEast", "EAFilledCylinderEast",
-        "MAFilledCylinderWest"}},
-      {"InnerB",
-       {"EBFilledCylinderEast", "MBFilledCylinderEast", "EBFilledCylinderSouth",
-        "EBFilledCylinderNorth", "EBFilledCylinderWest", "EBCylinderEast",
-        "MBFilledCylinderWest", "EBCylinderNorth", "EBCylinderSouth",
-        "EBCylinderWest", "MBFilledCylinderCenter", "EBFilledCylinderCenter",
-        "MBFilledCylinderNorth", "MBFilledCylinderSouth"}}};
+       {{"CAFilledCylinder", "CBCylinder", "CBFilledCylinder", "CACylinder"}}},
+      {"InnerA", {"EAFilledCylinder", "MAFilledCylinder", "EACylinder"}},
+      {"InnerB", {"EBFilledCylinder", "MBFilledCylinder", "EBCylinder"}}};
 
   if (include_inner_sphere_A) {
     block_names.insert(block_names.end(), {"InnerAShell0"});
@@ -178,7 +144,7 @@ std::string create_option_string(
     const bool with_additional_outer_radial_refinement,
     const bool with_additional_grid_points, const bool include_inner_sphere_A,
     const bool include_inner_sphere_B, const bool add_boundary_condition,
-    const bool use_equiangular_map, const std::array<double, 3>& center_objectA,
+    const std::array<double, 3>& center_objectA,
     const std::array<double, 3>& center_objectB,
     const double inner_radius_objectA, const double inner_radius_objectB,
     const double outer_radius) {
@@ -226,28 +192,30 @@ std::string create_option_string(
       [&include_inner_sphere_A, &include_inner_sphere_B](
           const bool is_h_refinement, const bool include_extra,
           const size_t value) {
-        const std::string same = "[" + get_output(value) + "," +
-                                 get_output(value) + "," + get_output(value) +
-                                 "]";
-        const std::string one_more = "[" + get_output(value + 1) + "," +
-                                     get_output(value) + "," +
-                                     get_output(value) + "]";
-        const std::string shell_same =
-            is_h_refinement ? get_output(value) : same;
-        const std::string shell_one_more =
-            is_h_refinement ? get_output(value + 1) : one_more;
+        const std::string same =
+            is_h_refinement
+                ? get_output(value)
+                : "[" + get_output(value) + "," + get_output(value) + "]";
+        const std::string sphere_one_more =
+            is_h_refinement
+                ? get_output(value + 1)
+                : "[" + get_output(value + 1) + "," + get_output(value) + "]";
+        const std::string cyl_one_more =
+            is_h_refinement
+                ? get_output(value + 1)
+                : "[" + get_output(value) + "," + get_output(value + 1) + "]";
         std::string result{};
         if (include_extra) {
-          result += "\n    Outer: " + one_more;
+          result += "\n    Outer: " + cyl_one_more;
           result += "\n    InnerA: " + same;
-          result += "\n    InnerB: " + one_more;
+          result += "\n    InnerB: " + cyl_one_more;
           if (include_inner_sphere_A) {
-            result += "\n    InnerSphereA: " + shell_same;
+            result += "\n    InnerSphereA: " + same;
           }
           if (include_inner_sphere_B) {
-            result += "\n    InnerSphereB: " + shell_same;
+            result += "\n    InnerSphereB: " + sphere_one_more;
           }
-          result += "\n    OuterSphere: " + shell_one_more;
+          result += "\n    OuterSphere: " + sphere_one_more;
         } else {
           result = " " + get_output(value);
         }
@@ -261,11 +229,10 @@ std::string create_option_string(
          "\n  CenterB: " + stringize(center_objectB) +
          "\n  RadiusB: " + stringize(inner_radius_objectB) +
          "\n  OuterRadius: " + stringize(outer_radius) +
-         "\n  UseEquiangularMap: " + stringize(use_equiangular_map) +
          "\n  IncludeInnerSphereA: " + stringize(include_inner_sphere_A) +
          "\n  IncludeInnerSphereB: " + stringize(include_inner_sphere_B) +
          "\n  InitialRefinement:" +
-         initial_structure(true, with_additional_outer_radial_refinement, 1) +
+         initial_structure(true, with_additional_outer_radial_refinement, 0) +
          "\n  InitialGridPoints:" +
          initial_structure(false, with_additional_grid_points, 3) + "\n" +
          time_dependence + boundary_conditions;
@@ -491,54 +458,54 @@ void test_parse_errors() {
   CHECK_THROWS_WITH(
       domain::creators::CylindricalBinaryCompactObject(
           {{2.0, 0.05, 0.0}}, {-5.0, 0.05, 0.0}, 1.0, 0.4, false, false, 1.0,
-          false, 1_st, 3_st, std::nullopt, create_inner_boundary_condition(),
+          1_st, 3_st, std::nullopt, create_inner_boundary_condition(),
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring("OuterRadius is too small"));
   CHECK_THROWS_WITH(
       domain::creators::CylindricalBinaryCompactObject(
           {{-2.0, 0.05, 0.0}}, {-5.0, 0.05, 0.0}, 1.0, 0.4, false, false, 25.0,
-          false, 1_st, 3_st, std::nullopt, create_inner_boundary_condition(),
+          1_st, 3_st, std::nullopt, create_inner_boundary_condition(),
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "The x-coordinate of the input CenterA is expected to be positive"));
   CHECK_THROWS_WITH(
       domain::creators::CylindricalBinaryCompactObject(
           {{2.0, 0.05, 0.0}}, {5.0, 0.05, 0.0}, 1.0, 0.4, false, false, 25.0,
-          false, 1_st, 3_st, std::nullopt, create_inner_boundary_condition(),
+          1_st, 3_st, std::nullopt, create_inner_boundary_condition(),
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "The x-coordinate of the input CenterB is expected to be negative"));
   CHECK_THROWS_WITH(
       domain::creators::CylindricalBinaryCompactObject(
           {{2.0, 0.05, 0.0}}, {-5.0, 0.05, 0.0}, -1.0, 0.4, false, false, 25.0,
-          false, 1_st, 3_st, std::nullopt, create_inner_boundary_condition(),
+          1_st, 3_st, std::nullopt, create_inner_boundary_condition(),
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring("RadiusA and RadiusB are expected "
                                          "to be positive"));
   CHECK_THROWS_WITH(
       domain::creators::CylindricalBinaryCompactObject(
           {{2.0, 0.05, 0.0}}, {-5.0, 0.05, 0.0}, 1.0, -0.4, false, false, 25.0,
-          false, 1_st, 3_st, std::nullopt, create_inner_boundary_condition(),
+          1_st, 3_st, std::nullopt, create_inner_boundary_condition(),
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring("RadiusA and RadiusB are expected "
                                          "to be positive"));
   CHECK_THROWS_WITH(
       domain::creators::CylindricalBinaryCompactObject(
           {{2.0, 0.05, 0.0}}, {-5.0, 0.05, 0.0}, 0.15, 0.4, false, false, 25.0,
-          false, 1_st, 3_st, std::nullopt, create_inner_boundary_condition(),
+          1_st, 3_st, std::nullopt, create_inner_boundary_condition(),
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "RadiusA should not be smaller than RadiusB"));
   CHECK_THROWS_WITH(
       domain::creators::CylindricalBinaryCompactObject(
           {{2.0, 0.05, 0.0}}, {-1.0, 0.05, 0.0}, 1.0, 0.4, false, false, 25.0,
-          false, 1_st, 3_st, std::nullopt, create_inner_boundary_condition(),
+          1_st, 3_st, std::nullopt, create_inner_boundary_condition(),
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring("We expect |x_A| <= |x_B|"));
   CHECK_THROWS_WITH(
       domain::creators::CylindricalBinaryCompactObject(
           {{4.0, 0.0, 0.0}}, {-4.0, 0.0, 0.0}, 1.0, 1.0, false, false, 25.0,
-          false, 1_st, 3_st,
+          1_st, 3_st,
           TimeDepOptions{
               0.0, std::nullopt,
               domain::creators::time_dependent_options::RotationMapOptions<
@@ -553,7 +520,7 @@ void test_parse_errors() {
   CHECK_THROWS_WITH(
       domain::creators::CylindricalBinaryCompactObject(
           {{2.0, 0.05, 0.0}}, {-5.0, 0.05, 0.0}, 1.0, 0.4, false, false, 25.0,
-          false, 1_st, 3_st, std::nullopt, create_inner_boundary_condition(),
+          1_st, 3_st, std::nullopt, create_inner_boundary_condition(),
           std::make_unique<TestHelpers::domain::BoundaryConditions::
                                TestPeriodicBoundaryCondition<3>>(),
           Options::Context{false, {}, 1, 1}),
@@ -562,7 +529,7 @@ void test_parse_errors() {
   CHECK_THROWS_WITH(
       domain::creators::CylindricalBinaryCompactObject(
           {{2.0, 0.05, 0.0}}, {-5.0, 0.05, 0.0}, 1.0, 0.4, false, false, 25.0,
-          false, 1_st, 3_st, std::nullopt,
+          1_st, 3_st, std::nullopt,
           std::make_unique<TestHelpers::domain::BoundaryConditions::
                                TestPeriodicBoundaryCondition<3>>(),
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
@@ -571,7 +538,7 @@ void test_parse_errors() {
   CHECK_THROWS_WITH(
       domain::creators::CylindricalBinaryCompactObject(
           {{2.0, 0.05, 0.0}}, {-5.0, 0.05, 0.0}, 1.0, 0.4, false, false, 25.0,
-          false, 1_st, 3_st, std::nullopt, nullptr,
+          1_st, 3_st, std::nullopt, nullptr,
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "Must specify either both inner and outer boundary "
@@ -579,51 +546,45 @@ void test_parse_errors() {
   CHECK_THROWS_WITH(
       domain::creators::CylindricalBinaryCompactObject(
           {{2.0, 0.05, 0.0}}, {-5.0, 0.05, 0.0}, 1.0, 0.4, false, false, 25.0,
-          false, 1_st, 3_st, std::nullopt, create_inner_boundary_condition(),
+          1_st, 3_st, std::nullopt, create_inner_boundary_condition(),
           nullptr, Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "Must specify either both inner and outer boundary "
           "conditions or neither."));
-  // InitialRefinement and InitialGridPoints
+  // InitialGridPoints
   CHECK_THROWS_WITH(
       domain::creators::CylindricalBinaryCompactObject(
           {{2.0, 0.05, 0.0}}, {-3.0, 0.05, 0.0}, 1.0, 0.4, false, false, 25.0,
-          false, std::array<size_t, 3>{1_st, 1_st, 1_st}, 3_st, std::nullopt,
-          create_inner_boundary_condition(), create_outer_boundary_condition(),
-          Options::Context{false, {}, 1, 1}),
-      Catch::Matchers::ContainsSubstring("Angular h-refinement"));
+          1_st, 4_st, std::nullopt, create_inner_boundary_condition(),
+          create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
+      Catch::Matchers::ContainsSubstring("odd number of angular grid points"));
   CHECK_THROWS_WITH(
       domain::creators::CylindricalBinaryCompactObject(
           {{2.0, 0.05, 0.0}}, {-3.0, 0.05, 0.0}, 1.0, 0.4, false, false, 25.0,
-          false, 1_st, std::array<size_t, 3>{{3_st, 4_st, 5_st}}, std::nullopt,
-          create_inner_boundary_condition(), create_outer_boundary_condition(),
-          Options::Context{false, {}, 1, 1}),
-      Catch::Matchers::ContainsSubstring("must have L_max = M_max"));
+          1_st, 1_st, std::nullopt, create_inner_boundary_condition(),
+          create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
+      Catch::Matchers::ContainsSubstring(
+          "must have more than 2 radial grid points"));
 }
 
 // This matches the structure in the option string
-std::unordered_map<std::string, std::variant<std::array<size_t, 3>, size_t>>
-make_initial_refinement(const size_t initial_value,
-                        const bool include_inner_sphere_A,
-                        const bool include_inner_sphere_B) {
-  std::unordered_map<std::string, std::variant<std::array<size_t, 3>, size_t>>
-      initial_map;
-  const std::array<size_t, 3> same{initial_value, initial_value, initial_value};
-  const std::array<size_t, 3> one_more{initial_value + 1, initial_value,
-                                       initial_value};
-  const size_t shell_same = initial_value;
-  const size_t shell_one_more = initial_value + 1;
+std::unordered_map<std::string, size_t> make_initial_refinement(
+    const size_t initial_value, const bool include_inner_sphere_A,
+    const bool include_inner_sphere_B) {
+  std::unordered_map<std::string, size_t> initial_map;
+  const size_t same = initial_value;
+  const size_t one_more = initial_value + 1;
 
   initial_map["Outer"] = one_more;
   initial_map["InnerA"] = same;
   initial_map["InnerB"] = one_more;
   if (include_inner_sphere_A) {
-    initial_map["InnerSphereA"] = shell_same;
+    initial_map["InnerSphereA"] = same;
   }
   if (include_inner_sphere_B) {
-    initial_map["InnerSphereB"] = shell_same;
+    initial_map["InnerSphereB"] = one_more;
   }
-  initial_map["OuterSphere"] = shell_one_more;
+  initial_map["OuterSphere"] = one_more;
 
   return initial_map;
 }
@@ -637,22 +598,21 @@ make_initial_grid_points(const size_t initial_value,
   std::unordered_map<std::string,
                      std::variant<std::array<size_t, 3>, std::array<size_t, 2>>>
       initial_map;
-  const std::array<size_t, 3> same{initial_value, initial_value, initial_value};
-  const std::array<size_t, 3> one_more{initial_value + 1, initial_value,
-                                       initial_value};
-  const std::array<size_t, 2> shell_same{initial_value, initial_value};
-  const std::array<size_t, 2> shell_one_more{initial_value + 1, initial_value};
 
-  initial_map["Outer"] = one_more;
+  const std::array<size_t, 2> same{initial_value, initial_value};
+  const std::array<size_t, 2> sphere_one_more{initial_value + 1, initial_value};
+  const std::array<size_t, 2> cyl_one_more{initial_value, initial_value + 1};
+
+  initial_map["Outer"] = cyl_one_more;
   initial_map["InnerA"] = same;
-  initial_map["InnerB"] = one_more;
+  initial_map["InnerB"] = cyl_one_more;
   if (include_inner_sphere_A) {
-    initial_map["InnerSphereA"] = shell_same;
+    initial_map["InnerSphereA"] = same;
   }
   if (include_inner_sphere_B) {
-    initial_map["InnerSphereB"] = shell_same;
+    initial_map["InnerSphereB"] = sphere_one_more;
   }
-  initial_map["OuterSphere"] = shell_one_more;
+  initial_map["OuterSphere"] = sphere_one_more;
 
   return initial_map;
 }
@@ -662,7 +622,7 @@ void test_cylindrical_bbh() {
 
   const std::vector<double> times_to_check{{1.0, 2.3}};
 
-  constexpr size_t refinement = 1;
+  constexpr size_t refinement = 0;
   constexpr size_t grid_points = 3;
 
   const double separation = 9.0;
@@ -672,17 +632,16 @@ void test_cylindrical_bbh() {
   // loop go over {true, false}
   const bool with_sphere_e = false;
   for (auto [include_inner_sphere_A, include_inner_sphere_B,
-             use_equiangular_map, with_additional_outer_radial_refinement,
+             with_additional_outer_radial_refinement,
              with_additional_grid_points, with_time_dependence,
              with_control_systems, with_boundary_conditions] :
        random_sample<5>(
            cartesian_product(make_array(true, false), make_array(true, false),
-                             make_array(true, false), make_array(true, false),
+                             make_array(true, false),
                              make_array(true, false), make_array(true, false),
                              make_array(true, false), make_array(true, false)),
            make_not_null(&gen))) {
     CAPTURE(with_sphere_e);
-    CAPTURE(use_equiangular_map);
     CAPTURE(with_boundary_conditions);
     CAPTURE(with_additional_outer_radial_refinement);
     CAPTURE(with_additional_grid_points);
@@ -741,7 +700,6 @@ void test_cylindrical_bbh() {
         include_inner_sphere_A,
         include_inner_sphere_B,
         outer_radius,
-        use_equiangular_map,
         initial_refinement,
         initial_grid_points,
         std::move(time_dep_opts),
@@ -756,9 +714,9 @@ void test_cylindrical_bbh() {
         create_option_string(
             with_time_dependence, with_additional_outer_radial_refinement,
             with_additional_grid_points, include_inner_sphere_A,
-            include_inner_sphere_B, with_boundary_conditions,
-            use_equiangular_map, center_objectA, center_objectB,
-            inner_radius_objectA, inner_radius_objectB, outer_radius),
+            include_inner_sphere_B, with_boundary_conditions, center_objectA,
+            center_objectB, inner_radius_objectA, inner_radius_objectB,
+            outer_radius),
         cyl_binary_compact_object, with_boundary_conditions);
   }
 }
@@ -766,12 +724,6 @@ void test_cylindrical_bbh() {
 // Make sure initial refinement and initial grid points for different blocks
 // are set to the correct values based on the input
 void test_initial_extents_and_refinement() {
-  using RefinementMap =
-      std::unordered_map<std::string,
-                         std::variant<std::array<size_t, 3>, size_t>>;
-  using GridPointsMap = std::unordered_map<
-      std::string, std::variant<std::array<size_t, 3>, std::array<size_t, 2>>>;
-
   const std::array<double, 3> center_A{{2.0, 0.05, 0.0}};
   const std::array<double, 3> center_B{{-2.0, 0.05, 0.0}};
   const double radius_A = 1.0;
@@ -779,24 +731,20 @@ void test_initial_extents_and_refinement() {
   const bool include_inner_sphere_A = true;
   const bool include_inner_sphere_B = true;
   const double outer_radius = 100.0;
-  const bool use_equiangular_map = false;
 
   // Set h and p refinement globally with one number
   const size_t global_refinement = 1;
-  const size_t global_grid_points = 12;
+  const size_t global_grid_points = 13;
 
   // Set h and p refinement locally per block group
   const RefinementMap local_refinement =
-      RefinementMap{{"InnerA", std::array<size_t, 3>{1, 1, 1}},
-                    {"InnerB", std::array<size_t, 3>{2, 2, 2}},
-                    {"Outer", std::array<size_t, 3>{2, 2, 2}},
-                    {"InnerSphereA", size_t{0}},
-                    {"InnerSphereB", size_t{1}},
-                    {"OuterSphere", size_t{2}}};
+      RefinementMap{{"InnerA", size_t{1}},       {"InnerB", size_t{0}},
+                    {"Outer", size_t{1}},        {"InnerSphereA", size_t{0}},
+                    {"InnerSphereB", size_t{1}}, {"OuterSphere", size_t{2}}};
   const GridPointsMap local_grid_points =
-      GridPointsMap{{"InnerA", std::array<size_t, 3>{5, 5, 5}},
-                    {"InnerB", std::array<size_t, 3>{7, 7, 7}},
-                    {"Outer", std::array<size_t, 3>{9, 9, 9}},
+      GridPointsMap{{"InnerA", std::array<size_t, 2>{5, 7}},
+                    {"InnerB", std::array<size_t, 2>{7, 9}},
+                    {"Outer", std::array<size_t, 2>{9, 11}},
                     {"InnerSphereA", std::array<size_t, 2>{4, 6}},
                     {"InnerSphereB", std::array<size_t, 2>{6, 8}},
                     {"OuterSphere", std::array<size_t, 2>{8, 10}}};
@@ -805,7 +753,7 @@ void test_initial_extents_and_refinement() {
   const auto cbco_global_creator =
       domain::creators::CylindricalBinaryCompactObject(
           center_A, center_B, radius_A, radius_B, include_inner_sphere_A,
-          include_inner_sphere_B, outer_radius, use_equiangular_map,
+          include_inner_sphere_B, outer_radius,
           global_refinement, global_grid_points, std::nullopt,
           create_inner_boundary_condition(), create_outer_boundary_condition(),
           Options::Context{false, {}, 1, 1});
@@ -820,7 +768,7 @@ void test_initial_extents_and_refinement() {
   const auto cbco_local_creator =
       domain::creators::CylindricalBinaryCompactObject(
           center_A, center_B, radius_A, radius_B, include_inner_sphere_A,
-          include_inner_sphere_B, outer_radius, use_equiangular_map,
+          include_inner_sphere_B, outer_radius,
           local_refinement, local_grid_points, std::nullopt,
           create_inner_boundary_condition(), create_outer_boundary_condition(),
           Options::Context{false, {}, 1, 1});
@@ -841,6 +789,7 @@ void test_initial_extents_and_refinement() {
     ASSERT(block_name_global == block_name_local,
            "This test assumes both test domains have the same block names in "
            "the same order.");
+    CAPTURE(block_name_global);
 
     std::array<size_t, 3> expected_refinement_from_global{};
     std::array<size_t, 3> expected_extents_from_global{};
@@ -849,42 +798,55 @@ void test_initial_extents_and_refinement() {
     // Set expected h and p refinement
     if (block_groups.at("InnerSphereA").contains(block_name_global)) {
       expected_refinement_from_global = {{1, 0, 0}};
-      expected_extents_from_global = {{12, ylm::Spherepack::n_theta_points(12),
-                                       ylm::Spherepack::n_phi_points(12)}};
+      expected_extents_from_global = {{13, ylm::Spherepack::n_theta_points(13),
+                                       ylm::Spherepack::n_phi_points(13)}};
       expected_refinement_from_local = {{0, 0, 0}};
       expected_extents_from_local = {{4, ylm::Spherepack::n_theta_points(6),
                                       ylm::Spherepack::n_phi_points(6)}};
     } else if (block_groups.at("InnerSphereB").contains(block_name_global)) {
       expected_refinement_from_global = {{1, 0, 0}};
-      expected_extents_from_global = {{12, ylm::Spherepack::n_theta_points(12),
-                                       ylm::Spherepack::n_phi_points(12)}};
+      expected_extents_from_global = {{13, ylm::Spherepack::n_theta_points(13),
+                                       ylm::Spherepack::n_phi_points(13)}};
       expected_refinement_from_local = {{1, 0, 0}};
       expected_extents_from_local = {{6, ylm::Spherepack::n_theta_points(8),
                                       ylm::Spherepack::n_phi_points(8)}};
     } else if (block_groups.at("OuterSphere").contains(block_name_global)) {
       expected_refinement_from_global = {{1, 0, 0}};
-      expected_extents_from_global = {{12, ylm::Spherepack::n_theta_points(12),
-                                       ylm::Spherepack::n_phi_points(12)}};
+      expected_extents_from_global = {{13, ylm::Spherepack::n_theta_points(13),
+                                       ylm::Spherepack::n_phi_points(13)}};
       expected_refinement_from_local = {{2, 0, 0}};
       expected_extents_from_local = {{8, ylm::Spherepack::n_theta_points(10),
                                       ylm::Spherepack::n_phi_points(10)}};
     } else if (block_groups.at("InnerA").contains(block_name_global)) {
-      expected_refinement_from_global = {{1, 1, 1}};
-      expected_extents_from_global = {{12, 12, 12}};
-      expected_refinement_from_local = {{1, 1, 1}};
-      expected_extents_from_local = {{5, 5, 5}};
+      expected_refinement_from_global = {{0, 0, 1}};
+      expected_refinement_from_local = {{0, 0, 1}};
+      expected_extents_from_local = {{5, 17, 7}};
+      if (block_name_global.find("Filled") != std::string::npos) {
+        expected_extents_from_global = {{13, 49, 13}};
+      } else {
+        expected_extents_from_global = {{13, 13, 13}};
+      }
     } else if (block_groups.at("InnerB").contains(block_name_global)) {
-      expected_refinement_from_global = {{1, 1, 1}};
-      expected_extents_from_global = {{12, 12, 12}};
-      expected_refinement_from_local = {{2, 2, 2}};
-      expected_extents_from_local = {{7, 7, 7}};
+      expected_refinement_from_global = {{0, 0, 1}};
+      expected_refinement_from_local = {{0, 0, 0}};
+      expected_extents_from_local = {{7, 25, 9}};
+      if (block_name_global.find("Filled") != std::string::npos) {
+        expected_extents_from_global = {{13, 49, 13}};
+      } else {
+        expected_extents_from_global = {{13, 13, 13}};
+      }
     } else if (block_groups.at("Outer").contains(block_name_global)) {
-      expected_refinement_from_global = {{1, 1, 1}};
-      expected_extents_from_global = {{12, 12, 12}};
-      expected_refinement_from_local = {{2, 2, 2}};
-      expected_extents_from_local = {{9, 9, 9}};
+      expected_refinement_from_global = {{0, 0, 1}};
+      expected_refinement_from_local = {{0, 0, 1}};
+      expected_extents_from_local = {{9, 33, 11}};
+      if (block_name_global.find("Filled") != std::string::npos) {
+        expected_extents_from_global = {{13, 49, 13}};
+      } else {
+        expected_extents_from_global = {{13, 13, 13}};
+      }
     } else {
-      ERROR("Block name not found in block groups.");
+      ERROR("Block name " << block_name_global
+                          << " not found in block groups.");
     }
 
     // Get actual h and p refinement constructed

--- a/tests/Unit/Domain/Creators/Test_CylindricalBinaryCompactObject.cpp
+++ b/tests/Unit/Domain/Creators/Test_CylindricalBinaryCompactObject.cpp
@@ -52,6 +52,9 @@ namespace {
 using ExpirationTimeMap = std::unordered_map<std::string, double>;
 using CylBCO = ::domain::creators::CylindricalBinaryCompactObject;
 using TimeDepOptions = domain::creators::bco::TimeDependentMapOptions<true>;
+using RefinementMap = std::unordered_map<std::string, size_t>;
+using GridPointsMap = std::unordered_map<
+    std::string, std::variant<std::array<size_t, 3>, std::array<size_t, 2>>>;
 
 std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
 create_inner_boundary_condition() {
@@ -88,51 +91,14 @@ std::pair<std::vector<std::string>,
 block_names_and_groups(const bool include_inner_sphere_A,
                        const bool include_inner_sphere_B) {
   std::vector<std::string> block_names{
-      "CAFilledCylinderCenter", "CAFilledCylinderEast",
-      "CAFilledCylinderNorth",  "CAFilledCylinderWest",
-      "CAFilledCylinderSouth",  "CACylinderEast",
-      "CACylinderNorth",        "CACylinderWest",
-      "CACylinderSouth",        "EAFilledCylinderCenter",
-      "EAFilledCylinderEast",   "EAFilledCylinderNorth",
-      "EAFilledCylinderWest",   "EAFilledCylinderSouth",
-      "EACylinderEast",         "EACylinderNorth",
-      "EACylinderWest",         "EACylinderSouth",
-      "EBFilledCylinderCenter", "EBFilledCylinderEast",
-      "EBFilledCylinderNorth",  "EBFilledCylinderWest",
-      "EBFilledCylinderSouth",  "EBCylinderEast",
-      "EBCylinderNorth",        "EBCylinderWest",
-      "EBCylinderSouth",        "MAFilledCylinderCenter",
-      "MAFilledCylinderEast",   "MAFilledCylinderNorth",
-      "MAFilledCylinderWest",   "MAFilledCylinderSouth",
-      "MBFilledCylinderCenter", "MBFilledCylinderEast",
-      "MBFilledCylinderNorth",  "MBFilledCylinderWest",
-      "MBFilledCylinderSouth",  "CBFilledCylinderCenter",
-      "CBFilledCylinderEast",   "CBFilledCylinderNorth",
-      "CBFilledCylinderWest",   "CBFilledCylinderSouth",
-      "CBCylinderEast",         "CBCylinderNorth",
-      "CBCylinderWest",         "CBCylinderSouth"};
+      "CAFilledCylinder", "CACylinder", "EAFilledCylinder", "EACylinder",
+      "EBFilledCylinder", "EBCylinder", "MAFilledCylinder", "MBFilledCylinder",
+      "CBFilledCylinder", "CBCylinder"};
   std::unordered_map<std::string, std::unordered_set<std::string>> block_groups{
       {"Outer",
-       {{"CAFilledCylinderCenter", "CBCylinderEast", "CAFilledCylinderEast",
-         "CAFilledCylinderNorth", "CBFilledCylinderNorth", "CACylinderEast",
-         "CBFilledCylinderEast", "CAFilledCylinderSouth", "CACylinderNorth",
-         "CAFilledCylinderWest", "CACylinderWest", "CACylinderSouth",
-         "CBFilledCylinderCenter", "CBFilledCylinderWest",
-         "CBFilledCylinderSouth", "CBCylinderNorth", "CBCylinderWest",
-         "CBCylinderSouth"}}},
-      {"InnerA",
-       {"EAFilledCylinderCenter", "MAFilledCylinderNorth", "EACylinderSouth",
-        "EAFilledCylinderSouth", "EACylinderNorth", "EACylinderWest",
-        "MAFilledCylinderCenter", "EAFilledCylinderNorth",
-        "EAFilledCylinderWest", "MAFilledCylinderSouth", "EACylinderEast",
-        "MAFilledCylinderEast", "EAFilledCylinderEast",
-        "MAFilledCylinderWest"}},
-      {"InnerB",
-       {"EBFilledCylinderEast", "MBFilledCylinderEast", "EBFilledCylinderSouth",
-        "EBFilledCylinderNorth", "EBFilledCylinderWest", "EBCylinderEast",
-        "MBFilledCylinderWest", "EBCylinderNorth", "EBCylinderSouth",
-        "EBCylinderWest", "MBFilledCylinderCenter", "EBFilledCylinderCenter",
-        "MBFilledCylinderNorth", "MBFilledCylinderSouth"}}};
+       {{"CAFilledCylinder", "CBCylinder", "CBFilledCylinder", "CACylinder"}}},
+      {"InnerA", {"EAFilledCylinder", "MAFilledCylinder", "EACylinder"}},
+      {"InnerB", {"EBFilledCylinder", "MBFilledCylinder", "EBCylinder"}}};
 
   if (include_inner_sphere_A) {
     block_names.insert(block_names.end(), {"InnerAShell0"});
@@ -178,7 +144,7 @@ std::string create_option_string(
     const bool with_additional_outer_radial_refinement,
     const bool with_additional_grid_points, const bool include_inner_sphere_A,
     const bool include_inner_sphere_B, const bool add_boundary_condition,
-    const bool use_equiangular_map, const std::array<double, 3>& center_objectA,
+    const std::array<double, 3>& center_objectA,
     const std::array<double, 3>& center_objectB,
     const double inner_radius_objectA, const double inner_radius_objectB,
     const double outer_radius) {
@@ -226,28 +192,27 @@ std::string create_option_string(
       [&include_inner_sphere_A, &include_inner_sphere_B](
           const bool is_h_refinement, const bool include_extra,
           const size_t value) {
-        const std::string same = "[" + get_output(value) + "," +
-                                 get_output(value) + "," + get_output(value) +
-                                 "]";
-        const std::string one_more = "[" + get_output(value + 1) + "," +
-                                     get_output(value) + "," +
-                                     get_output(value) + "]";
-        const std::string shell_same =
-            is_h_refinement ? get_output(value) : same;
-        const std::string shell_one_more =
-            is_h_refinement ? get_output(value + 1) : one_more;
+        const std::string same =
+            is_h_refinement ? "" + get_output(value) + "" :
+            "[" + get_output(value) + "," + get_output(value) + "]";
+        const std::string sphere_one_more =
+            is_h_refinement ? "" + get_output(value + 1) + "" :
+            "[" + get_output(value + 1) + "," + get_output(value) + "]";
+        const std::string cyl_one_more =
+            is_h_refinement ? "" + get_output(value + 1) + "" :
+            "[" + get_output(value) + "," + get_output(value + 1) + "]";
         std::string result{};
         if (include_extra) {
-          result += "\n    Outer: " + one_more;
+          result += "\n    Outer: " + cyl_one_more;
           result += "\n    InnerA: " + same;
-          result += "\n    InnerB: " + one_more;
+          result += "\n    InnerB: " + cyl_one_more;
           if (include_inner_sphere_A) {
-            result += "\n    InnerSphereA: " + shell_same;
+            result += "\n    InnerSphereA: " + same;
           }
           if (include_inner_sphere_B) {
-            result += "\n    InnerSphereB: " + shell_same;
+            result += "\n    InnerSphereB: " + sphere_one_more;
           }
-          result += "\n    OuterSphere: " + shell_one_more;
+          result += "\n    OuterSphere: " + sphere_one_more;
         } else {
           result = " " + get_output(value);
         }
@@ -261,11 +226,10 @@ std::string create_option_string(
          "\n  CenterB: " + stringize(center_objectB) +
          "\n  RadiusB: " + stringize(inner_radius_objectB) +
          "\n  OuterRadius: " + stringize(outer_radius) +
-         "\n  UseEquiangularMap: " + stringize(use_equiangular_map) +
          "\n  IncludeInnerSphereA: " + stringize(include_inner_sphere_A) +
          "\n  IncludeInnerSphereB: " + stringize(include_inner_sphere_B) +
          "\n  InitialRefinement:" +
-         initial_structure(true, with_additional_outer_radial_refinement, 1) +
+         initial_structure(true, with_additional_outer_radial_refinement, 0) +
          "\n  InitialGridPoints:" +
          initial_structure(false, with_additional_grid_points, 3) + "\n" +
          time_dependence + boundary_conditions;
@@ -491,54 +455,54 @@ void test_parse_errors() {
   CHECK_THROWS_WITH(
       domain::creators::CylindricalBinaryCompactObject(
           {{2.0, 0.05, 0.0}}, {-5.0, 0.05, 0.0}, 1.0, 0.4, false, false, 1.0,
-          false, 1_st, 3_st, std::nullopt, create_inner_boundary_condition(),
+          1_st, 3_st, std::nullopt, create_inner_boundary_condition(),
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring("OuterRadius is too small"));
   CHECK_THROWS_WITH(
       domain::creators::CylindricalBinaryCompactObject(
           {{-2.0, 0.05, 0.0}}, {-5.0, 0.05, 0.0}, 1.0, 0.4, false, false, 25.0,
-          false, 1_st, 3_st, std::nullopt, create_inner_boundary_condition(),
+          1_st, 3_st, std::nullopt, create_inner_boundary_condition(),
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "The x-coordinate of the input CenterA is expected to be positive"));
   CHECK_THROWS_WITH(
       domain::creators::CylindricalBinaryCompactObject(
           {{2.0, 0.05, 0.0}}, {5.0, 0.05, 0.0}, 1.0, 0.4, false, false, 25.0,
-          false, 1_st, 3_st, std::nullopt, create_inner_boundary_condition(),
+          1_st, 3_st, std::nullopt, create_inner_boundary_condition(),
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "The x-coordinate of the input CenterB is expected to be negative"));
   CHECK_THROWS_WITH(
       domain::creators::CylindricalBinaryCompactObject(
           {{2.0, 0.05, 0.0}}, {-5.0, 0.05, 0.0}, -1.0, 0.4, false, false, 25.0,
-          false, 1_st, 3_st, std::nullopt, create_inner_boundary_condition(),
+          1_st, 3_st, std::nullopt, create_inner_boundary_condition(),
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring("RadiusA and RadiusB are expected "
                                          "to be positive"));
   CHECK_THROWS_WITH(
       domain::creators::CylindricalBinaryCompactObject(
           {{2.0, 0.05, 0.0}}, {-5.0, 0.05, 0.0}, 1.0, -0.4, false, false, 25.0,
-          false, 1_st, 3_st, std::nullopt, create_inner_boundary_condition(),
+          1_st, 3_st, std::nullopt, create_inner_boundary_condition(),
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring("RadiusA and RadiusB are expected "
                                          "to be positive"));
   CHECK_THROWS_WITH(
       domain::creators::CylindricalBinaryCompactObject(
           {{2.0, 0.05, 0.0}}, {-5.0, 0.05, 0.0}, 0.15, 0.4, false, false, 25.0,
-          false, 1_st, 3_st, std::nullopt, create_inner_boundary_condition(),
+          1_st, 3_st, std::nullopt, create_inner_boundary_condition(),
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "RadiusA should not be smaller than RadiusB"));
   CHECK_THROWS_WITH(
       domain::creators::CylindricalBinaryCompactObject(
           {{2.0, 0.05, 0.0}}, {-1.0, 0.05, 0.0}, 1.0, 0.4, false, false, 25.0,
-          false, 1_st, 3_st, std::nullopt, create_inner_boundary_condition(),
+          1_st, 3_st, std::nullopt, create_inner_boundary_condition(),
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring("We expect |x_A| <= |x_B|"));
   CHECK_THROWS_WITH(
       domain::creators::CylindricalBinaryCompactObject(
           {{4.0, 0.0, 0.0}}, {-4.0, 0.0, 0.0}, 1.0, 1.0, false, false, 25.0,
-          false, 1_st, 3_st,
+          1_st, 3_st,
           TimeDepOptions{
               0.0, std::nullopt,
               domain::creators::time_dependent_options::RotationMapOptions<
@@ -553,7 +517,7 @@ void test_parse_errors() {
   CHECK_THROWS_WITH(
       domain::creators::CylindricalBinaryCompactObject(
           {{2.0, 0.05, 0.0}}, {-5.0, 0.05, 0.0}, 1.0, 0.4, false, false, 25.0,
-          false, 1_st, 3_st, std::nullopt, create_inner_boundary_condition(),
+          1_st, 3_st, std::nullopt, create_inner_boundary_condition(),
           std::make_unique<TestHelpers::domain::BoundaryConditions::
                                TestPeriodicBoundaryCondition<3>>(),
           Options::Context{false, {}, 1, 1}),
@@ -562,7 +526,7 @@ void test_parse_errors() {
   CHECK_THROWS_WITH(
       domain::creators::CylindricalBinaryCompactObject(
           {{2.0, 0.05, 0.0}}, {-5.0, 0.05, 0.0}, 1.0, 0.4, false, false, 25.0,
-          false, 1_st, 3_st, std::nullopt,
+          1_st, 3_st, std::nullopt,
           std::make_unique<TestHelpers::domain::BoundaryConditions::
                                TestPeriodicBoundaryCondition<3>>(),
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
@@ -571,7 +535,7 @@ void test_parse_errors() {
   CHECK_THROWS_WITH(
       domain::creators::CylindricalBinaryCompactObject(
           {{2.0, 0.05, 0.0}}, {-5.0, 0.05, 0.0}, 1.0, 0.4, false, false, 25.0,
-          false, 1_st, 3_st, std::nullopt, nullptr,
+          1_st, 3_st, std::nullopt, nullptr,
           create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "Must specify either both inner and outer boundary "
@@ -579,51 +543,45 @@ void test_parse_errors() {
   CHECK_THROWS_WITH(
       domain::creators::CylindricalBinaryCompactObject(
           {{2.0, 0.05, 0.0}}, {-5.0, 0.05, 0.0}, 1.0, 0.4, false, false, 25.0,
-          false, 1_st, 3_st, std::nullopt, create_inner_boundary_condition(),
+          1_st, 3_st, std::nullopt, create_inner_boundary_condition(),
           nullptr, Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "Must specify either both inner and outer boundary "
           "conditions or neither."));
-  // InitialRefinement and InitialGridPoints
+  // InitialGridPoints
   CHECK_THROWS_WITH(
       domain::creators::CylindricalBinaryCompactObject(
           {{2.0, 0.05, 0.0}}, {-3.0, 0.05, 0.0}, 1.0, 0.4, false, false, 25.0,
-          false, std::array<size_t, 3>{1_st, 1_st, 1_st}, 3_st, std::nullopt,
-          create_inner_boundary_condition(), create_outer_boundary_condition(),
-          Options::Context{false, {}, 1, 1}),
-      Catch::Matchers::ContainsSubstring("Angular h-refinement"));
+          1_st, 4_st, std::nullopt, create_inner_boundary_condition(),
+          create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
+      Catch::Matchers::ContainsSubstring("odd number of angular grid points"));
   CHECK_THROWS_WITH(
       domain::creators::CylindricalBinaryCompactObject(
           {{2.0, 0.05, 0.0}}, {-3.0, 0.05, 0.0}, 1.0, 0.4, false, false, 25.0,
-          false, 1_st, std::array<size_t, 3>{{3_st, 4_st, 5_st}}, std::nullopt,
-          create_inner_boundary_condition(), create_outer_boundary_condition(),
-          Options::Context{false, {}, 1, 1}),
-      Catch::Matchers::ContainsSubstring("must have L_max = M_max"));
+          1_st, 1_st, std::nullopt, create_inner_boundary_condition(),
+          create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
+      Catch::Matchers::ContainsSubstring(
+          "must have more than 2 radial grid points"));
 }
 
 // This matches the structure in the option string
-std::unordered_map<std::string, std::variant<std::array<size_t, 3>, size_t>>
-make_initial_refinement(const size_t initial_value,
-                        const bool include_inner_sphere_A,
-                        const bool include_inner_sphere_B) {
-  std::unordered_map<std::string, std::variant<std::array<size_t, 3>, size_t>>
-      initial_map;
-  const std::array<size_t, 3> same{initial_value, initial_value, initial_value};
-  const std::array<size_t, 3> one_more{initial_value + 1, initial_value,
-                                       initial_value};
-  const size_t shell_same = initial_value;
-  const size_t shell_one_more = initial_value + 1;
+std::unordered_map<std::string, size_t> make_initial_refinement(
+    const size_t initial_value, const bool include_inner_sphere_A,
+    const bool include_inner_sphere_B) {
+  std::unordered_map<std::string, size_t> initial_map;
+  const size_t same = initial_value;
+  const size_t one_more = initial_value + 1;
 
   initial_map["Outer"] = one_more;
   initial_map["InnerA"] = same;
   initial_map["InnerB"] = one_more;
   if (include_inner_sphere_A) {
-    initial_map["InnerSphereA"] = shell_same;
+    initial_map["InnerSphereA"] = same;
   }
   if (include_inner_sphere_B) {
-    initial_map["InnerSphereB"] = shell_same;
+    initial_map["InnerSphereB"] = one_more;
   }
-  initial_map["OuterSphere"] = shell_one_more;
+  initial_map["OuterSphere"] = one_more;
 
   return initial_map;
 }
@@ -637,22 +595,21 @@ make_initial_grid_points(const size_t initial_value,
   std::unordered_map<std::string,
                      std::variant<std::array<size_t, 3>, std::array<size_t, 2>>>
       initial_map;
-  const std::array<size_t, 3> same{initial_value, initial_value, initial_value};
-  const std::array<size_t, 3> one_more{initial_value + 1, initial_value,
-                                       initial_value};
-  const std::array<size_t, 2> shell_same{initial_value, initial_value};
-  const std::array<size_t, 2> shell_one_more{initial_value + 1, initial_value};
 
-  initial_map["Outer"] = one_more;
+  const std::array<size_t, 2> same{initial_value, initial_value};
+  const std::array<size_t, 2> sphere_one_more{initial_value + 1, initial_value};
+  const std::array<size_t, 2> cyl_one_more{initial_value, initial_value + 1};
+
+  initial_map["Outer"] = cyl_one_more;
   initial_map["InnerA"] = same;
-  initial_map["InnerB"] = one_more;
+  initial_map["InnerB"] = cyl_one_more;
   if (include_inner_sphere_A) {
-    initial_map["InnerSphereA"] = shell_same;
+    initial_map["InnerSphereA"] = same;
   }
   if (include_inner_sphere_B) {
-    initial_map["InnerSphereB"] = shell_same;
+    initial_map["InnerSphereB"] = sphere_one_more;
   }
-  initial_map["OuterSphere"] = shell_one_more;
+  initial_map["OuterSphere"] = sphere_one_more;
 
   return initial_map;
 }
@@ -662,7 +619,7 @@ void test_cylindrical_bbh() {
 
   const std::vector<double> times_to_check{{1.0, 2.3}};
 
-  constexpr size_t refinement = 1;
+  constexpr size_t refinement = 0;
   constexpr size_t grid_points = 3;
 
   const double separation = 9.0;
@@ -672,17 +629,16 @@ void test_cylindrical_bbh() {
   // loop go over {true, false}
   const bool with_sphere_e = false;
   for (auto [include_inner_sphere_A, include_inner_sphere_B,
-             use_equiangular_map, with_additional_outer_radial_refinement,
+             with_additional_outer_radial_refinement,
              with_additional_grid_points, with_time_dependence,
              with_control_systems, with_boundary_conditions] :
        random_sample<5>(
            cartesian_product(make_array(true, false), make_array(true, false),
-                             make_array(true, false), make_array(true, false),
+                             make_array(true, false),
                              make_array(true, false), make_array(true, false),
                              make_array(true, false), make_array(true, false)),
            make_not_null(&gen))) {
     CAPTURE(with_sphere_e);
-    CAPTURE(use_equiangular_map);
     CAPTURE(with_boundary_conditions);
     CAPTURE(with_additional_outer_radial_refinement);
     CAPTURE(with_additional_grid_points);
@@ -741,7 +697,6 @@ void test_cylindrical_bbh() {
         include_inner_sphere_A,
         include_inner_sphere_B,
         outer_radius,
-        use_equiangular_map,
         initial_refinement,
         initial_grid_points,
         std::move(time_dep_opts),
@@ -756,9 +711,9 @@ void test_cylindrical_bbh() {
         create_option_string(
             with_time_dependence, with_additional_outer_radial_refinement,
             with_additional_grid_points, include_inner_sphere_A,
-            include_inner_sphere_B, with_boundary_conditions,
-            use_equiangular_map, center_objectA, center_objectB,
-            inner_radius_objectA, inner_radius_objectB, outer_radius),
+            include_inner_sphere_B, with_boundary_conditions, center_objectA,
+            center_objectB, inner_radius_objectA, inner_radius_objectB,
+            outer_radius),
         cyl_binary_compact_object, with_boundary_conditions);
   }
 }
@@ -766,12 +721,6 @@ void test_cylindrical_bbh() {
 // Make sure initial refinement and initial grid points for different blocks
 // are set to the correct values based on the input
 void test_initial_extents_and_refinement() {
-  using RefinementMap =
-      std::unordered_map<std::string,
-                         std::variant<std::array<size_t, 3>, size_t>>;
-  using GridPointsMap = std::unordered_map<
-      std::string, std::variant<std::array<size_t, 3>, std::array<size_t, 2>>>;
-
   const std::array<double, 3> center_A{{2.0, 0.05, 0.0}};
   const std::array<double, 3> center_B{{-2.0, 0.05, 0.0}};
   const double radius_A = 1.0;
@@ -779,24 +728,20 @@ void test_initial_extents_and_refinement() {
   const bool include_inner_sphere_A = true;
   const bool include_inner_sphere_B = true;
   const double outer_radius = 100.0;
-  const bool use_equiangular_map = false;
 
   // Set h and p refinement globally with one number
   const size_t global_refinement = 1;
-  const size_t global_grid_points = 12;
+  const size_t global_grid_points = 13;
 
   // Set h and p refinement locally per block group
   const RefinementMap local_refinement =
-      RefinementMap{{"InnerA", std::array<size_t, 3>{1, 1, 1}},
-                    {"InnerB", std::array<size_t, 3>{2, 2, 2}},
-                    {"Outer", std::array<size_t, 3>{2, 2, 2}},
-                    {"InnerSphereA", size_t{0}},
-                    {"InnerSphereB", size_t{1}},
-                    {"OuterSphere", size_t{2}}};
+      RefinementMap{{"InnerA", size_t{1}},       {"InnerB", size_t{0}},
+                    {"Outer", size_t{1}},        {"InnerSphereA", size_t{0}},
+                    {"InnerSphereB", size_t{1}}, {"OuterSphere", size_t{2}}};
   const GridPointsMap local_grid_points =
-      GridPointsMap{{"InnerA", std::array<size_t, 3>{5, 5, 5}},
-                    {"InnerB", std::array<size_t, 3>{7, 7, 7}},
-                    {"Outer", std::array<size_t, 3>{9, 9, 9}},
+      GridPointsMap{{"InnerA", std::array<size_t, 2>{5, 7}},
+                    {"InnerB", std::array<size_t, 2>{7, 9}},
+                    {"Outer", std::array<size_t, 2>{9, 11}},
                     {"InnerSphereA", std::array<size_t, 2>{4, 6}},
                     {"InnerSphereB", std::array<size_t, 2>{6, 8}},
                     {"OuterSphere", std::array<size_t, 2>{8, 10}}};
@@ -805,7 +750,7 @@ void test_initial_extents_and_refinement() {
   const auto cbco_global_creator =
       domain::creators::CylindricalBinaryCompactObject(
           center_A, center_B, radius_A, radius_B, include_inner_sphere_A,
-          include_inner_sphere_B, outer_radius, use_equiangular_map,
+          include_inner_sphere_B, outer_radius,
           global_refinement, global_grid_points, std::nullopt,
           create_inner_boundary_condition(), create_outer_boundary_condition(),
           Options::Context{false, {}, 1, 1});
@@ -820,7 +765,7 @@ void test_initial_extents_and_refinement() {
   const auto cbco_local_creator =
       domain::creators::CylindricalBinaryCompactObject(
           center_A, center_B, radius_A, radius_B, include_inner_sphere_A,
-          include_inner_sphere_B, outer_radius, use_equiangular_map,
+          include_inner_sphere_B, outer_radius,
           local_refinement, local_grid_points, std::nullopt,
           create_inner_boundary_condition(), create_outer_boundary_condition(),
           Options::Context{false, {}, 1, 1});
@@ -841,6 +786,7 @@ void test_initial_extents_and_refinement() {
     ASSERT(block_name_global == block_name_local,
            "This test assumes both test domains have the same block names in "
            "the same order.");
+    CAPTURE(block_name_global);
 
     std::array<size_t, 3> expected_refinement_from_global{};
     std::array<size_t, 3> expected_extents_from_global{};
@@ -849,42 +795,55 @@ void test_initial_extents_and_refinement() {
     // Set expected h and p refinement
     if (block_groups.at("InnerSphereA").contains(block_name_global)) {
       expected_refinement_from_global = {{1, 0, 0}};
-      expected_extents_from_global = {{12, ylm::Spherepack::n_theta_points(12),
-                                       ylm::Spherepack::n_phi_points(12)}};
+      expected_extents_from_global = {{13, ylm::Spherepack::n_theta_points(13),
+                                       ylm::Spherepack::n_phi_points(13)}};
       expected_refinement_from_local = {{0, 0, 0}};
       expected_extents_from_local = {{4, ylm::Spherepack::n_theta_points(6),
                                       ylm::Spherepack::n_phi_points(6)}};
     } else if (block_groups.at("InnerSphereB").contains(block_name_global)) {
       expected_refinement_from_global = {{1, 0, 0}};
-      expected_extents_from_global = {{12, ylm::Spherepack::n_theta_points(12),
-                                       ylm::Spherepack::n_phi_points(12)}};
+      expected_extents_from_global = {{13, ylm::Spherepack::n_theta_points(13),
+                                       ylm::Spherepack::n_phi_points(13)}};
       expected_refinement_from_local = {{1, 0, 0}};
       expected_extents_from_local = {{6, ylm::Spherepack::n_theta_points(8),
                                       ylm::Spherepack::n_phi_points(8)}};
     } else if (block_groups.at("OuterSphere").contains(block_name_global)) {
       expected_refinement_from_global = {{1, 0, 0}};
-      expected_extents_from_global = {{12, ylm::Spherepack::n_theta_points(12),
-                                       ylm::Spherepack::n_phi_points(12)}};
+      expected_extents_from_global = {{13, ylm::Spherepack::n_theta_points(13),
+                                       ylm::Spherepack::n_phi_points(13)}};
       expected_refinement_from_local = {{2, 0, 0}};
       expected_extents_from_local = {{8, ylm::Spherepack::n_theta_points(10),
                                       ylm::Spherepack::n_phi_points(10)}};
     } else if (block_groups.at("InnerA").contains(block_name_global)) {
-      expected_refinement_from_global = {{1, 1, 1}};
-      expected_extents_from_global = {{12, 12, 12}};
-      expected_refinement_from_local = {{1, 1, 1}};
-      expected_extents_from_local = {{5, 5, 5}};
+      expected_refinement_from_global = {{0, 0, 1}};
+      expected_refinement_from_local = {{0, 0, 1}};
+      expected_extents_from_local = {{5, 17, 7}};
+      if (block_name_global.find("Filled") != std::string::npos) {
+        expected_extents_from_global = {{13, 49, 13}};
+      } else {
+        expected_extents_from_global = {{13, 13, 13}};
+      }
     } else if (block_groups.at("InnerB").contains(block_name_global)) {
-      expected_refinement_from_global = {{1, 1, 1}};
-      expected_extents_from_global = {{12, 12, 12}};
-      expected_refinement_from_local = {{2, 2, 2}};
-      expected_extents_from_local = {{7, 7, 7}};
+      expected_refinement_from_global = {{0, 0, 1}};
+      expected_refinement_from_local = {{0, 0, 0}};
+      expected_extents_from_local = {{7, 25, 9}};
+      if (block_name_global.find("Filled") != std::string::npos) {
+        expected_extents_from_global = {{13, 49, 13}};
+      } else {
+        expected_extents_from_global = {{13, 13, 13}};
+      }
     } else if (block_groups.at("Outer").contains(block_name_global)) {
-      expected_refinement_from_global = {{1, 1, 1}};
-      expected_extents_from_global = {{12, 12, 12}};
-      expected_refinement_from_local = {{2, 2, 2}};
-      expected_extents_from_local = {{9, 9, 9}};
+      expected_refinement_from_global = {{0, 0, 1}};
+      expected_refinement_from_local = {{0, 0, 1}};
+      expected_extents_from_local = {{9, 33, 11}};
+      if (block_name_global.find("Filled") != std::string::npos) {
+        expected_extents_from_global = {{13, 49, 13}};
+      } else {
+        expected_extents_from_global = {{13, 13, 13}};
+      }
     } else {
-      ERROR("Block name not found in block groups.");
+      ERROR("Block name " << block_name_global
+                          << " not found in block groups.");
     }
 
     // Get actual h and p refinement constructed

--- a/tests/Unit/Helpers/Domain/DomainTestHelpers.cpp
+++ b/tests/Unit/Helpers/Domain/DomainTestHelpers.cpp
@@ -278,22 +278,107 @@ void check_block_face_grid_points_align(
   const auto orientation =
       find_neighbor_orientation(host_block, neighbor_block);
   // Set up a Mesh on the shared face. Corner points are already checked by
-  // physical_separation, so check on Gauss points
+  // physical_separation, so check on Gauss points. For cylindrical blocks,
+  // GaussLobatto points are used so that endpoints are also checked since
+  // physical_separation cannot be called for cylindrical blocks since they do
+  // not have corners.
   Mesh<VolumeDim - 1> face_mesh;
-  if (host_block.topologies()[VolumeDim - 1] ==
+  if constexpr (VolumeDim == 3) {
+    if (host_block.topologies()[VolumeDim - 1] ==
       domain::Topology::CartoonCylinder) {
-    if constexpr (VolumeDim == 3) {
       face_mesh = Mesh<VolumeDim - 1>{
           {3, 1},
           {Spectral::Basis::Legendre, Spectral::Basis::Cartoon},
           {Spectral::Quadrature::Gauss, Spectral::Quadrature::AxialSymmetry}};
+    } else if (host_block.topologies() == domain::topologies::full_cylinder) {
+      if (neighbor_block.topologies() == domain::topologies::full_cylinder and
+          (direction == Direction<VolumeDim>::upper_zeta() or
+           direction == Direction<VolumeDim>::lower_zeta())) {
+        face_mesh = Mesh<VolumeDim - 1>{
+            {3, 9},
+            {Spectral::Basis::ZernikeB2, Spectral::Basis::ZernikeB2},
+            {Spectral::Quadrature::GaussRadauUpper,
+             Spectral::Quadrature::Equiangular}};
+      } else if (neighbor_block.topologies() ==
+                     domain::topologies::cylindrical_shell and
+                 (direction == Direction<VolumeDim>::upper_xi() or
+                  direction == Direction<VolumeDim>::lower_xi())) {
+        face_mesh = Mesh<VolumeDim - 1>{
+            {9, 5},
+            {Spectral::Basis::ZernikeB2, Spectral::Basis::Legendre},
+            {Spectral::Quadrature::Equiangular,
+             Spectral::Quadrature::GaussLobatto}};
+      } else {
+        ERROR(
+            "check_block_face_grid_points_align() for a filled cylinder host "
+            "block is only implemented for when a neighbor block is a filled "
+            "cylinder in the +/-zeta direction or a hollow cylinder in the "
+            "+/-xi direction.");
+      }
+    } else if (host_block.topologies() ==
+               domain::topologies::cylindrical_shell) {
+      // for some reason, clang-tidy thinks there are duplicate branches
+      // NOLINTBEGIN
+      if (neighbor_block.topologies() ==
+              domain::topologies::cylindrical_shell and
+          (direction == Direction<VolumeDim>::upper_xi() or
+           direction == Direction<VolumeDim>::lower_xi())) {
+        face_mesh = Mesh<VolumeDim - 1>{
+            {3, 9},
+            {Spectral::Basis::Fourier, Spectral::Basis::Legendre},
+            {Spectral::Quadrature::Equiangular,
+             Spectral::Quadrature::GaussLobatto}};
+      } else if (neighbor_block.topologies() ==
+                     domain::topologies::cylindrical_shell and
+                 (direction == Direction<VolumeDim>::upper_zeta() or
+                  direction == Direction<VolumeDim>::lower_zeta())) {
+        face_mesh = Mesh<VolumeDim - 1>{
+            {9, 5},
+            {Spectral::Basis::Legendre, Spectral::Basis::Fourier},
+            {Spectral::Quadrature::GaussLobatto,
+             Spectral::Quadrature::Equiangular}};
+      } else if (neighbor_block.topologies() ==
+                     domain::topologies::full_cylinder and
+                 (direction == Direction<VolumeDim>::upper_zeta() or
+                  direction == Direction<VolumeDim>::lower_zeta())) {
+        face_mesh = Mesh<VolumeDim - 1>{
+            {9, 5},
+            {Spectral::Basis::Legendre, Spectral::Basis::Fourier},
+            {Spectral::Quadrature::GaussLobatto,
+             Spectral::Quadrature::Equiangular}};
+      } else if (neighbor_block.topologies() ==
+                     domain::topologies::spherical_shell and
+                 (direction == Direction<VolumeDim>::upper_xi() or
+                  direction == Direction<VolumeDim>::lower_xi())) {
+        face_mesh = Mesh<VolumeDim - 1>{
+            {3, 9},
+            {Spectral::Basis::Fourier, Spectral::Basis::Legendre},
+            {Spectral::Quadrature::Equiangular,
+             Spectral::Quadrature::GaussLobatto}};
+      }  // NOLINTEND
+      else {
+        ERROR(
+            "check_block_face_grid_points_align() for a hollow cylinder host "
+            "block is only implemented for when a neighbor block is a hollow "
+            "cylinder in the +/-xi direction or a filled cylinder in the "
+            "+/-zeta direction.");
+      }
+    } else if (host_block.topologies() == domain::topologies::spherical_shell) {
+      ERROR(
+          "check_block_face_grid_points_align() is not implemented for "
+          "spherical shell host blocks.");
     } else {
-      ERROR("Cartoon basis used with non 3D mesh, got dim = " << VolumeDim);
+      face_mesh = Mesh<VolumeDim - 1>{3_st, Spectral::Basis::Legendre,
+                                    Spectral::Quadrature::Gauss};
     }
+  } else if (host_block.topologies()[VolumeDim - 1] ==
+      domain::Topology::CartoonCylinder) {
+    ERROR("Cartoon basis used with non 3D mesh, got dim = " << VolumeDim);
   } else {
     face_mesh = Mesh<VolumeDim - 1>{3_st, Spectral::Basis::Legendre,
                                     Spectral::Quadrature::Gauss};
   }
+
   // We want block logical coordinates on face_mesh on the host side and the
   // neighbor. The following returns element logical coordinates in the host
   // frame, which we then copy into tensors holding block logical coordinates,
@@ -543,6 +628,24 @@ void test_physical_separation(
             domain::check_block_face_grid_points_align(blocks[i], blocks[j],
                                                        time, functions_of_time);
           }
+        } else if constexpr (VolumeDim == 3) {
+           // For cylinder blocks, we don't test physical separation of corners
+           // with physical_separation() because there are no corners.
+           if ((blocks[i].topologies() == domain::topologies::full_cylinder and
+                blocks[j].topologies() == domain::topologies::full_cylinder) or
+               (blocks[i].topologies() == domain::topologies::full_cylinder and
+                blocks[j].topologies() ==
+                    domain::topologies::cylindrical_shell) or
+               (blocks[i].topologies() ==
+                    domain::topologies::cylindrical_shell and
+                blocks[j].topologies() ==
+                    domain::topologies::cylindrical_shell) or
+               (blocks[i].topologies() ==
+                    domain::topologies::cylindrical_shell and
+                blocks[j].topologies() == domain::topologies::full_cylinder)) {
+             domain::check_block_face_grid_points_align(
+                 blocks[i], blocks[j], time, functions_of_time);
+           }
         }
       }
     }


### PR DESCRIPTION
## Proposed changes

This swaps out the multi-cube block cylinders for single cylindrical blocks.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent was used, have a co-author trailer of the form
      "Co-Authored-By: <agent name> <agent email>" as the last line of the
      commit, e.g. "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>".

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
