### PR TITLE
Add Regge-Wheeler-Zerilli strain extraction

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -497,6 +497,23 @@ eprint = {https://doi.org/10.1137/0916035}
     year = "2012"
 }
 
+@article{Buchman:2024zsb,
+  author = {Buchman, Luisa T. and Duez, Matthew D. and Morales, Marlo and
+            Scheel, Mark A. and Kostersitz, Tim M. and Evans, Andrew M. and
+            Mitman, Keefe},
+  title = {Numerical Relativity Multimodal Waveforms using Absorbing Boundary
+           Conditions},
+  eprint = {2402.12544},
+  archivePrefix = {arXiv},
+  primaryClass = {gr-qc},
+  doi = {10.1088/1361-6382/ad65af},
+  url = {https://doi.org/10.1088/1361-6382/ad65af},
+  journal = {Class. Quant. Grav.},
+  volume = {41},
+  pages = {175011},
+  year = {2024}
+}
+
 @article{Casoni2012,
   author  = {Casoni, E. and Peraire, J. and Huerta, A.},
   title   = {One-dimensional shock-capturing for high-order discontinuous
@@ -2171,6 +2188,22 @@ journal = {The Astrophysical Journal}
   year =         2014
 }
 
+@article{Nagar:2005ea,
+  author = {Nagar, Alessandro and Rezzolla, Luciano},
+  title = {Gauge-invariant non-spherical metric perturbations of
+           {Schwarzschild} black-hole spacetimes},
+  eprint = {gr-qc/0502064},
+  archivePrefix = {arXiv},
+  primaryClass = {gr-qc},
+  doi = {10.1088/0264-9381/22/16/R01},
+  url = {https://doi.org/10.1088/0264-9381/22/16/R01},
+  journal = {Class. Quant. Grav.},
+  volume = {22},
+  pages = {R167},
+  year = {2005},
+  note = {Erratum: Class. Quant. Grav. 23, 4297 (2006)}
+}
+
 @article{Nee2024bur,
   author = {Nee, Peter James and Lara, Guillermo and Pfeiffer, Harald P. and
             Vu, Nils L.},
@@ -2560,12 +2593,62 @@ archivePrefix = {arXiv},
     year = "2007"
 }
 
+@article{Rinne:2008vn,
+  author = {Rinne, Oliver and Buchman, Luisa T. and Scheel, Mark A. and
+            Pfeiffer, Harald P.},
+  title = {Implementation of higher-order absorbing boundary conditions for
+           the {Einstein} equations},
+  eprint = {0811.3593},
+  archivePrefix = {arXiv},
+  primaryClass = {gr-qc},
+  reportNumber = {DAMTP-2008-108},
+  doi = {10.1088/0264-9381/26/7/075009},
+  url = {https://doi.org/10.1088/0264-9381/26/7/075009},
+  journal = {Class. Quant. Grav.},
+  volume = {26},
+  pages = {075009},
+  year = {2009}
+}
+
+@article{Ruiz:2007yx,
+  author = {Ruiz, Milton and Alcubierre, Miguel and N{\'u}{\~n}ez, Dar{\'i}o and
+            Takahashi, Ryoji},
+  title = {Multipole expansions for energy and momenta carried by
+           gravitational waves},
+  eprint = {0707.4654},
+  archivePrefix = {arXiv},
+  primaryClass = {gr-qc},
+  doi = {10.1007/s10714-007-0570-8},
+  url = {https://doi.org/10.1007/s10714-007-0570-8},
+  journal = {Gen. Rel. Grav.},
+  volume = {40},
+  pages = {1705--1729},
+  year = {2008},
+  note = {Erratum: Gen. Rel. Grav. 40, 2467 (2008)}
+}
+
 @book{Saad2003,
   title     = "Iterative Methods for Sparse Linear Systems: Second Edition",
   author    = "Saad, Yousef",
   isbn      = "978-0898715347",
   publisher = "Society for Industrial and Applied Mathematics",
   year      = "2003",
+}
+
+@article{Sarbach:2001qq,
+  author = {Sarbach, Olivier and Tiglio, Manuel},
+  title = {Gauge invariant perturbations of {Schwarzschild} black holes in
+           horizon penetrating coordinates},
+  eprint = {gr-qc/0104061},
+  archivePrefix = {arXiv},
+  primaryClass = {gr-qc},
+  reportNumber = {CGPG-01-4-5},
+  doi = {10.1103/PhysRevD.64.084016},
+  url = {https://doi.org/10.1103/PhysRevD.64.084016},
+  journal = {Phys. Rev. D},
+  volume = {64},
+  pages = {084016},
+  year = {2001}
 }
 
 @article{Schaal2015,

--- a/src/PointwiseFunctions/GeneralRelativity/Surfaces/CMakeLists.txt
+++ b/src/PointwiseFunctions/GeneralRelativity/Surfaces/CMakeLists.txt
@@ -15,6 +15,7 @@ spectre_target_sources(
   InverseSurfaceMetric.cpp
   Mass.cpp
   RadialDistance.cpp
+  ReggeWheelerZerilli.cpp
   RicciScalar.cpp
   Spin.cpp
   SurfaceIntegralOfScalar.cpp
@@ -33,6 +34,7 @@ spectre_target_headers(
   InverseSurfaceMetric.hpp
   Mass.hpp
   RadialDistance.hpp
+  ReggeWheelerZerilli.hpp
   RicciScalar.hpp
   Spin.hpp
   SurfaceIntegralOfScalar.hpp
@@ -53,6 +55,8 @@ target_link_libraries(
   ErrorHandling
   GeneralRelativity
   LinearAlgebra
+  SpinWeightedSphericalHarmonics
+  TensorYlm
   Utilities
   )
 

--- a/src/PointwiseFunctions/GeneralRelativity/Surfaces/ReggeWheelerZerilli.cpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Surfaces/ReggeWheelerZerilli.cpp
@@ -1,0 +1,481 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/GeneralRelativity/Surfaces/ReggeWheelerZerilli.hpp"
+
+#include <array>
+#include <cmath>
+#include <complex>
+#include <cstddef>
+#include <optional>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/SimpleSparseMatrix.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/SpherepackIterator.hpp"
+#include "NumericalAlgorithms/SpinWeightedSphericalHarmonics/SwshCoefficients.hpp"
+#include "NumericalAlgorithms/TensorYlm/CartToSphere.hpp"
+#include "NumericalAlgorithms/TensorYlm/TensorYlm.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/EqualWithinRoundoff.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/RuntimeCache.hpp"
+
+namespace gr::surfaces {
+namespace {
+
+// Check modal storage before the formulas index a complete Goldberg mode set.
+void assert_size(const ComplexModalVector& data, const size_t expected_size,
+                 const char* const name) {
+  ASSERT(data.size() == expected_size,
+         "Expected " << name << " to have size " << expected_size << " but got "
+                     << data.size());
+}
+
+// Check every tensor component because their views can have independent sizes.
+template <typename TensorType>
+void assert_tensor_size(const TensorType& tensor, const size_t expected_size,
+                        const char* const name) {
+  for (size_t storage_index = 0; storage_index < tensor.size();
+       ++storage_index) {
+    ASSERT(tensor[storage_index].size() == expected_size,
+           "Expected component "
+               << storage_index << " of " << name << " to have size "
+               << expected_size << " but got " << tensor[storage_index].size());
+  }
+}
+
+// Read a mode while keeping the Goldberg-ordering detail out of the formulas.
+std::complex<double> mode(const ComplexModalVector& data, const size_t l_max,
+                          const size_t l, const int m) {
+  return data[Spectral::Swsh::goldberg_mode_index(l_max, l, m)];
+}
+
+// Write a mode while keeping the Goldberg-ordering detail in one place.
+void set_mode(const gsl::not_null<ComplexModalVector*> data, const size_t l_max,
+              const size_t l, const int m, const std::complex<double>& value) {
+  (*data)[Spectral::Swsh::goldberg_mode_index(l_max, l, m)] = value;
+}
+
+// Complete modes computed only for m >= 0 using scalar-field reality.
+void fill_scalar_negative_m_modes(const gsl::not_null<ComplexModalVector*> data,
+                                  const size_t l_max) {
+  for (size_t l = 0; l <= l_max; ++l) {
+    for (int m = 1; m <= static_cast<int>(l); ++m) {
+      const double sign = m % 2 == 0 ? 1.0 : -1.0;
+      set_mode(data, l_max, l, -m, sign * conj(mode(*data, l_max, l, m)));
+    }
+  }
+}
+
+// Convert Spherepack's real a/b coefficients to orthonormal complex Ylm modes;
+// the phase and normalization account for the two libraries' conventions.
+std::complex<double> standard_mode_from_spherepack(const DataVector& data,
+                                                   const size_t l_max,
+                                                   const size_t l,
+                                                   const size_t m) {
+  ylm::SpherepackIterator iterator(l_max, l_max, 1, false);
+  const size_t a_index =
+      iterator.set(l, m, ylm::SpherepackIterator::CoefficientArray::a)();
+  const size_t b_index =
+      iterator.set(l, m, ylm::SpherepackIterator::CoefficientArray::b)();
+  const std::complex<double> spherepack_mode{data[a_index], data[b_index]};
+  const double sign = m % 2 == 0 ? 1.0 : -1.0;
+  return sign * sqrt(M_PI / 2.0) * spherepack_mode;
+}
+
+// Bundle the two tensor-basis transforms needed by RWZ extraction.
+struct CartesianToSphericalMatrices {
+  SimpleSparseMatrix rank_one{};
+  SimpleSparseMatrix rank_two_symmetric{};
+};
+
+// Build the standard TensorYlm basis transforms; only their rank-specific
+// bundling and caching are local here.
+CartesianToSphericalMatrices make_cartesian_to_spherical_matrices(
+    const size_t l_max) {
+  CartesianToSphericalMatrices result{};
+  ylm::TensorYlm::fill_cart_to_sphere<
+      typename tnsr::i<DataVector, 3, Frame::Inertial>::structure>(
+      make_not_null(&result.rank_one), l_max,
+      ylm::TensorYlm::CoefficientNormalization::Spherepack);
+  ylm::TensorYlm::fill_cart_to_sphere<
+      typename tnsr::ii<DataVector, 3, Frame::Inertial>::structure>(
+      make_not_null(&result.rank_two_symmetric), l_max,
+      ylm::TensorYlm::CoefficientNormalization::Spherepack);
+  return result;
+}
+
+// This matches the upper bound of the standard Spherepack cache. Larger
+// transforms remain supported, but are uncommon and are built on demand
+// without retaining potentially large sparse matrices.
+constexpr size_t maximum_cached_transform_l_max = 150;
+
+// Lazily reuse the comparatively expensive sparse transforms at common l_max.
+const CartesianToSphericalMatrices& cached_cartesian_to_spherical_matrices(
+    const size_t l_max) {
+  static const auto cache = make_runtime_cache<
+      CacheRange<size_t{2}, maximum_cached_transform_l_max + 1>>(
+      [](const size_t cached_l_max) {
+        return make_cartesian_to_spherical_matrices(cached_l_max);
+      });
+  return cache(l_max);
+}
+
+// Transform nodal Cartesian components first to Spherepack modes and then to
+// spherical tensor components. The GH Variables-wide transform has the same
+// stages but operates on a fixed tag list, so this tensor-level form
+// avoids manufacturing unrelated GH fields. Spherepack padding is zeroed
+// because it does not represent modes but is included in the sparse storage.
+template <typename TensorType>
+TensorType cartesian_to_spherical_tensor_modes(
+    const TensorType& nodal_tensor, const ylm::Spherepack& spherepack,
+    const SimpleSparseMatrix& cart_to_sphere_matrix) {
+  const size_t spectral_size = spherepack.spectral_size();
+  TensorType cartesian_modes{spectral_size, 0.0};
+  TensorType spherical_modes{spectral_size, 0.0};
+
+  for (size_t storage_index = 0; storage_index < nodal_tensor.size();
+       ++storage_index) {
+    cartesian_modes[storage_index] =
+        spherepack.phys_to_spec(nodal_tensor[storage_index]);
+  }
+
+  const ylm::SpherepackIterator iterator(spherepack.l_max(), spherepack.m_max(),
+                                         1, false);
+  for (size_t storage_index = 0; storage_index < cartesian_modes.size();
+       ++storage_index) {
+    for (size_t offset = 0; offset < spectral_size; ++offset) {
+      if (not iterator.compact_index(offset).has_value()) {
+        cartesian_modes[storage_index][offset] = 0.0;
+      }
+    }
+  }
+
+  std::vector<double> flattened_cartesian_modes(cartesian_modes.size() *
+                                                spectral_size);
+  std::vector<double> flattened_spherical_modes(
+      spherical_modes.size() * spectral_size, 0.0);
+  for (size_t storage_index = 0; storage_index < cartesian_modes.size();
+       ++storage_index) {
+    for (size_t mode_index = 0; mode_index < spectral_size; ++mode_index) {
+      flattened_cartesian_modes[storage_index * spectral_size + mode_index] =
+          cartesian_modes[storage_index][mode_index];
+    }
+  }
+
+  const gsl::span<double> cartesian_modes_span{flattened_cartesian_modes};
+  gsl::span<double> spherical_modes_span{flattened_spherical_modes};
+  cart_to_sphere_matrix.increment_multiply_on_right(
+      make_not_null(&spherical_modes_span), 0, 1, cartesian_modes_span, 0, 1);
+
+  for (size_t storage_index = 0; storage_index < spherical_modes.size();
+       ++storage_index) {
+    for (size_t mode_index = 0; mode_index < spectral_size; ++mode_index) {
+      spherical_modes[storage_index][mode_index] =
+          flattened_spherical_modes[storage_index * spectral_size + mode_index];
+    }
+  }
+  return spherical_modes;
+}
+
+// Enforce the coordinate-sphere assumption used for radial projections and
+// for interpreting the supplied Spherepack grid as extraction angles.
+void assert_points_are_on_coordinate_sphere(
+    const tnsr::I<DataVector, 3, Frame::Inertial>& inertial_coords,
+    const std::array<double, 3>& center, const double extraction_radius) {
+  auto centered_coords = inertial_coords;
+  for (size_t i = 0; i < 3; ++i) {
+    centered_coords.get(i) -= gsl::at(center, i);
+  }
+  const auto coordinate_radii = magnitude(centered_coords);
+  for (size_t s = 0; s < get(coordinate_radii).size(); ++s) {
+    ASSERT(equal_within_roundoff(get(coordinate_radii)[s], extraction_radius),
+           "Expected point "
+               << s << " to lie at coordinate radius " << extraction_radius
+               << " about the extraction center, but its radius is "
+               << get(coordinate_radii)[s]);
+  }
+}
+
+}  // namespace
+
+ReggeWheelerZerilli::ReggeWheelerZerilli(const size_t l_max)
+    : phi_plus(square(l_max + 1), 0.0),
+      phi_minus(square(l_max + 1), 0.0),
+      r_times_strain(square(l_max + 1), 0.0) {}
+
+void regge_wheeler_zerilli_moncrief(
+    const gsl::not_null<ReggeWheelerZerilli*> rwz_quantities,
+    const ComplexModalVector& h_t, const ComplexModalVector& dr_h_t,
+    const ComplexModalVector& dt_h_r, const ComplexModalVector& h_rr,
+    const ComplexModalVector& q_r, const ComplexModalVector& k,
+    const ComplexModalVector& dr_k, const ComplexModalVector& g,
+    const ComplexModalVector& dr_g, const size_t l_max,
+    const double extraction_radius) {
+  ASSERT(
+      extraction_radius > 0.0,
+      "The extraction radius must be positive, but is " << extraction_radius);
+  const size_t number_of_modes = square(l_max + 1);
+  assert_size(h_t, number_of_modes, "h_t");
+  assert_size(dr_h_t, number_of_modes, "dr_h_t");
+  assert_size(dt_h_r, number_of_modes, "dt_h_r");
+  assert_size(h_rr, number_of_modes, "h_rr");
+  assert_size(q_r, number_of_modes, "q_r");
+  assert_size(k, number_of_modes, "k");
+  assert_size(dr_k, number_of_modes, "dr_k");
+  assert_size(g, number_of_modes, "g");
+  assert_size(dr_g, number_of_modes, "dr_g");
+
+  rwz_quantities->phi_plus = ComplexModalVector{number_of_modes, 0.0};
+  rwz_quantities->phi_minus = ComplexModalVector{number_of_modes, 0.0};
+  rwz_quantities->r_times_strain =
+      SpinWeighted<ComplexModalVector, -2>{number_of_modes, 0.0};
+
+  const std::complex<double> imaginary_unit{0.0, 1.0};
+  for (size_t l = 2; l <= l_max; ++l) {
+    const auto lambda = static_cast<double>((l - 1) * (l + 2));
+    const auto l_l_plus_1 = static_cast<double>(l * (l + 1));
+    const double strain_prefactor =
+        sqrt(static_cast<double>((l - 1) * l * (l + 1) * (l + 2)));
+    for (int m = -static_cast<int>(l); m <= static_cast<int>(l); ++m) {
+      const auto p_r = mode(q_r, l_max, l, m) - 0.5 *
+                                                    square(extraction_radius) *
+                                                    mode(dr_g, l_max, l, m);
+      const auto z_r =
+          mode(h_rr, l_max, l, m) -
+          extraction_radius * mode(dr_k, l_max, l, m) -
+          0.5 * extraction_radius * l_l_plus_1 * mode(dr_g, l_max, l, m) -
+          2.0 * p_r / extraction_radius;
+      const auto k_invariant = mode(k, l_max, l, m) +
+                               0.5 * l_l_plus_1 * mode(g, l_max, l, m) -
+                               2.0 * p_r / extraction_radius;
+      const auto phi_minus = (extraction_radius * (mode(dt_h_r, l_max, l, m) -
+                                                   mode(dr_h_t, l_max, l, m)) +
+                              2.0 * mode(h_t, l_max, l, m)) /
+                             lambda;
+      const auto phi_plus = extraction_radius *
+                            (2.0 * z_r + lambda * k_invariant) /
+                            (lambda * l_l_plus_1);
+      const size_t index = Spectral::Swsh::goldberg_mode_index(l_max, l, m);
+      rwz_quantities->phi_plus[index] = phi_plus;
+      rwz_quantities->phi_minus[index] = phi_minus;
+      rwz_quantities->r_times_strain.data()[index] =
+          strain_prefactor * (phi_plus + imaginary_unit * phi_minus);
+    }
+  }
+}
+
+ReggeWheelerZerilli regge_wheeler_zerilli_moncrief(
+    const ComplexModalVector& h_t, const ComplexModalVector& dr_h_t,
+    const ComplexModalVector& dt_h_r, const ComplexModalVector& h_rr,
+    const ComplexModalVector& q_r, const ComplexModalVector& k,
+    const ComplexModalVector& dr_k, const ComplexModalVector& g,
+    const ComplexModalVector& dr_g, const size_t l_max,
+    const double extraction_radius) {
+  ReggeWheelerZerilli rwz_quantities{l_max};
+  regge_wheeler_zerilli_moncrief(make_not_null(&rwz_quantities), h_t, dr_h_t,
+                                 dt_h_r, h_rr, q_r, k, dr_k, g, dr_g, l_max,
+                                 extraction_radius);
+  return rwz_quantities;
+}
+
+void regge_wheeler_zerilli_moncrief_from_gh_vars(
+    const gsl::not_null<ReggeWheelerZerilli*> rwz_quantities,
+    const tnsr::aa<DataVector, 3, Frame::Inertial>& spacetime_metric,
+    const tnsr::aa<DataVector, 3, Frame::Inertial>& pi,
+    const tnsr::iaa<DataVector, 3, Frame::Inertial>& phi,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& inertial_coords,
+    const ylm::Spherepack& ylm_spherepack, const size_t extraction_l_max,
+    const std::array<double, 3>& center, const double extraction_radius) {
+  ASSERT(
+      extraction_radius > 0.0,
+      "The extraction radius must be positive, but is " << extraction_radius);
+  const size_t expected_number_of_points = ylm_spherepack.physical_size();
+  assert_tensor_size(inertial_coords, expected_number_of_points,
+                     "inertial_coords");
+  assert_tensor_size(spacetime_metric, expected_number_of_points,
+                     "spacetime_metric");
+  assert_tensor_size(pi, expected_number_of_points, "pi");
+  assert_tensor_size(phi, expected_number_of_points, "phi");
+  ASSERT(ylm_spherepack.m_max() == ylm_spherepack.l_max(),
+         "Regge-Wheeler-Zerilli extraction requires m_max == l_max, but got "
+             << "l_max = " << ylm_spherepack.l_max()
+             << " and m_max = " << ylm_spherepack.m_max());
+  ASSERT(extraction_l_max <= ylm_spherepack.l_max() and
+             ylm_spherepack.l_max() - extraction_l_max >= 2,
+         "Regge-Wheeler-Zerilli extraction of modes through l = "
+             << extraction_l_max
+             << " requires a TensorYlm grid with l_max >= " << extraction_l_max
+             << " + 2, but got l_max = " << ylm_spherepack.l_max());
+  assert_points_are_on_coordinate_sphere(inertial_coords, center,
+                                         extraction_radius);
+
+  const size_t transform_l_max = ylm_spherepack.l_max();
+  const size_t number_of_points = get<0>(inertial_coords).size();
+  const size_t number_of_modes = square(extraction_l_max + 1);
+
+  tnsr::i<DataVector, 3, Frame::Inertial> radial_unit_vector{number_of_points,
+                                                             0.0};
+  tnsr::i<DataVector, 3, Frame::Inertial> metric_time_space_perturbation{
+      number_of_points, 0.0};
+  tnsr::i<DataVector, 3, Frame::Inertial> dr_metric_time_space_perturbation{
+      number_of_points, 0.0};
+  tnsr::ii<DataVector, 3, Frame::Inertial> spatial_metric_perturbation{
+      number_of_points, 0.0};
+  tnsr::ii<DataVector, 3, Frame::Inertial> dt_spatial_metric{number_of_points,
+                                                             0.0};
+  tnsr::ii<DataVector, 3, Frame::Inertial> dr_spatial_metric{number_of_points,
+                                                             0.0};
+
+  for (size_t i = 0; i < 3; ++i) {
+    radial_unit_vector.get(i) =
+        (inertial_coords.get(i) - gsl::at(center, i)) / extraction_radius;
+  }
+
+  for (size_t i = 0; i < 3; ++i) {
+    metric_time_space_perturbation.get(i) = spacetime_metric.get(i + 1, 0);
+    dr_metric_time_space_perturbation.get(i) = 0.0;
+    for (size_t k = 0; k < 3; ++k) {
+      dr_metric_time_space_perturbation.get(i) +=
+          radial_unit_vector.get(k) * phi.get(k, i + 1, 0);
+    }
+    for (size_t j = i; j < 3; ++j) {
+      spatial_metric_perturbation.get(i, j) =
+          spacetime_metric.get(i + 1, j + 1);
+      if (i == j) {
+        spatial_metric_perturbation.get(i, j) -= 1.0;
+      }
+      dt_spatial_metric.get(i, j) = -pi.get(i + 1, j + 1);
+      dr_spatial_metric.get(i, j) = 0.0;
+      for (size_t k = 0; k < 3; ++k) {
+        dr_spatial_metric.get(i, j) +=
+            radial_unit_vector.get(k) * phi.get(k, i + 1, j + 1);
+      }
+    }
+  }
+
+  std::optional<CartesianToSphericalMatrices> uncached_matrices{};
+  if (transform_l_max > maximum_cached_transform_l_max) {
+    uncached_matrices.emplace(
+        make_cartesian_to_spherical_matrices(transform_l_max));
+  }
+  const auto& cart_to_sphere_matrices =
+      uncached_matrices.has_value()
+          ? *uncached_matrices
+          : cached_cartesian_to_spherical_matrices(transform_l_max);
+
+  const auto metric_time_space_modes = cartesian_to_spherical_tensor_modes(
+      metric_time_space_perturbation, ylm_spherepack,
+      cart_to_sphere_matrices.rank_one);
+  const auto dr_metric_time_space_modes = cartesian_to_spherical_tensor_modes(
+      dr_metric_time_space_perturbation, ylm_spherepack,
+      cart_to_sphere_matrices.rank_one);
+  const auto metric_modes = cartesian_to_spherical_tensor_modes(
+      spatial_metric_perturbation, ylm_spherepack,
+      cart_to_sphere_matrices.rank_two_symmetric);
+  const auto dt_metric_modes = cartesian_to_spherical_tensor_modes(
+      dt_spatial_metric, ylm_spherepack,
+      cart_to_sphere_matrices.rank_two_symmetric);
+  const auto dr_metric_modes = cartesian_to_spherical_tensor_modes(
+      dr_spatial_metric, ylm_spherepack,
+      cart_to_sphere_matrices.rank_two_symmetric);
+
+  ComplexModalVector h_t{number_of_modes, 0.0};
+  ComplexModalVector dr_h_t{number_of_modes, 0.0};
+  ComplexModalVector dt_h_r{number_of_modes, 0.0};
+  ComplexModalVector h_rr{number_of_modes, 0.0};
+  ComplexModalVector q_r{number_of_modes, 0.0};
+  ComplexModalVector k{number_of_modes, 0.0};
+  ComplexModalVector dr_k{number_of_modes, 0.0};
+  ComplexModalVector g{number_of_modes, 0.0};
+  ComplexModalVector dr_g{number_of_modes, 0.0};
+
+  const std::complex<double> imaginary_unit{0.0, 1.0};
+  for (size_t l = 2; l <= extraction_l_max; ++l) {
+    const double vector_prefactor =
+        1.0 / sqrt(2.0 * static_cast<double>(l * (l + 1)));
+    const double tensor_prefactor =
+        1.0 / sqrt(static_cast<double>((l - 1) * l * (l + 1) * (l + 2)));
+    for (size_t m = 0; m <= l; ++m) {
+      const auto v_m = standard_mode_from_spherepack(
+          get<1>(metric_time_space_modes), transform_l_max, l, m);
+      const auto v_mbar = standard_mode_from_spherepack(
+          get<2>(metric_time_space_modes), transform_l_max, l, m);
+      const auto dr_v_m = standard_mode_from_spherepack(
+          get<1>(dr_metric_time_space_modes), transform_l_max, l, m);
+      const auto dr_v_mbar = standard_mode_from_spherepack(
+          get<2>(dr_metric_time_space_modes), transform_l_max, l, m);
+      const auto t_ll = standard_mode_from_spherepack(get<0, 0>(metric_modes),
+                                                      transform_l_max, l, m);
+      const auto t_lm = standard_mode_from_spherepack(get<0, 1>(metric_modes),
+                                                      transform_l_max, l, m);
+      const auto t_lmbar = standard_mode_from_spherepack(
+          get<0, 2>(metric_modes), transform_l_max, l, m);
+      const auto t_mm = standard_mode_from_spherepack(get<1, 1>(metric_modes),
+                                                      transform_l_max, l, m);
+      const auto t_mmbar = standard_mode_from_spherepack(
+          get<1, 2>(metric_modes), transform_l_max, l, m);
+      const auto t_mbarmbar = standard_mode_from_spherepack(
+          get<2, 2>(metric_modes), transform_l_max, l, m);
+      const auto dt_t_lm = standard_mode_from_spherepack(
+          get<0, 1>(dt_metric_modes), transform_l_max, l, m);
+      const auto dt_t_lmbar = standard_mode_from_spherepack(
+          get<0, 2>(dt_metric_modes), transform_l_max, l, m);
+      const auto dr_t_mm = standard_mode_from_spherepack(
+          get<1, 1>(dr_metric_modes), transform_l_max, l, m);
+      const auto dr_t_mmbar = standard_mode_from_spherepack(
+          get<1, 2>(dr_metric_modes), transform_l_max, l, m);
+      const auto dr_t_mbarmbar = standard_mode_from_spherepack(
+          get<2, 2>(dr_metric_modes), transform_l_max, l, m);
+      const size_t index = Spectral::Swsh::goldberg_mode_index(
+          extraction_l_max, l, static_cast<int>(m));
+      h_t[index] = imaginary_unit * extraction_radius * vector_prefactor *
+                   (v_mbar + v_m);
+      dr_h_t[index] = imaginary_unit * vector_prefactor *
+                      (extraction_radius * (dr_v_mbar + dr_v_m) + v_mbar + v_m);
+      dt_h_r[index] = imaginary_unit * extraction_radius * vector_prefactor *
+                      (dt_t_lmbar + dt_t_lm);
+      h_rr[index] = t_ll;
+      q_r[index] = -extraction_radius * vector_prefactor * (t_lmbar - t_lm);
+      k[index] = t_mmbar;
+      dr_k[index] = dr_t_mmbar;
+      g[index] = tensor_prefactor * (t_mbarmbar + t_mm);
+      dr_g[index] = tensor_prefactor * (dr_t_mbarmbar + dr_t_mm);
+    }
+  }
+
+  fill_scalar_negative_m_modes(make_not_null(&h_t), extraction_l_max);
+  fill_scalar_negative_m_modes(make_not_null(&dr_h_t), extraction_l_max);
+  fill_scalar_negative_m_modes(make_not_null(&dt_h_r), extraction_l_max);
+  fill_scalar_negative_m_modes(make_not_null(&h_rr), extraction_l_max);
+  fill_scalar_negative_m_modes(make_not_null(&q_r), extraction_l_max);
+  fill_scalar_negative_m_modes(make_not_null(&k), extraction_l_max);
+  fill_scalar_negative_m_modes(make_not_null(&dr_k), extraction_l_max);
+  fill_scalar_negative_m_modes(make_not_null(&g), extraction_l_max);
+  fill_scalar_negative_m_modes(make_not_null(&dr_g), extraction_l_max);
+
+  regge_wheeler_zerilli_moncrief(rwz_quantities, h_t, dr_h_t, dt_h_r, h_rr, q_r,
+                                 k, dr_k, g, dr_g, extraction_l_max,
+                                 extraction_radius);
+}
+
+ReggeWheelerZerilli regge_wheeler_zerilli_moncrief_from_gh_vars(
+    const tnsr::aa<DataVector, 3, Frame::Inertial>& spacetime_metric,
+    const tnsr::aa<DataVector, 3, Frame::Inertial>& pi,
+    const tnsr::iaa<DataVector, 3, Frame::Inertial>& phi,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& inertial_coords,
+    const ylm::Spherepack& ylm_spherepack, const size_t extraction_l_max,
+    const std::array<double, 3>& center, const double extraction_radius) {
+  ReggeWheelerZerilli rwz_quantities{extraction_l_max};
+  regge_wheeler_zerilli_moncrief_from_gh_vars(
+      make_not_null(&rwz_quantities), spacetime_metric, pi, phi,
+      inertial_coords, ylm_spherepack, extraction_l_max, center,
+      extraction_radius);
+  return rwz_quantities;
+}
+
+}  // namespace gr::surfaces

--- a/src/PointwiseFunctions/GeneralRelativity/Surfaces/ReggeWheelerZerilli.hpp
+++ b/src/PointwiseFunctions/GeneralRelativity/Surfaces/ReggeWheelerZerilli.hpp
@@ -1,0 +1,237 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+
+#include "DataStructures/ComplexModalVector.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/SpinWeighted.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "NumericalAlgorithms/SphericalHarmonics/Spherepack.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace gr::surfaces {
+
+/*!
+ * \ingroup SurfacesGroup
+ * \brief Flat-background Regge-Wheeler-Zerilli functions and
+ * asymptotic strain.
+ *
+ * \details The strain convention is
+ *
+ * \f[
+ * h(t,\theta,\phi)=h_+(t,\theta,\phi)-i h_\times(t,\theta,\phi)
+ *   =\sum_{\ell,m}h_{\ell m}(t)\,{}_{-2}Y_{\ell m}(\theta,\phi).
+ * \f]
+ *
+ * The spin-weighted spherical harmonics use the orthonormal Goldberg
+ * convention, and the modes use Goldberg ordering through `l_max`. The
+ * `r_times_strain` field stores the leading-order wave-zone relation between
+ * the Regge-Wheeler-Zerilli functions and \f$r h_{\ell m}\f$. Here \f$r\f$ is
+ * the supplied coordinate extraction radius, which must approach the areal
+ * radius in the asymptotic gauge. This relation is not an exact finite-radius
+ * strain: in a flat background it omits terms of order \f$1/r\f$ in \f$r
+ * h_{\ell m}\f$, and applying the flat-background formula on a background with
+ * mass scale \f$M\f$ also omits relative corrections of order \f$M/r\f$.
+ *
+ * The stored quantity and mode convention match the data written by SpEC to
+ * `rh_FiniteRadii_CodeUnits.h5`; the `FiniteRadii` name identifies where the
+ * asymptotic formula is evaluated, not an exact finite-radius strain formula.
+ */
+struct ReggeWheelerZerilli {
+  /// Construct an empty result, for example for use as an output argument.
+  ReggeWheelerZerilli() = default;
+
+  /*!
+   * \brief Construct zero-initialized modes through `l_max`.
+   *
+   * \param l_max maximum spherical-harmonic degree represented in the result
+   */
+  explicit ReggeWheelerZerilli(size_t l_max);
+
+  /// Even-parity Zerilli-Moncrief function modes.
+  ComplexModalVector phi_plus{};
+
+  /// Odd-parity Regge-Wheeler-Moncrief function modes.
+  ComplexModalVector phi_minus{};
+
+  /// Spin-weight \f$-2\f$ modes of the leading-order asymptotic
+  /// \f$r(h_+-i h_\times)\f$.
+  SpinWeighted<ComplexModalVector, -2> r_times_strain{};
+};
+
+/// @{
+/*!
+ * \ingroup SurfacesGroup
+ * \brief Compute the flat-background Moncrief functions and
+ * \f$r h_{\ell m}\f$ from metric-perturbation amplitudes.
+ *
+ * \details Decompose a metric perturbation into odd- and even-parity scalar,
+ * vector, and tensor spherical harmonics as
+ *
+ * \f{align*}{
+ * \delta g^{\mathrm{odd}}_{Ab} &= h_b S_A,\\
+ * \delta g^{\mathrm{odd}}_{AB} &= 2k^{\mathrm{odd}}S_{AB},\\
+ * \delta g^{\mathrm{even}}_{ab} &= H_{ab}Y,\\
+ * \delta g^{\mathrm{even}}_{Ab} &= Q_bY_A,\\
+ * \delta g^{\mathrm{even}}_{AB}
+ *   &= r^2\left(K\hat{g}_{AB}Y+G Y_{AB}\right).
+ * \f}
+ *
+ * Here \f$a,b\in\{t,r\}\f$, \f$A,B\in\{\theta,\phi\}\f$,
+ * \f$\hat{g}_{AB}\f$ is the unit-sphere metric, and \f$S_A\f$,
+ * \f$S_{AB}\f$, \f$Y_A\f$, and \f$Y_{AB}\f$ are the odd-parity vector,
+ * odd-parity tensor, even-parity vector, and even-parity tensor harmonics,
+ * respectively. The odd-parity tensor amplitude \f$k^{\mathrm{odd}}\f$
+ * cancels from \f$\Phi^-\f$, so it is not an input. The input names
+ * \f$h_{rr}\f$, \f$q_r\f$, \f$k\f$, and \f$g\f$ denote the amplitudes
+ * \f$H_{rr}\f$, \f$Q_r\f$, \f$K\f$, and \f$G\f$ in this decomposition.
+ * Thus the inputs to this function are the modes
+ *
+ * \f[
+ * \left\{h_t,\partial_r h_t,\partial_t h_r,H_{rr},Q_r,K,
+ * \partial_r K,G,\partial_r G\right\}_{\ell m}.
+ * \f]
+ *
+ * This gauge-invariant construction is based on Sec. II of
+ * \cite Sarbach:2001qq. The explicit flat-background formulas, with the
+ * current SpEC sign convention, are Eqs. (8) and (9) of
+ * \cite Buchman:2024zsb. They agree with Eq. (18) of \cite Rinne:2008vn for
+ * \f$\Phi^-\f$, while Eq. (29) of that reference defines \f$\Phi^+\f$ with
+ * the opposite overall sign. For \f$\ell\geq2\f$, this function computes
+ *
+ * \f{align*}{
+ * p_r &= q_r - \frac{r^2}{2}\partial_r g,\\
+ * z_r &= h_{rr} - r\partial_r k
+ *        - \frac{r\ell(\ell+1)}{2}\partial_r g - \frac{2p_r}{r},\\
+ * k_\mathrm{inv} &= k + \frac{\ell(\ell+1)}{2}g - \frac{2p_r}{r},\\
+ * \Phi^-_{\ell m}
+ *   &= \frac{r(\partial_t h_r-\partial_r h_t)+2h_t}
+ *            {(\ell-1)(\ell+2)},\\
+ * \Phi^+_{\ell m}
+ *   &= \frac{r(2z_r+(\ell-1)(\ell+2)k_\mathrm{inv})}
+ *            {(\ell-1)\ell(\ell+1)(\ell+2)},\\
+ * r h_{\ell m}
+ *   &= \sqrt{(\ell-1)\ell(\ell+1)(\ell+2)}
+ *      \left(\Phi^+_{\ell m}+i\Phi^-_{\ell m}\right).
+ * \f}
+ *
+ * The \f$\Phi^-_{\ell m}\f$ and \f$\Phi^+_{\ell m}\f$ quantities are the
+ * flat-background Moncrief functions. The last equation is their
+ * leading-order relation to strain at large radius, as in Eq. (54) of
+ * \cite Buchman:2024zsb and Eq. (83) of \cite Nagar:2005ea. Equation (4.34)
+ * of \cite Ruiz:2007yx is equivalent because its functions are
+ * normalized as \f$2\Phi^\pm\f$. The returned value does not include
+ * subleading \f$1/r\f$ corrections to \f$r h_{\ell m}\f$.
+ *
+ * All inputs and outputs contain the full set of positive- and negative-m
+ * modes in Goldberg ordering and have size `square(l_max + 1)`. Modes with
+ * \f$\ell<2\f$ are set to zero.
+ *
+ * \param rwz_quantities output Moncrief functions and asymptotic strain modes
+ * \param h_t odd-parity amplitudes \f$h_{t,\ell m}\f$
+ * \param dr_h_t radial derivatives \f$\partial_r h_{t,\ell m}\f$
+ * \param dt_h_r time derivatives \f$\partial_t h_{r,\ell m}\f$
+ * \param h_rr even-parity amplitudes \f$H_{rr,\ell m}\f$
+ * \param q_r even-parity amplitudes \f$Q_{r,\ell m}\f$
+ * \param k even-parity amplitudes \f$K_{\ell m}\f$
+ * \param dr_k radial derivatives \f$\partial_r K_{\ell m}\f$
+ * \param g even-parity amplitudes \f$G_{\ell m}\f$
+ * \param dr_g radial derivatives \f$\partial_r G_{\ell m}\f$
+ * \param l_max maximum spherical-harmonic degree in the inputs and result
+ * \param extraction_radius coordinate extraction radius \f$r\f$
+ */
+void regge_wheeler_zerilli_moncrief(
+    gsl::not_null<ReggeWheelerZerilli*> rwz_quantities,
+    const ComplexModalVector& h_t, const ComplexModalVector& dr_h_t,
+    const ComplexModalVector& dt_h_r, const ComplexModalVector& h_rr,
+    const ComplexModalVector& q_r, const ComplexModalVector& k,
+    const ComplexModalVector& dr_k, const ComplexModalVector& g,
+    const ComplexModalVector& dr_g, size_t l_max, double extraction_radius);
+
+/// Return-by-value overload
+ReggeWheelerZerilli regge_wheeler_zerilli_moncrief(
+    const ComplexModalVector& h_t, const ComplexModalVector& dr_h_t,
+    const ComplexModalVector& dt_h_r, const ComplexModalVector& h_rr,
+    const ComplexModalVector& q_r, const ComplexModalVector& k,
+    const ComplexModalVector& dr_k, const ComplexModalVector& g,
+    const ComplexModalVector& dr_g, size_t l_max, double extraction_radius);
+/// @}
+
+/// @{
+/*!
+ * \ingroup SurfacesGroup
+ * \brief Compute flat-background RWZ quantities from generalized-harmonic
+ * variables on a coordinate sphere.
+ *
+ * \details The supplied generalized-harmonic variables are interpreted as a
+ * linear perturbation of Minkowski spacetime. The points in `inertial_coords`
+ * must be the collocation points of `ylm_spherepack` on the coordinate sphere
+ * with the supplied `center` and `extraction_radius`. The routine decomposes
+ * the perturbation into tensor spherical harmonics and evaluates the Moncrief
+ * gauge invariants, following the flat-background extraction described in
+ * Sec. 2.3 of \cite Rinne:2008vn, with the \f$\Phi^+\f$ sign convention noted
+ * in `regge_wheeler_zerilli_moncrief`. `extraction_radius` is the coordinate
+ * radius used in this decomposition. Interpreting `r_times_strain` as
+ * asymptotic physical strain requires this radius to approach the areal
+ * radius in the asymptotic gauge.
+ *
+ * The angular grid must have
+ * `ylm_spherepack.l_max() >= extraction_l_max + 2`. The two extra modes are
+ * needed to transform rank-2 Cartesian tensors without truncating the highest
+ * requested tensor-harmonic modes. The result contains modes through
+ * `extraction_l_max`.
+ *
+ * As in SpEC's finite-radius RWZ extraction, this linearized calculation uses
+ * \f$\partial_t g_{ij}=-\Pi_{ij}\f$ and
+ * \f$\partial_r g_{\alpha\beta}=n^i\Phi_{i\alpha\beta}\f$. It assumes the
+ * extraction region is sufficiently close to a flat, spherically symmetric
+ * background. On a background with mass scale \f$M\f$, the flat-background
+ * strain relation in general neglects relative corrections of order
+ * \f$M/r\f$, in addition to the subleading wave-zone terms described above.
+ *
+ * \note This function first computes the modal inputs \f$h_t\f$,
+ * \f$\partial_r h_t\f$, \f$\partial_t h_r\f$, \f$H_{rr}\f$, \f$Q_r\f$,
+ * \f$K\f$, \f$\partial_r K\f$, \f$G\f$, and \f$\partial_r G\f$ from the
+ * generalized-harmonic variables. It then calls
+ * `regge_wheeler_zerilli_moncrief` to form the Moncrief functions and
+ * asymptotic strain.
+ *
+ * \param rwz_quantities output Moncrief functions and asymptotic strain modes
+ * \param spacetime_metric spacetime metric \f$g_{\alpha\beta}\f$ at the
+ * angular collocation points
+ * \param pi generalized-harmonic variable \f$\Pi_{\alpha\beta}\f$, with
+ * \f$\partial_t g_{ij}=-\Pi_{ij}\f$ in the linearized calculation
+ * \param phi generalized-harmonic variable
+ * \f$\Phi_{i\alpha\beta}=\partial_i g_{\alpha\beta}\f$
+ * \param inertial_coords inertial coordinates of the angular collocation
+ * points
+ * \param ylm_spherepack spherical-harmonic transform describing the angular
+ * grid
+ * \param extraction_l_max maximum spherical-harmonic degree in the result
+ * \param center coordinate center of the extraction sphere
+ * \param extraction_radius coordinate radius \f$r\f$ of the extraction sphere
+ */
+void regge_wheeler_zerilli_moncrief_from_gh_vars(
+    gsl::not_null<ReggeWheelerZerilli*> rwz_quantities,
+    const tnsr::aa<DataVector, 3, Frame::Inertial>& spacetime_metric,
+    const tnsr::aa<DataVector, 3, Frame::Inertial>& pi,
+    const tnsr::iaa<DataVector, 3, Frame::Inertial>& phi,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& inertial_coords,
+    const ylm::Spherepack& ylm_spherepack, size_t extraction_l_max,
+    const std::array<double, 3>& center, double extraction_radius);
+
+/// Return-by-value overload
+ReggeWheelerZerilli regge_wheeler_zerilli_moncrief_from_gh_vars(
+    const tnsr::aa<DataVector, 3, Frame::Inertial>& spacetime_metric,
+    const tnsr::aa<DataVector, 3, Frame::Inertial>& pi,
+    const tnsr::iaa<DataVector, 3, Frame::Inertial>& phi,
+    const tnsr::I<DataVector, 3, Frame::Inertial>& inertial_coords,
+    const ylm::Spherepack& ylm_spherepack, size_t extraction_l_max,
+    const std::array<double, 3>& center, double extraction_radius);
+/// @}
+
+}  // namespace gr::surfaces

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Surfaces/CMakeLists.txt
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Surfaces/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LIBRARY "Test_GrSurfaces")
 set(LIBRARY_SOURCES
   Test_ComputeItems.cpp
   Test_GrSurfaces.cpp
+  Test_ReggeWheelerZerilli.cpp
   Test_Tags.cpp
   )
 
@@ -17,11 +18,14 @@ target_link_libraries(
   ApparentHorizonFinder
   DataStructures
   GeneralRelativity
+  GeneralRelativitySolutions
+  GeneralizedHarmonic
   GrSurfaces
   GrSurfacesHelpers
   SphericalHarmonics
-  Strahlkorper
   SphericalHarmonicsHelpers
-  XctsSolutions
+  SpinWeightedSphericalHarmonics
+  Strahlkorper
   Utilities
+  XctsSolutions
 )

--- a/tests/Unit/PointwiseFunctions/GeneralRelativity/Surfaces/Test_ReggeWheelerZerilli.cpp
+++ b/tests/Unit/PointwiseFunctions/GeneralRelativity/Surfaces/Test_ReggeWheelerZerilli.cpp
@@ -1,0 +1,703 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cmath>
+#include <complex>
+#include <cstddef>
+#include <string>
+
+#include "DataStructures/ComplexDataVector.hpp"
+#include "DataStructures/ComplexModalVector.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Evolution/Systems/GeneralizedHarmonic/Tags.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "NumericalAlgorithms/SpinWeightedSphericalHarmonics/SwshCoefficients.hpp"
+#include "NumericalAlgorithms/SpinWeightedSphericalHarmonics/SwshCollocation.hpp"
+#include "NumericalAlgorithms/SpinWeightedSphericalHarmonics/SwshTransform.hpp"
+#include "NumericalAlgorithms/Strahlkorper/Strahlkorper.hpp"
+#include "NumericalAlgorithms/Strahlkorper/StrahlkorperFunctions.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/TeukolskyWave.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/WrappedGr.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Surfaces/ReggeWheelerZerilli.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+
+size_t mode_index(const size_t l_max, const size_t l, const int m) {
+  return Spectral::Swsh::goldberg_mode_index(l_max, l, m);
+}
+
+std::complex<double> mode(const ComplexModalVector& modes, const size_t l_max,
+                          const size_t l, const int m) {
+  return modes[mode_index(l_max, l, m)];
+}
+
+std::complex<double> strain_mode(const gr::surfaces::ReggeWheelerZerilli& rwz,
+                                 const size_t l_max, const size_t l,
+                                 const int m) {
+  return mode(rwz.r_times_strain.data(), l_max, l, m);
+}
+
+void set_mode(const gsl::not_null<ComplexModalVector*> modes,
+              const size_t l_max, const size_t l, const int m,
+              const std::complex<double>& value) {
+  (*modes)[mode_index(l_max, l, m)] = value;
+}
+
+struct MoncriefInputs {
+  std::complex<double> h_t{};
+  std::complex<double> dr_h_t{};
+  std::complex<double> dt_h_r{};
+  std::complex<double> h_rr{};
+  std::complex<double> q_r{};
+  std::complex<double> k{};
+  std::complex<double> dr_k{};
+  std::complex<double> g{};
+  std::complex<double> dr_g{};
+};
+
+void test_moncrief_modes() {
+  constexpr size_t l_max = 3;
+  constexpr double radius = 10.0;
+  const size_t number_of_modes = square(l_max + 1);
+  ComplexModalVector h_t{number_of_modes, 0.0};
+  ComplexModalVector dr_h_t{number_of_modes, 0.0};
+  ComplexModalVector dt_h_r{number_of_modes, 0.0};
+  ComplexModalVector h_rr{number_of_modes, 0.0};
+  ComplexModalVector q_r{number_of_modes, 0.0};
+  ComplexModalVector k{number_of_modes, 0.0};
+  ComplexModalVector dr_k{number_of_modes, 0.0};
+  ComplexModalVector g{number_of_modes, 0.0};
+  ComplexModalVector dr_g{number_of_modes, 0.0};
+
+  const MoncriefInputs input_22{{1.0, -0.5}, {-0.25, 0.75}, {0.8, 0.1},
+                                {0.5, -0.3}, {-0.4, 0.2},   {0.3, 0.7},
+                                {-0.1, 0.4}, {0.2, -0.6},   {0.05, 0.15}};
+  const MoncriefInputs input_3m1{{-0.4, 0.9},   {0.3, -0.2}, {-0.8, 0.5},
+                                 {1.1, 0.4},    {0.6, -0.7}, {-0.2, 0.1},
+                                 {0.45, -0.35}, {0.15, 0.2}, {-0.05, 0.08}};
+
+  const auto set_inputs = [&h_t, &dr_h_t, &dt_h_r, &h_rr, &q_r, &k, &dr_k, &g,
+                           &dr_g](const size_t l, const int m,
+                                  const MoncriefInputs& input) {
+    set_mode(make_not_null(&h_t), l_max, l, m, input.h_t);
+    set_mode(make_not_null(&dr_h_t), l_max, l, m, input.dr_h_t);
+    set_mode(make_not_null(&dt_h_r), l_max, l, m, input.dt_h_r);
+    set_mode(make_not_null(&h_rr), l_max, l, m, input.h_rr);
+    set_mode(make_not_null(&q_r), l_max, l, m, input.q_r);
+    set_mode(make_not_null(&k), l_max, l, m, input.k);
+    set_mode(make_not_null(&dr_k), l_max, l, m, input.dr_k);
+    set_mode(make_not_null(&g), l_max, l, m, input.g);
+    set_mode(make_not_null(&dr_g), l_max, l, m, input.dr_g);
+  };
+  set_inputs(2, 2, input_22);
+  // This independently supplied negative-m mode verifies that the modal API
+  // consumes the full Goldberg data instead of reconstructing negative m.
+  set_inputs(3, -1, input_3m1);
+
+  // Modes below l=2 are outside the RWZ radiative sector.
+  set_mode(make_not_null(&h_t), l_max, 1, 1, {10.0, 20.0});
+  set_mode(make_not_null(&h_rr), l_max, 1, -1, {-30.0, 40.0});
+
+  const auto rwz = gr::surfaces::regge_wheeler_zerilli_moncrief(
+      h_t, dr_h_t, dt_h_r, h_rr, q_r, k, dr_k, g, dr_g, l_max, radius);
+  static_assert(decltype(rwz.r_times_strain)::spin == -2);
+
+  // Reference values obtained by substituting the inputs above into the
+  // Moncrief definitions documented in ReggeWheelerZerilli.hpp. Keeping the
+  // values here avoids reproducing the implementation formulas in the test.
+  const std::complex<double> expected_phi_plus_22{2.95, -331.0 / 60.0};
+  const std::complex<double> expected_phi_minus_22{3.125, -1.875};
+  const std::complex<double> expected_phi_plus_3m1{-31.0 / 300.0,
+                                                   281.0 / 150.0};
+  const std::complex<double> expected_phi_minus_3m1{-1.18, 0.88};
+  const std::complex<double> imaginary_unit{0.0, 1.0};
+  ComplexModalVector expected_phi_plus{number_of_modes, 0.0};
+  ComplexModalVector expected_phi_minus{number_of_modes, 0.0};
+  ComplexModalVector expected_r_times_strain{number_of_modes, 0.0};
+  set_mode(make_not_null(&expected_phi_plus), l_max, 2, 2,
+           expected_phi_plus_22);
+  set_mode(make_not_null(&expected_phi_minus), l_max, 2, 2,
+           expected_phi_minus_22);
+  set_mode(make_not_null(&expected_r_times_strain), l_max, 2, 2,
+           sqrt(24.0) *
+               (expected_phi_plus_22 + imaginary_unit * expected_phi_minus_22));
+  set_mode(make_not_null(&expected_phi_plus), l_max, 3, -1,
+           expected_phi_plus_3m1);
+  set_mode(make_not_null(&expected_phi_minus), l_max, 3, -1,
+           expected_phi_minus_3m1);
+  set_mode(make_not_null(&expected_r_times_strain), l_max, 3, -1,
+           sqrt(120.0) * (expected_phi_plus_3m1 +
+                          imaginary_unit * expected_phi_minus_3m1));
+  CHECK_ITERABLE_APPROX(rwz.phi_plus, expected_phi_plus);
+  CHECK_ITERABLE_APPROX(rwz.phi_minus, expected_phi_minus);
+  CHECK_ITERABLE_APPROX(rwz.r_times_strain.data(), expected_r_times_strain);
+
+  gr::surfaces::ReggeWheelerZerilli output_argument_result{};
+  gr::surfaces::regge_wheeler_zerilli_moncrief(
+      make_not_null(&output_argument_result), h_t, dr_h_t, dt_h_r, h_rr, q_r, k,
+      dr_k, g, dr_g, l_max, radius);
+  CHECK_ITERABLE_APPROX(output_argument_result.phi_plus, rwz.phi_plus);
+  CHECK_ITERABLE_APPROX(output_argument_result.phi_minus, rwz.phi_minus);
+  CHECK_ITERABLE_APPROX(output_argument_result.r_times_strain.data(),
+                        rwz.r_times_strain.data());
+}
+
+struct GhSphereData {
+  tnsr::I<DataVector, 3, Frame::Inertial> coords{};
+  tnsr::aa<DataVector, 3, Frame::Inertial> spacetime_metric{};
+  tnsr::aa<DataVector, 3, Frame::Inertial> pi{};
+  tnsr::iaa<DataVector, 3, Frame::Inertial> phi{};
+};
+
+GhSphereData minkowski_data(
+    const ylm::Strahlkorper<Frame::Inertial>& strahlkorper) {
+  GhSphereData result{};
+  result.coords = ylm::cartesian_coords(strahlkorper);
+  const size_t size = get<0>(result.coords).size();
+  result.spacetime_metric = tnsr::aa<DataVector, 3, Frame::Inertial>{size, 0.0};
+  result.pi = tnsr::aa<DataVector, 3, Frame::Inertial>{size, 0.0};
+  result.phi = tnsr::iaa<DataVector, 3, Frame::Inertial>{size, 0.0};
+  get<0, 0>(result.spacetime_metric) = -1.0;
+  for (size_t i = 0; i < 3; ++i) {
+    result.spacetime_metric.get(i + 1, i + 1) = 1.0;
+  }
+  return result;
+}
+
+void check_all_modes_zero(const gr::surfaces::ReggeWheelerZerilli& rwz,
+                          const double tolerance) {
+  const ComplexModalVector zeros{rwz.phi_plus.size(), 0.0};
+  const Approx zero_approx = Approx::custom().epsilon(0.0).margin(tolerance);
+  CHECK_ITERABLE_CUSTOM_APPROX(rwz.phi_plus, zeros, zero_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(rwz.phi_minus, zeros, zero_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(rwz.r_times_strain.data(), zeros, zero_approx);
+}
+
+void test_minkowski() {
+  constexpr size_t l_max = 5;
+  constexpr size_t angular_l_max = l_max + 2;
+  constexpr double radius = 3.0;
+  const std::array<double, 3> center{{0.1, -0.2, 0.3}};
+  const ylm::Strahlkorper<Frame::Inertial> strahlkorper{
+      angular_l_max, angular_l_max, radius, center};
+  const auto data = minkowski_data(strahlkorper);
+  const auto rwz = gr::surfaces::regge_wheeler_zerilli_moncrief_from_gh_vars(
+      data.spacetime_metric, data.pi, data.phi, data.coords,
+      strahlkorper.ylm_spherepack(), l_max, center, radius);
+  check_all_modes_zero(rwz, 1.0e-14);
+}
+
+struct ExpectedSpecMode {
+  size_t l;
+  int m;
+  std::complex<double> r_times_strain;
+};
+
+// Generated with SpEC 85326db0d633ab6436b621d09e90d072373fb1b7 by
+// applying ComputeReggeWheelerZerilliFlat to the analytic data in
+// spec_regression_data(). Increasing the SpEC surface resolution from 12x24
+// to 16x32 changed r*h by at most 1.6e-16.
+constexpr std::array<ExpectedSpecMode, 21> expected_spec_modes{{
+    {2, -2, {-1.60948834257061972e-3, -7.57939163199307050e-4}},
+    {2, -1, {1.67894093521450292e-3, 8.21352399961057132e-4}},
+    {2, 0, {-1.07991384088803721e-3, 1.05624449643029975e-2}},
+    {2, 1, {1.93259388226050280e-4, 7.24722705848362958e-5}},
+    {2, 2, {2.09263681313602004e-3, -2.41272267488550161e-3}},
+    {3, -3, {-3.17254857543564691e-4, -5.19276916255269946e-4}},
+    {3, -2, {1.08617106159982087e-3, 2.83452535812188681e-4}},
+    {3, -1, {-1.93770994694657868e-4, -1.50648003650769217e-6}},
+    {3, 0, {-4.18792644190715119e-4, -9.39347986969824787e-5}},
+    {3, 1, {-8.28752330079265552e-4, 2.56101606204803701e-5}},
+    {3, 2, {6.28835877768316154e-4, -1.11951841875375374e-4}},
+    {3, 3, {-1.09398226739523185e-5, -2.74224888359522550e-4}},
+    {4, -4, {-9.28962092157553291e-5, 4.76390816491117177e-6}},
+    {4, -3, {6.90561312513063432e-5, 3.36859176833184848e-6}},
+    {4, -2, {5.58182292094264632e-5, -5.40176411700038356e-6}},
+    {4, -1, {-2.99203882940425269e-5, 6.49336086380552212e-5}},
+    {4, 0, {7.23132835029881857e-5, 3.98577153166085395e-5}},
+    {4, 1, {1.97347241939539583e-5, 1.90981201876619865e-5}},
+    {4, 2, {-3.78123488193597389e-5, 5.58182292094248233e-5}},
+    {4, 3, {-4.21073971044347184e-5, -3.70545094519757307e-5}},
+    {4, 4, {7.86044847210584251e-5, -7.14586224736726697e-5}},
+}};
+
+GhSphereData spec_regression_data(
+    const ylm::Strahlkorper<Frame::Inertial>& strahlkorper) {
+  constexpr double epsilon = 1.0e-3;
+  auto result = minkowski_data(strahlkorper);
+  for (size_t s = 0; s < get<0>(result.coords).size(); ++s) {
+    const double x = get<0>(result.coords)[s] / 8.0;
+    const double y = get<1>(result.coords)[s] / 8.0;
+    const double z = get<2>(result.coords)[s] / 8.0;
+    const std::array<double, 3> radial{{x, y, z}};
+
+    const double t11 =
+        epsilon * (0.70 * x + 0.20 * y * z + 0.10 * (x * x - y * y));
+    const double t22 =
+        epsilon * (-0.40 * y + 0.30 * x * z - 0.12 * (3.0 * z * z - 1.0));
+    const double t33 = epsilon * (0.25 * z + 0.18 * x * y);
+    const double t12 = epsilon * (0.31 * x * y + 0.17 * z + 0.07 * x * x * z);
+    const double t13 = epsilon * (-0.29 * y * z + 0.16 * x + 0.05 * y * y * x);
+    const double t23 = epsilon * (0.37 * x * z - 0.14 * y + 0.06 * z * z * y);
+    get<1, 1>(result.spacetime_metric)[s] += t11;
+    get<2, 2>(result.spacetime_metric)[s] += t22;
+    get<3, 3>(result.spacetime_metric)[s] += t33;
+    get<1, 2>(result.spacetime_metric)[s] = t12;
+    get<1, 3>(result.spacetime_metric)[s] = t13;
+    get<2, 3>(result.spacetime_metric)[s] = t23;
+
+    get<1, 0>(result.spacetime_metric)[s] =
+        epsilon * (0.21 * y + 0.13 * x * z + 0.09 * (y * y - z * z));
+    get<2, 0>(result.spacetime_metric)[s] =
+        epsilon * (-0.27 * x + 0.19 * y * z + 0.11 * x * y * z);
+    get<3, 0>(result.spacetime_metric)[s] =
+        epsilon * (0.23 * x * y - 0.15 * z + 0.08 * x * x * y);
+
+    const std::array<std::array<double, 3>, 3> dt_spatial_metric{{
+        {{epsilon * (0.12 * x * y - 0.20 * z + 0.03 * y * z * z),
+          epsilon * (-0.18 * x + 0.09 * y * z + 0.04 * x * x * y),
+          epsilon * (0.22 * y + 0.08 * x * z - 0.06 * x * y * y)}},
+        {{0.0, epsilon * (0.15 * x - 0.11 * y * y + 0.07 * x * y * z),
+          epsilon * (-0.24 * z + 0.05 * x * y + 0.02 * y * z * z)}},
+        {{0.0, 0.0,
+          epsilon * (-0.10 * y + 0.17 * x * z - 0.08 * (x * x - z * z))}},
+    }};
+    const std::array<std::array<double, 3>, 3> dr_spatial_metric{{
+        {{epsilon * (-0.16 * y + 0.09 * x * z + 0.05 * x * x * y),
+          epsilon * (0.13 * z + 0.06 * x * y - 0.04 * y * y * z),
+          epsilon * (0.19 * x - 0.12 * y * z + 0.03 * x * z * z)}},
+        {{0.0, epsilon * (0.14 * z - 0.08 * x * y + 0.02 * x * x * z),
+          epsilon * (-0.17 * y + 0.10 * x * z + 0.05 * x * x * y)}},
+        {{0.0, 0.0,
+          epsilon * (0.11 * x + 0.07 * y * z - 0.09 * (y * y - z * z))}},
+    }};
+    const std::array<double, 3> dr_metric_time_space{{
+        epsilon * (0.08 * x - 0.14 * y * z + 0.06 * x * x * y),
+        epsilon * (-0.12 * y + 0.16 * x * z - 0.04 * y * y * z),
+        epsilon * (0.18 * z + 0.05 * x * y - 0.07 * x * z * z),
+    }};
+
+    for (size_t i = 0; i < 3; ++i) {
+      for (size_t j = i; j < 3; ++j) {
+        result.pi.get(i + 1, j + 1)[s] =
+            -gsl::at(gsl::at(dt_spatial_metric, i), j);
+        for (size_t k = 0; k < 3; ++k) {
+          result.phi.get(k, i + 1, j + 1)[s] =
+              gsl::at(radial, k) * gsl::at(gsl::at(dr_spatial_metric, i), j);
+        }
+      }
+      for (size_t k = 0; k < 3; ++k) {
+        result.phi.get(k, i + 1, 0)[s] =
+            gsl::at(radial, k) * gsl::at(dr_metric_time_space, i);
+      }
+    }
+  }
+  return result;
+}
+
+void test_against_spec() {
+  constexpr size_t l_max = 4;
+  constexpr size_t angular_l_max = l_max + 2;
+  constexpr double radius = 8.0;
+  const std::array<double, 3> center{{0.0, 0.0, 0.0}};
+  const ylm::Strahlkorper<Frame::Inertial> strahlkorper{
+      angular_l_max, angular_l_max, radius, center};
+  const auto data = spec_regression_data(strahlkorper);
+  const auto rwz = gr::surfaces::regge_wheeler_zerilli_moncrief_from_gh_vars(
+      data.spacetime_metric, data.pi, data.phi, data.coords,
+      strahlkorper.ylm_spherepack(), l_max, center, radius);
+
+  ComplexModalVector expected_r_times_strain{square(l_max + 1), 0.0};
+  for (const auto& expected : expected_spec_modes) {
+    set_mode(make_not_null(&expected_r_times_strain), l_max, expected.l,
+             expected.m, expected.r_times_strain);
+  }
+  const Approx spec_approx = Approx::custom().epsilon(0.0).margin(5.0e-13);
+  CHECK_ITERABLE_CUSTOM_APPROX(rwz.r_times_strain.data(),
+                               expected_r_times_strain, spec_approx);
+}
+
+using SpatialMetricTag =
+    gr::Tags::SpatialMetric<DataVector, 3, Frame::Inertial>;
+using DtSpatialMetricTag = ::Tags::dt<SpatialMetricTag>;
+
+tnsr::I<DataVector, 3, Frame::Inertial> radially_shifted_coords(
+    const tnsr::I<DataVector, 3, Frame::Inertial>& coords,
+    const std::array<double, 3>& center, const double radius,
+    const double radial_offset) {
+  auto result = coords;
+  const double scale = 1.0 + radial_offset / radius;
+  for (size_t i = 0; i < 3; ++i) {
+    result.get(i) =
+        gsl::at(center, i) + scale * (coords.get(i) - gsl::at(center, i));
+  }
+  return result;
+}
+
+GhSphereData teukolsky_gh_data(
+    const gr::Solutions::TeukolskyWave& solution,
+    const ylm::Strahlkorper<Frame::Inertial>& strahlkorper, const double time) {
+  const auto& center = solution.center();
+  const double radius = strahlkorper.average_radius();
+  GhSphereData result{};
+  result.coords = ylm::cartesian_coords(strahlkorper);
+  const size_t size = get<0>(result.coords).size();
+  result.spacetime_metric = tnsr::aa<DataVector, 3, Frame::Inertial>{size, 0.0};
+  result.pi = tnsr::aa<DataVector, 3, Frame::Inertial>{size, 0.0};
+  result.phi = tnsr::iaa<DataVector, 3, Frame::Inertial>{size, 0.0};
+
+  const auto vars = solution.variables(
+      result.coords, time, tmpl::list<SpatialMetricTag, DtSpatialMetricTag>{});
+  const auto& spatial_metric_perturbation = get<SpatialMetricTag>(vars);
+  const auto& dt_spatial_metric = get<DtSpatialMetricTag>(vars);
+  get<0, 0>(result.spacetime_metric) = -1.0;
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = i; j < 3; ++j) {
+      result.spacetime_metric.get(i + 1, j + 1) =
+          spatial_metric_perturbation.get(i, j);
+      if (i == j) {
+        result.spacetime_metric.get(i + 1, j + 1) += 1.0;
+      }
+      result.pi.get(i + 1, j + 1) = -dt_spatial_metric.get(i, j);
+    }
+  }
+
+  const double step = 1.0e-3 * radius;
+  const auto metric_at_offset = [&solution, &result, &center, radius,
+                                 time](const double offset) {
+    const auto offset_coords =
+        radially_shifted_coords(result.coords, center, radius, offset);
+    return get<SpatialMetricTag>(
+        solution.variable<SpatialMetricTag>(offset_coords, time));
+  };
+  const auto metric_m2 = metric_at_offset(-2.0 * step);
+  const auto metric_m1 = metric_at_offset(-step);
+  const auto metric_p1 = metric_at_offset(step);
+  const auto metric_p2 = metric_at_offset(2.0 * step);
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = i; j < 3; ++j) {
+      const DataVector dr_metric =
+          (metric_m2.get(i, j) - 8.0 * metric_m1.get(i, j) +
+           8.0 * metric_p1.get(i, j) - metric_p2.get(i, j)) /
+          (12.0 * step);
+      for (size_t k = 0; k < 3; ++k) {
+        result.phi.get(k, i + 1, j + 1) =
+            (result.coords.get(k) - gsl::at(center, k)) / radius * dr_metric;
+      }
+    }
+  }
+  return result;
+}
+
+gr::surfaces::ReggeWheelerZerilli extract_teukolsky_wave(
+    const gr::Solutions::TeukolskyWave& solution, const size_t l_max,
+    const double radius, const double time) {
+  const size_t angular_l_max = l_max + 2;
+  const auto& center = solution.center();
+  const ylm::Strahlkorper<Frame::Inertial> strahlkorper{
+      angular_l_max, angular_l_max, radius, center};
+  const auto data = teukolsky_gh_data(solution, strahlkorper, time);
+  return gr::surfaces::regge_wheeler_zerilli_moncrief_from_gh_vars(
+      data.spacetime_metric, data.pi, data.phi, data.coords,
+      strahlkorper.ylm_spherepack(), l_max, center, radius);
+}
+
+gr::surfaces::ReggeWheelerZerilli extract_teukolsky_wave(
+    const double amplitude, const int input_m, const std::string& parity,
+    const std::array<double, 3>& center) {
+  constexpr size_t l_max = 6;
+  constexpr double radius = 10.0;
+  constexpr double time = 2.4;
+  const gr::Solutions::TeukolskyWave solution{
+      amplitude, input_m, parity, "outgoing", center, 8.0, 1.5, false};
+  return extract_teukolsky_wave(solution, l_max, radius, time);
+}
+
+SpinWeighted<ComplexModalVector, -2> direct_teukolsky_strain_modes(
+    const gr::Solutions::TeukolskyWave& solution, const size_t l_max,
+    const double radius, const double time) {
+  tnsr::i<DataVector, 3> unit_cartesian_coords{};
+  tnsr::i<DataVector, 2, Frame::Spherical<Frame::Inertial>> angular_coords{};
+  Spectral::Swsh::create_angular_and_cartesian_coordinates(
+      make_not_null(&unit_cartesian_coords), make_not_null(&angular_coords),
+      l_max);
+
+  const size_t number_of_points =
+      Spectral::Swsh::number_of_swsh_collocation_points(l_max);
+  tnsr::I<DataVector, 3, Frame::Inertial> inertial_coords{number_of_points};
+  for (size_t i = 0; i < 3; ++i) {
+    inertial_coords.get(i) =
+        gsl::at(solution.center(), i) + radius * unit_cartesian_coords.get(i);
+  }
+  const auto spatial_metric_vars =
+      solution.variable<SpatialMetricTag>(inertial_coords, time);
+  const auto& spatial_metric_perturbation =
+      get<SpatialMetricTag>(spatial_metric_vars);
+
+  // Project the analytic metric perturbation onto the standard orthonormal
+  // polarization basis. This gives h_+ - i h_cross independently of the RWZ
+  // tensor-harmonic decomposition and RWZ-function normalization.
+  SpinWeighted<ComplexDataVector, -2> direct_strain{number_of_points, 0.0};
+  for (size_t s = 0; s < number_of_points; ++s) {
+    const double theta = get<0>(angular_coords)[s];
+    const double phi = get<1>(angular_coords)[s];
+    const std::array<double, 3> e_theta{
+        {cos(theta) * cos(phi), cos(theta) * sin(phi), -sin(theta)}};
+    const std::array<double, 3> e_phi{{-sin(phi), cos(phi), 0.0}};
+    double h_theta_theta = 0.0;
+    double h_theta_phi = 0.0;
+    double h_phi_phi = 0.0;
+    for (size_t i = 0; i < 3; ++i) {
+      for (size_t j = 0; j < 3; ++j) {
+        const double metric_component =
+            spatial_metric_perturbation.get(i, j)[s];
+        h_theta_theta +=
+            metric_component * gsl::at(e_theta, i) * gsl::at(e_theta, j);
+        h_theta_phi +=
+            metric_component * gsl::at(e_theta, i) * gsl::at(e_phi, j);
+        h_phi_phi += metric_component * gsl::at(e_phi, i) * gsl::at(e_phi, j);
+      }
+    }
+    direct_strain.data()[s] = 0.5 * (h_theta_theta - h_phi_phi) -
+                              std::complex<double>{0.0, h_theta_phi};
+  }
+  return Spectral::Swsh::libsharp_to_goldberg_modes(
+      Spectral::Swsh::swsh_transform(l_max, 1, direct_strain), l_max);
+}
+
+void test_teukolsky_wave() {
+  constexpr size_t l_max = 6;
+  constexpr double amplitude = 1.0e-3;
+  constexpr double radius = 10.0;
+  constexpr double time = 2.4;
+  constexpr double profile_radius = 8.0;
+  constexpr double profile_width = 1.5;
+  constexpr double tolerance = 2.0e-10;
+  const Approx teukolsky_approx =
+      Approx::custom().epsilon(0.0).margin(tolerance);
+  const std::array<double, 3> center{{0.3, -0.4, 0.2}};
+  const auto even = extract_teukolsky_wave(amplitude, 0, "even", center);
+  const auto even_double =
+      extract_teukolsky_wave(2.0 * amplitude, 0, "even", center);
+  const auto odd = extract_teukolsky_wave(amplitude, 2, "odd", center);
+  const auto odd_at_origin = extract_teukolsky_wave(
+      amplitude, 2, "odd", std::array<double, 3>{{0.0, 0.0, 0.0}});
+
+  // Evaluate the Gaussian profile and its derivatives. Substitution of the
+  // Teukolsky metric (Eqs. (5)--(10) of Teukolsky 1982) into the documented
+  // Moncrief definitions gives the two nonzero modes below. The square-root
+  // factors convert the real Teukolsky angular functions to orthonormal Y_lm.
+  const double profile_coordinate = radius - profile_radius - time;
+  const double derivative_factor = -2.0 / square(profile_width);
+  const double profile =
+      amplitude * exp(-square(profile_coordinate) / square(profile_width));
+  const double profile_1 = derivative_factor * profile_coordinate * profile;
+  const double profile_2 =
+      derivative_factor * (profile + profile_coordinate * profile_1);
+  const double profile_3 =
+      derivative_factor * (2.0 * profile_1 + profile_coordinate * profile_2);
+  const double profile_4 =
+      derivative_factor * (3.0 * profile_2 + profile_coordinate * profile_3);
+  const std::complex<double> expected_phi_plus_20{
+      0.5 * sqrt(M_PI / 5.0) *
+          (profile_4 - 3.0 * profile_3 / radius +
+           3.0 * profile_2 / square(radius)),
+      0.0};
+  const std::complex<double> expected_phi_minus_22{
+      0.0, -sqrt(2.0 * M_PI / 15.0) * (profile_3 - 3.0 * profile_2 / radius +
+                                       3.0 * profile_1 / square(radius))};
+  const std::complex<double> imaginary_unit{0.0, 1.0};
+  const size_t number_of_modes = square(l_max + 1);
+  ComplexModalVector expected_even_phi_plus{number_of_modes, 0.0};
+  ComplexModalVector expected_odd_phi_minus{number_of_modes, 0.0};
+  ComplexModalVector expected_even_strain{number_of_modes, 0.0};
+  ComplexModalVector expected_odd_strain{number_of_modes, 0.0};
+  const ComplexModalVector zero_modes{number_of_modes, 0.0};
+  set_mode(make_not_null(&expected_even_phi_plus), l_max, 2, 0,
+           expected_phi_plus_20);
+  set_mode(make_not_null(&expected_even_strain), l_max, 2, 0,
+           sqrt(24.0) * expected_phi_plus_20);
+  set_mode(make_not_null(&expected_odd_phi_minus), l_max, 2, 2,
+           expected_phi_minus_22);
+  set_mode(make_not_null(&expected_odd_phi_minus), l_max, 2, -2,
+           conj(expected_phi_minus_22));
+  set_mode(make_not_null(&expected_odd_strain), l_max, 2, 2,
+           sqrt(24.0) * imaginary_unit * expected_phi_minus_22);
+  set_mode(make_not_null(&expected_odd_strain), l_max, 2, -2,
+           sqrt(24.0) * imaginary_unit * conj(expected_phi_minus_22));
+
+  CHECK_ITERABLE_CUSTOM_APPROX(even.phi_plus, expected_even_phi_plus,
+                               teukolsky_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(even.phi_minus, zero_modes, teukolsky_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(even.r_times_strain.data(), expected_even_strain,
+                               teukolsky_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(odd.phi_plus, zero_modes, teukolsky_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(odd.phi_minus, expected_odd_phi_minus,
+                               teukolsky_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(odd.r_times_strain.data(), expected_odd_strain,
+                               teukolsky_approx);
+
+  auto expected_even_double = expected_even_strain;
+  expected_even_double *= 2.0;
+  CHECK_ITERABLE_CUSTOM_APPROX(even_double.r_times_strain.data(),
+                               expected_even_double, teukolsky_approx);
+  CHECK_ITERABLE_CUSTOM_APPROX(odd.r_times_strain.data(),
+                               odd_at_origin.r_times_strain.data(),
+                               teukolsky_approx);
+}
+
+void test_teukolsky_wave_strain_normalization() {
+  constexpr size_t l_max = 6;
+  constexpr double amplitude = 1.0e-3;
+  constexpr double inner_radius = 40.0;
+  constexpr double outer_radius = 80.0;
+  // Keep the outgoing pulse at the same retarded time as the existing
+  // Teukolsky test while moving the extraction sphere into the wave zone.
+  constexpr double time_minus_radius = 2.4 - 10.0;
+  const std::array<double, 3> center{{0.3, -0.4, 0.2}};
+
+  const auto check_parity = [&center, inner_radius, outer_radius](
+                                const int input_m, const std::string& parity) {
+    const gr::Solutions::TeukolskyWave solution{
+        amplitude, input_m, parity, "outgoing", center, 8.0, 1.5, false};
+    const auto inner_rwz = extract_teukolsky_wave(
+        solution, l_max, inner_radius, inner_radius + time_minus_radius);
+    const auto outer_rwz = extract_teukolsky_wave(
+        solution, l_max, outer_radius, outer_radius + time_minus_radius);
+    const auto inner_direct = direct_teukolsky_strain_modes(
+        solution, l_max, inner_radius, inner_radius + time_minus_radius);
+    const auto outer_direct = direct_teukolsky_strain_modes(
+        solution, l_max, outer_radius, outer_radius + time_minus_radius);
+
+    const std::complex<double> inner_expected =
+        inner_radius * mode(inner_direct.data(), l_max, 2, input_m);
+    const std::complex<double> outer_expected =
+        outer_radius * mode(outer_direct.data(), l_max, 2, input_m);
+    const std::complex<double> inner_actual =
+        strain_mode(inner_rwz, l_max, 2, input_m);
+    const std::complex<double> outer_actual =
+        strain_mode(outer_rwz, l_max, 2, input_m);
+    const double inner_error = abs(inner_actual - inner_expected);
+    const double outer_error = abs(outer_actual - outer_expected);
+    CAPTURE(input_m);
+    CAPTURE(parity);
+    CAPTURE(inner_actual);
+    CAPTURE(inner_expected);
+    CAPTURE(outer_actual);
+    CAPTURE(outer_expected);
+    CAPTURE(inner_error);
+    CAPTURE(outer_error);
+    CHECK(abs(outer_expected) > 1.0e-6);
+    CHECK(outer_error < 0.6 * inner_error);
+    CHECK(outer_error < 0.015 * abs(outer_expected));
+  };
+
+  check_parity(0, "even");
+  check_parity(0, "odd");
+}
+
+void test_spherical_schwarzschild_has_no_radiative_modes() {
+  constexpr size_t l_max = 8;
+  constexpr size_t angular_l_max = l_max + 2;
+  constexpr double radius = 10.0;
+  const std::array<double, 3> center{{0.0, 0.0, 0.0}};
+  const std::array<double, 3> spin{{0.0, 0.0, 0.0}};
+  const std::array<double, 3> velocity{{0.0, 0.0, 0.0}};
+  const ylm::Strahlkorper<Frame::Inertial> strahlkorper{
+      angular_l_max, angular_l_max, radius, center};
+  const auto coords = ylm::cartesian_coords(strahlkorper);
+  const gh::Solutions::WrappedGr<gr::Solutions::KerrSchild> solution{
+      1.0, spin, center, velocity};
+  const auto gh_vars = solution.variables(
+      coords, 0.0,
+      tmpl::list<gr::Tags::SpacetimeMetric<DataVector, 3>,
+                 gh::Tags::Pi<DataVector, 3>, gh::Tags::Phi<DataVector, 3>>{});
+  const auto rwz = gr::surfaces::regge_wheeler_zerilli_moncrief_from_gh_vars(
+      get<gr::Tags::SpacetimeMetric<DataVector, 3>>(gh_vars),
+      get<gh::Tags::Pi<DataVector, 3>>(gh_vars),
+      get<gh::Tags::Phi<DataVector, 3>>(gh_vars), coords,
+      strahlkorper.ylm_spherepack(), l_max, center, radius);
+  check_all_modes_zero(rwz, 1.0e-11);
+}
+
+#ifdef SPECTRE_DEBUG
+void test_input_validation() {
+  constexpr size_t l_max = 3;
+  const size_t number_of_modes = square(l_max + 1);
+  const ComplexModalVector modes{number_of_modes, 0.0};
+  const ComplexModalVector wrong_size_modes{number_of_modes - 1, 0.0};
+  CHECK_THROWS_WITH(
+      (gr::surfaces::regge_wheeler_zerilli_moncrief(
+          wrong_size_modes, modes, modes, modes, modes, modes, modes, modes,
+          modes, l_max, 2.0)),
+      Catch::Matchers::ContainsSubstring("Expected h_t to have size"));
+  CHECK_THROWS_WITH(
+      (gr::surfaces::regge_wheeler_zerilli_moncrief(modes, modes, modes, modes,
+                                                    modes, modes, modes, modes,
+                                                    modes, l_max, 0.0)),
+      Catch::Matchers::ContainsSubstring("extraction radius must be positive"));
+
+  const ylm::Spherepack incomplete_spherepack{4, 3};
+  const size_t size = incomplete_spherepack.physical_size();
+  const tnsr::aa<DataVector, 3, Frame::Inertial> spacetime_metric{size, 0.0};
+  const tnsr::aa<DataVector, 3, Frame::Inertial> pi{size, 0.0};
+  const tnsr::iaa<DataVector, 3, Frame::Inertial> phi{size, 0.0};
+  const tnsr::I<DataVector, 3, Frame::Inertial> coords{size, 0.0};
+  CHECK_THROWS_WITH(
+      (gr::surfaces::regge_wheeler_zerilli_moncrief_from_gh_vars(
+          spacetime_metric, pi, phi, coords, incomplete_spherepack, 2,
+          std::array<double, 3>{{0.0, 0.0, 0.0}}, 2.0)),
+      Catch::Matchers::ContainsSubstring("requires m_max == l_max"));
+
+  constexpr double radius = 2.0;
+  const std::array<double, 3> center{{0.0, 0.0, 0.0}};
+  const ylm::Strahlkorper<Frame::Inertial> underresolved_strahlkorper{
+      4, 4, radius, center};
+  const auto underresolved_data = minkowski_data(underresolved_strahlkorper);
+  CHECK_THROWS_WITH(
+      (gr::surfaces::regge_wheeler_zerilli_moncrief_from_gh_vars(
+          underresolved_data.spacetime_metric, underresolved_data.pi,
+          underresolved_data.phi, underresolved_data.coords,
+          underresolved_strahlkorper.ylm_spherepack(), 3, center, radius)),
+      Catch::Matchers::ContainsSubstring(
+          "requires a TensorYlm grid with l_max"));
+
+  const tnsr::aa<DataVector, 3, Frame::Inertial> wrong_size_spacetime_metric{
+      get<0>(underresolved_data.coords).size() - 1, 0.0};
+  CHECK_THROWS_WITH(
+      (gr::surfaces::regge_wheeler_zerilli_moncrief_from_gh_vars(
+          wrong_size_spacetime_metric, underresolved_data.pi,
+          underresolved_data.phi, underresolved_data.coords,
+          underresolved_strahlkorper.ylm_spherepack(), 2, center, radius)),
+      Catch::Matchers::ContainsSubstring(
+          "component 0 of spacetime_metric to have size"));
+}
+#endif
+
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.PointwiseFunctions.GeneralRelativity.Surfaces."
+    "ReggeWheelerZerilli",
+    "[PointwiseFunctions][Unit]") {
+  test_moncrief_modes();
+  test_minkowski();
+  test_against_spec();
+  test_teukolsky_wave();
+  test_teukolsky_wave_strain_normalization();
+  test_spherical_schwarzschild_has_no_radiative_modes();
+#ifdef SPECTRE_DEBUG
+  test_input_validation();
+#endif
+}


### PR DESCRIPTION
## Proposed changes

This PR adds code that computes the Regge-Wheeler-Zerilli strain to spectre and tests it against a Teukolsky wave input and against a result from SpEC.

I have taken one pass through the code to review it.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent was used, have a co-author trailer of the form
      "Co-Authored-By: <agent name> <agent email>" as the last line of the
      commit, e.g. "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>".

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
