### PR TITLE
Setup subcell with non-hypercube blocks

### DIFF
--- a/src/Domain/Structure/Topology.hpp
+++ b/src/Domain/Structure/Topology.hpp
@@ -40,7 +40,9 @@ namespace domain {
 /// Topology::I1
 ///
 /// \note Currently the hybrid DG-Subcell scheme can be used only in Elements
-/// for which all dimensions have Topology::I1
+/// whose topologies are all among I1, B1Radial, CartoonSphere, and
+/// CartoonCylinder.  Elements with other topologies are automatically treated
+/// as DG-only.
 enum class Topology : uint8_t {
   Uninitialized = 0,
   I1 = 1,

--- a/src/Domain/Tags.hpp
+++ b/src/Domain/Tags.hpp
@@ -104,6 +104,13 @@ struct MappedCoordinates
       const typename MapTag::type& element_map,
       const tnsr::I<DataVector, MapTag::dim, typename MapTag::source_frame>&
           source_coords) {
+    if (source_coords.get(0).size() == 0) {
+      // When subcell is not supported on an element due to topology, the
+      // subcell mesh is
+      // {0, Basis::Uninitialized, Quadrature::Uninitialized}. It is never
+      // used, but the compute items still need to run
+      return;
+    }
     *target_coords = element_map(source_coords);
   }
 };

--- a/src/Evolution/DgSubcell/Actions/Initialize.hpp
+++ b/src/Evolution/DgSubcell/Actions/Initialize.hpp
@@ -174,7 +174,10 @@ struct SetSubcellGrid {
                             first_block_id);
         });
 
+    // Non-hypercube topologies (e.g. spherical shells) can never use subcell
+    // and are automatically treated as DG-only.
     const bool subcell_allowed_in_element =
+        fd::dg_mesh_supports_subcell(dg_mesh) and
         not alg::found(subcell_options.only_dg_block_ids(),
                        element.id().block_id()) and
         not bordering_dg_block;

--- a/src/Evolution/DgSubcell/Actions/TciAndRollback.hpp
+++ b/src/Evolution/DgSubcell/Actions/TciAndRollback.hpp
@@ -26,6 +26,7 @@
 #include "Evolution/DgSubcell/Actions/Labels.hpp"
 #include "Evolution/DgSubcell/ActiveGrid.hpp"
 #include "Evolution/DgSubcell/GhostData.hpp"
+#include "Evolution/DgSubcell/Mesh.hpp"
 #include "Evolution/DgSubcell/NeighborRdmpAndVolumeData.hpp"
 #include "Evolution/DgSubcell/Projection.hpp"
 #include "Evolution/DgSubcell/RdmpTci.hpp"
@@ -66,6 +67,10 @@ namespace evolution::dg::subcell::Actions {
 /*!
  * \brief Run the troubled-cell indicator on the candidate solution and perform
  * the time step rollback if needed.
+ *
+ * Elements that cannot use subcell (e.g. non-hypercube topology or DG-only
+ * blocks) skip the TCI entirely, set the TCI decision to 0, clear ghost data,
+ * and continue.
  *
  * Interior cells are marked as troubled if
  * `subcell_options.always_use_subcells()` is `true`, or if either the RDMP
@@ -155,13 +160,30 @@ struct TciAndRollback {
                             first_block_id);
         });
 
-    // Subcell is allowed in the element if 2 conditions are met:
-    // (i)  The current element block id is not marked as DG only
-    // (ii) The current element is not bordering a DG only block.
+    // Subcell is allowed in the element if 3 conditions are met:
+    // (i)   The DG mesh topology supports subcell
+    // (ii)  The current element block id is not marked as DG only
+    // (iii) The current element is not bordering a DG only block.
     const bool subcell_allowed_in_element =
+        fd::dg_mesh_supports_subcell(dg_mesh) and
         not alg::found(subcell_options.only_dg_block_ids(),
                        element.id().block_id()) and
         not bordering_dg_block;
+
+    // Elements that can never use subcell (e.g. non-hypercube topology or
+    // DG-only blocks) should skip the TCI entirely, since the TCI projects
+    // to the subcell mesh which is unsupported for these elements.
+    if (not subcell_allowed_in_element) {
+      db::mutate<Tags::TciDecision,
+                 subcell::Tags::GhostDataForReconstruction<Dim>>(
+          [](const gsl::not_null<int*> tci_decision_ptr,
+             const auto neighbor_data_ptr) {
+            *tci_decision_ptr = 0;
+            neighbor_data_ptr->clear();
+          },
+          make_not_null(&box));
+      return {Parallel::AlgorithmExecution::Continue, std::nullopt};
+    }
 
     // The reason we pass in the persson_exponent explicitly instead of
     // leaving it to the user is because the value of the exponent that
@@ -172,8 +194,7 @@ struct TciAndRollback {
     // exponent it should use, and to keep the interface between the TCIs
     // consistent, we also pass the exponent in separately here.
     std::tuple<int, RdmpTciData> tci_result = db::mutate_apply<TciMutator>(
-        make_not_null(&box), subcell_options.persson_exponent(),
-        not subcell_allowed_in_element);
+        make_not_null(&box), subcell_options.persson_exponent(), false);
 
     const int tci_decision = std::get<0>(tci_result);
     db::mutate<Tags::TciDecision>(
@@ -186,15 +207,15 @@ struct TciAndRollback {
 
     // If either:
     //
-    // 1. we are not allowed to do subcell in this block
-    // 2. the element is at an outer boundary _and_ we aren't allow to go to
-    //    subcell at an outer boundary.
+    // 1. we are not allowed to do subcell in this block (handled by the
+    //    early return above)
+    // 2. the element is at an outer boundary _and_ we aren't allowed to go
+    //    to subcell at an outer boundary.
     // 3. the cell is not troubled
     //
     // then we can remove the current neighbor data and update the RDMP TCI
     // data.
-    if (not subcell_allowed_in_element or
-        (cell_has_external_boundary and
+    if ((cell_has_external_boundary and
          not subcell_enabled_at_external_boundary) or
         not cell_is_troubled) {
       db::mutate<subcell::Tags::GhostDataForReconstruction<Dim>,

--- a/src/Evolution/DgSubcell/BackgroundGrVars.hpp
+++ b/src/Evolution/DgSubcell/BackgroundGrVars.hpp
@@ -101,6 +101,13 @@ struct BackgroundGrVars : tt::ConformsTo<db::protocols::Mutator> {
       const tnsr::I<DataVector, volume_dim, Frame::Inertial>&
           subcell_inertial_coords,
       const bool did_rollback, const T& solution_or_data) {
+    // Skip for elements whose topology does not support subcell.
+    // For non-hypercube elements, fd::mesh() returns the DG mesh unchanged,
+    // so the subcell mesh won't have FiniteDifference basis.
+    if (subcell_mesh.basis(0) != Spectral::Basis::FiniteDifference) {
+      return;
+    }
+
     const size_t num_subcell_pts = subcell_mesh.number_of_grid_points();
 
     if (gsl::at(*subcell_face_gr_vars, 0).number_of_grid_points() != 0) {

--- a/src/Evolution/DgSubcell/GhostZoneInverseJacobian.hpp
+++ b/src/Evolution/DgSubcell/GhostZoneInverseJacobian.hpp
@@ -69,6 +69,13 @@ struct GhostZoneInverseJacobian {
       const Mesh<Dim>& subcell_mesh,
       const ElementMap<Dim, Frame::Grid>& element_map,
       const ReconstructorType& reconstructor) {
+    // Skip for elements whose topology does not support subcell.
+    // For non-hypercube elements, fd::mesh() returns the DG mesh unchanged,
+    // so the subcell mesh won't have FiniteDifference basis.
+    if (subcell_mesh.basis(0) != Spectral::Basis::FiniteDifference) {
+      return;
+    }
+
     using neighbor_tags = tmpl::list<
         evolution::dg::subcell::Tags::Coordinates<Dim, Frame::Grid>,
         evolution::dg::subcell::fd::Tags::InverseJacobianLogicalToGrid<Dim>>;

--- a/src/Evolution/DgSubcell/Mesh.cpp
+++ b/src/Evolution/DgSubcell/Mesh.cpp
@@ -16,6 +16,20 @@
 
 namespace evolution::dg::subcell::fd {
 template <size_t Dim>
+bool dg_mesh_supports_subcell(const Mesh<Dim>& dg_mesh) {
+  for (size_t d = 0; d < Dim; ++d) {
+    const auto basis_d = dg_mesh.basis(d);
+    if (basis_d != Spectral::Basis::Legendre and
+        basis_d != Spectral::Basis::Chebyshev and
+        basis_d != Spectral::Basis::Cartoon and
+        basis_d != Spectral::Basis::ZernikeB1) {
+      return false;
+    }
+  }
+  return true;
+}
+
+template <size_t Dim>
 void verify_subcell_mesh(const Mesh<Dim>& subcell_mesh, const bool neighbor) {
   const std::string neighbor_str = neighbor ? " neighbor" : "";
   if constexpr (Dim == 3) {
@@ -66,6 +80,12 @@ void verify_subcell_mesh(const Mesh<Dim>& subcell_mesh, const bool neighbor) {
 
 template <size_t Dim>
 Mesh<Dim> mesh(const Mesh<Dim>& dg_mesh) {
+  if (not dg_mesh_supports_subcell(dg_mesh)) {
+    // Non-hypercube topology.  Return uninitialized mesh: subcell should never
+    // be used on this element.
+    return Mesh<Dim>{0_st, Spectral::Basis::Uninitialized,
+                     Spectral::Quadrature::Uninitialized};
+  }
   if (dg_mesh.basis(Dim - 1) != Spectral::Basis::Cartoon) {
     ASSERT(dg_mesh.basis() == make_array<Dim>(Spectral::Basis::Legendre) or
                dg_mesh.basis() == make_array<Dim>(Spectral::Basis::Chebyshev),
@@ -209,6 +229,9 @@ Mesh<Dim> dg_mesh(const Mesh<Dim>& subcell_mesh, const Spectral::Basis basis,
   return Mesh<Dim>{extents, basis, quadrature};
 }
 
+template bool dg_mesh_supports_subcell(const Mesh<1>& dg_mesh);
+template bool dg_mesh_supports_subcell(const Mesh<2>& dg_mesh);
+template bool dg_mesh_supports_subcell(const Mesh<3>& dg_mesh);
 template void verify_subcell_mesh(const Mesh<1>& subcell_mesh,
                                   const bool neighbor);
 template void verify_subcell_mesh(const Mesh<2>& subcell_mesh,

--- a/src/Evolution/DgSubcell/Mesh.hpp
+++ b/src/Evolution/DgSubcell/Mesh.hpp
@@ -21,9 +21,24 @@ class Index;
 
 namespace evolution::dg::subcell::fd {
 /*!
+ * \brief Returns `true` if the DG mesh has a topology compatible with
+ * switching to subcell (finite-difference).
+ *
+ * Only meshes using Legendre, Chebyshev, or Cartoon bases are compatible.
+ * Non-hypercube topologies (e.g., ZernikeB3 for filled balls) return `false`.
+ */
+template <size_t Dim>
+bool dg_mesh_supports_subcell(const Mesh<Dim>& dg_mesh);
+
+/*!
  * \brief Computes the cell-centered finite-difference mesh from the DG mesh,
  * using \f$2N-1\f$ grid points per dimension, where \f$N\f$ is the degree of
  * the DG basis.
+ *
+ * If the DG mesh uses a basis that is not compatible with subcell (i.e.,
+ * `dg_mesh_supports_subcell()` returns `false`), the returned mesh is
+ * uninitialized (`{0_st, Basis::Uninitialized, Quadrature::Uninitialized}`).
+ * The uninitialized mesh should never be used for actual subcell computations.
  */
 template <size_t Dim>
 Mesh<Dim> mesh(const Mesh<Dim>& dg_mesh);

--- a/src/Evolution/DgSubcell/SetInterpolators.hpp
+++ b/src/Evolution/DgSubcell/SetInterpolators.hpp
@@ -90,8 +90,18 @@ struct SetInterpolators {
       const ElementMap<Dim, Frame::Grid>& element_map,
       const ReconstructorType& reconstructor,
       const evolution::dg::subcell::SubcellOptions& subcell_options) {
-    if (alg::found(subcell_options.only_dg_block_ids(),
-                   element.id().block_id())) {
+    // Skip for elements that are DG-only: either in a DG-only block,
+    // bordering a DG-only block, or on a non-subcell-compatible mesh.
+    if (not fd::dg_mesh_supports_subcell(my_dg_mesh) or
+        alg::found(subcell_options.only_dg_block_ids(),
+                   element.id().block_id()) or
+        alg::any_of(
+            element.neighbors(),
+            [&subcell_options](const auto& direction_and_neighbors) {
+              return alg::found(
+                  subcell_options.only_dg_block_ids(),
+                  direction_and_neighbors.second.ids().begin()->block_id());
+            })) {
       return;
     }
     const bool enable_extension_directions =

--- a/src/Evolution/DgSubcell/SubcellOptions.cpp
+++ b/src/Evolution/DgSubcell/SubcellOptions.cpp
@@ -12,13 +12,17 @@
 #include <utility>
 #include <vector>
 
+#include "Domain/Block.hpp"
 #include "Domain/Creators/DomainCreator.hpp"
+#include "Domain/Domain.hpp"
 #include "Domain/Structure/BlockGroups.hpp"
+#include "Domain/Structure/Topology.hpp"
 #include "Options/Context.hpp"
 #include "Options/Options.hpp"
 #include "Utilities/Algorithm.hpp"
 #include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
 #include "Utilities/Serialization/PupStlCpp17.hpp"
 
 namespace evolution::dg::subcell {
@@ -62,6 +66,25 @@ SubcellOptions::SubcellOptions(
   }
 }
 
+namespace {
+bool topology_supports_subcell(const domain::Topology topology) {
+  return topology == domain::Topology::I1 or
+         topology == domain::Topology::B1Radial or
+         topology == domain::Topology::CartoonSphere or
+         topology == domain::Topology::CartoonCylinder;
+}
+
+template <size_t Dim>
+bool block_supports_subcell(const Block<Dim>& block) {
+  for (size_t d = 0; d < Dim; ++d) {
+    if (not topology_supports_subcell(gsl::at(block.topologies(), d))) {
+      return false;
+    }
+  }
+  return true;
+}
+}  // namespace
+
 template <size_t Dim>
 SubcellOptions::SubcellOptions(
     const SubcellOptions& subcell_options_with_block_names,
@@ -71,6 +94,16 @@ SubcellOptions::SubcellOptions(
       subcell_options_with_block_names.only_dg_block_and_group_names_.value_or(
           std::vector<std::string>{}),
       domain_creator.block_names(), domain_creator.block_groups());
+
+  // Auto-detect blocks whose topology does not support subcell (e.g.
+  // spherical shells, filled balls) and add them to the DG-only list.
+  const auto domain = domain_creator.create_domain();
+  for (const auto& block : domain.blocks()) {
+    if (not block_supports_subcell(block) and
+        not alg::found(*only_dg_block_ids_, block.id())) {
+      only_dg_block_ids_->push_back(block.id());
+    }
+  }
 }
 
 void SubcellOptions::pup(PUP::er& p) {

--- a/src/Evolution/DgSubcell/SubcellOptions.hpp
+++ b/src/Evolution/DgSubcell/SubcellOptions.hpp
@@ -239,7 +239,9 @@ class SubcellOptions {
   ///
   /// The `DomainCreator` is used to convert block and group names into IDs
   /// and also to check that all listed block names and groups are in the
-  /// domain.
+  /// domain.  In addition, blocks whose topology does not support subcell
+  /// (e.g. spherical shells, filled balls) are automatically added to the
+  /// DG-only list.
   ///
   /// \note This is a workaround since our option parser does not allow us to
   /// retrieve options specified somewhere completely different in the input

--- a/src/Evolution/DgSubcell/Tags/Coordinates.hpp
+++ b/src/Evolution/DgSubcell/Tags/Coordinates.hpp
@@ -49,9 +49,17 @@ struct LogicalCoordinatesCompute
   using base = Coordinates<VolumeDim, Frame::ElementLogical>;
   using return_type = typename base::type;
   using argument_tags = tmpl::list<Mesh<VolumeDim>>;
-  static constexpr auto function = static_cast<void (*)(
-      gsl::not_null<return_type*>, const ::Mesh<VolumeDim>&)>(
-      &logical_coordinates<VolumeDim>);
+  static void function(const gsl::not_null<return_type*> logical_coords,
+                       const ::Mesh<VolumeDim>& mesh) {
+    if (mesh.number_of_grid_points() == 0) {
+      // When subcell is not supported on an element due to topology, the
+      // subcell mesh is
+      // {0, Basis::Uninitialized, Quadrature::Uninitialized}. It is never
+      // used, but the compute items still need to run: leave coordinates empty.
+      return;
+    }
+    logical_coordinates(logical_coords, mesh);
+  }
 };
 
 /// The inertial coordinates on the subcell grid

--- a/src/Evolution/DiscontinuousGalerkin/Actions/ApplyBoundaryCorrections.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/ApplyBoundaryCorrections.hpp
@@ -293,9 +293,9 @@ bool receive_boundary_data(
       if constexpr (using_subcell_v<Metavariables>) {
         if (time_stepping_policy == TimeSteppingPolicy::EqualRate) {
           evolution::dg::subcell::receive_subcell_data_for_dg<volume_dim>(
-              &db::as_access(*box), mortar_id, received_mortar_data);
+              &db::as_access(*box), received_mortar_id, received_mortar_data);
           evolution::dg::subcell::neighbor_tci_decision<volume_dim>(
-              make_not_null(&db::as_access(*box)), mortar_id,
+              make_not_null(&db::as_access(*box)), received_mortar_id,
               received_mortar_data);
         }
       }

--- a/src/Evolution/Systems/Burgers/Subcell/SetInitialRdmpData.cpp
+++ b/src/Evolution/Systems/Burgers/Subcell/SetInitialRdmpData.cpp
@@ -7,6 +7,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Evolution/DgSubcell/ActiveGrid.hpp"
+#include "Evolution/DgSubcell/Mesh.hpp"
 #include "Evolution/DgSubcell/PerssonTci.hpp"
 #include "Evolution/DgSubcell/Projection.hpp"
 #include "Evolution/DgSubcell/TwoMeshRdmpTci.hpp"
@@ -19,7 +20,10 @@ void SetInitialRdmpData::apply(
     const Scalar<DataVector>& u,
     const evolution::dg::subcell::ActiveGrid active_grid,
     const Mesh<1>& dg_mesh, const Mesh<1>& subcell_mesh) {
-  if (active_grid == evolution::dg::subcell::ActiveGrid::Subcell) {
+  // Also skip projection for non-hypercube elements (which can never use
+  // subcell) to avoid projecting onto the invalid subcell mesh
+  if (active_grid == evolution::dg::subcell::ActiveGrid::Subcell or
+      not evolution::dg::subcell::fd::dg_mesh_supports_subcell(dg_mesh)) {
     *rdmp_tci_data = {{max(get(u))}, {min(get(u))}};
   } else {
     using std::max;

--- a/src/Evolution/Systems/ForceFree/Subcell/SetInitialRdmpData.cpp
+++ b/src/Evolution/Systems/ForceFree/Subcell/SetInitialRdmpData.cpp
@@ -7,6 +7,7 @@
 #include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Evolution/DgSubcell/ActiveGrid.hpp"
+#include "Evolution/DgSubcell/Mesh.hpp"
 #include "Evolution/DgSubcell/Projection.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 
@@ -18,7 +19,10 @@ void SetInitialRdmpData::apply(
     const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
     const evolution::dg::subcell::ActiveGrid active_grid,
     const Mesh<3>& dg_mesh, const Mesh<3>& subcell_mesh) {
-  if (active_grid == evolution::dg::subcell::ActiveGrid::Subcell) {
+  // Also skip projection for non-hypercube elements (which can never use
+  // subcell) to avoid projecting onto the invalid subcell mesh
+  if (active_grid == evolution::dg::subcell::ActiveGrid::Subcell or
+      not evolution::dg::subcell::fd::dg_mesh_supports_subcell(dg_mesh)) {
     const Scalar<DataVector> tilde_e_magnitude = magnitude(tilde_e);
     const Scalar<DataVector> tilde_b_magnitude = magnitude(tilde_b);
 

--- a/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/ResizeAndComputePrimitives.cpp
+++ b/src/Evolution/Systems/GrMhd/GhValenciaDivClean/Subcell/ResizeAndComputePrimitives.cpp
@@ -9,6 +9,7 @@
 #include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
+#include "Evolution/DgSubcell/Mesh.hpp"
 #include "Evolution/DgSubcell/Reconstruction.hpp"
 #include "Evolution/DgSubcell/ReconstructionMethod.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAl.hpp"
@@ -45,7 +46,8 @@ void ResizeAndComputePrims<OrderedListOfRecoverySchemes>::apply(
     const Scalar<DataVector> fd_pressure =
         get<hydro::Tags::Pressure<DataVector>>(*prim_vars);
     prim_vars->initialize(num_grid_points);
-    if (get(fd_pressure).size() == subcell_mesh.number_of_grid_points()) {
+    if (evolution::dg::subcell::fd::dg_mesh_supports_subcell(dg_mesh) and
+        get(fd_pressure).size() == subcell_mesh.number_of_grid_points()) {
       evolution::dg::subcell::fd::reconstruct(
           make_not_null(
               &get(get<hydro::Tags::Pressure<DataVector>>(*prim_vars))),

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/ResizeAndComputePrimitives.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/ResizeAndComputePrimitives.cpp
@@ -9,6 +9,7 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
+#include "Evolution/DgSubcell/Mesh.hpp"
 #include "Evolution/DgSubcell/Reconstruction.hpp"
 #include "Evolution/DgSubcell/ReconstructionMethod.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/KastaunEtAl.hpp"
@@ -46,7 +47,8 @@ void ResizeAndComputePrims<OrderedListOfRecoverySchemes>::apply(
     const Scalar<DataVector> fd_pressure =
         get<hydro::Tags::Pressure<DataVector>>(*prim_vars);
     prim_vars->initialize(num_grid_points);
-    if (get(fd_pressure).size() == subcell_mesh.number_of_grid_points()) {
+    if (evolution::dg::subcell::fd::dg_mesh_supports_subcell(dg_mesh) and
+        get(fd_pressure).size() == subcell_mesh.number_of_grid_points()) {
       evolution::dg::subcell::fd::reconstruct(
           make_not_null(
               &get(get<hydro::Tags::Pressure<DataVector>>(*prim_vars))),

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/SetInitialRdmpData.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/SetInitialRdmpData.cpp
@@ -10,6 +10,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Evolution/DgSubcell/ActiveGrid.hpp"
+#include "Evolution/DgSubcell/Mesh.hpp"
 #include "Evolution/DgSubcell/PerssonTci.hpp"
 #include "Evolution/DgSubcell/Projection.hpp"
 #include "Evolution/DgSubcell/TwoMeshRdmpTci.hpp"
@@ -23,7 +24,10 @@ void SetInitialRdmpData::apply(
     const tnsr::I<DataVector, 3, Frame::Inertial>& tilde_b,
     const evolution::dg::subcell::ActiveGrid active_grid,
     const Mesh<3>& dg_mesh, const Mesh<3>& subcell_mesh) {
-  if (active_grid == evolution::dg::subcell::ActiveGrid::Subcell) {
+  // Also skip projection for non-hypercube elements (which can never use
+  // subcell) to avoid projecting onto the invalid subcell mesh
+  if (active_grid == evolution::dg::subcell::ActiveGrid::Subcell or
+      not evolution::dg::subcell::fd::dg_mesh_supports_subcell(dg_mesh)) {
     const Scalar<DataVector> tilde_b_magnitude = magnitude(tilde_b);
 
     rdmp_tci_data->max_variables_values =

--- a/src/Evolution/Systems/NewtonianEuler/Subcell/SetInitialRdmpData.cpp
+++ b/src/Evolution/Systems/NewtonianEuler/Subcell/SetInitialRdmpData.cpp
@@ -9,6 +9,7 @@
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
 #include "Evolution/DgSubcell/ActiveGrid.hpp"
+#include "Evolution/DgSubcell/Mesh.hpp"
 #include "Evolution/DgSubcell/PerssonTci.hpp"
 #include "Evolution/DgSubcell/Projection.hpp"
 #include "Evolution/DgSubcell/TwoMeshRdmpTci.hpp"
@@ -23,7 +24,10 @@ void SetInitialRdmpData<Dim>::apply(
         tmpl::list<MassDensityCons, MomentumDensity, EnergyDensity>>& vars,
     const evolution::dg::subcell::ActiveGrid active_grid,
     const Mesh<Dim>& dg_mesh, const Mesh<Dim>& subcell_mesh) {
-  if (active_grid == evolution::dg::subcell::ActiveGrid::Subcell) {
+  // Also skip projection for non-hypercube elements (which can never use
+  // subcell) to avoid projecting onto the invalid subcell mesh
+  if (active_grid == evolution::dg::subcell::ActiveGrid::Subcell or
+      not evolution::dg::subcell::fd::dg_mesh_supports_subcell(dg_mesh)) {
     const Scalar<DataVector>& mass_density = get<MassDensityCons>(vars);
     const Scalar<DataVector>& energy_density = get<EnergyDensity>(vars);
     *rdmp_tci_data = {{max(get(mass_density)), max(get(energy_density))},

--- a/src/Evolution/Systems/ScalarAdvection/Subcell/SetInitialRdmpData.cpp
+++ b/src/Evolution/Systems/ScalarAdvection/Subcell/SetInitialRdmpData.cpp
@@ -8,6 +8,7 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
+#include "Evolution/DgSubcell/Mesh.hpp"
 #include "Evolution/DgSubcell/PerssonTci.hpp"
 #include "Evolution/DgSubcell/Projection.hpp"
 #include "Evolution/DgSubcell/TwoMeshRdmpTci.hpp"
@@ -20,7 +21,10 @@ void SetInitialRdmpData<Dim>::apply(
     const Scalar<DataVector>& u,
     const evolution::dg::subcell::ActiveGrid active_grid,
     const Mesh<Dim>& dg_mesh, const Mesh<Dim>& subcell_mesh) {
-  if (active_grid == evolution::dg::subcell::ActiveGrid::Subcell) {
+  // Also skip projection for non-hypercube elements (which can never use
+  // subcell) to avoid projecting onto the invalid subcell mesh
+  if (active_grid == evolution::dg::subcell::ActiveGrid::Subcell or
+      not evolution::dg::subcell::fd::dg_mesh_supports_subcell(dg_mesh)) {
     *rdmp_tci_data = {{max(get(u))}, {min(get(u))}};
   } else {
     using std::max;

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStarSphericalShells.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStarSphericalShells.yaml
@@ -1,0 +1,295 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+Executable: EvolveGhValenciaDivClean
+Testing:
+  Check: parse;execute
+  Timeout: 30
+  Priority: High
+ExpectedOutput:
+  - GhMhdTovStarVolume0.h5
+  - GhMhdTovStarReductions.h5
+
+---
+
+Parallelization:
+  ElementDistribution: NumGridPoints
+
+ResourceInfo:
+  AvoidGlobalProc0: false
+  Singletons: Auto
+
+Evolution:
+  InitialTime: 0.0
+  InitialTimeStep: &initial_time_step 0.0001
+  InitialSlabSize: *initial_time_step
+  MinimumTimeStep: 1e-7
+  LocalTimeStepping: Off
+  TimeStepper:
+    # Both RK3 and AM-PC 3 should work. These are the "standard" time steppers
+    # for spectre for hydro right now.
+    Rk3HesthavenSsp:
+    # AdamsMoultonPc:
+    #   Order: 3
+  LtsStepChoosers:
+  VariableOrderAlgorithm:
+    GoalOrder: 3
+
+PhaseChangeAndTriggers:
+  - Trigger:
+      Slabs:
+        EvenlySpaced:
+          Interval: 1000
+          Offset: 5
+    PhaseChanges:
+      - VisitAndReturn(LoadBalancing)
+
+InitialData: &InitialData
+  GeneralizedHarmonic(TovStar):
+    CentralDensity: 1.28e-3
+    EquationOfState:
+        PolytropicFluid:
+            PolytropicConstant: 100.0
+            PolytropicExponent: 2.0
+    Coordinates: Isotropic
+
+EquationOfState:
+  FromInitialData
+
+# Star surface (radius ~ 7.9) is contained in FD deformed cube elements, while
+# the outer region is always DG non-hypercube elements
+DomainCreator:
+  NonconformingSphericalShells:
+    InnerRadius: 5.0
+    InterfaceRadius: 12.0
+    OuterRadius: 18.0
+    InitialRadialRefinement: 1
+    InitialAngularRefinementOfWedges: 0
+    InitialNumberOfRadialGridPoints: 6
+    InitialSphericalHarmonicL: 10
+    InitialNumberOfAngularGridPointsOfWedges: 6
+    InnerBoundaryCondition:
+      DirichletAnalytic:
+        AnalyticPrescription: *InitialData
+    OuterBoundaryCondition:
+      DirichletAnalytic:
+        AnalyticPrescription: *InitialData
+
+VariableFixing:
+  FixConservatives:
+    Enable: false # Only needed when not using Kastaun for recovery
+    CutoffD: &CutoffD 1.1e-15
+    MinimumValueOfD: &MinimumD 1.0e-15
+    CutoffYe: 0.0
+    MinimumValueOfYe: 0.0
+    SafetyFactorForB: &BSafetyFactor 1.0e-12
+    SafetyFactorForS: 1.0e-12
+    SafetyFactorForSCutoffD: 1.0e-8
+    SafetyFactorForSSlope: 0.0001
+    MagneticField: AssumeZero
+  FixToAtmosphere:
+    DensityOfAtmosphere: 1.0e-15
+    DensityCutoff: &AtmosphereDensityCutoff 1.1e-15
+    VelocityLimiting:
+      AtmosphereMaxVelocity: 0
+      NearAtmosphereMaxVelocity: 1.0e-4
+      AtmosphereDensityCutoff: 3.0e-15
+      TransitionDensityBound: 3.0e-14
+    KappaLimiting:
+      DensityLowerBound: 2.0e-14
+      EplisonKappaMinus: 1.0e-3
+      DensityUpperBound: 2.0e-13
+      EpsilonKappaMax: 0.01
+      LimitAboveDensityUpperBound: False
+      MinTemperature: FromEos
+  LimitLorentzFactor:
+    Enable: false # Only needed when not using Kastaun for recovery
+    MaxDensityCutoff: 1.0e-12
+    LorentzFactorCap: 1.0
+
+PrimitiveFromConservative:
+  CutoffDForInversion: *CutoffD
+  DensityWhenSkippingInversion: *MinimumD
+  KastaunMaxLorentzFactor: 10.0
+
+EvolutionSystem:
+  ValenciaDivClean:
+    DampingParameter: 0.0
+  GeneralizedHarmonic:
+    GaugeCondition:
+      AnalyticChristoffel:
+        AnalyticPrescription: *InitialData
+    DampingFunctionGamma0:
+      GaussianPlusConstant:
+        Constant: 0.01
+        Amplitude: 0.12
+        # Width comes from the radius of the star in code units.
+        Width: 7.884855
+        Center: [0.0, 0.0, 0.0]
+    DampingFunctionGamma1:
+      GaussianPlusConstant:
+        Constant: -0.999
+        Amplitude: 0.999
+        # Width is chosen so that the outer boundary is a few sigma out,
+        # but large enough that the bulk dynamics have gamma_2=0
+        Width: 30.0
+        Center: [0.0, 0.0, 0.0]
+    DampingFunctionGamma2:
+      GaussianPlusConstant:
+        Constant: 0.01
+        Amplitude: 1.2
+        # Width comes from the radius of the star in code units.
+        Width: 7.884855
+        Center: [0.0, 0.0, 0.0]
+
+
+SpatialDiscretization:
+  BoundaryCorrection:
+    ProductAveragedUpwindPenaltyAndRusanov:
+      AveragedUpwindPenalty:
+      Rusanov:
+  DiscontinuousGalerkin:
+    Formulation: StrongInertial
+    Quadrature: GaussLobatto
+    Filtering:
+      - Hypercube:
+          HalfPower: 64
+          Enable: true
+          BlocksToFilter: All
+          VolumeFilterOnSubstep: true
+          BoundaryCorrectionFilterOnSubstep: false
+          VolumeFilterEveryNSteps: None
+          BoundaryCorrectionFilterEveryNSteps: None
+      - SphericalShell:
+          NumModesToKill: 1
+          AngularHalfPower: 64
+          RadialHalfPower: 64
+          Enable: true
+          BlocksToFilter: All
+          VolumeFilterOnSubstep: true
+          BoundaryCorrectionFilterOnSubstep: false
+          VolumeFilterEveryNSteps: None
+          BoundaryCorrectionFilterEveryNSteps: None
+    Subcell:
+      TroubledCellIndicator:
+        PerssonTci:
+          Exponent: 4.0
+          NumHighestModes: 1
+        RdmpTci:
+          Delta0: 1.0e-7
+          Epsilon: 1.0e-3
+        FdToDgTci:
+          NumberOfStepsBetweenTciCalls: 1
+          MinTciCallsAfterRollback: 1
+          MinimumClearTcis: 1
+        AlwaysUseSubcells: true
+        EnableExtensionDirections: false
+        UseHalo: false
+        OnlyDgBlocksAndGroups: None # non-hypercube blocks automatically DG
+      SubcellToDgReconstructionMethod: DimByDim
+      FiniteDifferenceDerivativeOrder: 2
+      FdInterpolationOrder: 1
+    TciOptions:
+      MinimumValueOfD: 1.0e-20
+      MinimumValueOfYe: 1.0e-20
+      MinimumValueOfTildeTau: 1.0e-50
+      AtmosphereDensity: *AtmosphereDensityCutoff
+      SafetyFactorForB: *BSafetyFactor
+      MagneticFieldCutoff: DoNotCheckMagneticField
+  SubcellSolver:
+    Reconstructor:
+      MonotonisedCentralPrim:
+        AtmosphereTreatment: Never
+        ReconstructRhoTimesTemperature: true
+    FilterOptions:
+      SpacetimeDissipation: 0.1
+
+EventsAndTriggersAtCheckpoints:
+
+EventsAndTriggersAtSlabs:
+  - Trigger:
+      Slabs:
+        EvenlySpaced:
+          Interval: 5
+          Offset: 0
+    Events:
+      - ChangeSlabSize:
+          DelayChange: 5
+          StepChoosers:
+            - Cfl:
+                SafetyFactor: 0.6
+            - LimitIncrease:
+                Factor: 1.5
+  - Trigger:
+      Slabs:
+        EvenlySpaced:
+          Interval: 1
+          Offset: 0
+    Events:
+      - ObserveNorms:
+          SubfileName: Errors
+          TensorsToObserve:
+            - Name: Error(SpacetimeMetric)
+              NormType: L2Norm
+              Components: Sum
+            - Name: Error(Pi)
+              NormType: L2Norm
+              Components: Sum
+            - Name: Error(Phi)
+              NormType: L2Norm
+              Components: Sum
+            - Name: Error(RestMassDensity)
+              NormType: L2Norm
+              Components: Sum
+            - Name: Error(Pressure)
+              NormType: L2Norm
+              Components: Sum
+  - Trigger:
+      Slabs:
+        EvenlySpaced:
+          Interval: 2
+          Offset: 0
+    Events:
+      - ObserveFields:
+          SubfileName: VolumeData
+          VariablesToObserve:
+            - RestMassDensity
+            - Pressure
+            - MagneticField
+            - PointwiseL2Norm(GaugeConstraint)
+          InterpolateToMesh: None
+          ProjectToMesh: None
+          CoordinatesFloatingPointType: Double
+          FloatingPointTypes: [Double]
+          BlocksToObserve: All
+  - Trigger:
+      Slabs:
+        Specified:
+          Values: [3]
+    Events:
+      - Completion
+
+EventsAndTriggersAtSteps:
+
+InterpolationTargets:
+  BondiSachsInterpolation:
+    LMax: 16
+    Radius: [1]
+    Center: [0, 0, 0]
+    AngularOrdering: Cce
+
+Cce:
+  BondiSachsOutputFilePrefix: "BondiSachs"
+
+Observers:
+  VolumeFileName: "GhMhdTovStarVolume"
+  ReductionFileName: "GhMhdTovStarReductions"
+
+Interpolator:
+  Verbosity: Silent
+
+EventsAndDenseTriggers:
+
+EventsRunAtCleanup:
+  ObservationValue: -1000.0
+  Events:

--- a/tests/Unit/Domain/Test_Tags.cpp
+++ b/tests/Unit/Domain/Test_Tags.cpp
@@ -159,6 +159,26 @@ void test_compute_tags() {
       expected_jacobian);
 }
 
+void test_mapped_coordinates_zero_size() {
+  // MappedCoordinates must return empty (zero-size) coordinates when the
+  // source coordinates are zero-size, as arises for non-hypercube elements
+  // where the subcell logical coordinates are left empty
+  constexpr size_t dim = 3;
+  auto map = element_map<dim>();
+  const tnsr::I<DataVector, dim, Frame::ElementLogical> empty_logical_coords{};
+  const auto box = db::create<
+      tmpl::list<Tags::ElementMap<dim, Frame::Grid>,
+                 Tags::Coordinates<dim, Frame::ElementLogical>>,
+      db::AddComputeTags<Tags::MappedCoordinates<
+          Tags::ElementMap<dim, Frame::Grid>,
+          Tags::Coordinates<dim, Frame::ElementLogical>, Tags::Coordinates>>>(
+      std::move(map), empty_logical_coords);
+  const auto& grid_coords = db::get<Tags::Coordinates<dim, Frame::Grid>>(box);
+  for (size_t d = 0; d < dim; ++d) {
+    CHECK(grid_coords.get(d).size() == 0);
+  }
+}
+
 SPECTRE_TEST_CASE("Unit.Domain.Tags", "[Unit][Domain]") {
   test_simple_tags<1>();
   test_simple_tags<2>();
@@ -167,6 +187,8 @@ SPECTRE_TEST_CASE("Unit.Domain.Tags", "[Unit][Domain]") {
   test_compute_tags<1>();
   test_compute_tags<2>();
   test_compute_tags<3>();
+
+  test_mapped_coordinates_zero_size();
 }
 }  // namespace
 }  // namespace domain

--- a/tests/Unit/Evolution/DgSubcell/Actions/Test_TciAndRollback.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Actions/Test_TciAndRollback.cpp
@@ -352,9 +352,13 @@ void test_impl(const bool rdmp_fails, const bool tci_fails,
   const bool self_block_dg_only =
       alg::found(subcell_options.only_dg_block_ids(), element.id().block_id());
 
-  // assign value of passed in variable.  Used as a test in apply() above
-  metavars::expected_evolve_on_dg_after_tci_failure =
-      bordering_dg_block or self_block_dg_only;
+  const bool subcell_allowed_in_element =
+      not self_block_dg_only and not bordering_dg_block;
+
+  // When subcell is not allowed, the TCI is skipped entirely (early return),
+  // so evolve_on_dg_after_tci_failure is never checked.  When subcell IS
+  // allowed, the TCI always receives false for this parameter.
+  metavars::expected_evolve_on_dg_after_tci_failure = false;
 
   const int tci_decision{-1};
 
@@ -551,18 +555,25 @@ void test_impl(const bool rdmp_fails, const bool tci_fails,
     CHECK(active_grid_from_box == evolution::dg::subcell::ActiveGrid::Dg);
     CHECK_FALSE(did_rollback_from_box);
 
-    const auto subcell_vars = evolution::dg::subcell::fd::project(
-        evolved_vars, dg_mesh,
-        evolution::dg::subcell::fd::mesh(dg_mesh).extents());
-    const evolution::dg::subcell::RdmpTciData expected_rdmp_data{
-        {std::max(max(get(get<Var1>(evolved_vars))),
-                  max(get(get<Var1>(subcell_vars))))},
-        {std::min(min(get(get<Var1>(evolved_vars))),
-                  min(get(get<Var1>(subcell_vars))))}};
-
-    CHECK(ActionTesting::get_databox_tag<
-              comp, evolution::dg::subcell::Tags::DataForRdmpTci>(runner, 0) ==
-          expected_rdmp_data);
+    if (subcell_allowed_in_element) {
+      // TCI was invoked and updated RDMP data
+      const auto subcell_vars = evolution::dg::subcell::fd::project(
+          evolved_vars, dg_mesh,
+          evolution::dg::subcell::fd::mesh(dg_mesh).extents());
+      const evolution::dg::subcell::RdmpTciData expected_rdmp_data{
+          {std::max(max(get(get<Var1>(evolved_vars))),
+                    max(get(get<Var1>(subcell_vars))))},
+          {std::min(min(get(get<Var1>(evolved_vars))),
+                    min(get(get<Var1>(subcell_vars))))}};
+      CHECK(ActionTesting::get_databox_tag<
+                comp, evolution::dg::subcell::Tags::DataForRdmpTci>(
+                runner, 0) == expected_rdmp_data);
+    } else {
+      // Early return: RDMP data unchanged from initial value
+      CHECK(ActionTesting::get_databox_tag<
+                comp, evolution::dg::subcell::Tags::DataForRdmpTci>(
+                runner, 0) == initial_rdmp_tci_data);
+    }
 
     CHECK(time_stepper_history_from_box.size() == time_stepper_history.size());
     CHECK(time_stepper_history_from_box.substeps().size() ==
@@ -595,9 +606,16 @@ void test_impl(const bool rdmp_fails, const bool tci_fails,
         runner, 0);
     CHECK(ghost_data_for_reconstruction.empty());
   }
-  CHECK(ActionTesting::get_databox_tag<
-            comp, evolution::dg::subcell::Tags::TciDecision>(runner, 0) ==
-        (metavars::tci_invoked ? (rdmp_fails ? 10 : (tci_fails ? 5 : 0)) : -1));
+  // When subcell is not allowed in the element, the TCI is skipped and the
+  // decision is explicitly set to 0.  Otherwise the TCI is invoked and the
+  // decision comes from its return value.
+  const int expected_tci_decision =
+      subcell_allowed_in_element ? (rdmp_fails ? 10 : (tci_fails ? 5 : 0)) : 0;
+  CHECK(metavars::tci_invoked == subcell_allowed_in_element);
+  CHECK(
+      ActionTesting::get_databox_tag<comp,
+                                     evolution::dg::subcell::Tags::TciDecision>(
+          runner, 0) == expected_tci_decision);
 }
 
 template <size_t Dim>

--- a/tests/Unit/Evolution/DgSubcell/Test_Mesh.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_Mesh.cpp
@@ -180,31 +180,33 @@ void test_cartoon_mesh() {
     CHECK(evolution::dg::subcell::fd::dg_mesh(subcell_axial, BasisType,
                                               QuadratureType) == dg_axial);
   }
+  // mesh(): unsupported bases return the uninitialized sentinel rather than
+  // asserting, since subcell is never used on such elements.
+  {
+    const Mesh<3> zernike_b2_cartoon{
+        {{3, 1, 1}},
+        {Spectral::Basis::ZernikeB2, Spectral::Basis::Cartoon,
+         Spectral::Basis::Cartoon},
+        {Spectral::Quadrature::GaussRadauUpper,
+         Spectral::Quadrature::SphericalSymmetry,
+         Spectral::Quadrature::SphericalSymmetry}};
+    CHECK(evolution::dg::subcell::fd::mesh(zernike_b2_cartoon) ==
+          Mesh<3>{0_st, Spectral::Basis::Uninitialized,
+                  Spectral::Quadrature::Uninitialized});
+    // FiniteDifference is also not a valid DG basis, so it returns the
+    // uninitialized sentinel.
+    const Mesh<3> fd_cartoon{
+        {{3, 3, 1}},
+        {Spectral::Basis::FiniteDifference, BasisType,
+         Spectral::Basis::Cartoon},
+        {Spectral::Quadrature::CellCentered, QuadratureType,
+         Spectral::Quadrature::AxialSymmetry}};
+    CHECK(evolution::dg::subcell::fd::mesh(fd_cartoon) ==
+          Mesh<3>{0_st, Spectral::Basis::Uninitialized,
+                  Spectral::Quadrature::Uninitialized});
+  }
 
 #ifdef SPECTRE_DEBUG
-  // mesh() assert: non-Legendre/Chebyshev dimension mixed with Cartoon
-  CHECK_THROWS_WITH(
-      evolution::dg::subcell::fd::mesh(
-          Mesh<3>{{{3, 1, 1}},
-                  {Spectral::Basis::ZernikeB2, Spectral::Basis::Cartoon,
-                   Spectral::Basis::Cartoon},
-                  {Spectral::Quadrature::GaussRadauUpper,
-                   Spectral::Quadrature::SphericalSymmetry,
-                   Spectral::Quadrature::SphericalSymmetry}}),
-      Catch::Matchers::ContainsSubstring(
-          "The DG mesh that is being converted to subcell can only mix "
-          "Legendre, Chebyshev, or ZernikeB1 with Cartoon"));
-  CHECK_THROWS_WITH(
-      evolution::dg::subcell::fd::mesh(
-          Mesh<3>{{{3, 3, 1}},
-                  {Spectral::Basis::FiniteDifference, BasisType,
-                   Spectral::Basis::Cartoon},
-                  {Spectral::Quadrature::CellCentered, QuadratureType,
-                   Spectral::Quadrature::AxialSymmetry}}),
-      Catch::Matchers::ContainsSubstring(
-          "The DG mesh that is being converted to subcell can only mix "
-          "Legendre, Chebyshev, or ZernikeB1 with Cartoon"));
-
   // dg_mesh() assert: non-FiniteDifference dimension mixed with Cartoon
   CHECK_THROWS_WITH(
       evolution::dg::subcell::fd::dg_mesh(
@@ -265,4 +267,67 @@ SPECTRE_TEST_CASE("Unit.Evolution.Subcell.FD.Mesh", "[Evolution][Unit]") {
   test_cartoon_mesh<Spectral::Basis::Chebyshev, Spectral::Quadrature::Gauss>();
   test_zernike_b1_cartoon_mesh();
   print_comparison_point_computation();
+
+  INFO("Test dg_mesh_supports_subcell");
+  {
+    CHECK(evolution::dg::subcell::fd::dg_mesh_supports_subcell(Mesh<1>{
+        5, Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto}));
+    CHECK(evolution::dg::subcell::fd::dg_mesh_supports_subcell(Mesh<2>{
+        5, Spectral::Basis::Chebyshev, Spectral::Quadrature::GaussLobatto}));
+    CHECK(evolution::dg::subcell::fd::dg_mesh_supports_subcell(
+        Mesh<3>{5, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss}));
+    CHECK(evolution::dg::subcell::fd::dg_mesh_supports_subcell(
+        Mesh<3>{{{5, 1, 1}},
+                {Spectral::Basis::Legendre, Spectral::Basis::Cartoon,
+                 Spectral::Basis::Cartoon},
+                {Spectral::Quadrature::GaussLobatto,
+                 Spectral::Quadrature::SphericalSymmetry,
+                 Spectral::Quadrature::SphericalSymmetry}}));
+    CHECK(evolution::dg::subcell::fd::dg_mesh_supports_subcell(
+        Mesh<3>{{{5, 1, 1}},
+                {Spectral::Basis::ZernikeB1, Spectral::Basis::Cartoon,
+                 Spectral::Basis::Cartoon},
+                {Spectral::Quadrature::GaussRadauUpper,
+                 Spectral::Quadrature::SphericalSymmetry,
+                 Spectral::Quadrature::SphericalSymmetry}}));
+
+    CHECK_FALSE(evolution::dg::subcell::fd::dg_mesh_supports_subcell(Mesh<3>{
+        {{5, 5, 9}},
+        {Spectral::Basis::ZernikeB3, Spectral::Basis::ZernikeB3,
+         Spectral::Basis::ZernikeB3},
+        {Spectral::Quadrature::GaussRadauUpper, Spectral::Quadrature::Gauss,
+         Spectral::Quadrature::Equiangular}}));
+    CHECK_FALSE(evolution::dg::subcell::fd::dg_mesh_supports_subcell(Mesh<3>{
+        {{5, 6, 11}},
+        {Spectral::Basis::SphericalHarmonic, Spectral::Basis::SphericalHarmonic,
+         Spectral::Basis::SphericalHarmonic},
+        {Spectral::Quadrature::GaussLobatto, Spectral::Quadrature::Gauss,
+         Spectral::Quadrature::Equiangular}}));
+    CHECK_FALSE(evolution::dg::subcell::fd::dg_mesh_supports_subcell(
+        Mesh<1>{5, Spectral::Basis::FiniteDifference,
+                Spectral::Quadrature::CellCentered}));
+  }
+
+  INFO("Test fd::mesh with unsupported bases");
+  {
+    const Mesh<3> zernike_b3_mesh{
+        {{5, 5, 9}},
+        {Spectral::Basis::ZernikeB3, Spectral::Basis::ZernikeB3,
+         Spectral::Basis::ZernikeB3},
+        {Spectral::Quadrature::GaussRadauUpper, Spectral::Quadrature::Gauss,
+         Spectral::Quadrature::Equiangular}};
+    CHECK(evolution::dg::subcell::fd::mesh(zernike_b3_mesh) ==
+          Mesh<3>{0_st, Spectral::Basis::Uninitialized,
+                  Spectral::Quadrature::Uninitialized});
+
+    const Mesh<3> spherical_harmonic_mesh{
+        {{5, 6, 11}},
+        {Spectral::Basis::SphericalHarmonic, Spectral::Basis::SphericalHarmonic,
+         Spectral::Basis::SphericalHarmonic},
+        {Spectral::Quadrature::GaussLobatto, Spectral::Quadrature::Gauss,
+         Spectral::Quadrature::Equiangular}};
+    CHECK(evolution::dg::subcell::fd::mesh(spherical_harmonic_mesh) ==
+          Mesh<3>{0_st, Spectral::Basis::Uninitialized,
+                  Spectral::Quadrature::Uninitialized});
+  }
 }

--- a/tests/Unit/Evolution/DgSubcell/Test_SubcellOptions.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_SubcellOptions.cpp
@@ -4,15 +4,26 @@
 #include "Framework/TestingFramework.hpp"
 
 #include <cstddef>
+#include <memory>
 #include <string>
+#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
+#include "Domain/Block.hpp"
+#include "Domain/BoundaryConditions/BoundaryCondition.hpp"
 #include "Domain/Creators/Cylinder.hpp"
+#include "Domain/Creators/DomainCreator.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/Structure/BlockNeighbors.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Domain/Structure/Topology.hpp"
 #include "Evolution/DgSubcell/ReconstructionMethod.hpp"
 #include "Evolution/DgSubcell/SubcellOptions.hpp"
 #include "Evolution/DgSubcell/Tags/SubcellOptions.hpp"
 #include "Framework/TestCreation.hpp"
 #include "Framework/TestHelpers.hpp"
+#include "Utilities/Algorithm.hpp"
 #include "Utilities/Serialization/Serialize.hpp"
 
 namespace evolution::dg::subcell {
@@ -201,6 +212,73 @@ SPECTRE_TEST_CASE("Unit.Evolution.Subcell.SubcellOptions",
             cylinder}
             .only_dg_block_ids()
             .size() == 4);
+
+  INFO("Test auto-detection of non-hypercube blocks");
+  {
+    // Create a domain creator that produces a domain with a mix of hypercube
+    // and non-hypercube blocks to test auto-detection.
+    struct MixedTopologyCreator : public DomainCreator<3> {
+      Domain<3> create_domain() const override {
+        std::vector<Block<3>> blocks;
+        // Block 0: hypercube (I1 in all dimensions)
+        blocks.emplace_back(nullptr, 0, DirectionMap<3, BlockNeighbors<3>>{},
+                            "Cube", domain::topologies::hypercube<3>);
+        // Block 1: spherical shell (non-hypercube)
+        blocks.emplace_back(nullptr, 1, DirectionMap<3, BlockNeighbors<3>>{},
+                            "Shell", domain::topologies::spherical_shell);
+        // Block 2: filled sphere (non-hypercube)
+        blocks.emplace_back(nullptr, 2, DirectionMap<3, BlockNeighbors<3>>{},
+                            "Ball", domain::topologies::full_sphere);
+        // Block 3: another hypercube
+        blocks.emplace_back(nullptr, 3, DirectionMap<3, BlockNeighbors<3>>{},
+                            "Cube2", domain::topologies::hypercube<3>);
+        return Domain<3>{std::move(blocks)};
+      }
+      std::vector<DirectionMap<
+          3, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
+      external_boundary_conditions() const override {
+        return {};
+      }
+      std::vector<std::string> block_names() const override {
+        return {"Cube", "Shell", "Ball", "Cube2"};
+      }
+      std::vector<std::array<size_t, 3>> initial_extents() const override {
+        return {};
+      }
+      std::vector<std::array<size_t, 3>> initial_refinement_levels()
+          const override {
+        return {};
+      }
+    };
+    const MixedTopologyCreator mixed_creator{};
+
+    // No user-specified DG-only blocks: auto-detection should find Shell
+    // (block 1) and Ball (block 2)
+    const SubcellOptions mixed_opts{
+        SubcellOptions{4.0, 1_st, 1.0e-3, 1.0e-4, false, false,
+                       fd::ReconstructionMethod::DimByDim, false, std::nullopt,
+                       ::fd::DerivativeOrder::Two, 1, 1, 1},
+        mixed_creator};
+    // Blocks 1 and 2 should be auto-detected as DG-only
+    CHECK(mixed_opts.only_dg_block_ids().size() == 2);
+    CHECK(alg::found(mixed_opts.only_dg_block_ids(), size_t{1}));
+    CHECK(alg::found(mixed_opts.only_dg_block_ids(), size_t{2}));
+    CHECK_FALSE(alg::found(mixed_opts.only_dg_block_ids(), size_t{0}));
+    CHECK_FALSE(alg::found(mixed_opts.only_dg_block_ids(), size_t{3}));
+
+    // With user-specified DG-only block that overlaps with auto-detected:
+    // should not duplicate
+    const SubcellOptions mixed_opts_with_user{
+        SubcellOptions{4.0, 1_st, 1.0e-3, 1.0e-4, false, false,
+                       fd::ReconstructionMethod::DimByDim, false,
+                       std::optional{std::vector<std::string>{"Shell"}},
+                       ::fd::DerivativeOrder::Two, 1, 1, 1},
+        mixed_creator};
+    // Shell (block 1) from user + Ball (block 2) from auto-detection = 2
+    CHECK(mixed_opts_with_user.only_dg_block_ids().size() == 2);
+    CHECK(alg::found(mixed_opts_with_user.only_dg_block_ids(), size_t{1}));
+    CHECK(alg::found(mixed_opts_with_user.only_dg_block_ids(), size_t{2}));
+  }
 }
 }  // namespace
 }  // namespace evolution::dg::subcell

--- a/tests/Unit/Evolution/DgSubcell/Test_Tags.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_Tags.cpp
@@ -429,6 +429,21 @@ void test(const bool moving_mesh) {
   TestHelpers::db::test_compute_tag<subcell::Tags::ObserverMeshCompute<Dim>>(
       "ObserverMesh");
 }
+void test_logical_coordinates_zero_mesh() {
+  // LogicalCoordinatesCompute must return empty (zero-size) coordinates when
+  // the subcell mesh is the uninitialized sentinel (zero extents), as used for
+  // non-hypercube elements where subcell is not supported
+  const auto box = db::create<
+      tmpl::list<subcell::Tags::Mesh<3>>,
+      db::AddComputeTags<subcell::Tags::LogicalCoordinatesCompute<3>>>(
+      Mesh<3>{0_st, Spectral::Basis::Uninitialized,
+              Spectral::Quadrature::Uninitialized});
+  const auto& coords =
+      db::get<subcell::Tags::Coordinates<3, Frame::ElementLogical>>(box);
+  for (size_t d = 0; d < 3; ++d) {
+    CHECK(coords.get(d).size() == 0);
+  }
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Evolution.Subcell.Tags", "[Evolution][Unit]") {
@@ -460,4 +475,5 @@ SPECTRE_TEST_CASE("Unit.Evolution.Subcell.Tags", "[Evolution][Unit]") {
     test<2>(moving_mesh);
     test<3>(moving_mesh);
   }
+  test_logical_coordinates_zero_mesh();
 }


### PR DESCRIPTION
## Proposed changes

The most straightforward way to approach this is to simply not do anything in non-hypercube topologies. This is determined in options parsing by topology / other code by I1-like bases.

Slice of input file domain (which has a note for `OnlyDgBlocksAndGroups` that the non-hypercube elements don't need to be specified):
<img width="426" height="421" alt="Screenshot 2026-08-04 at 9 27 29 AM" src="https://github.com/user-attachments/assets/65fb0409-e5c9-49ba-9cdb-d889bee9bb76" />


<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent was used, have a co-author trailer of the form
      "Co-Authored-By: <agent name> <agent email>" as the last line of the
      commit, e.g. "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>".

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
