### PR TITLE
Generalize amr::Limits policy to specify resolution bounds independently for different topologies

### DIFF
--- a/src/Domain/Structure/CMakeLists.txt
+++ b/src/Domain/Structure/CMakeLists.txt
@@ -21,6 +21,7 @@ spectre_target_sources(
   HasBoundary.cpp
   Hypercube.cpp
   InitialElementIds.cpp
+  IsValidDgMesh.cpp
   NeighborIsConforming.cpp
   Neighbors.cpp
   ObjectLabel.cpp
@@ -53,6 +54,7 @@ spectre_target_headers(
   Hypercube.hpp
   IndexToSliceAt.hpp
   InitialElementIds.hpp
+  IsValidDgMesh.hpp
   MaxNumberOfNeighbors.hpp
   NeighborIsConforming.hpp
   Neighbors.hpp

--- a/src/Domain/Structure/IsValidDgMesh.cpp
+++ b/src/Domain/Structure/IsValidDgMesh.cpp
@@ -1,0 +1,108 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Domain/Structure/IsValidDgMesh.hpp"
+
+#include <cstddef>
+
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/Topology.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/IsValidDgMesh.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace domain {
+template <size_t Dim>
+bool is_valid_dg_mesh(const Mesh<Dim>& mesh, const Element<Dim>& element) {
+  // only need to verify consistency of topology and basis as quadrature will
+  // be checked in is_valid_dg_mesh(mesh)
+  const auto& topologies = element.topologies();
+  for (size_t d = 0; d < Dim; ++d) {
+    const auto topology = gsl::at(topologies, d);
+    const auto basis = mesh.basis(d);
+    const auto& segment_id = element.id().segment_id(d);
+    const auto refinement_level = segment_id.refinement_level();
+    const auto segment_id_index = segment_id.index();
+    switch (topology) {
+      case Topology::I1: {
+        if (basis == Spectral::Basis::Legendre or
+            basis == Spectral::Basis::Chebyshev) {
+          break;
+        } else {
+          return false;
+        }
+      }
+      case Topology::S1: {
+        if (basis == Spectral::Basis::Fourier and refinement_level == 0_st) {
+          break;
+        } else {
+          return false;
+        }
+      }
+      case Topology::S2Colatitude:
+        [[fallthrough]];
+      case Topology::S2Longitude: {
+        if (basis == Spectral::Basis::SphericalHarmonic and
+            refinement_level == 0_st) {
+          break;
+        } else {
+          return false;
+        }
+      }
+      case Topology::B1Radial: {
+        if (basis == Spectral::Basis::ZernikeB1 and segment_id_index == 0_st) {
+          break;
+        } else {
+          return false;
+        }
+      }
+      case Topology::B2Radial:
+        if (basis == Spectral::Basis::ZernikeB2 and segment_id_index == 0_st) {
+          break;
+        } else {
+          return false;
+        }
+      case Topology::B2Angular: {
+        if (basis == Spectral::Basis::ZernikeB2 and refinement_level == 0_st) {
+          break;
+        } else {
+          return false;
+        }
+      }
+      case Topology::B3Radial:
+        if (basis == Spectral::Basis::ZernikeB3 and segment_id_index == 0_st) {
+          break;
+        } else {
+          return false;
+        }
+      case Topology::B3Colatitude:
+        [[fallthrough]];
+      case Topology::B3Longitude: {
+        if (basis == Spectral::Basis::ZernikeB3 and refinement_level == 0_st) {
+          break;
+        } else {
+          return false;
+        }
+      }
+      case Topology::CartoonSphere:
+        [[fallthrough]];
+      case Topology::CartoonCylinder: {
+        if (basis == Spectral::Basis::Cartoon and refinement_level == 0_st) {
+          break;
+        } else {
+          return false;
+        }
+      }
+      default:
+        ERROR("Invalid basis");
+    }
+  }
+  return Spectral::is_valid_dg_mesh(mesh);
+}
+
+template bool is_valid_dg_mesh(const Mesh<1>& mesh, const Element<1>& element);
+template bool is_valid_dg_mesh(const Mesh<2>& mesh, const Element<2>& element);
+template bool is_valid_dg_mesh(const Mesh<3>& mesh, const Element<3>& element);
+}  // namespace domain

--- a/src/Domain/Structure/IsValidDgMesh.hpp
+++ b/src/Domain/Structure/IsValidDgMesh.hpp
@@ -1,0 +1,23 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+/// \cond
+template <size_t Dim>
+class Element;
+template <size_t Dim>
+class Mesh;
+/// \endcond
+
+namespace domain {
+/// \brief Returns true if mesh is valid for DG on the given element
+///
+/// \details A Mesh is valid for DG on an Element if:
+/// - the Mesh satisfies Spectral::is_valid_dg_mesh
+/// - the Basis of the Mesh is appropriate for the topologies of the Element
+template <size_t Dim>
+bool is_valid_dg_mesh(const Mesh<Dim>& mesh, const Element<Dim>& element);
+}  // namespace domain

--- a/src/Evolution/Ader/Matrices.cpp
+++ b/src/Evolution/Ader/Matrices.cpp
@@ -19,7 +19,7 @@ template <Spectral::Basis BasisType, Spectral::Quadrature QuadratureType,
           typename SpectralQuantityGenerator>
 const auto& precomputed_spectral_quantity(const size_t num_points) {
   constexpr size_t max_num_points =
-      Spectral::maximum_number_of_points<BasisType>;
+      Spectral::maximum_number_of_points<BasisType, QuadratureType>;
   constexpr size_t min_num_points =
       Spectral::minimum_number_of_points<BasisType, QuadratureType>;
   ASSERT(num_points >= min_num_points,

--- a/src/Evolution/DgSubcell/Matrices.cpp
+++ b/src/Evolution/DgSubcell/Matrices.cpp
@@ -56,16 +56,19 @@ const Matrix& projection_matrix(const Mesh<1>& dg_mesh,
          "Parity must be set when using ZernikeB1");
 
   const static auto zernike_b1_cache = make_static_cache<
-      CacheRange<
-          Spectral::minimum_number_of_points<
-              Spectral::Basis::ZernikeB1,
-              Spectral::Quadrature::GaussRadauUpper>,
-          Spectral::maximum_number_of_points<Spectral::Basis::ZernikeB1> + 1>,
+      CacheRange<Spectral::minimum_number_of_points<
+                     Spectral::Basis::ZernikeB1,
+                     Spectral::Quadrature::GaussRadauUpper>,
+                 Spectral::maximum_number_of_points<
+                     Spectral::Basis::ZernikeB1,
+                     Spectral::Quadrature::GaussRadauUpper> +
+                     1>,
       CacheRange<Spectral::minimum_number_of_points<
                      Spectral::Basis::FiniteDifference,
                      Spectral::Quadrature::CellCentered>,
                  Spectral::maximum_number_of_points<
-                     Spectral::Basis::FiniteDifference> +
+                     Spectral::Basis::FiniteDifference,
+                     Spectral::Quadrature::CellCentered> +
                      1>,
       CacheEnumeration<Spectral::Quadrature, Spectral::Quadrature::CellCentered,
                        Spectral::Quadrature::FaceCentered>,
@@ -87,12 +90,15 @@ const Matrix& projection_matrix(const Mesh<1>& dg_mesh,
       CacheRange<
           Spectral::minimum_number_of_points<
               Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto>,
-          Spectral::maximum_number_of_points<Spectral::Basis::Legendre> + 1>,
+          Spectral::maximum_number_of_points<
+              Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto> +
+              1>,
       CacheRange<Spectral::minimum_number_of_points<
                      Spectral::Basis::FiniteDifference,
                      Spectral::Quadrature::CellCentered>,
                  Spectral::maximum_number_of_points<
-                     Spectral::Basis::FiniteDifference> +
+                     Spectral::Basis::FiniteDifference,
+                     Spectral::Quadrature::CellCentered> +
                      1>,
       CacheEnumeration<Spectral::Quadrature, Spectral::Quadrature::Gauss,
                        Spectral::Quadrature::GaussLobatto>,
@@ -391,17 +397,29 @@ const Matrix& reconstruction_matrix(const Mesh<Dim>& dg_mesh,
     case Spectral::Quadrature::GaussLobatto:
       return reconstruction_matrix_impl<Spectral::Quadrature::GaussLobatto>(
           dg_mesh, subcell_extents,
-          std::make_index_sequence<
-              Spectral::maximum_number_of_points<Spectral::Basis::Legendre> +
-              1>{});
+          std::make_index_sequence<Spectral::maximum_number_of_points<
+                                       Spectral::Basis::Legendre,
+                                       Spectral::Quadrature::GaussLobatto> +
+                                   1>{});
     case Spectral::Quadrature::Gauss:
       return reconstruction_matrix_impl<Spectral::Quadrature::Gauss>(
           dg_mesh, subcell_extents,
           std::make_index_sequence<
-              Spectral::maximum_number_of_points<Spectral::Basis::Legendre> +
+              Spectral::maximum_number_of_points<Spectral::Basis::Legendre,
+                                                 Spectral::Quadrature::Gauss> +
               1>{});
     case Spectral::Quadrature::AxialSymmetry:
-      [[fallthrough]];
+      ASSERT(Dim == 1,
+             "Cartoon basis should only be used with DimByDim reconstruction, "
+             "so only a mesh slice "
+             "should get here, got Dim = "
+                 << Dim);
+      return reconstruction_matrix_impl<Spectral::Quadrature::AxialSymmetry>(
+          dg_mesh, subcell_extents,
+          std::make_index_sequence<Spectral::maximum_number_of_points<
+                                       Spectral::Basis::Cartoon,
+                                       Spectral::Quadrature::AxialSymmetry> +
+                                   1>{});
     case Spectral::Quadrature::SphericalSymmetry:
       ASSERT(Dim == 1,
              "Cartoon basis should only be used with DimByDim reconstruction, "
@@ -412,7 +430,9 @@ const Matrix& reconstruction_matrix(const Mesh<Dim>& dg_mesh,
           Spectral::Quadrature::SphericalSymmetry>(
           dg_mesh, subcell_extents,
           std::make_index_sequence<
-              Spectral::maximum_number_of_points<Spectral::Basis::Cartoon> +
+              Spectral::maximum_number_of_points<
+                  Spectral::Basis::Cartoon,
+                  Spectral::Quadrature::SphericalSymmetry> +
               1>{});
     default:
       ERROR(
@@ -440,16 +460,19 @@ const Matrix& reconstruction_matrix(const Mesh<1>& dg_mesh,
                 "would be singular)");
 
   static const auto cache = make_runtime_cache<
-      CacheRange<
-          Spectral::minimum_number_of_points<
-              Spectral::Basis::ZernikeB1,
-              Spectral::Quadrature::GaussRadauUpper>,
-          Spectral::maximum_number_of_points<Spectral::Basis::ZernikeB1> + 1>,
+      CacheRange<Spectral::minimum_number_of_points<
+                     Spectral::Basis::ZernikeB1,
+                     Spectral::Quadrature::GaussRadauUpper>,
+                 Spectral::maximum_number_of_points<
+                     Spectral::Basis::ZernikeB1,
+                     Spectral::Quadrature::GaussRadauUpper> +
+                     1>,
       CacheRange<Spectral::minimum_number_of_points<
                      Spectral::Basis::FiniteDifference,
                      Spectral::Quadrature::CellCentered>,
                  Spectral::maximum_number_of_points<
-                     Spectral::Basis::FiniteDifference> +
+                     Spectral::Basis::FiniteDifference,
+                     Spectral::Quadrature::CellCentered> +
                      1>,
       CacheEnumeration<Spectral::Parity, Spectral::Parity::Even,
                        Spectral::Parity::Odd>>(
@@ -571,40 +594,44 @@ const Matrix& projection_matrix(const Mesh<1>& dg_mesh,
   ASSERT(ghost_zone_size <= max_ghost_zone_size and ghost_zone_size >= 2,
          "ghost_zone_size must be in [2, " << max_ghost_zone_size
                                            << " ] but got " << ghost_zone_size);
-  static const auto cache = make_static_cache<
-      CacheRange<
-          Spectral::minimum_number_of_points<
-              Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto>,
-          Spectral::maximum_number_of_points<Spectral::Basis::Legendre> + 1>,
-      CacheRange<Spectral::minimum_number_of_points<
-                     Spectral::Basis::FiniteDifference,
-                     Spectral::Quadrature::CellCentered>,
-                 Spectral::maximum_number_of_points<
-                     Spectral::Basis::FiniteDifference> +
-                     1>,
-      CacheRange<2_st, max_ghost_zone_size + 1>,
-      CacheEnumeration<Spectral::Quadrature, Spectral::Quadrature::Gauss,
-                       Spectral::Quadrature::GaussLobatto>,
-      CacheEnumeration<Side, Side::Lower, Side::Upper>>(
-      [](const size_t local_num_dg_points, const size_t local_num_fd_points,
-         const size_t local_ghost_zone_size,
-         const Spectral::Quadrature dg_quadrature, const Side local_side) {
-        const DataVector& fd_points =
-            Spectral::collocation_points<Spectral::Basis::FiniteDifference,
-                                         Spectral::Quadrature::CellCentered>(
-                local_num_fd_points);
-        DataVector target_points(local_ghost_zone_size);
-        for (size_t i = 0; i < local_ghost_zone_size; ++i) {
-          target_points[i] = fd_points[local_side == Side::Lower
-                                           ? i
-                                           : (local_num_fd_points -
-                                              local_ghost_zone_size + i)];
-        }
-        return Spectral::interpolation_matrix(
-            Mesh<1>{local_num_dg_points, Spectral::Basis::Legendre,
-                    dg_quadrature},
-            target_points);
-      });
+  static const auto cache =
+      make_static_cache<
+          CacheRange<Spectral::minimum_number_of_points<
+                         Spectral::Basis::Legendre,
+                         Spectral::Quadrature::GaussLobatto>,
+                     Spectral::maximum_number_of_points<
+                         Spectral::Basis::Legendre,
+                         Spectral::Quadrature::GaussLobatto> +
+                         1>,
+          CacheRange<Spectral::minimum_number_of_points<
+                         Spectral::Basis::FiniteDifference,
+                         Spectral::Quadrature::CellCentered>,
+                     Spectral::maximum_number_of_points<
+                         Spectral::Basis::FiniteDifference,
+                         Spectral::Quadrature::CellCentered> +
+                         1>,
+          CacheRange<2_st, max_ghost_zone_size + 1>,
+          CacheEnumeration<Spectral::Quadrature, Spectral::Quadrature::Gauss,
+                           Spectral::Quadrature::GaussLobatto>,
+          CacheEnumeration<Side, Side::Lower, Side::Upper>>(
+          [](const size_t local_num_dg_points, const size_t local_num_fd_points,
+             const size_t local_ghost_zone_size,
+             const Spectral::Quadrature dg_quadrature, const Side local_side) {
+            const DataVector& fd_points = Spectral::collocation_points<
+                Spectral::Basis::FiniteDifference,
+                Spectral::Quadrature::CellCentered>(local_num_fd_points);
+            DataVector target_points(local_ghost_zone_size);
+            for (size_t i = 0; i < local_ghost_zone_size; ++i) {
+              target_points[i] = fd_points[local_side == Side::Lower
+                                               ? i
+                                               : (local_num_fd_points -
+                                                  local_ghost_zone_size + i)];
+            }
+            return Spectral::interpolation_matrix(
+                Mesh<1>{local_num_dg_points, Spectral::Basis::Legendre,
+                        dg_quadrature},
+                target_points);
+          });
   return cache(dg_mesh.extents(0), subcell_extents, ghost_zone_size,
                dg_mesh.quadrature(0), side);
 }

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/Krivodonova.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/Krivodonova.hpp
@@ -439,8 +439,9 @@ class Krivodonova<VolumeDim, tmpl::list<Tags...>> {
    * \brief The \f$\alpha_i\f$ values in the Krivodonova algorithm.
    */
   struct Alphas {
-    using type = std::array<
-        double, Spectral::maximum_number_of_points<Spectral::Basis::Legendre>>;
+    using type = std::array<double, Spectral::maximum_number_of_points<
+                                        Spectral::Basis::Legendre,
+                                        Spectral::Quadrature::GaussLobatto>>;
     static constexpr Options::String help = {
         "The alpha parameters of the Krivodonova limiter"};
   };
@@ -466,8 +467,9 @@ class Krivodonova<VolumeDim, tmpl::list<Tags...>> {
       "necessary."};
 
   explicit Krivodonova(
-      std::array<double,
-                 Spectral::maximum_number_of_points<Spectral::Basis::Legendre>>
+      std::array<double, Spectral::maximum_number_of_points<
+                             Spectral::Basis::Legendre,
+                             Spectral::Quadrature::GaussLobatto>>
           alphas,
       bool disable_for_debugging = false, const Options::Context& context = {});
 
@@ -544,17 +546,19 @@ class Krivodonova<VolumeDim, tmpl::list<Tags...>> {
       const typename Tag::type& nodal_tensor, const Mesh<Dim>& mesh) const;
 
   std::array<double,
-             Spectral::maximum_number_of_points<Spectral::Basis::Legendre>>
-      alphas_ = make_array<
-          Spectral::maximum_number_of_points<Spectral::Basis::Legendre>>(
+             Spectral::maximum_number_of_points<
+                 Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto>>
+      alphas_ = make_array<Spectral::maximum_number_of_points<
+          Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto>>(
           std::numeric_limits<double>::signaling_NaN());
   bool disable_for_debugging_{false};
 };
 
 template <size_t VolumeDim, typename... Tags>
 Krivodonova<VolumeDim, tmpl::list<Tags...>>::Krivodonova(
-    std::array<double,
-               Spectral::maximum_number_of_points<Spectral::Basis::Legendre>>
+    std::array<double, Spectral::maximum_number_of_points<
+                           Spectral::Basis::Legendre,
+                           Spectral::Quadrature::GaussLobatto>>
         alphas,
     bool disable_for_debugging, const Options::Context& context)
     : alphas_(alphas), disable_for_debugging_(disable_for_debugging) {

--- a/src/Evolution/DiscontinuousGalerkin/Limiters/WenoOscillationIndicator.cpp
+++ b/src/Evolution/DiscontinuousGalerkin/Limiters/WenoOscillationIndicator.cpp
@@ -54,8 +54,9 @@ ModalVector modal_derivative(const ModalVector& coeffs) {
 // carried out using the orthogonality relations between these basis functions.
 double compute_sum_of_legendre_derivs(
     const size_t number_of_modes, const size_t m, const size_t n,
-    const std::array<
-        double, Spectral::maximum_number_of_points<Spectral::Basis::Legendre>>&
+    const std::array<double, Spectral::maximum_number_of_points<
+                                 Spectral::Basis::Legendre,
+                                 Spectral::Quadrature::GaussLobatto>>&
         weights_for_derivatives) {
   ModalVector coeffs_m(number_of_modes, 0.);
   coeffs_m[m] = 1.;
@@ -110,11 +111,12 @@ Matrix compute_indicator_matrix(
     const Index<VolumeDim>& extents) {
   Matrix result(extents.product() - 1, extents.product() - 1);
 
-  const std::array<
-      double, Spectral::maximum_number_of_points<Spectral::Basis::Legendre>>
+  const std::array<double, Spectral::maximum_number_of_points<
+                               Spectral::Basis::Legendre,
+                               Spectral::Quadrature::GaussLobatto>>
       weights_for_derivatives = [&derivative_weight]() {
-        auto weights = make_array<
-            Spectral::maximum_number_of_points<Spectral::Basis::Legendre>>(1.);
+        auto weights = make_array<Spectral::maximum_number_of_points<
+            Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto>>(1.);
         if (derivative_weight ==
             Limiters::Weno_detail::DerivativeWeight::PowTwoEll) {
           for (size_t l = 0; l < weights.size(); ++l) {
@@ -184,7 +186,8 @@ const Matrix& cached_indicator_matrix_from_mesh_index(
   // Oscillation indicator needs at least two grid points
   constexpr size_t min = 2;
   constexpr size_t max =
-      Spectral::maximum_number_of_points<Spectral::Basis::Legendre>;
+      Spectral::maximum_number_of_points<Spectral::Basis::Legendre,
+                                         Spectral::Quadrature::GaussLobatto>;
   if constexpr (VolumeDim == 1) {
     const auto cache = make_static_cache<CacheEnumerationDerivativeWeight,
                                          CacheRange<min, max>>(

--- a/src/Evolution/Initialization/DgDomain.hpp
+++ b/src/Evolution/Initialization/DgDomain.hpp
@@ -30,6 +30,7 @@
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/Element.hpp"
 #include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/IsValidDgMesh.hpp"
 #include "Domain/Tags.hpp"
 #include "Domain/Tags/NeighborMesh.hpp"
 #include "Domain/TagsTimeDependent.hpp"
@@ -44,6 +45,7 @@
 #include "Parallel/Tags/ArrayIndex.hpp"
 #include "ParallelAlgorithms/Amr/Protocols/Projector.hpp"
 #include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -155,6 +157,9 @@ struct Domain {
     const Spectral::Basis i1_basis{Spectral::Basis::Legendre};
     *mesh = ::domain::create_initial_mesh(initial_extents, *element, i1_basis,
                                           i1_quadrature);
+    if (not ::domain::is_valid_dg_mesh(*mesh, *element)) {
+      ERROR("Invalid mesh: " << *mesh << " for Element " << *element);
+    }
     const auto& my_block = domain.blocks()[element_id.block_id()];
     *element_map = ElementMap<dim, Frame::Grid>{element_id, my_block};
 

--- a/src/Evolution/Systems/Cce/LinearSolve.cpp
+++ b/src/Evolution/Systems/Cce/LinearSolve.cpp
@@ -96,10 +96,11 @@ Matrix q_integration_matrix(const size_t number_of_points) {
 const Matrix& precomputed_cce_q_integrator(
     const size_t number_of_radial_grid_points) {
   static const auto lazy_matrix_cache = make_static_cache<CacheRange<
-      1_st, Spectral::maximum_number_of_points<Spectral::Basis::Legendre> + 1>>(
-      [](const size_t local_number_of_radial_points) {
-        return q_integration_matrix(local_number_of_radial_points);
-      });
+      1_st, Spectral::maximum_number_of_points<
+                Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto> +
+                1>>([](const size_t local_number_of_radial_points) {
+    return q_integration_matrix(local_number_of_radial_points);
+  });
   return lazy_matrix_cache(number_of_radial_grid_points);
 }
 

--- a/src/NumericalAlgorithms/LinearOperators/Filters/Hypercube.tpp
+++ b/src/NumericalAlgorithms/LinearOperators/Filters/Hypercube.tpp
@@ -270,7 +270,8 @@ const Matrix& Hypercube<Dim, TagList>::filter_matrix(
       half_power_,
       make_static_cache<
           CacheRange<1_st, Spectral::maximum_number_of_points<
-                               Spectral::Basis::Legendre> +
+                               Spectral::Basis::Legendre,
+                               Spectral::Quadrature::GaussLobatto> +
                                1>,
           CacheEnumeration<Spectral::Basis, Spectral::Basis::Legendre,
                            Spectral::Basis::Chebyshev,
@@ -280,15 +281,18 @@ const Matrix& Hypercube<Dim, TagList>::filter_matrix(
                            Spectral::Quadrature::AxialSymmetry,
                            Spectral::Quadrature::SphericalSymmetry>>(
           compute_filter),
-      make_static_cache<CacheRange<
-          1_st, Spectral::maximum_number_of_points<Spectral::Basis::Fourier> +
-                    1>>([compute_filter](const size_t extents) {
+      make_static_cache<
+          CacheRange<1_st, Spectral::maximum_number_of_points<
+                               Spectral::Basis::Fourier,
+                               Spectral::Quadrature::Equiangular> +
+                               1>>([compute_filter](const size_t extents) {
         return compute_filter(extents, Spectral::Basis::Fourier,
                               Spectral::Quadrature::Equiangular);
       }),
       make_static_cache<
           CacheRange<1_st, Spectral::maximum_number_of_points<
-                               Spectral::Basis::ZernikeB1> +
+                               Spectral::Basis::ZernikeB1,
+                               Spectral::Quadrature::GaussRadauUpper> +
                                1>,
           CacheEnumeration<Spectral::Parity, Spectral::Parity::Even,
                            Spectral::Parity::Odd>>(

--- a/src/NumericalAlgorithms/Spectral/BoundaryInterpolationMatrices.cpp
+++ b/src/NumericalAlgorithms/Spectral/BoundaryInterpolationMatrices.cpp
@@ -25,9 +25,9 @@ const std::pair<Matrix, Matrix>& boundary_interpolation_matrices(
       QuadratureType == Spectral::Quadrature::Gauss,
       "We only compute the boundary interpolation for Gauss quadrature "
       "since for Gauss-Lobatto you can just copy values off the volume.");
-  static const auto cache = make_static_cache<
-      CacheRange<Spectral::minimum_number_of_points<BasisType, QuadratureType>,
-                 Spectral::maximum_number_of_points<BasisType> + 1>>(
+  static const auto cache = make_static_cache<CacheRange<
+      Spectral::minimum_number_of_points<BasisType, QuadratureType>,
+      Spectral::maximum_number_of_points<BasisType, QuadratureType> + 1>>(
       [](const size_t local_num_points) {
         return std::pair<Matrix, Matrix>{
             interpolation_matrix<BasisType, QuadratureType>(local_num_points,

--- a/src/NumericalAlgorithms/Spectral/BoundaryInterpolationTerm.cpp
+++ b/src/NumericalAlgorithms/Spectral/BoundaryInterpolationTerm.cpp
@@ -27,9 +27,9 @@ const std::pair<DataVector, DataVector>& boundary_interpolation_term(
       "We only compute the time derivative correction interpolation for Gauss "
       "quadrature since for Gauss-Lobatto you can just copy values off the "
       "volume.");
-  static const auto cache = make_static_cache<
-      CacheRange<Spectral::minimum_number_of_points<BasisType, QuadratureType>,
-                 Spectral::maximum_number_of_points<BasisType> + 1>>(
+  static const auto cache = make_static_cache<CacheRange<
+      Spectral::minimum_number_of_points<BasisType, QuadratureType>,
+      Spectral::maximum_number_of_points<BasisType, QuadratureType> + 1>>(
       [](const size_t local_num_points) {
         const Matrix interp_matrix =
             interpolation_matrix<BasisType, Quadrature::GaussLobatto>(

--- a/src/NumericalAlgorithms/Spectral/BoundaryLiftingTerm.cpp
+++ b/src/NumericalAlgorithms/Spectral/BoundaryLiftingTerm.cpp
@@ -26,9 +26,9 @@ const std::pair<DataVector, DataVector>& boundary_lifting_term(
       QuadratureType == Spectral::Quadrature::Gauss,
       "We only compute the boundary lifting for Gauss quadrature "
       "since for Gauss-Lobatto you can just copy values off the volume.");
-  static const auto cache = make_static_cache<
-      CacheRange<Spectral::minimum_number_of_points<BasisType, QuadratureType>,
-                 Spectral::maximum_number_of_points<BasisType> + 1>>(
+  static const auto cache = make_static_cache<CacheRange<
+      Spectral::minimum_number_of_points<BasisType, QuadratureType>,
+      Spectral::maximum_number_of_points<BasisType, QuadratureType> + 1>>(
       [](const size_t local_num_points) {
         const auto& matrices =
             boundary_interpolation_matrices<BasisType, QuadratureType>(

--- a/src/NumericalAlgorithms/Spectral/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Spectral/CMakeLists.txt
@@ -19,6 +19,7 @@ spectre_target_sources(
   DifferentiationMatrix.cpp
   Filtering.cpp
   FiniteDifference.cpp
+  Hash.cpp
   IntegrationMatrix.cpp
   InterpolationWeights.cpp
   InterpolationMatrix.cpp
@@ -59,6 +60,7 @@ spectre_target_headers(
   FilteringB3.hpp
   FilteringB3.tpp
   GetSpectralQuantityForMesh.hpp
+  Hash.hpp
   IntegrationMatrix.hpp
   InterpolationWeights.hpp
   InterpolationMatrix.hpp

--- a/src/NumericalAlgorithms/Spectral/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Spectral/CMakeLists.txt
@@ -63,6 +63,7 @@ spectre_target_headers(
   InterpolationMatrix.hpp
   InverseWeightFunctionValues.hpp
   Legendre.hpp
+  Limits.hpp
   LinearFilteringMatrix.hpp
   LogicalCoordinates.hpp
   MaximumNumberOfPoints.hpp

--- a/src/NumericalAlgorithms/Spectral/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Spectral/CMakeLists.txt
@@ -22,6 +22,7 @@ spectre_target_sources(
   IntegrationMatrix.cpp
   InterpolationWeights.cpp
   InterpolationMatrix.cpp
+  IsValidDgMesh.cpp
   LinearFilteringMatrix.cpp
   LogicalCoordinates.cpp
   Mesh.cpp
@@ -62,6 +63,7 @@ spectre_target_headers(
   InterpolationWeights.hpp
   InterpolationMatrix.hpp
   InverseWeightFunctionValues.hpp
+  IsValidDgMesh.hpp
   Legendre.hpp
   Limits.hpp
   LinearFilteringMatrix.hpp

--- a/src/NumericalAlgorithms/Spectral/Filtering.cpp
+++ b/src/NumericalAlgorithms/Spectral/Filtering.cpp
@@ -169,8 +169,8 @@ const Matrix& zero_lowest_modes(const Mesh<1>& mesh,
     case Basis::Legendre:
       switch (mesh.quadrature(0)) {
         case Spectral::Quadrature::GaussLobatto: {
-          constexpr size_t max_num_points =
-              Spectral::maximum_number_of_points<Spectral::Basis::Legendre>;
+          constexpr size_t max_num_points = Spectral::maximum_number_of_points<
+              Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto>;
           constexpr size_t min_num_points = Spectral::minimum_number_of_points<
               Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto>;
           const auto cache =
@@ -182,7 +182,8 @@ const Matrix& zero_lowest_modes(const Mesh<1>& mesh,
         }
         case Spectral::Quadrature::Gauss: {
           constexpr size_t max_num_points =
-              Spectral::maximum_number_of_points<Spectral::Basis::Legendre>;
+              Spectral::maximum_number_of_points<Spectral::Basis::Legendre,
+                                                 Spectral::Quadrature::Gauss>;
           constexpr size_t min_num_points =
               Spectral::minimum_number_of_points<Spectral::Basis::Legendre,
                                                  Spectral::Quadrature::Gauss>;
@@ -200,8 +201,8 @@ const Matrix& zero_lowest_modes(const Mesh<1>& mesh,
     case Basis::Chebyshev:
       switch (mesh.quadrature(0)) {
         case Spectral::Quadrature::GaussLobatto: {
-          constexpr size_t max_num_points =
-              Spectral::maximum_number_of_points<Spectral::Basis::Chebyshev>;
+          constexpr size_t max_num_points = Spectral::maximum_number_of_points<
+              Spectral::Basis::Chebyshev, Spectral::Quadrature::GaussLobatto>;
           constexpr size_t min_num_points = Spectral::minimum_number_of_points<
               Spectral::Basis::Chebyshev, Spectral::Quadrature::GaussLobatto>;
           const auto cache =
@@ -213,7 +214,8 @@ const Matrix& zero_lowest_modes(const Mesh<1>& mesh,
         }
         case Spectral::Quadrature::Gauss: {
           constexpr size_t max_num_points =
-              Spectral::maximum_number_of_points<Spectral::Basis::Chebyshev>;
+              Spectral::maximum_number_of_points<Spectral::Basis::Chebyshev,
+                                                 Spectral::Quadrature::Gauss>;
           constexpr size_t min_num_points =
               Spectral::minimum_number_of_points<Spectral::Basis::Chebyshev,
                                                  Spectral::Quadrature::Gauss>;
@@ -242,8 +244,9 @@ const Matrix& zero_lowest_modes(const Mesh<1>& mesh,
                      << " (" << mesh.number_of_grid_points() - m
                      << " modes), you cannot zero " << number_of_modes_to_zero
                      << " modes.");
-          constexpr size_t max_num_pts =
-              Spectral::maximum_number_of_points<Spectral::Basis::ZernikeB1>;
+          constexpr size_t max_num_pts = Spectral::maximum_number_of_points<
+              Spectral::Basis::ZernikeB1,
+              Spectral::Quadrature::GaussRadauUpper>;
           constexpr size_t min_num_pts = Spectral::minimum_number_of_points<
               Spectral::Basis::ZernikeB1,
               Spectral::Quadrature::GaussRadauUpper>;
@@ -274,8 +277,8 @@ const Matrix& zero_highest_modes(const Mesh<1>& mesh,
                                    << number_of_modes_to_zero << " modes.");
       switch (mesh.quadrature(0)) {
         case Spectral::Quadrature::GaussLobatto: {
-          constexpr size_t max_num_points =
-              Spectral::maximum_number_of_points<Spectral::Basis::Legendre>;
+          constexpr size_t max_num_points = Spectral::maximum_number_of_points<
+              Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto>;
           constexpr size_t min_num_points = Spectral::minimum_number_of_points<
               Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto>;
           const auto cache =
@@ -287,7 +290,8 @@ const Matrix& zero_highest_modes(const Mesh<1>& mesh,
         }
         case Spectral::Quadrature::Gauss: {
           constexpr size_t max_num_points =
-              Spectral::maximum_number_of_points<Spectral::Basis::Legendre>;
+              Spectral::maximum_number_of_points<Spectral::Basis::Legendre,
+                                                 Spectral::Quadrature::Gauss>;
           constexpr size_t min_num_points =
               Spectral::minimum_number_of_points<Spectral::Basis::Legendre,
                                                  Spectral::Quadrature::Gauss>;
@@ -309,8 +313,8 @@ const Matrix& zero_highest_modes(const Mesh<1>& mesh,
                                    << number_of_modes_to_zero << " modes.");
       switch (mesh.quadrature(0)) {
         case Spectral::Quadrature::GaussLobatto: {
-          constexpr size_t max_num_points =
-              Spectral::maximum_number_of_points<Spectral::Basis::Chebyshev>;
+          constexpr size_t max_num_points = Spectral::maximum_number_of_points<
+              Spectral::Basis::Chebyshev, Spectral::Quadrature::GaussLobatto>;
           constexpr size_t min_num_points = Spectral::minimum_number_of_points<
               Spectral::Basis::Chebyshev, Spectral::Quadrature::GaussLobatto>;
           const auto cache =
@@ -322,7 +326,8 @@ const Matrix& zero_highest_modes(const Mesh<1>& mesh,
         }
         case Spectral::Quadrature::Gauss: {
           constexpr size_t max_num_points =
-              Spectral::maximum_number_of_points<Spectral::Basis::Chebyshev>;
+              Spectral::maximum_number_of_points<Spectral::Basis::Chebyshev,
+                                                 Spectral::Quadrature::Gauss>;
           constexpr size_t min_num_points =
               Spectral::minimum_number_of_points<Spectral::Basis::Chebyshev,
                                                  Spectral::Quadrature::Gauss>;
@@ -350,8 +355,8 @@ const Matrix& zero_highest_modes(const Mesh<1>& mesh,
                      << mesh.number_of_grid_points() / 2
                      << " m-modes), you cannot zero " << number_of_modes_to_zero
                      << " modes.");
-          constexpr size_t max_num_points =
-              Spectral::maximum_number_of_points<Spectral::Basis::Fourier>;
+          constexpr size_t max_num_points = Spectral::maximum_number_of_points<
+              Spectral::Basis::Fourier, Spectral::Quadrature::Equiangular>;
           const auto cache =
               make_static_cache<CacheRange<1_st, max_num_points + 1>,
                                 CacheRange<0_st, max_num_points / 2 + 1>>(

--- a/src/NumericalAlgorithms/Spectral/Hash.cpp
+++ b/src/NumericalAlgorithms/Spectral/Hash.cpp
@@ -1,0 +1,19 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/Spectral/Hash.hpp"
+
+#include <boost/functional/hash.hpp>
+#include <functional>
+#include <utility>
+
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+
+// clang-tidy: do not modify std namespace (okay for hash)
+namespace std {  // NOLINT
+size_t hash<std::pair<Spectral::Basis, Spectral::Quadrature>>::operator()(
+    const std::pair<Spectral::Basis, Spectral::Quadrature>& p) const {
+  return boost::hash<std::pair<Spectral::Basis, Spectral::Quadrature>>{}(p);
+}
+}  // namespace std

--- a/src/NumericalAlgorithms/Spectral/Hash.hpp
+++ b/src/NumericalAlgorithms/Spectral/Hash.hpp
@@ -1,0 +1,23 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <functional>
+#include <utility>
+
+/// \cond
+namespace Spectral {
+enum class Basis : uint8_t;
+enum class Quadrature : uint8_t;
+}  // namespace Spectral
+/// \endcond
+
+namespace std {
+template <>
+// NOLINTNEXTLINE(cert-dcl58-cpp)
+struct hash<std::pair<Spectral::Basis, Spectral::Quadrature>> {
+  size_t operator()(
+      const std::pair<Spectral::Basis, Spectral::Quadrature>& p) const;
+};
+}  // namespace std

--- a/src/NumericalAlgorithms/Spectral/InterpolationMatrix.cpp
+++ b/src/NumericalAlgorithms/Spectral/InterpolationMatrix.cpp
@@ -43,7 +43,7 @@ Matrix interpolation_matrix(const size_t num_points, const T& target_points) {
     return Fourier::interpolation_matrix(num_points, target_points);
   }
   constexpr size_t max_num_points =
-      Spectral::maximum_number_of_points<BasisType>;
+      Spectral::maximum_number_of_points<BasisType, QuadratureType>;
   constexpr size_t min_num_points =
       Spectral::minimum_number_of_points<BasisType, QuadratureType>;
   ASSERT(num_points >= min_num_points,

--- a/src/NumericalAlgorithms/Spectral/IsValidDgMesh.cpp
+++ b/src/NumericalAlgorithms/Spectral/IsValidDgMesh.cpp
@@ -1,0 +1,238 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/Spectral/IsValidDgMesh.hpp"
+
+#include <array>
+#include <cstddef>
+
+#include "DataStructures/Index.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/Limits.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace Spectral {
+template <size_t Dim>
+bool is_valid_dg_mesh(const Mesh<Dim>& mesh) {
+  const auto& extents = mesh.extents();
+  const auto& bases = mesh.basis();
+  const auto& quadratures = mesh.quadrature();
+
+  for (size_t d = 0; d < Dim; ++d) {
+    const auto extent = gsl::at(extents.indices(), d);
+    const auto basis = gsl::at(bases, d);
+    const auto quadrature = gsl::at(quadratures, d);
+    if (extent < limits::min(basis, quadrature)) {
+      return false;
+    }
+    if (extent > limits::max(basis, quadrature)) {
+      return false;
+    }
+
+    switch (basis) {
+      case Basis::Uninitialized:
+        ERROR("Uninitialized basis");
+      case Basis::Legendre:
+        [[fallthrough]];
+      case Basis::Chebyshev: {
+        if (quadrature == Quadrature::GaussLobatto or
+            quadrature == Quadrature::Gauss) {
+          break;
+        } else {
+          return false;
+        }
+      }
+      case Basis::FiniteDifference:
+        return false;
+      case Basis::SphericalHarmonic: {
+        if constexpr (Dim == 1) {
+          return false;
+        } else if constexpr (Dim == 2) {
+          if (d == 0) {
+            if (bases[1] == Basis::SphericalHarmonic and
+                quadrature == Quadrature::Gauss and
+                quadratures[1] == Quadrature::Equiangular and
+                extents[1] == 2 * extents[0] - 1) {
+              break;
+            } else {
+              return false;
+            }
+          } else {
+            if (bases[0] == Basis::SphericalHarmonic) {
+              break;
+            } else {
+              return false;
+            }
+          }
+        } else {
+          ASSERT(Dim == 3, "Invalid Dim " << Dim);
+          if (d == 0) {
+            return false;
+          } else if (d == 1) {
+            if (bases[2] == Basis::SphericalHarmonic and
+                quadrature == Quadrature::Gauss and
+                quadratures[2] == Quadrature::Equiangular and
+                extents[2] == 2 * extents[1] - 1 and
+                (bases[0] == Basis::Legendre or bases[0] == Basis::Chebyshev)) {
+              break;
+            } else {
+              return false;
+            }
+          } else {
+            if (bases[1] == Basis::SphericalHarmonic) {
+              break;
+            } else {
+              return false;
+            }
+          }
+        }
+      }
+      case Basis::Fourier: {
+        if (quadrature == Quadrature::Equiangular and extent % 2 == 1) {
+          break;
+        } else {
+          return false;
+        }
+      }
+      case Basis::ZernikeB1: {
+        if constexpr (Dim == 3) {
+          if (d == 0 and quadrature == Quadrature::GaussRadauUpper and
+              (bases[1] == Basis::Legendre or bases[1] == Basis::Cartoon or
+               bases[1] == Basis::Chebyshev or
+               bases[1] == Basis::HalfFourier) and
+              bases[2] == Basis::Cartoon) {
+            break;
+          } else {
+            return false;
+          }
+        } else {
+          return false;
+        }
+      }
+      case Basis::ZernikeB2: {
+        if constexpr (Dim == 1) {
+          return false;
+        } else if constexpr (Dim == 2) {
+          if (d == 0) {
+            if (bases[1] == Basis::ZernikeB2 and
+                quadrature == Quadrature::GaussRadauUpper and
+                quadratures[1] == Quadrature::Equiangular and
+                extents[1] == 4 * extents[0] - 3) {
+              break;
+            } else {
+              return false;
+            }
+          } else {
+            if (bases[0] == Basis::ZernikeB2) {
+              break;
+            } else {
+              return false;
+            }
+          }
+        } else {
+          ASSERT(Dim == 3, "Invalid Dim " << Dim);
+          if (d == 2) {
+            return false;
+          } else if (d == 0) {
+            if (bases[1] == Basis::ZernikeB2 and
+                quadrature == Quadrature::GaussRadauUpper and
+                quadratures[1] == Quadrature::Equiangular and
+                extents[1] == 4 * extents[0] - 3 and
+                (bases[2] == Basis::Legendre or bases[2] == Basis::Chebyshev)) {
+              break;
+            } else {
+              return false;
+            }
+          } else {
+            if (bases[0] == Basis::ZernikeB2) {
+              break;
+            } else {
+              return false;
+            }
+          }
+        }
+      }
+      // NOLINTNEXTLINE(bugprone-branch-clone)
+      case Basis::ZernikeB3: {
+        if constexpr (Dim == 3) {
+          if (d == 0) {
+            if (bases[1] == Basis::ZernikeB3 and
+                bases[2] == Basis::ZernikeB3 and
+                quadrature == Quadrature::GaussRadauUpper and
+                quadratures[1] == Quadrature::Gauss and
+                quadratures[2] == Quadrature::Equiangular and
+                extents[2] == 2 * extents[1] - 1 and
+                extents[1] == 2 * extents[0] - 1) {
+              break;
+            } else {
+              return false;
+            }
+          } else {
+            if (bases[0] == Basis::ZernikeB3) {
+              break;
+            } else {
+              return false;
+            }
+          }
+        } else {
+          return false;
+        }
+      }
+      case Basis::Cartoon: {
+        if constexpr (Dim == 3) {
+          if (d == 1) {
+            if ((bases[0] == Basis::Legendre or bases[0] == Basis::ZernikeB1 or
+                 bases[0] == Basis::Chebyshev) and
+                bases[2] == Basis::Cartoon and
+                quadrature == Quadrature::SphericalSymmetry and
+                quadratures[2] == Quadrature::SphericalSymmetry) {
+              break;
+            } else {
+              return false;
+            }
+          } else if (d == 2) {
+            if (bases[1] == Basis::Cartoon or
+                ((bases[0] == Basis::Legendre or bases[0] == Basis::ZernikeB1 or
+                  bases[0] == Basis::Chebyshev) and
+                 (bases[1] == Basis::Legendre or bases[1] == Basis::ZernikeB1 or
+                  bases[1] == Basis::Chebyshev or
+                  bases[1] == Basis::HalfFourier) and
+                 quadrature == Quadrature::AxialSymmetry)) {
+              break;
+            } else {
+              return false;
+            }
+          } else {
+            return false;
+          }
+        } else {
+          return false;
+        }
+      }
+      case Basis::HalfFourier: {
+        if constexpr (Dim == 3) {
+          if (d == 1 and quadrature == Quadrature::Equiangular and
+              (bases[0] == Basis::Legendre or bases[0] == Basis::ZernikeB1 or
+               bases[0] == Basis::Chebyshev) and
+              bases[2] == Basis::Cartoon) {
+            break;
+          } else {
+            return false;
+          }
+        } else {
+          return false;
+        }
+      }
+      default:
+        ERROR("Invalid basis");
+    }
+  }
+  return true;
+}
+
+template bool is_valid_dg_mesh(const Mesh<1>& mesh);
+template bool is_valid_dg_mesh(const Mesh<2>& mesh);
+template bool is_valid_dg_mesh(const Mesh<3>& mesh);
+}  // namespace Spectral

--- a/src/NumericalAlgorithms/Spectral/IsValidDgMesh.hpp
+++ b/src/NumericalAlgorithms/Spectral/IsValidDgMesh.hpp
@@ -1,0 +1,29 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+/// \cond
+template <size_t Dim>
+class Mesh;
+/// \endcond
+
+namespace Spectral {
+/// \brief Returns true if mesh is valid for DG
+///
+/// \details A mesh is valid if it:
+/// - does not have a Basis::FiniteDifference
+/// - has a consistent Basis and Quadrature (based on topology),
+/// - has valid extents for the Basis and Quadrature.
+/// In addition:
+/// - for Quadrature::Equiangular (as part of periodic angular topologoy such
+///   as S1, S2, B2, or B3), we require that the extent is odd in that
+///   dimension
+/// - For multidimensional topologies, we enforce that their extents
+///   in the coupled dimensions are kept in sync in order to resolve the
+///   highest angular mode
+template <size_t Dim>
+bool is_valid_dg_mesh(const Mesh<Dim>& mesh);
+}  // namespace Spectral

--- a/src/NumericalAlgorithms/Spectral/Limits.hpp
+++ b/src/NumericalAlgorithms/Spectral/Limits.hpp
@@ -1,0 +1,95 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+
+/// Limits on the extents of a Mesh based on Basis and Quadrature.  The minima
+/// are strict requirements except for spherical harmonics which are set by the
+/// package (SPHEREPACK) used to implement them.  The maxima are set to limit
+/// the sizes of static caches, so can be changed if desired.
+namespace Spectral::limits {
+/// The minimum allowed mode \f$L\f$ for SPHEREPACK, the package used for a
+/// spherical harmonic basis
+static constexpr size_t min_spherical_harmonic_mode = 2;
+
+/// The maximum allowed mode \f$L\f$ for spherical harmonics in S2 or B3
+/// topologies
+static constexpr size_t max_spherical_harmonic_mode = 40;
+
+/// The maximum allowed mode \f$M\f$ for a Fourier series in S1 or B2 topologies
+static constexpr size_t max_fourier_mode = 40;
+
+/// The maximum allowed mode \f$N\f$ for polynomial series in I1 or B1
+/// topologies
+static constexpr size_t max_i1_polynomial_mode = 20;
+
+/// \brief The maximum allowed extent for a given Basis and Quadrature
+///
+/// \details The maxima are chosen to limit the size of static caches.
+/// Let \f$N\f$ be the highest represented polynomial mode, \f$L\f$ the highest
+/// represented spherical harmonic mode, and \f$M\f$ the highest represented
+/// Fourier mode.  Then the maxima are set as follows:
+/// - \f$N+1\f$ for Basis::Legendre, Basis::Chebyshev and Basis::ZernikeB1
+/// - \f$2N+2\f$ for Basis::FiniteDifference as for DG-subcell
+///   \f$n_{FD} = 2 n_{DG}\f$ for Quadrature::FaceCentered
+/// - \f$(L+1, 2L+1)\f$ for Basis::SphericalHarmonic
+/// - \f$2M+1\f$ for Basis::Fourier
+/// - \f$(M/2 + 1, 2M+1)\f$ for Basis::ZernikeB2
+/// - \f$(L/2 + 1, L+1, 2L+1)\f$ for Basis::ZernikeB3
+/// - 1 for Basis::Cartoon
+constexpr size_t max(const Basis basis, const Quadrature quadrature) {
+  if (basis == Basis::Legendre or basis == Basis::Chebyshev or
+      basis == Basis::ZernikeB1) {
+    return max_i1_polynomial_mode + 1;
+  } else if (basis == Basis::FiniteDifference) {
+    return 2 * max_i1_polynomial_mode + 2;
+  } else if (basis == Basis::Cartoon) {
+    return 1;
+  } else if (basis == Basis::SphericalHarmonic or basis == Basis::ZernikeB3) {
+    if (quadrature == Quadrature::Gauss) {
+      return max_spherical_harmonic_mode + 1;
+    } else if (quadrature == Quadrature::Equiangular) {
+      return 2 * max_spherical_harmonic_mode + 1;
+    } else if (quadrature == Quadrature::GaussRadauUpper) {
+      return max_spherical_harmonic_mode / 2 + 1;
+    }
+  } else if (basis == Basis::ZernikeB2 and
+             quadrature == Quadrature::GaussRadauUpper) {
+    return max_fourier_mode / 2 + 1;
+  } else if (basis == Basis::HalfFourier) {
+    return max_fourier_mode + 1;
+  } else if (quadrature == Quadrature::Equiangular) {
+    return 2 * max_fourier_mode + 1;
+  }
+  return 0;
+}
+
+/// \brief The minimum extent for a given Basis and Quadrature
+///
+/// \details The minimum is 1 except for the following:
+/// - 2 for Quadrature::GaussLobatto and Quadrature::FaceCentered as they have
+///   collocation points on the boundaries
+/// - \f$(3, 5)\f$ for the angular directions of Basis::SphericalHarmonic or
+///   \f$(2, 3, 5)\f$ for the directions of Basis::ZernikeB3 as this is a
+///   requirement of the package SPHEREPACK that implements spherical harmonics
+constexpr size_t min(const Basis basis, const Quadrature quadrature) {
+  if (quadrature == Quadrature::GaussLobatto or
+      quadrature == Quadrature::FaceCentered or
+      (basis == Basis::ZernikeB3 and
+       quadrature == Quadrature::GaussRadauUpper)) {
+    return 2;
+  } else if (basis == Basis::SphericalHarmonic or basis == Basis::ZernikeB3) {
+    if (quadrature == Quadrature::Gauss) {
+      return min_spherical_harmonic_mode + 1;
+    } else if (quadrature == Quadrature::Equiangular) {
+      return 2 * min_spherical_harmonic_mode + 1;
+    }
+  }
+  return 1;
+}
+}  // namespace Spectral::limits

--- a/src/NumericalAlgorithms/Spectral/MaximumNumberOfPoints.hpp
+++ b/src/NumericalAlgorithms/Spectral/MaximumNumberOfPoints.hpp
@@ -5,24 +5,9 @@
 
 #include <cstddef>
 
-#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/Limits.hpp"
 
 namespace Spectral {
-/*!
- * \brief Maximum number of allowed collocation points.
- *
- * \details We choose a limit of 24 FD grid points because for DG-subcell the
- * number of points in an element is `2 * number_dg_points - 1` for cell
- * centered, and `2 * number_dg_points` for face-centered. Because there is no
- * way of generically retrieving the maximum number of grid points for a non-FD
- * basis, we need to hard-code both values here. If the number of grid points is
- * increased for the non-FD bases, it should also be increased for the FD basis.
- * Note that for good task-based parallelization 24 grid points is already a
- * fairly large number.
- */
-template <Basis basis>
-constexpr size_t maximum_number_of_points =
-    basis == Basis::Fourier            ? 81
-    : basis == Basis::FiniteDifference ? 40
-                                       : 20;
+template <Basis basis, Quadrature quadrature>
+constexpr size_t maximum_number_of_points = limits::max(basis, quadrature);
 }  // namespace Spectral

--- a/src/NumericalAlgorithms/Spectral/MinimumNumberOfPoints.hpp
+++ b/src/NumericalAlgorithms/Spectral/MinimumNumberOfPoints.hpp
@@ -4,54 +4,10 @@
 #pragma once
 
 #include <cstddef>
-#include <limits>
 
-#include "NumericalAlgorithms/Spectral/Basis.hpp"
-#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "NumericalAlgorithms/Spectral/Limits.hpp"
 
 namespace Spectral {
-namespace detail {
-constexpr size_t minimum_number_of_points(const Basis /*basis*/,
-                                          const Quadrature quadrature) {
-  // NOLINTNEXTLINE(bugprone-branch-clone)
-  if (quadrature == Quadrature::Gauss) {
-    return 1;
-    // NOLINTNEXTLINE(bugprone-branch-clone)
-  } else if (quadrature == Quadrature::GaussLobatto) {
-    return 2;
-    // NOLINTNEXTLINE(bugprone-branch-clone)
-  } else if (quadrature == Quadrature::GaussRadauUpper) {
-    return 1;
-    // NOLINTNEXTLINE(bugprone-branch-clone)
-  } else if (quadrature == Quadrature::CellCentered) {
-    return 1;
-    // NOLINTNEXTLINE(bugprone-branch-clone)
-  } else if (quadrature == Quadrature::FaceCentered) {
-    return 2;
-    // NOLINTNEXTLINE(bugprone-branch-clone)
-  } else if (quadrature == Quadrature::Equiangular) {
-    return 1;
-    // NOLINTNEXTLINE(bugprone-branch-clone)
-  } else if (quadrature == Quadrature::AxialSymmetry) {
-    return 1;
-  } else if (quadrature == Quadrature::SphericalSymmetry) {
-    return 1;
-  }
-  return std::numeric_limits<size_t>::max();
-}
-}  // namespace detail
-
-/*!
- * \brief Minimum number of possible collocation points for a quadrature type.
- *
- * \details Since Gauss-Lobatto quadrature has points on the domain boundaries
- * it must have at least two collocation points. Gauss quadrature can have only
- * one collocation point.
- *
- * \details For `CellCentered` the minimum number of points is 1, while for
- * `FaceCentered` it is 2.
- */
 template <Basis basis, Quadrature quadrature>
-constexpr size_t minimum_number_of_points =
-    detail::minimum_number_of_points(basis, quadrature);
+constexpr size_t minimum_number_of_points = limits::min(basis, quadrature);
 }  // namespace Spectral

--- a/src/NumericalAlgorithms/Spectral/PrecomputedSpectralQuantity.hpp
+++ b/src/NumericalAlgorithms/Spectral/PrecomputedSpectralQuantity.hpp
@@ -23,7 +23,7 @@ template <Basis BasisType, Quadrature QuadratureType,
           typename SpectralQuantityGenerator>
 const auto& precomputed_spectral_quantity(const size_t num_points) {
   constexpr size_t max_num_points =
-      Spectral::maximum_number_of_points<BasisType>;
+      Spectral::maximum_number_of_points<BasisType, QuadratureType>;
   constexpr size_t min_num_points =
       Spectral::minimum_number_of_points<BasisType, QuadratureType>;
   ASSERT(num_points >= min_num_points,
@@ -46,7 +46,7 @@ template <Basis BasisType, Quadrature QuadratureType,
 const auto& precomputed_spectral_quantity_with_parity(const size_t num_points,
                                                       const Parity parity) {
   constexpr size_t max_num_points =
-      Spectral::maximum_number_of_points<BasisType>;
+      Spectral::maximum_number_of_points<BasisType, QuadratureType>;
   constexpr size_t min_num_points =
       Spectral::minimum_number_of_points<BasisType, QuadratureType>;
   ASSERT(num_points >= min_num_points,
@@ -73,7 +73,7 @@ const auto& precomputed_two_indexed_spectral_quantity(const size_t num_points,
                                                       const size_t m,
                                                       const size_t N) {
   constexpr size_t max_num_points =
-      Spectral::maximum_number_of_points<BasisType>;
+      Spectral::maximum_number_of_points<BasisType, QuadratureType>;
   constexpr size_t min_num_points =
       Spectral::minimum_number_of_points<BasisType, QuadratureType>;
   ASSERT(num_points >= min_num_points,

--- a/src/NumericalAlgorithms/Spectral/Projection.cpp
+++ b/src/NumericalAlgorithms/Spectral/Projection.cpp
@@ -39,8 +39,10 @@ namespace Spectral {
 namespace {
 void verify_meshes(const Mesh<1>& parent_mesh, const Mesh<1>& child_mesh,
                    const SegmentSize size) {
-  constexpr size_t max_points_l = maximum_number_of_points<Basis::Legendre>;
-  constexpr size_t max_points_f = maximum_number_of_points<Basis::Fourier>;
+  constexpr size_t max_points_l =
+      maximum_number_of_points<Basis::Legendre, Quadrature::GaussLobatto>;
+  constexpr size_t max_points_f =
+      maximum_number_of_points<Basis::Fourier, Quadrature::Equiangular>;
 
   // Legendre with Legendre (any segment size)
   const bool both_legendre = parent_mesh.basis(0) == Basis::Legendre and
@@ -102,8 +104,10 @@ const Matrix& projection_matrix_child_to_parent(const Mesh<1>& child_mesh,
                                                 const Mesh<1>& parent_mesh,
                                                 const SegmentSize size,
                                                 const bool operand_is_massive) {
-  constexpr size_t max_points_l = maximum_number_of_points<Basis::Legendre>;
-  constexpr size_t max_points_f = maximum_number_of_points<Basis::Fourier>;
+  constexpr size_t max_points_l =
+      maximum_number_of_points<Basis::Legendre, Quadrature::GaussLobatto>;
+  constexpr size_t max_points_f =
+      maximum_number_of_points<Basis::Fourier, Quadrature::Equiangular>;
   verify_meshes(parent_mesh, child_mesh, size);
 
   if (operand_is_massive) {
@@ -375,7 +379,8 @@ projection_matrix_child_to_parent(
 const Matrix& projection_matrix_parent_to_child(const Mesh<1>& parent_mesh,
                                                 const Mesh<1>& child_mesh,
                                                 const SegmentSize size) {
-  constexpr size_t max_points_l = maximum_number_of_points<Basis::Legendre>;
+  constexpr size_t max_points_l =
+      maximum_number_of_points<Basis::Legendre, Quadrature::GaussLobatto>;
   verify_meshes(parent_mesh, child_mesh, size);
 
   // For Fourier with SegmentSize::Full, the element-to-mortar projection is

--- a/src/ParallelAlgorithms/Amr/Actions/AdjustDomain.hpp
+++ b/src/ParallelAlgorithms/Amr/Actions/AdjustDomain.hpp
@@ -18,6 +18,7 @@
 #include "Domain/Structure/DirectionalIdMap.hpp"
 #include "Domain/Structure/Element.hpp"
 #include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/IsValidDgMesh.hpp"
 #include "Domain/Structure/Neighbors.hpp"
 #include "Domain/Tags.hpp"
 #include "Domain/Tags/NeighborMesh.hpp"
@@ -38,6 +39,7 @@
 #include "ParallelAlgorithms/Amr/Tags.hpp"
 #include "Utilities/Algorithm.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/Literals.hpp"
 #include "Utilities/PrettyType.hpp"
@@ -253,6 +255,13 @@ struct AdjustDomain {
               old_mesh.extents(),
               db::get<::domain::Tags::Mesh<volume_dim>>(box).extents());
         }
+      }
+
+      const auto& new_mesh = db::get<::domain::Tags::Mesh<volume_dim>>(box);
+      const auto& new_element =
+          db::get<::domain::Tags::Element<volume_dim>>(box);
+      if (not domain::is_valid_dg_mesh(new_mesh, new_element)) {
+        ERROR("Invalid mesh " << new_mesh << " for Element " << new_element);
       }
 
       // Run the projectors on all elements, even if they did no p-refinement.

--- a/src/ParallelAlgorithms/Amr/Actions/InitializeChild.hpp
+++ b/src/ParallelAlgorithms/Amr/Actions/InitializeChild.hpp
@@ -19,6 +19,7 @@
 #include "Domain/Structure/DirectionalIdMap.hpp"
 #include "Domain/Structure/Element.hpp"
 #include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/IsValidDgMesh.hpp"
 #include "Domain/Structure/Neighbors.hpp"
 #include "Domain/Tags.hpp"
 #include "Domain/Tags/NeighborMesh.hpp"
@@ -27,6 +28,7 @@
 #include "ParallelAlgorithms/Amr/Projectors/Mesh.hpp"
 #include "ParallelAlgorithms/Amr/Tags.hpp"
 #include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -70,6 +72,9 @@ struct InitializeChild {
     Element<volume_dim> child(child_id, std::move(neighbors.first));
     Mesh<volume_dim> child_mesh =
         amr::projectors::mesh(parent_mesh, parent_info.flags);
+    if (not domain::is_valid_dg_mesh(child_mesh, child)) {
+      ERROR("Invalid mesh " << child_mesh << " for Element " << child);
+    }
 
     // Default initialization of amr::Tags::Info and amr::Tags::NeighborInfo
     // is okay

--- a/src/ParallelAlgorithms/Amr/Actions/InitializeParent.hpp
+++ b/src/ParallelAlgorithms/Amr/Actions/InitializeParent.hpp
@@ -20,6 +20,7 @@
 #include "Domain/Structure/DirectionalIdMap.hpp"
 #include "Domain/Structure/Element.hpp"
 #include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/IsValidDgMesh.hpp"
 #include "Domain/Structure/Neighbors.hpp"
 #include "Domain/Tags.hpp"
 #include "Domain/Tags/NeighborMesh.hpp"
@@ -27,6 +28,7 @@
 #include "Parallel/ElementRegistration.hpp"
 #include "ParallelAlgorithms/Amr/Projectors/Mesh.hpp"
 #include "ParallelAlgorithms/Initialization/MutateAssign.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
 #include "Utilities/Gsl.hpp"
 #include "Utilities/TMPL.hpp"
 
@@ -86,6 +88,9 @@ struct InitializeParent {
     }
     Mesh<volume_dim> parent_mesh =
         amr::projectors::parent_mesh(projected_children_meshes);
+    if (not domain::is_valid_dg_mesh(parent_mesh, parent)) {
+      ERROR("Invalid mesh " << parent_mesh << " for Element " << parent);
+    }
 
     // Default initialization of amr::Tags::Info and amr::Tags::NeighborInfo
     // is okay

--- a/src/ParallelAlgorithms/Amr/Events/RefineMesh.hpp
+++ b/src/ParallelAlgorithms/Amr/Events/RefineMesh.hpp
@@ -16,6 +16,7 @@
 #include "Domain/Tags.hpp"
 #include "IO/Logging/Tags.hpp"
 #include "IO/Logging/Verbosity.hpp"
+#include "NumericalAlgorithms/Spectral/IsValidDgMesh.hpp"
 #include "Options/String.hpp"
 #include "Parallel/GlobalCache.hpp"
 #include "Parallel/Printf/Printf.hpp"
@@ -158,6 +159,9 @@ class RefineMesh : public Event {
           [&old_mesh,
            &overall_decision](const gsl::not_null<Mesh<volume_dim>*> mesh) {
             *mesh = amr::projectors::mesh(old_mesh, overall_decision);
+            if (not Spectral::is_valid_dg_mesh(*mesh)) {
+              ERROR("Invalid mesh: " << *mesh);
+            }
           },
           box);
 

--- a/src/ParallelAlgorithms/Amr/Policies/EnforcePolicies.cpp
+++ b/src/ParallelAlgorithms/Amr/Policies/EnforcePolicies.cpp
@@ -5,8 +5,8 @@
 
 #include "Domain/Amr/Flag.hpp"
 #include "Domain/Structure/ElementId.hpp"
+#include "NumericalAlgorithms/Spectral/Limits.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
-#include "NumericalAlgorithms/Spectral/MinimumNumberOfPoints.hpp"
 #include "ParallelAlgorithms/Amr/Policies/Isotropy.hpp"
 #include "ParallelAlgorithms/Amr/Policies/Limits.hpp"
 #include "ParallelAlgorithms/Amr/Policies/Policies.hpp"
@@ -56,9 +56,9 @@ void enforce_policies(const gsl::not_null<std::array<Flag, Dim>*> amr_decision,
       error_if_beyond_limits(d, "MaximumRefinement");
       gsl::at(*amr_decision, d) = Flag::DoNothing;
     }
-    const size_t minimum_resolution = std::max(
-        limits.minimum_resolution(), Spectral::detail::minimum_number_of_points(
-                                         mesh.basis(d), mesh.quadrature(d)));
+    const size_t minimum_resolution =
+        std::max(limits.minimum_resolution(),
+                 Spectral::limits::min(mesh.basis(d), mesh.quadrature(d)));
     if (gsl::at(*amr_decision, d) == Flag::DecreaseResolution and
         mesh.extents(d) <= minimum_resolution) {
       error_if_beyond_limits(d, "MinimumResolution");

--- a/src/ParallelAlgorithms/Amr/Policies/EnforcePolicies.cpp
+++ b/src/ParallelAlgorithms/Amr/Policies/EnforcePolicies.cpp
@@ -5,7 +5,6 @@
 
 #include "Domain/Amr/Flag.hpp"
 #include "Domain/Structure/ElementId.hpp"
-#include "NumericalAlgorithms/Spectral/Limits.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "ParallelAlgorithms/Amr/Policies/Isotropy.hpp"
 #include "ParallelAlgorithms/Amr/Policies/Limits.hpp"
@@ -56,16 +55,15 @@ void enforce_policies(const gsl::not_null<std::array<Flag, Dim>*> amr_decision,
       error_if_beyond_limits(d, "MaximumRefinement");
       gsl::at(*amr_decision, d) = Flag::DoNothing;
     }
-    const size_t minimum_resolution =
-        std::max(limits.minimum_resolution(),
-                 Spectral::limits::min(mesh.basis(d), mesh.quadrature(d)));
     if (gsl::at(*amr_decision, d) == Flag::DecreaseResolution and
-        mesh.extents(d) <= minimum_resolution) {
+        mesh.extents(d) <=
+            limits.minimum_resolution(mesh.basis(d), mesh.quadrature(d))) {
       error_if_beyond_limits(d, "MinimumResolution");
       gsl::at(*amr_decision, d) = Flag::DoNothing;
     }
     if (gsl::at(*amr_decision, d) == Flag::IncreaseResolution and
-        mesh.extents(d) >= limits.maximum_resolution()) {
+        mesh.extents(d) >=
+            limits.maximum_resolution(mesh.basis(d), mesh.quadrature(d))) {
       error_if_beyond_limits(d, "MaximumResolution");
       gsl::at(*amr_decision, d) = Flag::DoNothing;
     }

--- a/src/ParallelAlgorithms/Amr/Policies/Limits.cpp
+++ b/src/ParallelAlgorithms/Amr/Policies/Limits.cpp
@@ -16,7 +16,8 @@ namespace amr {
 Limits::Limits()
     : maximum_refinement_level_(ElementId<1>::max_refinement_level),
       maximum_resolution_(
-          Spectral::maximum_number_of_points<Spectral::Basis::Legendre>) {}
+          Spectral::maximum_number_of_points<
+              Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto>) {}
 
 Limits::Limits(
     const std::optional<std::array<size_t, 2>>& refinement_level_bounds,
@@ -30,10 +31,11 @@ Limits::Limits(
                                     : ElementId<1>::max_refinement_level),
       minimum_resolution_(
           resolution_bounds.has_value() ? resolution_bounds.value()[0] : 1),
-      maximum_resolution_(
-          resolution_bounds.has_value()
-              ? resolution_bounds.value()[1]
-              : Spectral::maximum_number_of_points<Spectral::Basis::Legendre>),
+      maximum_resolution_(resolution_bounds.has_value()
+                              ? resolution_bounds.value()[1]
+                              : Spectral::maximum_number_of_points<
+                                    Spectral::Basis::Legendre,
+                                    Spectral::Quadrature::GaussLobatto>),
       error_beyond_limits_(error_beyond_limits) {
   if (minimum_refinement_level_ > ElementId<1>::max_refinement_level) {
     PARSE_ERROR(context,
@@ -60,24 +62,28 @@ Limits::Limits(
                              "' cannot be smaller than '1'.");
   }
   if (minimum_resolution_ >
-      Spectral::maximum_number_of_points<Spectral::Basis::Legendre>) {
-    PARSE_ERROR(
-        context,
-        "NumGridPoints lower bound '" + std::to_string(minimum_resolution_) +
-            "' cannot be larger than '" +
-            std::to_string(
-                Spectral::maximum_number_of_points<Spectral::Basis::Legendre>) +
-            "'.");
+      Spectral::maximum_number_of_points<Spectral::Basis::Legendre,
+                                         Spectral::Quadrature::GaussLobatto>) {
+    PARSE_ERROR(context,
+                "NumGridPoints lower bound '" +
+                    std::to_string(minimum_resolution_) +
+                    "' cannot be larger than '" +
+                    std::to_string(Spectral::maximum_number_of_points<
+                                   Spectral::Basis::Legendre,
+                                   Spectral::Quadrature::GaussLobatto>) +
+                    "'.");
   }
   if (maximum_resolution_ >
-      Spectral::maximum_number_of_points<Spectral::Basis::Legendre>) {
-    PARSE_ERROR(
-        context,
-        "NumGridPoints upper bound '" + std::to_string(maximum_resolution_) +
-            "' cannot be larger than '" +
-            std::to_string(
-                Spectral::maximum_number_of_points<Spectral::Basis::Legendre>) +
-            "'.");
+      Spectral::maximum_number_of_points<Spectral::Basis::Legendre,
+                                         Spectral::Quadrature::GaussLobatto>) {
+    PARSE_ERROR(context,
+                "NumGridPoints upper bound '" +
+                    std::to_string(maximum_resolution_) +
+                    "' cannot be larger than '" +
+                    std::to_string(Spectral::maximum_number_of_points<
+                                   Spectral::Basis::Legendre,
+                                   Spectral::Quadrature::GaussLobatto>) +
+                    "'.");
   }
   if (minimum_refinement_level_ > maximum_refinement_level_) {
     PARSE_ERROR(context,

--- a/src/ParallelAlgorithms/Amr/Policies/Limits.cpp
+++ b/src/ParallelAlgorithms/Amr/Policies/Limits.cpp
@@ -8,20 +8,81 @@
 
 #include "Domain/Structure/ElementId.hpp"
 #include "NumericalAlgorithms/Spectral/Basis.hpp"
-#include "NumericalAlgorithms/Spectral/MaximumNumberOfPoints.hpp"
+#include "NumericalAlgorithms/Spectral/Limits.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
 #include "Options/ParseError.hpp"
+#include "Utilities/StdHelpers.hpp"
 
 namespace amr {
+namespace {
+std::unordered_map<std::pair<Spectral::Basis, Spectral::Quadrature>, size_t>
+make_map(const size_t polynomial_n, const size_t fourier_m,
+         const size_t spherical_harmonic_l) {
+  std::unordered_map<std::pair<Spectral::Basis, Spectral::Quadrature>, size_t>
+      result{};
+  result.emplace(std::make_pair(Spectral::Basis::Chebyshev,
+                                Spectral::Quadrature::GaussLobatto),
+                 polynomial_n == 0 ? 2 : polynomial_n + 1);
+  result.emplace(
+      std::make_pair(Spectral::Basis::Chebyshev, Spectral::Quadrature::Gauss),
+      polynomial_n + 1);
+  result.emplace(std::make_pair(Spectral::Basis::Legendre,
+                                Spectral::Quadrature::GaussLobatto),
+                 polynomial_n == 0 ? 2 : polynomial_n + 1);
+  result.emplace(
+      std::make_pair(Spectral::Basis::Legendre, Spectral::Quadrature::Gauss),
+      polynomial_n + 1);
+  result.emplace(std::make_pair(Spectral::Basis::SphericalHarmonic,
+                                Spectral::Quadrature::Gauss),
+                 spherical_harmonic_l + 1);
+  result.emplace(std::make_pair(Spectral::Basis::SphericalHarmonic,
+                                Spectral::Quadrature::Equiangular),
+                 2 * spherical_harmonic_l + 1);
+  result.emplace(std::make_pair(Spectral::Basis::Fourier,
+                                Spectral::Quadrature::Equiangular),
+                 2 * fourier_m + 1);
+  result.emplace(std::make_pair(Spectral::Basis::ZernikeB1,
+                                Spectral::Quadrature::GaussRadauUpper),
+                 polynomial_n + 1);
+  result.emplace(std::make_pair(Spectral::Basis::ZernikeB2,
+                                Spectral::Quadrature::GaussRadauUpper),
+                 fourier_m / 2 + 1);
+  result.emplace(std::make_pair(Spectral::Basis::ZernikeB2,
+                                Spectral::Quadrature::Equiangular),
+                 2 * fourier_m + 1);
+  result.emplace(std::make_pair(Spectral::Basis::ZernikeB3,
+                                Spectral::Quadrature::GaussRadauUpper),
+                 spherical_harmonic_l / 2 + 1);
+  result.emplace(
+      std::make_pair(Spectral::Basis::ZernikeB3, Spectral::Quadrature::Gauss),
+      spherical_harmonic_l + 1);
+  result.emplace(std::make_pair(Spectral::Basis::ZernikeB3,
+                                Spectral::Quadrature::Equiangular),
+                 2 * spherical_harmonic_l + 1);
+  result.emplace(std::make_pair(Spectral::Basis::Cartoon,
+                                Spectral::Quadrature::SphericalSymmetry),
+                 1);
+  result.emplace(std::make_pair(Spectral::Basis::Cartoon,
+                                Spectral::Quadrature::AxialSymmetry),
+                 1);
+  return result;
+}
+}  // namespace
 
 Limits::Limits()
     : maximum_refinement_level_(ElementId<1>::max_refinement_level),
+      minimum_resolution_(
+          make_map(0, 0, Spectral::limits::min_spherical_harmonic_mode)),
       maximum_resolution_(
-          Spectral::maximum_number_of_points<
-              Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto>) {}
+          make_map(Spectral::limits::max_i1_polynomial_mode,
+                   Spectral::limits::max_fourier_mode,
+                   Spectral::limits::max_spherical_harmonic_mode)) {}
 
 Limits::Limits(
     const std::optional<std::array<size_t, 2>>& refinement_level_bounds,
-    const std::optional<std::array<size_t, 2>>& resolution_bounds,
+    const std::optional<std::array<size_t, 2>>& polynomial_mode_bounds,
+    const std::optional<std::array<size_t, 2>>& fourier_mode_bounds,
+    const std::optional<std::array<size_t, 2>>& spherical_harmonic_bounds,
     const bool error_beyond_limits, const Options::Context& context)
     : minimum_refinement_level_(refinement_level_bounds.has_value()
                                     ? refinement_level_bounds.value()[0]
@@ -29,93 +90,94 @@ Limits::Limits(
       maximum_refinement_level_(refinement_level_bounds.has_value()
                                     ? refinement_level_bounds.value()[1]
                                     : ElementId<1>::max_refinement_level),
-      minimum_resolution_(
-          resolution_bounds.has_value() ? resolution_bounds.value()[0] : 1),
-      maximum_resolution_(resolution_bounds.has_value()
-                              ? resolution_bounds.value()[1]
-                              : Spectral::maximum_number_of_points<
-                                    Spectral::Basis::Legendre,
-                                    Spectral::Quadrature::GaussLobatto>),
+      minimum_resolution_(make_map(
+          polynomial_mode_bounds.has_value() ? polynomial_mode_bounds.value()[0]
+                                             : 0,
+          fourier_mode_bounds.has_value() ? fourier_mode_bounds.value()[0] : 0,
+          spherical_harmonic_bounds.has_value()
+              ? spherical_harmonic_bounds.value()[0]
+              : Spectral::limits::min_spherical_harmonic_mode)),
+      maximum_resolution_(make_map(
+          polynomial_mode_bounds.has_value()
+              ? polynomial_mode_bounds.value()[1]
+              : Spectral::limits::max_i1_polynomial_mode,
+          fourier_mode_bounds.has_value() ? fourier_mode_bounds.value()[1]
+                                          : Spectral::limits::max_fourier_mode,
+          spherical_harmonic_bounds.has_value()
+              ? spherical_harmonic_bounds.value()[1]
+              : Spectral::limits::max_spherical_harmonic_mode)),
       error_beyond_limits_(error_beyond_limits) {
-  if (minimum_refinement_level_ > ElementId<1>::max_refinement_level) {
-    PARSE_ERROR(context,
-                "RefinementLevel lower bound '" +
-                    std::to_string(minimum_refinement_level_) +
-                    "' cannot be larger than '" +
-                    std::to_string(ElementId<1>::max_refinement_level) + "'.");
+  if (minimum_refinement_level_ > maximum_refinement_level_) {
+    PARSE_ERROR(context, "RefinementLevel lower bound '" +
+                             std::to_string(minimum_refinement_level_) +
+                             "' cannot be larger than upper bound '" +
+                             std::to_string(maximum_refinement_level_) + "'.");
   }
   if (maximum_refinement_level_ > ElementId<1>::max_refinement_level) {
     PARSE_ERROR(context,
                 "RefinementLevel upper bound '" +
                     std::to_string(maximum_refinement_level_) +
-                    "' cannot be larger than '" +
+                    "' cannot be larger than refinement limit '" +
                     std::to_string(ElementId<1>::max_refinement_level) + "'.");
   }
-  if (minimum_resolution_ < 1) {
-    PARSE_ERROR(context, "NumGridPoints lower bound '" +
-                             std::to_string(minimum_resolution_) +
-                             "' cannot be smaller than '1'.");
+  if (polynomial_mode_bounds.has_value()) {
+    const auto [min, max] = polynomial_mode_bounds.value();
+    if (min > max) {
+      PARSE_ERROR(context, "NumPolynomialModes lower bound '" +
+                               std::to_string(min) +
+                               "' cannot be larger than upper bound '" +
+                               std::to_string(max));
+    }
+    if (max > Spectral::limits::max_i1_polynomial_mode) {
+      PARSE_ERROR(context,
+                  "NumPolynomialModes upper bound '" + std::to_string(max) +
+                      "' cannot be larger than "
+                      "Spectral::limits::max_i1_polynomial_mode '" +
+                      std::to_string(Spectral::limits::max_i1_polynomial_mode));
+    }
   }
-  if (maximum_resolution_ < 1) {
-    PARSE_ERROR(context, "NumGridPoints upper bound '" +
-                             std::to_string(maximum_resolution_) +
-                             "' cannot be smaller than '1'.");
+  if (fourier_mode_bounds.has_value()) {
+    const auto [min, max] = fourier_mode_bounds.value();
+    if (min > max) {
+      PARSE_ERROR(context, "FourierM lower bound '" + std::to_string(min) +
+                               "' cannot be larger than upper bound '" +
+                               std::to_string(max));
+    }
+    if (max > Spectral::limits::max_fourier_mode) {
+      PARSE_ERROR(context,
+                  "FourierM upper bound '" + std::to_string(max) +
+                      "' cannot be larger than "
+                      "Spectral::limits::max_fourier_mode '" +
+                      std::to_string(Spectral::limits::max_fourier_mode));
+    }
   }
-  if (minimum_resolution_ >
-      Spectral::maximum_number_of_points<Spectral::Basis::Legendre,
-                                         Spectral::Quadrature::GaussLobatto>) {
-    PARSE_ERROR(context,
-                "NumGridPoints lower bound '" +
-                    std::to_string(minimum_resolution_) +
-                    "' cannot be larger than '" +
-                    std::to_string(Spectral::maximum_number_of_points<
-                                   Spectral::Basis::Legendre,
-                                   Spectral::Quadrature::GaussLobatto>) +
-                    "'.");
-  }
-  if (maximum_resolution_ >
-      Spectral::maximum_number_of_points<Spectral::Basis::Legendre,
-                                         Spectral::Quadrature::GaussLobatto>) {
-    PARSE_ERROR(context,
-                "NumGridPoints upper bound '" +
-                    std::to_string(maximum_resolution_) +
-                    "' cannot be larger than '" +
-                    std::to_string(Spectral::maximum_number_of_points<
-                                   Spectral::Basis::Legendre,
-                                   Spectral::Quadrature::GaussLobatto>) +
-                    "'.");
-  }
-  if (minimum_refinement_level_ > maximum_refinement_level_) {
-    PARSE_ERROR(context,
-                "RefinementLevel lower bound '" +
-                    std::to_string(minimum_refinement_level_) +
-                    "' cannot be larger than RefinementLevel upper bound '" +
-                    std::to_string(maximum_refinement_level_) + "'.");
-  }
-  if (minimum_resolution_ > maximum_resolution_) {
-    PARSE_ERROR(context,
-                "NumGridPoints lower bound '" +
-                    std::to_string(minimum_resolution_) +
-                    "' cannot be larger than NumGridPoints upper bound '" +
-                    std::to_string(maximum_resolution_) + "'.");
+  if (spherical_harmonic_bounds.has_value()) {
+    const auto [min, max] = spherical_harmonic_bounds.value();
+    if (min > max) {
+      PARSE_ERROR(context, "SphericalHarmonicL lower bound '" +
+                               std::to_string(min) +
+                               "' cannot be larger than upper bound '" +
+                               std::to_string(max));
+    }
+    if (max > Spectral::limits::max_spherical_harmonic_mode) {
+      PARSE_ERROR(
+          context,
+          "SphericalHarmonicL upper bound '" + std::to_string(max) +
+              "' cannot be larger than "
+              "Spectral::limits::max_spherical_harmonic_mode '" +
+              std::to_string(Spectral::limits::max_spherical_harmonic_mode));
+    }
   }
 }
 
-Limits::Limits(size_t minimum_refinement_level, size_t maximum_refinement_level,
-               size_t minimum_resolution, size_t maximum_resolution)
-    : minimum_refinement_level_(minimum_refinement_level),
-      maximum_refinement_level_(maximum_refinement_level),
-      minimum_resolution_(minimum_resolution),
-      maximum_resolution_(maximum_resolution) {
-  ASSERT(minimum_refinement_level_ <= maximum_refinement_level_,
-         "The minimum refinement level '" +
-             std::to_string(minimum_refinement_level_) +
-             "' cannot be larger than the maximum refinement level '" +
-             std::to_string(maximum_refinement_level_) + "'.");
-  ASSERT(minimum_resolution_ <= maximum_resolution_,
-         "The minimum resolution '" + std::to_string(minimum_resolution_) +
-             "' cannot be larger than the maximum resolution '" +
-             std::to_string(maximum_resolution_) + "'.");
+size_t Limits::minimum_resolution(const Spectral::Basis basis,
+                                  const Spectral::Quadrature quadrature) const {
+  return minimum_resolution_.at(std::pair{basis, quadrature});
+}
+
+size_t Limits::maximum_resolution(const Spectral::Basis basis,
+                                  const Spectral::Quadrature quadrature) const {
+  return maximum_resolution_.at(std::pair{basis, quadrature});
 }
 
 void Limits::pup(PUP::er& p) {
@@ -127,14 +189,28 @@ void Limits::pup(PUP::er& p) {
 }
 
 bool operator==(const Limits& lhs, const Limits& rhs) {
-  return lhs.minimum_refinement_level() == rhs.minimum_refinement_level() and
-         lhs.maximum_refinement_level() == rhs.maximum_refinement_level() and
-         lhs.minimum_resolution() == rhs.minimum_resolution() and
-         lhs.maximum_resolution() == rhs.maximum_resolution() and
-         lhs.error_beyond_limits() == rhs.error_beyond_limits();
+  return lhs.minimum_refinement_level_ == rhs.minimum_refinement_level_ and
+         lhs.maximum_refinement_level_ == rhs.maximum_refinement_level_ and
+         lhs.minimum_resolution_ == rhs.minimum_resolution_ and
+         lhs.maximum_resolution_ == rhs.maximum_resolution_ and
+         lhs.error_beyond_limits_ == rhs.error_beyond_limits_;
 }
 
 bool operator!=(const Limits& lhs, const Limits& rhs) {
   return not(lhs == rhs);
+}
+
+std::ostream& Limits::print(std::ostream& os) const {
+  using ::operator<<;
+  os << "ErrorBeyondLimits: " << std::boolalpha << error_beyond_limits_ << "\n";
+  os << "RefinementLevel: [" << minimum_refinement_level_ << ", "
+     << maximum_refinement_level_ << "]\n";
+  os << "Minimum resolution:\n" << minimum_resolution_ << "\n";
+  os << "Maximum resolution:\n" << maximum_resolution_ << "\n";
+  return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const Limits& limits) {
+  return limits.print(os);
 }
 }  // namespace amr

--- a/src/ParallelAlgorithms/Amr/Policies/Limits.hpp
+++ b/src/ParallelAlgorithms/Amr/Policies/Limits.hpp
@@ -6,7 +6,10 @@
 #include <array>
 #include <cstddef>
 #include <optional>
+#include <unordered_map>
+#include <utility>
 
+#include "NumericalAlgorithms/Spectral/Hash.hpp"
 #include "Options/Auto.hpp"
 #include "Options/Context.hpp"
 #include "Options/String.hpp"
@@ -16,6 +19,10 @@
 namespace PUP {
 class er;
 }  // namespace PUP
+namespace Spectral {
+enum class Basis : uint8_t;
+enum class Quadrature : uint8_t;
+}  // namespace Spectral
 /// \endcond
 
 namespace amr {
@@ -24,15 +31,14 @@ namespace amr {
 /// \details
 /// - For a default constructed Limits, the refinement level is
 ///   bounded between 0 and ElementId<Dim>::max_refinement_level, and the
-///   resolution is bounded between 1 and
-///   Spectral::maximum_number_of_points<Spectral::Basis::Legendre>
-///   which are limits based on the implementation details of ElementId and
-///   Mesh. There is no error for attempting to go beyond the limits.
-/// - If you specify the limits on the refinement levels and resolutions, they
-///   must respect the above limits.
-/// - Depending upon which Spectral::Basis is chosen, the actual minimum
-///   resolution may be higher (usually 2), but this is automatically enforced
-///   by EnforcePolicies.
+///   resolution is bounded between Spectral::limits::min and
+///   Spectral::limits::max which are limits based on the implementation details
+///   of ElementId and Mesh. ErrorBeyondLimits is set to false.
+/// - Specifying `Auto` for any option uses the above limits.
+/// - If you specify a lower bound that violates the above limits, the limit
+///   will be raised to that needed by the code.
+/// - If you specify an upper bound that violates the above limits, the code
+///   will error on parsing the option.
 class Limits {
  public:
   /// Inclusive bounds on the refinement level
@@ -42,11 +48,26 @@ class Limits {
         "Inclusive bounds on the refinement level for AMR."};
   };
 
-  /// Inclusive bounds on the number of grid points per dimension
-  struct NumGridPoints {
+  /// Inclusive bounds on the number of polynomial modes for a I1 or B1 topology
+  struct NumPolynomialModes {
     using type = Options::Auto<std::array<size_t, 2>>;
     static constexpr Options::String help = {
-        "Inclusive bounds on the number of grid points per dimension for AMR."};
+        "Inclusive bounds on the number of polynomial modes for a I1 or B1 "
+        "topology."};
+  };
+
+  /// Inclusive bounds on the \f$m\f$ of Fourier modes for a S1 or B2 topology
+  struct FourierM {
+    using type = Options::Auto<std::array<size_t, 2>>;
+    static constexpr Options::String help = {
+        "Inclusive bounds on m for the Fourier series in topology S1 or B2."};
+  };
+
+  /// Inclusive bounds on the \f$\ell\f$ of spherical harmonic modes
+  struct SphericalHarmonicL {
+    using type = Options::Auto<std::array<size_t, 2>>;
+    static constexpr Options::String help = {
+        "Inclusive bounds on l for spherical harmonics in topology S2 or B3."};
   };
 
   /// \brief Whether the code should error if EnforcePolicies has to prevent
@@ -62,7 +83,8 @@ class Limits {
         "NumGridPoints limit, error"};
   };
 
-  using options = tmpl::list<RefinementLevel, NumGridPoints, ErrorBeyondLimits>;
+  using options = tmpl::list<RefinementLevel, NumPolynomialModes, FourierM,
+                             SphericalHarmonicL, ErrorBeyondLimits>;
 
   static constexpr Options::String help = {
       "Limits on refinement level and resolution for adaptive mesh "
@@ -71,29 +93,34 @@ class Limits {
   Limits();
 
   Limits(const std::optional<std::array<size_t, 2>>& refinement_level_bounds,
-         const std::optional<std::array<size_t, 2>>& resolution_bounds,
+         const std::optional<std::array<size_t, 2>>& polynomial_mode_bounds,
+         const std::optional<std::array<size_t, 2>>& fourier_mode_bounds,
+         const std::optional<std::array<size_t, 2>>& spherical_harmonic_bounds,
          bool error_beyond_limits, const Options::Context& context = {});
-
-  Limits(size_t minimum_refinement_level, size_t maximum_refinement_level,
-         size_t minimum_resolution, size_t maximum_resolution);
 
   size_t minimum_refinement_level() const { return minimum_refinement_level_; }
   size_t maximum_refinement_level() const { return maximum_refinement_level_; }
-  size_t minimum_resolution() const { return minimum_resolution_; }
-  size_t maximum_resolution() const { return maximum_resolution_; }
+  size_t minimum_resolution(Spectral::Basis basis,
+                            Spectral::Quadrature quadrature) const;
+  size_t maximum_resolution(Spectral::Basis basis,
+                            Spectral::Quadrature quadrature) const;
   bool error_beyond_limits() const { return error_beyond_limits_; }
 
+  std::ostream& print(std::ostream& os) const;
   void pup(PUP::er& p);
 
  private:
+  friend bool operator==(const Limits& lhs, const Limits& rhs);
   size_t minimum_refinement_level_{0};
   size_t maximum_refinement_level_{16};
-  size_t minimum_resolution_{1};
-  size_t maximum_resolution_{20};
+  std::unordered_map<std::pair<Spectral::Basis, Spectral::Quadrature>, size_t>
+      minimum_resolution_;
+  std::unordered_map<std::pair<Spectral::Basis, Spectral::Quadrature>, size_t>
+      maximum_resolution_;
   bool error_beyond_limits_{false};
 };
 
-bool operator==(const Limits& lhs, const Limits& rhs);
+std::ostream& operator<<(std::ostream& os, const Limits& limits);
 
 bool operator!=(const Limits& lhs, const Limits& rhs);
 }  // namespace amr

--- a/src/ParallelAlgorithms/Amr/Policies/Policies.cpp
+++ b/src/ParallelAlgorithms/Amr/Policies/Policies.cpp
@@ -22,6 +22,15 @@ void Policies::pup(PUP::er& p) {
   p | allow_coarsening_;
 }
 
+std::ostream& operator<<(std::ostream& os, const Policies& policies) {
+  os << "Isotropy: " << policies.isotropy() << "\n";
+  os << "EnforceTwoToOneBalanceInNormalDirection: "
+     << policies.enforce_two_to_one_balance_in_normal_direction() << "\n";
+  os << "AllowCoarsening: " << policies.allow_coarsening() << "\n";
+  os << "Limits: " << policies.limits() << "\n";
+  return os;
+}
+
 bool operator==(const Policies& lhs, const Policies& rhs) {
   return lhs.isotropy() == rhs.isotropy() and lhs.limits() == rhs.limits() and
          lhs.enforce_two_to_one_balance_in_normal_direction() ==

--- a/src/ParallelAlgorithms/Amr/Policies/Policies.hpp
+++ b/src/ParallelAlgorithms/Amr/Policies/Policies.hpp
@@ -82,6 +82,8 @@ class Policies {
   bool allow_coarsening_{true};
 };
 
+std::ostream& operator<<(std::ostream& os, const Policies& policies);
+
 bool operator==(const Policies& lhs, const Policies& rhs);
 
 bool operator!=(const Policies& lhs, const Policies& rhs);

--- a/support/Pipelines/Bbh/InitialData.yaml
+++ b/support/Pipelines/Bbh/InitialData.yaml
@@ -174,7 +174,9 @@ Amr:
     EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic
     Limits:
-      NumGridPoints: Auto
+      NumPolynomialModes: Auto
+      FourierM: Auto
+      SphericalHarmonicL: Auto
       RefinementLevel: Auto
       ErrorBeyondLimits: False
     AllowCoarsening: True

--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -318,7 +318,9 @@ Amr:
     Isotropy: Anisotropic
     Limits:
       RefinementLevel: Auto
-      NumGridPoints: Auto
+      NumPolynomialModes: Auto
+      FourierM: Auto
+      SphericalHarmonicL: Auto
       ErrorBeyondLimits: False
     AllowCoarsening: True
   Verbosity: Quiet

--- a/support/Pipelines/Bbh/Ringdown.yaml
+++ b/support/Pipelines/Bbh/Ringdown.yaml
@@ -190,7 +190,9 @@ Amr:
     Isotropy: Anisotropic
     Limits:
       RefinementLevel: Auto
-      NumGridPoints: Auto
+      NumPolynomialModes: Auto
+      FourierM: Auto
+      SphericalHarmonicL: Auto
       ErrorBeyondLimits: False
     AllowCoarsening: True
   Verbosity: Quiet

--- a/tests/InputFiles/Elasticity/BentBeam.yaml
+++ b/tests/InputFiles/Elasticity/BentBeam.yaml
@@ -122,7 +122,9 @@ Amr:
     EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic
     Limits:
-      NumGridPoints: Auto
+      NumPolynomialModes: Auto
+      FourierM: Auto
+      SphericalHarmonicL: Auto
       RefinementLevel: Auto
       ErrorBeyondLimits: False
     AllowCoarsening: True

--- a/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
+++ b/tests/InputFiles/Elasticity/HalfSpaceMirror.yaml
@@ -155,7 +155,9 @@ Amr:
     EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic
     Limits:
-      NumGridPoints: Auto
+      NumPolynomialModes: Auto
+      FourierM: Auto
+      SphericalHarmonicL: Auto
       RefinementLevel: Auto
       ErrorBeyondLimits: False
     AllowCoarsening: True

--- a/tests/InputFiles/Elasticity/SingleCoatingMirror.yaml
+++ b/tests/InputFiles/Elasticity/SingleCoatingMirror.yaml
@@ -172,7 +172,9 @@ Amr:
     EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic
     Limits:
-      NumGridPoints: Auto
+      NumPolynomialModes: Auto
+      FourierM: Auto
+      SphericalHarmonicL: Auto
       RefinementLevel: Auto
       ErrorBeyondLimits: False
     AllowCoarsening: True

--- a/tests/InputFiles/ExampleExecutables/RandomAmr1D.yaml
+++ b/tests/InputFiles/ExampleExecutables/RandomAmr1D.yaml
@@ -28,7 +28,9 @@ Amr:
     Isotropy: Anisotropic
     Limits:
       RefinementLevel: [0, 8]
-      NumGridPoints: Auto
+      NumPolynomialModes: Auto
+      FourierM: Auto
+      SphericalHarmonicL: Auto
       ErrorBeyondLimits: False
     AllowCoarsening: True
   Verbosity: Verbose

--- a/tests/InputFiles/ExampleExecutables/RandomAmrKeepCoarseGrids1D.yaml
+++ b/tests/InputFiles/ExampleExecutables/RandomAmrKeepCoarseGrids1D.yaml
@@ -28,7 +28,9 @@ Amr:
     Isotropy: Anisotropic
     Limits:
       RefinementLevel: [0, 8]
-      NumGridPoints: Auto
+      NumPolynomialModes: Auto
+      FourierM: Auto
+      SphericalHarmonicL: Auto
       ErrorBeyondLimits: False
     AllowCoarsening: False
   MaxCoarseLevels: Auto

--- a/tests/InputFiles/ExportCoordinates/Input1D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input1D.yaml
@@ -27,7 +27,9 @@ Amr:
     Isotropy: Anisotropic
     Limits:
       RefinementLevel: [0, 4]
-      NumGridPoints: Auto
+      NumPolynomialModes: Auto
+      FourierM: Auto
+      SphericalHarmonicL: Auto
       ErrorBeyondLimits: False
     AllowCoarsening: True
   Verbosity: Verbose

--- a/tests/InputFiles/ExportCoordinates/Input2D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input2D.yaml
@@ -22,7 +22,9 @@ Amr:
     Isotropy: Anisotropic
     Limits:
       RefinementLevel: Auto
-      NumGridPoints: Auto
+      NumPolynomialModes: Auto
+      FourierM: Auto
+      SphericalHarmonicL: Auto
       ErrorBeyondLimits: False
     AllowCoarsening: True
   Verbosity: Quiet

--- a/tests/InputFiles/ExportCoordinates/Input3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/Input3D.yaml
@@ -22,7 +22,9 @@ Amr:
     Isotropy: Anisotropic
     Limits:
       RefinementLevel: Auto
-      NumGridPoints: Auto
+      NumPolynomialModes: Auto
+      FourierM: Auto
+      SphericalHarmonicL: Auto
       ErrorBeyondLimits: False
     AllowCoarsening: True
   Verbosity: Quiet

--- a/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
+++ b/tests/InputFiles/ExportCoordinates/InputTimeDependent3D.yaml
@@ -23,7 +23,9 @@ Amr:
     Isotropy: Anisotropic
     Limits:
       RefinementLevel: Auto
-      NumGridPoints: Auto
+      NumPolynomialModes: Auto
+      FourierM: Auto
+      SphericalHarmonicL: Auto
       ErrorBeyondLimits: False
     AllowCoarsening: True
   Verbosity: Quiet

--- a/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/CylindricalBinaryBlackHole.yaml
@@ -193,7 +193,9 @@ Amr:
     Isotropy: Anisotropic
     Limits:
       RefinementLevel: Auto
-      NumGridPoints: Auto
+      NumPolynomialModes: Auto
+      FourierM: Auto
+      SphericalHarmonicL: Auto
       ErrorBeyondLimits: False
     AllowCoarsening: True
   Verbosity: Quiet

--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave1D.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave1D.yaml
@@ -39,7 +39,9 @@ Amr:
     Isotropy: Anisotropic
     Limits:
       RefinementLevel: Auto
-      NumGridPoints: Auto
+      NumPolynomialModes: Auto
+      FourierM: Auto
+      SphericalHarmonicL: Auto
       ErrorBeyondLimits: False
     AllowCoarsening: True
   Verbosity: Quiet

--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave1DLts.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave1DLts.yaml
@@ -46,7 +46,9 @@ Amr:
     Isotropy: Anisotropic
     Limits:
       RefinementLevel: Auto
-      NumGridPoints: Auto
+      NumPolynomialModes: Auto
+      FourierM: Auto
+      SphericalHarmonicL: Auto
       ErrorBeyondLimits: False
     AllowCoarsening: True
   Verbosity: Quiet

--- a/tests/InputFiles/GeneralizedHarmonic/GaugeWave3D.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/GaugeWave3D.yaml
@@ -40,7 +40,9 @@ Amr:
     Isotropy: Anisotropic
     Limits:
       RefinementLevel: Auto
-      NumGridPoints: Auto
+      NumPolynomialModes: Auto
+      FourierM: Auto
+      SphericalHarmonicL: Auto
       ErrorBeyondLimits: False
     AllowCoarsening: True
   Verbosity: Quiet

--- a/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/KerrSchild.yaml
@@ -60,7 +60,9 @@ Amr:
     Isotropy: Anisotropic
     Limits:
       RefinementLevel: Auto
-      NumGridPoints: Auto
+      NumPolynomialModes: Auto
+      FourierM: Auto
+      SphericalHarmonicL: Auto
       ErrorBeyondLimits: False
     AllowCoarsening: True
   Verbosity: Quiet

--- a/tests/InputFiles/GeneralizedHarmonic/SchwarzschildCartoonSphere1D.yaml
+++ b/tests/InputFiles/GeneralizedHarmonic/SchwarzschildCartoonSphere1D.yaml
@@ -39,7 +39,9 @@ Amr:
     Isotropy: Anisotropic
     Limits:
       RefinementLevel: Auto
-      NumGridPoints: Auto
+      NumPolynomialModes: Auto
+      FourierM: Auto
+      SphericalHarmonicL: Auto
       ErrorBeyondLimits: False
     AllowCoarsening: True
   Verbosity: Quiet

--- a/tests/InputFiles/Poisson/Lorentzian.yaml
+++ b/tests/InputFiles/Poisson/Lorentzian.yaml
@@ -58,7 +58,9 @@ Amr:
     EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic
     Limits:
-      NumGridPoints: Auto
+      NumPolynomialModes: Auto
+      FourierM: Auto
+      SphericalHarmonicL: Auto
       RefinementLevel: Auto
       ErrorBeyondLimits: False
     AllowCoarsening: True

--- a/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids1D.yaml
@@ -87,7 +87,9 @@ Amr:
     EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic
     Limits:
-      NumGridPoints: Auto
+      NumPolynomialModes: Auto
+      FourierM: Auto
+      SphericalHarmonicL: Auto
       RefinementLevel: Auto
       ErrorBeyondLimits: False
     AllowCoarsening: True

--- a/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids2D.yaml
@@ -125,7 +125,9 @@ Amr:
     EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic
     Limits:
-      NumGridPoints: Auto
+      NumPolynomialModes: Auto
+      FourierM: Auto
+      SphericalHarmonicL: Auto
       RefinementLevel: Auto
       ErrorBeyondLimits: False
     AllowCoarsening: True

--- a/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
+++ b/tests/InputFiles/Poisson/ProductOfSinusoids3D.yaml
@@ -128,7 +128,9 @@ Amr:
     EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic
     Limits:
-      NumGridPoints: Auto
+      NumPolynomialModes: Auto
+      FourierM: Auto
+      SphericalHarmonicL: Auto
       RefinementLevel: Auto
       ErrorBeyondLimits: False
     AllowCoarsening: True

--- a/tests/InputFiles/Punctures/MultiplePunctures.yaml
+++ b/tests/InputFiles/Punctures/MultiplePunctures.yaml
@@ -82,7 +82,9 @@ Amr:
     EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic
     Limits:
-      NumGridPoints: Auto
+      NumPolynomialModes: Auto
+      FourierM: Auto
+      SphericalHarmonicL: Auto
       RefinementLevel: Auto
       ErrorBeyondLimits: False
     AllowCoarsening: True

--- a/tests/InputFiles/ScalarWave/NonconformingSphericalWave.yaml
+++ b/tests/InputFiles/ScalarWave/NonconformingSphericalWave.yaml
@@ -31,7 +31,9 @@ Amr:
     Isotropy: Anisotropic
     Limits:
       RefinementLevel: Auto
-      NumGridPoints: Auto
+      NumPolynomialModes: Auto
+      FourierM: Auto
+      SphericalHarmonicL: Auto
       ErrorBeyondLimits: False
   Verbosity: Verbose
 

--- a/tests/InputFiles/ScalarWave/PlaneWave1D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1D.yaml
@@ -42,7 +42,9 @@ Amr:
     Isotropy: Anisotropic
     Limits:
       RefinementLevel: Auto
-      NumGridPoints: Auto
+      NumPolynomialModes: Auto
+      FourierM: Auto
+      SphericalHarmonicL: Auto
       ErrorBeyondLimits: False
     AllowCoarsening: True
   Verbosity: Verbose

--- a/tests/InputFiles/ScalarWave/PlaneWave1DEventsAndTriggersExample.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1DEventsAndTriggersExample.yaml
@@ -42,7 +42,9 @@ Amr:
     Isotropy: Anisotropic
     Limits:
       RefinementLevel: Auto
-      NumGridPoints: Auto
+      NumPolynomialModes: Auto
+      FourierM: Auto
+      SphericalHarmonicL: Auto
       ErrorBeyondLimits: False
     AllowCoarsening: True
   Verbosity: Verbose

--- a/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave1DObserveExample.yaml
@@ -44,7 +44,9 @@ Amr:
     Isotropy: Anisotropic
     Limits:
       RefinementLevel: Auto
-      NumGridPoints: Auto
+      NumPolynomialModes: Auto
+      FourierM: Auto
+      SphericalHarmonicL: Auto
       ErrorBeyondLimits: False
     AllowCoarsening: True
   Verbosity: Verbose

--- a/tests/InputFiles/ScalarWave/PlaneWave2D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave2D.yaml
@@ -38,7 +38,9 @@ Amr:
     Isotropy: Anisotropic
     Limits:
       RefinementLevel: Auto
-      NumGridPoints: Auto
+      NumPolynomialModes: Auto
+      FourierM: Auto
+      SphericalHarmonicL: Auto
       ErrorBeyondLimits: False
     AllowCoarsening: True
   Verbosity: Verbose

--- a/tests/InputFiles/ScalarWave/PlaneWave3D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave3D.yaml
@@ -32,7 +32,9 @@ Amr:
     Isotropy: Anisotropic
     Limits:
       RefinementLevel: Auto
-      NumGridPoints: Auto
+      NumPolynomialModes: Auto
+      FourierM: Auto
+      SphericalHarmonicL: Auto
       ErrorBeyondLimits: False
     AllowCoarsening: True
   Verbosity: Verbose

--- a/tests/InputFiles/ScalarWave/PlaneWave3DCartoonSphere2D.yaml
+++ b/tests/InputFiles/ScalarWave/PlaneWave3DCartoonSphere2D.yaml
@@ -30,7 +30,9 @@ Amr:
     Isotropy: Anisotropic
     Limits:
       RefinementLevel: Auto
-      NumGridPoints: Auto
+      NumPolynomialModes: Auto
+      FourierM: Auto
+      SphericalHarmonicL: Auto
       ErrorBeyondLimits: False
     AllowCoarsening: True
   Verbosity: Verbose

--- a/tests/InputFiles/SelfForce/GrCircularOrbit.yaml
+++ b/tests/InputFiles/SelfForce/GrCircularOrbit.yaml
@@ -104,7 +104,9 @@ Amr:
     Isotropy: Anisotropic
     EnforceTwoToOneBalanceInNormalDirection: True
     Limits:
-      NumGridPoints: Auto
+      NumPolynomialModes: Auto
+      FourierM: Auto
+      SphericalHarmonicL: Auto
       RefinementLevel: Auto
       ErrorBeyondLimits: True
     AllowCoarsening: True

--- a/tests/InputFiles/SelfForce/ScalarCircularOrbit.yaml
+++ b/tests/InputFiles/SelfForce/ScalarCircularOrbit.yaml
@@ -142,7 +142,9 @@ Amr:
     Isotropy: Anisotropic
     EnforceTwoToOneBalanceInNormalDirection: True
     Limits:
-      NumGridPoints: Auto
+      NumPolynomialModes: Auto
+      FourierM: Auto
+      SphericalHarmonicL: Auto
       RefinementLevel: Auto
       ErrorBeyondLimits: True
     AllowCoarsening: True

--- a/tests/InputFiles/Xcts/BinaryBlackHole.yaml
+++ b/tests/InputFiles/Xcts/BinaryBlackHole.yaml
@@ -167,7 +167,9 @@ Amr:
     EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic
     Limits:
-      NumGridPoints: Auto
+      NumPolynomialModes: Auto
+      FourierM: Auto
+      SphericalHarmonicL: Auto
       RefinementLevel: Auto
       ErrorBeyondLimits: False
     AllowCoarsening: True

--- a/tests/InputFiles/Xcts/HeadOnBns.yaml
+++ b/tests/InputFiles/Xcts/HeadOnBns.yaml
@@ -238,7 +238,9 @@ Amr:
     EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic
     Limits:
-      NumGridPoints: Auto
+      NumPolynomialModes: Auto
+      FourierM: Auto
+      SphericalHarmonicL: Auto
       RefinementLevel: Auto
       ErrorBeyondLimits: False
     AllowCoarsening: True

--- a/tests/InputFiles/Xcts/KerrSchild.yaml
+++ b/tests/InputFiles/Xcts/KerrSchild.yaml
@@ -123,7 +123,9 @@ Amr:
     EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic
     Limits:
-      NumGridPoints: Auto
+      NumPolynomialModes: Auto
+      FourierM: Auto
+      SphericalHarmonicL: Auto
       RefinementLevel: Auto
       ErrorBeyondLimits: False
     AllowCoarsening: True

--- a/tests/InputFiles/Xcts/KerrSchildTeukolsky.yaml
+++ b/tests/InputFiles/Xcts/KerrSchildTeukolsky.yaml
@@ -82,7 +82,9 @@ Amr:
     EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic
     Limits:
-      NumGridPoints: Auto
+      NumPolynomialModes: Auto
+      FourierM: Auto
+      SphericalHarmonicL: Auto
       RefinementLevel: Auto
       ErrorBeyondLimits: False
     AllowCoarsening: True

--- a/tests/InputFiles/Xcts/TovStar.yaml
+++ b/tests/InputFiles/Xcts/TovStar.yaml
@@ -170,7 +170,9 @@ Amr:
     EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic
     Limits:
-      NumGridPoints: Auto
+      NumPolynomialModes: Auto
+      FourierM: Auto
+      SphericalHarmonicL: Auto
       RefinementLevel: Auto
       ErrorBeyondLimits: False
     AllowCoarsening: True

--- a/tests/Unit/Domain/Structure/CMakeLists.txt
+++ b/tests/Unit/Domain/Structure/CMakeLists.txt
@@ -18,6 +18,7 @@ set(LIBRARY_SOURCES
   Test_Hypercube.cpp
   Test_IndexToSliceAt.cpp
   Test_InitialElementIds.cpp
+  Test_IsValidDgMesh.cpp
   Test_NeighborIsConforming.cpp
   Test_Neighbors.cpp
   Test_ObjectLabel.cpp

--- a/tests/Unit/Domain/Structure/Test_IsValidDgMesh.cpp
+++ b/tests/Unit/Domain/Structure/Test_IsValidDgMesh.cpp
@@ -1,0 +1,415 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/IsValidDgMesh.hpp"
+#include "Domain/Structure/Neighbors.hpp"
+#include "Domain/Structure/SegmentId.hpp"
+#include "Domain/Structure/Topology.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "Utilities/Literals.hpp"
+
+namespace domain {
+namespace {
+void test_1d() {
+  const auto extents = std::array{3_st};
+  const DirectionMap<1, Neighbors<1>> neighbors{};
+  const ElementId<1> root_id{0_st};
+  const ElementId<1> refined_id{0_st, std::array{SegmentId{1_st, 0_st}}};
+
+  CHECK(is_valid_dg_mesh(
+      Mesh<1>{extents, Spectral::bases::hypercube<1>,
+              Spectral::quadratures::hypercube<1>},
+      Element<1>{root_id, neighbors, topologies::hypercube<1>}));
+  CHECK(is_valid_dg_mesh(
+      Mesh<1>{extents, Spectral::bases::hypercube<1>,
+              Spectral::quadratures::hypercube<1>},
+      Element<1>{refined_id, neighbors, topologies::hypercube<1>}));
+  CHECK_FALSE(is_valid_dg_mesh(
+      Mesh<1>{extents, Spectral::bases::hypercube<1>,
+              Spectral::quadratures::hypercube<1>},
+      Element<1>{root_id, neighbors, topologies::hypertorus<1>}));
+  CHECK(is_valid_dg_mesh(
+      Mesh<1>{extents, Spectral::bases::hypertorus<1>,
+              Spectral::quadratures::hypertorus<1>},
+      Element<1>{root_id, neighbors, topologies::hypertorus<1>}));
+  CHECK_FALSE(is_valid_dg_mesh(
+      Mesh<1>{extents, Spectral::bases::hypertorus<1>,
+              Spectral::quadratures::hypertorus<1>},
+      Element<1>{refined_id, neighbors, topologies::hypertorus<1>}));
+  CHECK_FALSE(is_valid_dg_mesh(
+      Mesh<1>{extents, Spectral::bases::hypertorus<1>,
+              Spectral::quadratures::hypertorus<1>},
+      Element<1>{root_id, neighbors, topologies::hypercube<1>}));
+}
+
+void test_2d() {
+  const auto extents = std::array{3_st, 5_st};
+  const DirectionMap<2, Neighbors<2>> neighbors{};
+  const ElementId<2> root_id{0_st};
+  const ElementId<2> xi_refined_id_lower{
+      0_st, std::array{SegmentId{1_st, 0_st}, SegmentId{0_st, 0_st}}};
+  const ElementId<2> xi_refined_id_upper{
+      0_st, std::array{SegmentId{1_st, 1_st}, SegmentId{0_st, 0_st}}};
+  const ElementId<2> eta_refined_id_lower{
+      0_st, std::array{SegmentId{0_st, 0_st}, SegmentId{1_st, 0_st}}};
+
+  CHECK(is_valid_dg_mesh(
+      Mesh<2>{extents, Spectral::bases::hypercube<2>,
+              Spectral::quadratures::hypercube<2>},
+      Element<2>{root_id, neighbors, topologies::hypercube<2>}));
+  CHECK(is_valid_dg_mesh(
+      Mesh<2>{extents, Spectral::bases::hypercube<2>,
+              Spectral::quadratures::hypercube<2>},
+      Element<2>{xi_refined_id_lower, neighbors, topologies::hypercube<2>}));
+  CHECK(is_valid_dg_mesh(
+      Mesh<2>{extents, Spectral::bases::hypercube<2>,
+              Spectral::quadratures::hypercube<2>},
+      Element<2>{eta_refined_id_lower, neighbors, topologies::hypercube<2>}));
+  CHECK_FALSE(is_valid_dg_mesh(
+      Mesh<2>{extents, Spectral::bases::hypercube<2>,
+              Spectral::quadratures::hypercube<2>},
+      Element<2>{root_id, neighbors, topologies::hypertorus<2>}));
+  CHECK(is_valid_dg_mesh(
+      Mesh<2>{extents, Spectral::bases::hypertorus<2>,
+              Spectral::quadratures::hypertorus<2>},
+      Element<2>{root_id, neighbors, topologies::hypertorus<2>}));
+  CHECK_FALSE(is_valid_dg_mesh(
+      Mesh<2>{extents, Spectral::bases::hypertorus<2>,
+              Spectral::quadratures::hypertorus<2>},
+      Element<2>{xi_refined_id_lower, neighbors, topologies::hypertorus<2>}));
+  CHECK_FALSE(is_valid_dg_mesh(
+      Mesh<2>{extents, Spectral::bases::hypertorus<2>,
+              Spectral::quadratures::hypertorus<2>},
+      Element<2>{eta_refined_id_lower, neighbors, topologies::hypertorus<2>}));
+  CHECK_FALSE(is_valid_dg_mesh(
+      Mesh<2>{extents, Spectral::bases::hypertorus<2>,
+              Spectral::quadratures::hypertorus<2>},
+      Element<2>{root_id, neighbors, topologies::hypercube<2>}));
+  CHECK(is_valid_dg_mesh(Mesh<2>{extents, Spectral::bases::annulus<>,
+                                 Spectral::quadratures::annulus<>},
+                         Element<2>{root_id, neighbors, topologies::annulus}));
+  CHECK(is_valid_dg_mesh(
+      Mesh<2>{extents, Spectral::bases::annulus<>,
+              Spectral::quadratures::annulus<>},
+      Element<2>{xi_refined_id_lower, neighbors, topologies::annulus}));
+  CHECK_FALSE(is_valid_dg_mesh(
+      Mesh<2>{extents, Spectral::bases::annulus<>,
+              Spectral::quadratures::annulus<>},
+      Element<2>{eta_refined_id_lower, neighbors, topologies::annulus}));
+  CHECK_FALSE(
+      is_valid_dg_mesh(Mesh<2>{extents, Spectral::bases::annulus<>,
+                               Spectral::quadratures::annulus<>},
+                       Element<2>{root_id, neighbors, topologies::disk}));
+  CHECK(is_valid_dg_mesh(
+      Mesh<2>{extents, Spectral::bases::spherical_surface,
+              Spectral::quadratures::spherical_surface},
+      Element<2>{root_id, neighbors, topologies::spherical_surface}));
+  CHECK_FALSE(
+      is_valid_dg_mesh(Mesh<2>{extents, Spectral::bases::spherical_surface,
+                               Spectral::quadratures::spherical_surface},
+                       Element<2>{xi_refined_id_lower, neighbors,
+                                  topologies::spherical_surface}));
+  CHECK_FALSE(
+      is_valid_dg_mesh(Mesh<2>{extents, Spectral::bases::spherical_surface,
+                               Spectral::quadratures::spherical_surface},
+                       Element<2>{eta_refined_id_lower, neighbors,
+                                  topologies::spherical_surface}));
+  CHECK_FALSE(
+      is_valid_dg_mesh(Mesh<2>{extents, Spectral::bases::spherical_surface,
+                               Spectral::quadratures::spherical_surface},
+                       Element<2>{root_id, neighbors, topologies::disk}));
+  const auto disk_extents = std::array{2_st, 5_st};
+  CHECK(is_valid_dg_mesh(
+      Mesh<2>{disk_extents, Spectral::bases::disk, Spectral::quadratures::disk},
+      Element<2>{root_id, neighbors, topologies::disk}));
+  CHECK(is_valid_dg_mesh(
+      Mesh<2>{disk_extents, Spectral::bases::disk, Spectral::quadratures::disk},
+      Element<2>{xi_refined_id_lower, neighbors, topologies::disk}));
+  CHECK_FALSE(is_valid_dg_mesh(
+      Mesh<2>{disk_extents, Spectral::bases::disk, Spectral::quadratures::disk},
+      Element<2>{xi_refined_id_upper, neighbors, topologies::disk}));
+  CHECK_FALSE(is_valid_dg_mesh(
+      Mesh<2>{disk_extents, Spectral::bases::disk, Spectral::quadratures::disk},
+      Element<2>{eta_refined_id_lower, neighbors, topologies::disk}));
+  CHECK_FALSE(is_valid_dg_mesh(
+      Mesh<2>{disk_extents, Spectral::bases::disk, Spectral::quadratures::disk},
+      Element<2>{root_id, neighbors, topologies::annulus}));
+}
+
+void test_3d() {
+  const auto extents = std::array{3_st, 5_st, 9_st};
+  const DirectionMap<3, Neighbors<3>> neighbors{};
+  const ElementId<3> root_id{0_st};
+  const ElementId<3> xi_refined_id_lower{
+      0_st, std::array{SegmentId{1_st, 0_st}, SegmentId{0_st, 0_st},
+                       SegmentId{0_st, 0_st}}};
+  const ElementId<3> xi_refined_id_upper{
+      0_st, std::array{SegmentId{1_st, 1_st}, SegmentId{0_st, 0_st},
+                       SegmentId{0_st, 0_st}}};
+  const ElementId<3> eta_refined_id_lower{
+      0_st, std::array{SegmentId{0_st, 0_st}, SegmentId{1_st, 0_st},
+                       SegmentId{0_st, 0_st}}};
+  const ElementId<3> zeta_refined_id_lower{
+      0_st, std::array{SegmentId{0_st, 0_st}, SegmentId{0_st, 0_st},
+                       SegmentId{1_st, 0_st}}};
+
+  CHECK(is_valid_dg_mesh(
+      Mesh<3>{extents, Spectral::bases::hypercube<3>,
+              Spectral::quadratures::hypercube<3>},
+      Element<3>{root_id, neighbors, topologies::hypercube<3>}));
+  CHECK(is_valid_dg_mesh(
+      Mesh<3>{extents, Spectral::bases::hypercube<3>,
+              Spectral::quadratures::hypercube<3>},
+      Element<3>{xi_refined_id_lower, neighbors, topologies::hypercube<3>}));
+  CHECK(is_valid_dg_mesh(
+      Mesh<3>{extents, Spectral::bases::hypercube<3>,
+              Spectral::quadratures::hypercube<3>},
+      Element<3>{eta_refined_id_lower, neighbors, topologies::hypercube<3>}));
+  CHECK(is_valid_dg_mesh(
+      Mesh<3>{extents, Spectral::bases::hypercube<3>,
+              Spectral::quadratures::hypercube<3>},
+      Element<3>{zeta_refined_id_lower, neighbors, topologies::hypercube<3>}));
+  CHECK_FALSE(is_valid_dg_mesh(
+      Mesh<3>{extents, Spectral::bases::hypercube<3>,
+              Spectral::quadratures::hypercube<3>},
+      Element<3>{root_id, neighbors, topologies::hypertorus<3>}));
+  CHECK(is_valid_dg_mesh(
+      Mesh<3>{extents, Spectral::bases::hypertorus<3>,
+              Spectral::quadratures::hypertorus<3>},
+      Element<3>{root_id, neighbors, topologies::hypertorus<3>}));
+  CHECK_FALSE(is_valid_dg_mesh(
+      Mesh<3>{extents, Spectral::bases::hypertorus<3>,
+              Spectral::quadratures::hypertorus<3>},
+      Element<3>{xi_refined_id_lower, neighbors, topologies::hypertorus<3>}));
+  CHECK_FALSE(is_valid_dg_mesh(
+      Mesh<3>{extents, Spectral::bases::hypertorus<3>,
+              Spectral::quadratures::hypertorus<3>},
+      Element<3>{eta_refined_id_lower, neighbors, topologies::hypertorus<3>}));
+  CHECK_FALSE(is_valid_dg_mesh(
+      Mesh<3>{extents, Spectral::bases::hypertorus<3>,
+              Spectral::quadratures::hypertorus<3>},
+      Element<3>{zeta_refined_id_lower, neighbors, topologies::hypertorus<3>}));
+  CHECK_FALSE(is_valid_dg_mesh(
+      Mesh<3>{extents, Spectral::bases::hypertorus<3>,
+              Spectral::quadratures::hypertorus<3>},
+      Element<3>{root_id, neighbors, topologies::hypercube<3>}));
+  CHECK(is_valid_dg_mesh(
+      Mesh<3>{extents, Spectral::bases::spherical_shell<>,
+              Spectral::quadratures::spherical_shell<>},
+      Element<3>{root_id, neighbors, topologies::spherical_shell}));
+  CHECK(is_valid_dg_mesh(
+      Mesh<3>{extents, Spectral::bases::spherical_shell<>,
+              Spectral::quadratures::spherical_shell<>},
+      Element<3>{xi_refined_id_lower, neighbors, topologies::spherical_shell}));
+  CHECK_FALSE(
+      is_valid_dg_mesh(Mesh<3>{extents, Spectral::bases::spherical_shell<>,
+                               Spectral::quadratures::spherical_shell<>},
+                       Element<3>{eta_refined_id_lower, neighbors,
+                                  topologies::spherical_shell}));
+  CHECK_FALSE(
+      is_valid_dg_mesh(Mesh<3>{extents, Spectral::bases::spherical_shell<>,
+                               Spectral::quadratures::spherical_shell<>},
+                       Element<3>{zeta_refined_id_lower, neighbors,
+                                  topologies::spherical_shell}));
+  CHECK_FALSE(is_valid_dg_mesh(
+      Mesh<3>{extents, Spectral::bases::spherical_shell<>,
+              Spectral::quadratures::spherical_shell<>},
+      Element<3>{root_id, neighbors, topologies::full_sphere}));
+  const auto cylindrical_extents = std::array{3_st, 9_st, 3_st};
+  CHECK(is_valid_dg_mesh(
+      Mesh<3>{cylindrical_extents, Spectral::bases::cylindrical_shell<>,
+              Spectral::quadratures::cylindrical_shell<>},
+      Element<3>{root_id, neighbors, topologies::cylindrical_shell}));
+  CHECK(is_valid_dg_mesh(
+      Mesh<3>{cylindrical_extents, Spectral::bases::cylindrical_shell<>,
+              Spectral::quadratures::cylindrical_shell<>},
+      Element<3>{xi_refined_id_lower, neighbors,
+                 topologies::cylindrical_shell}));
+  CHECK_FALSE(is_valid_dg_mesh(
+      Mesh<3>{cylindrical_extents, Spectral::bases::cylindrical_shell<>,
+              Spectral::quadratures::cylindrical_shell<>},
+      Element<3>{eta_refined_id_lower, neighbors,
+                 topologies::cylindrical_shell}));
+  CHECK(is_valid_dg_mesh(
+      Mesh<3>{cylindrical_extents, Spectral::bases::cylindrical_shell<>,
+              Spectral::quadratures::cylindrical_shell<>},
+      Element<3>{zeta_refined_id_lower, neighbors,
+                 topologies::cylindrical_shell}));
+  CHECK_FALSE(is_valid_dg_mesh(
+      Mesh<3>{cylindrical_extents, Spectral::bases::cylindrical_shell<>,
+              Spectral::quadratures::cylindrical_shell<>},
+      Element<3>{root_id, neighbors, topologies::full_cylinder}));
+  CHECK(is_valid_dg_mesh(
+      Mesh<3>{cylindrical_extents, Spectral::bases::full_cylinder<>,
+              Spectral::quadratures::full_cylinder<>},
+      Element<3>{root_id, neighbors, topologies::full_cylinder}));
+  CHECK(is_valid_dg_mesh(
+      Mesh<3>{cylindrical_extents, Spectral::bases::full_cylinder<>,
+              Spectral::quadratures::full_cylinder<>},
+      Element<3>{xi_refined_id_lower, neighbors, topologies::full_cylinder}));
+  CHECK_FALSE(is_valid_dg_mesh(
+      Mesh<3>{cylindrical_extents, Spectral::bases::full_cylinder<>,
+              Spectral::quadratures::full_cylinder<>},
+      Element<3>{xi_refined_id_upper, neighbors, topologies::full_cylinder}));
+  CHECK_FALSE(is_valid_dg_mesh(
+      Mesh<3>{cylindrical_extents, Spectral::bases::full_cylinder<>,
+              Spectral::quadratures::full_cylinder<>},
+      Element<3>{eta_refined_id_lower, neighbors, topologies::full_cylinder}));
+  CHECK(is_valid_dg_mesh(
+      Mesh<3>{cylindrical_extents, Spectral::bases::full_cylinder<>,
+              Spectral::quadratures::full_cylinder<>},
+      Element<3>{zeta_refined_id_lower, neighbors, topologies::full_cylinder}));
+  CHECK_FALSE(is_valid_dg_mesh(
+      Mesh<3>{cylindrical_extents, Spectral::bases::full_cylinder<>,
+              Spectral::quadratures::full_cylinder<>},
+      Element<3>{root_id, neighbors, topologies::cylindrical_shell}));
+  CHECK(is_valid_dg_mesh(
+      Mesh<3>{extents, Spectral::bases::full_sphere,
+              Spectral::quadratures::full_sphere},
+      Element<3>{root_id, neighbors, topologies::full_sphere}));
+  CHECK(is_valid_dg_mesh(
+      Mesh<3>{extents, Spectral::bases::full_sphere,
+              Spectral::quadratures::full_sphere},
+      Element<3>{xi_refined_id_lower, neighbors, topologies::full_sphere}));
+  CHECK_FALSE(is_valid_dg_mesh(
+      Mesh<3>{extents, Spectral::bases::full_sphere,
+              Spectral::quadratures::full_sphere},
+      Element<3>{xi_refined_id_upper, neighbors, topologies::full_sphere}));
+  CHECK_FALSE(is_valid_dg_mesh(
+      Mesh<3>{extents, Spectral::bases::full_sphere,
+              Spectral::quadratures::full_sphere},
+      Element<3>{eta_refined_id_lower, neighbors, topologies::full_sphere}));
+  CHECK_FALSE(is_valid_dg_mesh(
+      Mesh<3>{extents, Spectral::bases::full_sphere,
+              Spectral::quadratures::full_sphere},
+      Element<3>{zeta_refined_id_lower, neighbors, topologies::full_sphere}));
+  CHECK_FALSE(is_valid_dg_mesh(
+      Mesh<3>{extents, Spectral::bases::full_sphere,
+              Spectral::quadratures::full_sphere},
+      Element<3>{root_id, neighbors, topologies::spherical_shell}));
+  const auto cartoon_sphere_extents = std::array{3_st, 1_st, 1_st};
+  CHECK(is_valid_dg_mesh(
+      Mesh<3>{cartoon_sphere_extents, Spectral::bases::cartoon_sphere_inner,
+              Spectral::quadratures::cartoon_sphere_inner},
+      Element<3>{root_id, neighbors, topologies::cartoon_sphere_inner}));
+  CHECK(is_valid_dg_mesh(
+      Mesh<3>{cartoon_sphere_extents, Spectral::bases::cartoon_sphere_inner,
+              Spectral::quadratures::cartoon_sphere_inner},
+      Element<3>{xi_refined_id_lower, neighbors,
+                 topologies::cartoon_sphere_inner}));
+  CHECK_FALSE(is_valid_dg_mesh(
+      Mesh<3>{cartoon_sphere_extents, Spectral::bases::cartoon_sphere_inner,
+              Spectral::quadratures::cartoon_sphere_inner},
+      Element<3>{xi_refined_id_upper, neighbors,
+                 topologies::cartoon_sphere_inner}));
+  CHECK_FALSE(is_valid_dg_mesh(
+      Mesh<3>{cartoon_sphere_extents, Spectral::bases::cartoon_sphere_inner,
+              Spectral::quadratures::cartoon_sphere_inner},
+      Element<3>{eta_refined_id_lower, neighbors,
+                 topologies::cartoon_sphere_inner}));
+  CHECK_FALSE(is_valid_dg_mesh(
+      Mesh<3>{cartoon_sphere_extents, Spectral::bases::cartoon_sphere_inner,
+              Spectral::quadratures::cartoon_sphere_inner},
+      Element<3>{zeta_refined_id_lower, neighbors,
+                 topologies::cartoon_sphere_inner}));
+  CHECK_FALSE(is_valid_dg_mesh(
+      Mesh<3>{cartoon_sphere_extents, Spectral::bases::cartoon_sphere_inner,
+              Spectral::quadratures::cartoon_sphere_inner},
+      Element<3>{root_id, neighbors, topologies::full_sphere}));
+  CHECK(is_valid_dg_mesh(
+      Mesh<3>{cartoon_sphere_extents, Spectral::bases::cartoon_sphere<>,
+              Spectral::quadratures::cartoon_sphere<>},
+      Element<3>{root_id, neighbors, topologies::cartoon_sphere}));
+  CHECK(is_valid_dg_mesh(
+      Mesh<3>{cartoon_sphere_extents, Spectral::bases::cartoon_sphere<>,
+              Spectral::quadratures::cartoon_sphere<>},
+      Element<3>{xi_refined_id_lower, neighbors, topologies::cartoon_sphere}));
+  CHECK_FALSE(is_valid_dg_mesh(
+      Mesh<3>{cartoon_sphere_extents, Spectral::bases::cartoon_sphere<>,
+              Spectral::quadratures::cartoon_sphere<>},
+      Element<3>{eta_refined_id_lower, neighbors, topologies::cartoon_sphere}));
+  CHECK_FALSE(is_valid_dg_mesh(
+      Mesh<3>{cartoon_sphere_extents, Spectral::bases::cartoon_sphere<>,
+              Spectral::quadratures::cartoon_sphere<>},
+      Element<3>{zeta_refined_id_lower, neighbors,
+                 topologies::cartoon_sphere}));
+  CHECK_FALSE(is_valid_dg_mesh(
+      Mesh<3>{cartoon_sphere_extents, Spectral::bases::cartoon_sphere<>,
+              Spectral::quadratures::cartoon_sphere<>},
+      Element<3>{root_id, neighbors, topologies::spherical_shell}));
+  const auto cartoon_cylinder_extents = std::array{3_st, 3_st, 1_st};
+  CHECK(is_valid_dg_mesh(
+      Mesh<3>{cartoon_cylinder_extents, Spectral::bases::cartoon_cylinder<>,
+              Spectral::quadratures::cartoon_cylinder<>},
+      Element<3>{root_id, neighbors, topologies::cartoon_cylinder}));
+  CHECK(is_valid_dg_mesh(
+      Mesh<3>{cartoon_cylinder_extents, Spectral::bases::cartoon_cylinder<>,
+              Spectral::quadratures::cartoon_cylinder<>},
+      Element<3>{xi_refined_id_lower, neighbors,
+                 topologies::cartoon_cylinder}));
+  CHECK(is_valid_dg_mesh(
+      Mesh<3>{cartoon_cylinder_extents, Spectral::bases::cartoon_cylinder<>,
+              Spectral::quadratures::cartoon_cylinder<>},
+      Element<3>{eta_refined_id_lower, neighbors,
+                 topologies::cartoon_cylinder}));
+  CHECK_FALSE(is_valid_dg_mesh(
+      Mesh<3>{cartoon_cylinder_extents, Spectral::bases::cartoon_cylinder<>,
+              Spectral::quadratures::cartoon_cylinder<>},
+      Element<3>{zeta_refined_id_lower, neighbors,
+                 topologies::cartoon_cylinder}));
+  CHECK_FALSE(is_valid_dg_mesh(
+      Mesh<3>{cartoon_cylinder_extents, Spectral::bases::cartoon_cylinder<>,
+              Spectral::quadratures::cartoon_cylinder<>},
+      Element<3>{root_id, neighbors, topologies::cylindrical_shell}));
+  CHECK(is_valid_dg_mesh(
+      Mesh<3>{cartoon_cylinder_extents,
+              Spectral::bases::cartoon_cylinder_inner<>,
+              Spectral::quadratures::cartoon_cylinder_inner<>},
+      Element<3>{root_id, neighbors, topologies::cartoon_cylinder_inner}));
+  CHECK(
+      is_valid_dg_mesh(Mesh<3>{cartoon_cylinder_extents,
+                               Spectral::bases::cartoon_cylinder_inner<>,
+                               Spectral::quadratures::cartoon_cylinder_inner<>},
+                       Element<3>{xi_refined_id_lower, neighbors,
+                                  topologies::cartoon_cylinder_inner}));
+  CHECK_FALSE(
+      is_valid_dg_mesh(Mesh<3>{cartoon_cylinder_extents,
+                               Spectral::bases::cartoon_cylinder_inner<>,
+                               Spectral::quadratures::cartoon_cylinder_inner<>},
+                       Element<3>{xi_refined_id_upper, neighbors,
+                                  topologies::cartoon_cylinder_inner}));
+  CHECK(
+      is_valid_dg_mesh(Mesh<3>{cartoon_cylinder_extents,
+                               Spectral::bases::cartoon_cylinder_inner<>,
+                               Spectral::quadratures::cartoon_cylinder_inner<>},
+                       Element<3>{eta_refined_id_lower, neighbors,
+                                  topologies::cartoon_cylinder_inner}));
+  CHECK_FALSE(
+      is_valid_dg_mesh(Mesh<3>{cartoon_cylinder_extents,
+                               Spectral::bases::cartoon_cylinder_inner<>,
+                               Spectral::quadratures::cartoon_cylinder_inner<>},
+                       Element<3>{zeta_refined_id_lower, neighbors,
+                                  topologies::cartoon_cylinder_inner}));
+  CHECK_FALSE(is_valid_dg_mesh(
+      Mesh<3>{cartoon_cylinder_extents,
+              Spectral::bases::cartoon_cylinder_inner<>,
+              Spectral::quadratures::cartoon_cylinder_inner<>},
+      Element<3>{root_id, neighbors, topologies::full_cylinder}));
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Domain.Structure.IsValidDgMesh", "[Domain][Unit]") {
+  test_1d();
+  test_2d();
+  test_3d();
+}
+}  // namespace domain

--- a/tests/Unit/Evolution/Ader/Test_Matrices.cpp
+++ b/tests/Unit/Evolution/Ader/Test_Matrices.cpp
@@ -284,13 +284,16 @@ void test_predictor_inverse_temporal_matrix() {
   for (size_t i = Spectral::minimum_number_of_points<
            Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto>;
        i <=
-       std::min(Spectral::maximum_number_of_points<Spectral::Basis::Legendre>,
-                12_st);
+       std::min(
+           Spectral::maximum_number_of_points<
+               Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto>,
+           12_st);
 
        /*The maximum number of allowed collocation points is given by
-       `Spectral::maximum_number_of_points<Spectral::Basis::Legendre>`, but
-       the matrices corresponding to numbers of points above 12 are not
-       tested, because we only derived the expected matrices up to 12 points.*/
+       `Spectral::maximum_number_of_points<Spectral::Basis::Legendre,
+       Spectral::Quadrature::GaussLobatto>`, but the matrices corresponding to
+       numbers of points above 12 are not tested, because we only derived the
+       expected matrices up to 12 points.*/
        ++i) {
     perform_check(i);
   }

--- a/tests/Unit/Evolution/DgSubcell/Test_Mesh.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_Mesh.cpp
@@ -58,7 +58,8 @@ template <Spectral::Basis BasisType, Spectral::Quadrature QuadratureType>
 void test_mesh() {
   constexpr size_t min_num_pts =
       Spectral::minimum_number_of_points<BasisType, QuadratureType>;
-  constexpr size_t max_num_pts = Spectral::maximum_number_of_points<BasisType>;
+  constexpr size_t max_num_pts =
+      Spectral::maximum_number_of_points<BasisType, QuadratureType>;
 #ifdef SPECTRE_DEBUG
   CHECK_THROWS_WITH(
       evolution::dg::subcell::fd::dg_mesh(

--- a/tests/Unit/Evolution/DgSubcell/Test_PerssonTci.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_PerssonTci.cpp
@@ -116,8 +116,10 @@ void test_persson() {
   // We lower the maximum number of 1d points in 3d in order to reduce total
   // test runtime.
   const size_t maximum_number_of_points_1d =
-      Dim == 3 ? 7
-               : Spectral::maximum_number_of_points<Spectral::Basis::Legendre>;
+      Dim == 3
+          ? 7
+          : Spectral::maximum_number_of_points<
+                Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto>;
   for (const double persson_exponent : {1.0, 10.0}) {
     for (size_t num_pts_1d = 4; num_pts_1d < maximum_number_of_points_1d;
          ++num_pts_1d) {

--- a/tests/Unit/Evolution/DgSubcell/Test_RdmpTci.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_RdmpTci.cpp
@@ -137,8 +137,10 @@ void test_rdmp() {
   // We lower the maximum number of 1d points in 3d in order to reduce total
   // test runtime.
   const size_t maximum_number_of_points_1d =
-      Dim == 3 ? 7
-               : Spectral::maximum_number_of_points<Spectral::Basis::Legendre>;
+      Dim == 3
+          ? 7
+          : Spectral::maximum_number_of_points<
+                Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto>;
   for (size_t num_pts_1d = 2; num_pts_1d < maximum_number_of_points_1d;
        ++num_pts_1d) {
     test_rdmp_impl<Dim>(past_max_values, past_min_values, 1.0e-4, 1.0e-3,

--- a/tests/Unit/Evolution/DgSubcell/Test_TwoMeshRdmpTci.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_TwoMeshRdmpTci.cpp
@@ -100,8 +100,10 @@ void test_two_mesh_rdmp() {
   // We lower the maximum number of 1d points in 3d in order to reduce total
   // test runtime.
   const size_t maximum_number_of_points_1d =
-      Dim == 3 ? 7
-               : Spectral::maximum_number_of_points<Spectral::Basis::Legendre>;
+      Dim == 3
+          ? 7
+          : Spectral::maximum_number_of_points<
+                Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto>;
   for (size_t num_pts_1d = 4; num_pts_1d < maximum_number_of_points_1d;
        ++num_pts_1d) {
     test_two_mesh_rdmp_impl<Dim>(num_pts_1d, 0, 1.0e-4, 1.0e-3, 1);

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_Krivodonova.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Limiters/Test_Krivodonova.cpp
@@ -125,9 +125,8 @@ void test_limiting_two_neighbors() {
   using Limiter = Krivodonova<dim, tmpl::list<ScalarTag<0>, VectorTag<dim, 0>>>;
   // Use non-unity but close alpha values to make the math easier but still
   // test thoroughly.
-  Limiter krivodonova{
-      make_array<Spectral::maximum_number_of_points<Spectral::Basis::Legendre>>(
-          0.99)};
+  Limiter krivodonova{make_array<Spectral::maximum_number_of_points<
+      Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto>>(0.99)};
 
   NeighborData<dim, typename Limiter::PackagedData> neighbor_data{};
 
@@ -262,9 +261,8 @@ void test_limiting_different_values_different_tensors() {
   using Limiter = Krivodonova<dim, tmpl::list<ScalarTag<0>, VectorTag<dim, 0>>>;
   // Use non-unity but close alpha values to make the math easier but still
   // test thoroughly.
-  Limiter krivodonova{
-      make_array<Spectral::maximum_number_of_points<Spectral::Basis::Legendre>>(
-          0.99)};
+  const Limiter krivodonova{make_array<Spectral::maximum_number_of_points<
+      Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto>>(0.99)};
 
   NeighborData<dim, typename Limiter::PackagedData> neighbor_data{};
 
@@ -320,7 +318,9 @@ void run() {
   INFO("Testing 1d limiter");
   for (size_t order = Spectral::minimum_number_of_points<
            Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto>;
-       order < Spectral::maximum_number_of_points<Spectral::Basis::Legendre>;
+       order <
+       Spectral::maximum_number_of_points<Spectral::Basis::Legendre,
+                                          Spectral::Quadrature::GaussLobatto>;
        ++order) {
     test_package_data(order);
   }
@@ -819,9 +819,8 @@ void test_limiting_different_values_different_tensors() {
   using Limiter = Krivodonova<dim, tmpl::list<ScalarTag<0>, VectorTag<dim, 0>>>;
   // Use non-unity but close alpha values to make the math easier but still
   // test thoroughly.
-  Limiter krivodonova{
-      make_array<Spectral::maximum_number_of_points<Spectral::Basis::Legendre>>(
-          0.99)};
+  const Limiter krivodonova{make_array<Spectral::maximum_number_of_points<
+      Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto>>(0.99)};
 
   NeighborData<dim, typename Limiter::PackagedData> neighbor_data{};
 
@@ -923,9 +922,8 @@ void run() {
   using Limiter = Krivodonova<dim, tmpl::list<ScalarTag<0>>>;
   // Use non-unity but close alpha values to make the math easier but still
   // test thoroughly.
-  Limiter krivodonova{
-      make_array<Spectral::maximum_number_of_points<Spectral::Basis::Legendre>>(
-          0.99)};
+  Limiter krivodonova{make_array<Spectral::maximum_number_of_points<
+      Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto>>(0.99)};
 
   NeighborData<dim, typename Limiter::PackagedData> neighbor_data{};
 
@@ -2553,9 +2551,8 @@ void test_limiting_different_values_different_tensors() {
   using Limiter = Krivodonova<dim, tmpl::list<ScalarTag<0>, VectorTag<dim, 0>>>;
   // Use non-unity but close alpha values to make the math easier but still
   // test thoroughly.
-  Limiter krivodonova{
-      make_array<Spectral::maximum_number_of_points<Spectral::Basis::Legendre>>(
-          0.99)};
+  const Limiter krivodonova{make_array<Spectral::maximum_number_of_points<
+      Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto>>(0.99)};
 
   NeighborData<dim, typename Limiter::PackagedData> neighbor_data{};
 
@@ -2786,9 +2783,8 @@ void run() {
   using Limiter = Krivodonova<dim, tmpl::list<ScalarTag<0>, VectorTag<dim, 0>>>;
   // Use non-unity but close alpha values to make the math easier but still
   // test thoroughly.
-  Limiter krivodonova{
-      make_array<Spectral::maximum_number_of_points<Spectral::Basis::Legendre>>(
-          0.99)};
+  Limiter krivodonova{make_array<Spectral::maximum_number_of_points<
+      Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto>>(0.99)};
 
   NeighborData<dim, typename Limiter::PackagedData> neighbor_data{};
 

--- a/tests/Unit/Helpers/NumericalAlgorithms/Spectral/PolynomialTestFunctions.cpp
+++ b/tests/Unit/Helpers/NumericalAlgorithms/Spectral/PolynomialTestFunctions.cpp
@@ -77,7 +77,7 @@ void test_orthogonal_polynomial() {
   const auto xi_target = make_with_random_values<DataVector>(
       make_not_null(&generator), make_not_null(&xi_distribution), 5_st);
   for (size_t n = Spectral::minimum_number_of_points<basis, quadrature>;
-       n <= Spectral::maximum_number_of_points<basis>; ++n) {
+       n <= Spectral::maximum_number_of_points<basis, quadrature>; ++n) {
     const DataVector& xi = Spectral::collocation_points<basis, quadrature>(n);
     const Matrix& dm = Spectral::differentiation_matrix<basis, quadrature>(n);
     const DataVector& integration_weights =

--- a/tests/Unit/Helpers/PointwiseFunctions/AnalyticSolutions/FirstOrderEllipticSolutionsTestHelpers.hpp
+++ b/tests/Unit/Helpers/PointwiseFunctions/AnalyticSolutions/FirstOrderEllipticSolutionsTestHelpers.hpp
@@ -226,7 +226,9 @@ void verify_smooth_solution(
     PackageFluxesArgs&& package_fluxes_args) {
   INFO("Verify smooth solution");
   const size_t max_points = std::min(
-      Spectral::maximum_number_of_points<Spectral::Basis::Legendre>, 12_st);
+      Spectral::maximum_number_of_points<Spectral::Basis::Legendre,
+                                         Spectral::Quadrature::GaussLobatto>,
+      12_st);
   for (size_t num_points = Spectral::minimum_number_of_points<
            Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto>;
        num_points <= max_points; num_points++) {
@@ -264,7 +266,9 @@ void verify_solution_with_power_law_convergence(
     const double tolerance_offset, const double tolerance_pow) {
   INFO("Verify solution with power-law convergence");
   const size_t max_points = std::min(
-      Spectral::maximum_number_of_points<Spectral::Basis::Legendre>, 12_st);
+      Spectral::maximum_number_of_points<Spectral::Basis::Legendre,
+                                         Spectral::Quadrature::GaussLobatto>,
+      12_st);
   for (size_t num_points = Spectral::minimum_number_of_points<
            Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto>;
        num_points <= max_points; num_points++) {

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Filters/Test_Hypercube.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Filters/Test_Hypercube.cpp
@@ -320,8 +320,9 @@ void test_apply_in_volume() {
 
   const size_t max_pts =
       BasisType == Spectral::Basis::Fourier
-          ? Spectral::maximum_number_of_points<BasisType> / (3 * Dim)
-          : Spectral::maximum_number_of_points<BasisType> / Dim;
+          ? Spectral::maximum_number_of_points<BasisType, QuadratureType> /
+                (3 * Dim)
+          : Spectral::maximum_number_of_points<BasisType, QuadratureType> / Dim;
   for (size_t num_pts =
            Spectral::minimum_number_of_points<BasisType, QuadratureType>;
        num_pts < max_pts; ++num_pts) {
@@ -366,8 +367,9 @@ void test_apply_on_boundary() {
 
   const size_t max_pts =
       BasisType == Spectral::Basis::Fourier
-          ? Spectral::maximum_number_of_points<BasisType> / (3 * Dim)
-          : Spectral::maximum_number_of_points<BasisType> / Dim;
+          ? Spectral::maximum_number_of_points<BasisType, QuadratureType> /
+                (3 * Dim)
+          : Spectral::maximum_number_of_points<BasisType, QuadratureType> / Dim;
   for (size_t num_pts =
            Spectral::minimum_number_of_points<BasisType, QuadratureType>;
        num_pts < max_pts; ++num_pts) {

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_CoefficientTransforms.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_CoefficientTransforms.cpp
@@ -103,7 +103,7 @@ template <typename ModalVectorType, typename NodalVectorType,
           typename Generator>
 void test_1d(const gsl::not_null<Generator*> generator) {
   UniformCustomDistribution<size_t> dist{
-      1, Spectral::maximum_number_of_points<Basis> - 1};
+      1, Spectral::maximum_number_of_points<Basis, Quadrature> - 1};
   const size_t order = dist(*generator);
   // Start at 1st order so we are independent of the minimum number of
   // coefficients.
@@ -126,7 +126,7 @@ void test_2d(const gsl::not_null<Generator*> generator) {
   // Start at one higher order so we can drop one order in the y-direction.
   UniformCustomDistribution<size_t> dist{
       Spectral::minimum_number_of_points<Basis, Quadrature> + 1,
-      Spectral::maximum_number_of_points<Basis> - 1};
+      Spectral::maximum_number_of_points<Basis, Quadrature> - 1};
   const size_t order = dist(*generator);
   CAPTURE(order);
   const Mesh<2> mesh({{order + 1, order}}, Basis, Quadrature);
@@ -152,7 +152,7 @@ void test_3d(const gsl::not_null<Generator*> generator) {
   // two in z-direction.
   UniformCustomDistribution<size_t> dist{
       Spectral::minimum_number_of_points<Basis, Quadrature> + 2,
-      Spectral::maximum_number_of_points<Basis> - 2};
+      Spectral::maximum_number_of_points<Basis, Quadrature> - 2};
   const size_t order = dist(*generator);
   CAPTURE(order);
   const Mesh<3> mesh({{order + 1, order, order - 1}}, Basis, Quadrature);

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_DefiniteIntegral.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_DefiniteIntegral.cpp
@@ -355,7 +355,8 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.DefiniteIntegral",
       Spectral::minimum_number_of_points<Spectral::Basis::Legendre,
                                          Spectral::Quadrature::GaussLobatto>;
   constexpr size_t max_extents =
-      Spectral::maximum_number_of_points<Spectral::Basis::Legendre>;
+      Spectral::maximum_number_of_points<Spectral::Basis::Legendre,
+                                         Spectral::Quadrature::GaussLobatto>;
   for (size_t n0 = min_extents; n0 <= max_extents; ++n0) {
     test_definite_integral_1d(Mesh<1>{n0, Spectral::Basis::Legendre,
                                       Spectral::Quadrature::GaussLobatto});
@@ -425,7 +426,8 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.DefiniteIntegral",
       Spectral::minimum_number_of_points<Spectral::Basis::FiniteDifference,
                                          Spectral::Quadrature::CellCentered>;
   constexpr size_t max_extents_fd =
-    Spectral::maximum_number_of_points<Spectral::Basis::FiniteDifference>;
+      Spectral::maximum_number_of_points<Spectral::Basis::FiniteDifference,
+                                         Spectral::Quadrature::CellCentered>;
   for (size_t n0 = min_extents_fd; n0 <= max_extents_fd; ++n0) {
     test_midpoint_integral_1d(Mesh<1>{n0, Spectral::Basis::FiniteDifference,
                                       Spectral::Quadrature::CellCentered});

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Divergence.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_Divergence.cpp
@@ -189,11 +189,19 @@ void test_divergence() {
   TestHelpers::db::test_prefix_tag<Tags::div<TensorTag>>("div(Flux1)");
 
   const size_t n0 =
-      Spectral::maximum_number_of_points<Spectral::Basis::Legendre> / 2;
+      Spectral::maximum_number_of_points<Spectral::Basis::Legendre,
+                                         Spectral::Quadrature::GaussLobatto> /
+      2;
   const size_t n1 =
-      Spectral::maximum_number_of_points<Spectral::Basis::Legendre> / 2 + 1;
+      Spectral::maximum_number_of_points<Spectral::Basis::Legendre,
+                                         Spectral::Quadrature::GaussLobatto> /
+          2 +
+      1;
   const size_t n2 =
-      Spectral::maximum_number_of_points<Spectral::Basis::Legendre> / 2 - 1;
+      Spectral::maximum_number_of_points<Spectral::Basis::Legendre,
+                                         Spectral::Quadrature::GaussLobatto> /
+          2 -
+      1;
   const Mesh<1> mesh_1d{
       {{n0}}, Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto};
   const Mesh<2> mesh_2d{{{n0, n1}},
@@ -298,11 +306,19 @@ void test_divergence_compute_item_impl(
 
 void test_divergence_compute() {
   const size_t n0 =
-      Spectral::maximum_number_of_points<Spectral::Basis::Legendre> / 2;
+      Spectral::maximum_number_of_points<Spectral::Basis::Legendre,
+                                         Spectral::Quadrature::GaussLobatto> /
+      2;
   const size_t n1 =
-      Spectral::maximum_number_of_points<Spectral::Basis::Legendre> / 2 + 1;
+      Spectral::maximum_number_of_points<Spectral::Basis::Legendre,
+                                         Spectral::Quadrature::GaussLobatto> /
+          2 +
+      1;
   const size_t n2 =
-      Spectral::maximum_number_of_points<Spectral::Basis::Legendre> / 2 - 1;
+      Spectral::maximum_number_of_points<Spectral::Basis::Legendre,
+                                         Spectral::Quadrature::GaussLobatto> /
+          2 -
+      1;
   const Mesh<1> mesh_1d{
       {{n0}}, Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto};
   const Mesh<2> mesh_2d{{{n0, n1}},
@@ -682,11 +698,19 @@ void test_cartoon_chooser() {
 
   // With non-cartoon
   const size_t n0 =
-      Spectral::maximum_number_of_points<Spectral::Basis::Legendre> / 2;
+      Spectral::maximum_number_of_points<Spectral::Basis::Legendre,
+                                         Spectral::Quadrature::GaussLobatto> /
+      2;
   const size_t n1 =
-      Spectral::maximum_number_of_points<Spectral::Basis::Legendre> / 2 + 1;
+      Spectral::maximum_number_of_points<Spectral::Basis::Legendre,
+                                         Spectral::Quadrature::GaussLobatto> /
+          2 +
+      1;
   const size_t n2 =
-      Spectral::maximum_number_of_points<Spectral::Basis::Legendre> / 2 - 1;
+      Spectral::maximum_number_of_points<Spectral::Basis::Legendre,
+                                         Spectral::Quadrature::GaussLobatto> /
+          2 -
+      1;
 
   const Mesh<3> mesh_lgl{{{n0, n1, n2}},
                          Spectral::Basis::Legendre,

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_IndefiniteIntegral.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_IndefiniteIntegral.cpp
@@ -60,7 +60,7 @@ template <typename VectorType, Spectral::Basis BasisType,
           Spectral::Quadrature QuadratureType>
 void test_zero_bc() {
   const size_t min_pts = 2;
-  REQUIRE(5 <= Spectral::maximum_number_of_points<BasisType>);
+  REQUIRE(5 <= Spectral::maximum_number_of_points<BasisType, QuadratureType>);
 
   MAKE_GENERATOR(generator);
   UniformCustomDistribution<

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_MeanValue.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_MeanValue.cpp
@@ -29,7 +29,8 @@ void test_mean_value() {
       Spectral::minimum_number_of_points<Spectral::Basis::Legendre,
                                          Spectral::Quadrature::GaussLobatto>;
   constexpr size_t max_extents =
-      Spectral::maximum_number_of_points<Spectral::Basis::Legendre>;
+      Spectral::maximum_number_of_points<Spectral::Basis::Legendre,
+                                         Spectral::Quadrature::GaussLobatto>;
   for (size_t nx = min_extents; nx <= max_extents; ++nx) {
     for (size_t ny = min_extents; ny <= max_extents; ++ny) {
       for (size_t nz = min_extents; nz <= max_extents; ++nz) {
@@ -61,7 +62,8 @@ void test_mean_value_on_boundary() {
       Spectral::minimum_number_of_points<Spectral::Basis::Legendre,
                                          Spectral::Quadrature::GaussLobatto>;
   constexpr size_t max_extents =
-      Spectral::maximum_number_of_points<Spectral::Basis::Legendre>;
+      Spectral::maximum_number_of_points<Spectral::Basis::Legendre,
+                                         Spectral::Quadrature::GaussLobatto>;
   for (size_t nx = min_extents; nx <= max_extents; ++nx) {
     for (size_t ny = min_extents; ny <= max_extents; ++ny) {
       for (size_t nz = min_extents; nz <= max_extents; ++nz) {
@@ -180,7 +182,8 @@ void test_mean_value_on_boundary_1d() {
       Spectral::minimum_number_of_points<Spectral::Basis::Legendre,
                                          Spectral::Quadrature::GaussLobatto>;
   constexpr size_t max_extents =
-      Spectral::maximum_number_of_points<Spectral::Basis::Legendre>;
+      Spectral::maximum_number_of_points<Spectral::Basis::Legendre,
+                                         Spectral::Quadrature::GaussLobatto>;
   for (size_t nx = min_extents; nx < max_extents; ++nx) {
     const Mesh<1> mesh{nx, Spectral::Basis::Legendre,
                        Spectral::Quadrature::GaussLobatto};

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
@@ -2073,7 +2073,9 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.LogicalDerivs",
       Spectral::minimum_number_of_points<Spectral::Basis::Legendre,
                                          Spectral::Quadrature::GaussLobatto>;
   constexpr size_t max_points =
-      Spectral::maximum_number_of_points<Spectral::Basis::Legendre> / 2;
+      Spectral::maximum_number_of_points<Spectral::Basis::Legendre,
+                                         Spectral::Quadrature::GaussLobatto> /
+      2;
   for (size_t n0 = min_points; n0 <= max_points; ++n0) {
     // To keep test time reasonable we don't check all possible values.
     if (n0 > 6 and n0 != max_points) {
@@ -2251,11 +2253,19 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.PartialDerivs",
   test_partial_derivatives_hollow_cylinder<two_vars<DataVector, 3>,
                                            one_var<DataVector, 3>>();
   const size_t n0 =
-      Spectral::maximum_number_of_points<Spectral::Basis::Legendre> / 2;
+      Spectral::maximum_number_of_points<Spectral::Basis::Legendre,
+                                         Spectral::Quadrature::GaussLobatto> /
+      2;
   const size_t n1 =
-      Spectral::maximum_number_of_points<Spectral::Basis::Legendre> / 2 + 1;
+      Spectral::maximum_number_of_points<Spectral::Basis::Legendre,
+                                         Spectral::Quadrature::GaussLobatto> /
+          2 +
+      1;
   const size_t n2 =
-      Spectral::maximum_number_of_points<Spectral::Basis::Legendre> / 2 - 1;
+      Spectral::maximum_number_of_points<Spectral::Basis::Legendre,
+                                         Spectral::Quadrature::GaussLobatto> /
+          2 -
+      1;
   const Mesh<1> mesh_1d{n0, Spectral::Basis::Legendre,
                         Spectral::Quadrature::GaussLobatto};
   test_partial_derivatives_1d<two_vars<DataVector, 1>>(mesh_1d);

--- a/tests/Unit/NumericalAlgorithms/Spectral/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Spectral/CMakeLists.txt
@@ -29,6 +29,7 @@ set(LIBRARY_SOURCES
   Test_IntegrationMatrix.cpp
   Test_InterpolationMatrix.cpp
   Test_InterpolationWeights.cpp
+  Test_IsValidDgMesh.cpp
   Test_Legendre.cpp
   Test_LegendreGauss.cpp
   Test_LegendreGaussLobatto.cpp

--- a/tests/Unit/NumericalAlgorithms/Spectral/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Spectral/CMakeLists.txt
@@ -32,6 +32,7 @@ set(LIBRARY_SOURCES
   Test_Legendre.cpp
   Test_LegendreGauss.cpp
   Test_LegendreGaussLobatto.cpp
+  Test_Limits.cpp
   Test_LinearFilterMatrix.cpp
   Test_LogicalCoordinates.cpp
   Test_Mesh.cpp

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_BasisFunctionNormalizationSquare.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_BasisFunctionNormalizationSquare.cpp
@@ -22,7 +22,7 @@ void test() {
   CAPTURE(basis);
   CAPTURE(quadrature);
   for (size_t n = minimum_number_of_points<basis, quadrature>;
-       n <= maximum_number_of_points<basis>; ++n) {
+       n <= maximum_number_of_points<basis, quadrature>; ++n) {
     CAPTURE(n);
     const auto& [xi, w] =
         compute_collocation_points_and_weights<basis, quadrature>(n);
@@ -47,7 +47,7 @@ void test_two_index() {
   CAPTURE(basis);
   CAPTURE(quadrature);
   for (size_t n = minimum_number_of_points<basis, quadrature>;
-       n <= maximum_number_of_points<basis>; ++n) {
+       n <= maximum_number_of_points<basis, quadrature>; ++n) {
     CAPTURE(n);
     const auto& [xi, w] =
         compute_collocation_points_and_weights<basis, quadrature>(n);

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_CollocationPointsAndWeights.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_CollocationPointsAndWeights.cpp
@@ -20,7 +20,7 @@ void test() {
   CAPTURE(basis);
   CAPTURE(quadrature);
   for (size_t n = minimum_number_of_points<basis, quadrature>;
-       n <= maximum_number_of_points<basis>; ++n) {
+       n <= maximum_number_of_points<basis, quadrature>; ++n) {
     CAPTURE(n);
     const auto& [xi, w] =
         compute_collocation_points_and_weights<basis, quadrature>(n);
@@ -49,7 +49,7 @@ void test_radial_zernike() {
   CAPTURE(quadrature);
   const Approx custom_approx = Approx::custom().epsilon(1.e-12).scale(1.0);
   for (size_t n = minimum_number_of_points<basis, quadrature>;
-       n <= maximum_number_of_points<basis>; ++n) {
+       n <= maximum_number_of_points<basis, quadrature>; ++n) {
     CAPTURE(n);
     const auto& [xi, w] =
         compute_collocation_points_and_weights<basis, quadrature>(n);

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_DifferentiationMatrix.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_DifferentiationMatrix.cpp
@@ -23,7 +23,7 @@ void test() {
   CAPTURE(quadrature);
   const auto custom_approx = Approx::custom().epsilon(5.0e-13).scale(1.0);
   for (size_t n = minimum_number_of_points<basis, quadrature>;
-       n <= maximum_number_of_points<basis>; ++n) {
+       n <= maximum_number_of_points<basis, quadrature>; ++n) {
     CAPTURE(n);
     const Matrix& m = differentiation_matrix<basis, quadrature>(n);
     const DataVector one{n, 1.0};
@@ -39,7 +39,7 @@ void test_with_parity() {
   CAPTURE(quadrature);
   const auto custom_approx = Approx::custom().epsilon(5.0e-13).scale(1.0);
   for (size_t n = minimum_number_of_points<basis, quadrature>;
-       n <= maximum_number_of_points<basis>; ++n) {
+       n <= maximum_number_of_points<basis, quadrature>; ++n) {
     CAPTURE(n);
     const Matrix& m_even =
         differentiation_matrix<basis, quadrature>(n, Parity::Even);

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_Filtering.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_Filtering.cpp
@@ -33,7 +33,8 @@ void test_exponential_filter(const double alpha, const unsigned half_power,
   CAPTURE(eps);
   for (size_t num_pts =
            Spectral::minimum_number_of_points<BasisType, QuadratureType>;
-       num_pts <= Spectral::maximum_number_of_points<BasisType>; ++num_pts) {
+       num_pts <= Spectral::maximum_number_of_points<BasisType, QuadratureType>;
+       ++num_pts) {
     CAPTURE(num_pts);
     const Mesh<1> mesh{num_pts, BasisType, QuadratureType};
     ModalVector initial_modal_coeffs(num_pts);
@@ -152,7 +153,8 @@ void test_zero_lowest_modes() {
   CAPTURE(QuadratureType);
   for (size_t num_pts =
            Spectral::minimum_number_of_points<BasisType, QuadratureType>;
-       num_pts <= Spectral::maximum_number_of_points<BasisType>; ++num_pts) {
+       num_pts <= Spectral::maximum_number_of_points<BasisType, QuadratureType>;
+       ++num_pts) {
     CAPTURE(num_pts);
     for (size_t number_of_modes_to_filter = 0;
          number_of_modes_to_filter < num_pts; ++number_of_modes_to_filter) {
@@ -189,7 +191,8 @@ void test_zero_lowest_modes_zernike_b1() {
   const Approx local_approx = Approx::custom().epsilon(1.0e-12).scale(1.0);
   for (size_t num_pts = 2;
        num_pts <=
-       Spectral::maximum_number_of_points<Spectral::Basis::ZernikeB1>;
+       Spectral::maximum_number_of_points<
+           Spectral::Basis::ZernikeB1, Spectral::Quadrature::GaussRadauUpper>;
        ++num_pts) {
     CAPTURE(num_pts);
     const Mesh<1> mesh{num_pts, Spectral::Basis::ZernikeB1,
@@ -246,7 +249,8 @@ void test_zero_highest_modes() {
   CAPTURE(QuadratureType);
   for (size_t num_pts =
            Spectral::minimum_number_of_points<BasisType, QuadratureType>;
-       num_pts <= Spectral::maximum_number_of_points<BasisType>; ++num_pts) {
+       num_pts <= Spectral::maximum_number_of_points<BasisType, QuadratureType>;
+       ++num_pts) {
     CAPTURE(num_pts);
     // Zeroing modes is a round trip through the modal<->nodal transforms, so
     // the retained modes are reproduced and the dropped modes vanish to

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_IndefiniteIntegral.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_IndefiniteIntegral.cpp
@@ -66,12 +66,12 @@ void check_integration(const size_t min_pts, const size_t max_pts) {
 SPECTRE_TEST_CASE("Unit.NumericalAlgorithms.Spectral.IndefiniteIntegral",
                   "[NumericalAlgorithms][Spectral][Unit]") {
   check_integration<Basis::Chebyshev, Quadrature::GaussLobatto>(
-      2, maximum_number_of_points<Basis::Chebyshev>);
+      2, maximum_number_of_points<Basis::Chebyshev, Quadrature::GaussLobatto>);
   check_integration<Basis::Chebyshev, Quadrature::Gauss>(
-      2, maximum_number_of_points<Basis::Chebyshev>);
+      2, maximum_number_of_points<Basis::Chebyshev, Quadrature::Gauss>);
   check_integration<Basis::Legendre, Quadrature::GaussLobatto>(
-      2, maximum_number_of_points<Basis::Legendre>);
+      2, maximum_number_of_points<Basis::Legendre, Quadrature::GaussLobatto>);
   check_integration<Basis::Legendre, Quadrature::Gauss>(
-      2, maximum_number_of_points<Basis::Legendre>);
+      2, maximum_number_of_points<Basis::Legendre, Quadrature::Gauss>);
 }
 }  // namespace Spectral

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_IntegrationMatrix.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_IntegrationMatrix.cpp
@@ -22,7 +22,7 @@ void test() {
   CAPTURE(basis);
   CAPTURE(quadrature);
   for (size_t n = minimum_number_of_points<basis, quadrature>;
-       n <= maximum_number_of_points<basis>; ++n) {
+       n <= maximum_number_of_points<basis, quadrature>; ++n) {
     CAPTURE(n);
     const Matrix& m = integration_matrix<basis, quadrature>(n);
     if (UNLIKELY(n == 1)) {

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_InterpolationMatrix.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_InterpolationMatrix.cpp
@@ -31,7 +31,7 @@ void test(const DataVector& target_pts) {
                                  ? Approx::custom().epsilon(5.0e-12).scale(1.0)
                                  : Approx::custom().epsilon(5.0e-13).scale(1.0);
   for (size_t n = minimum_number_of_points<basis, quadrature>;
-       n <= maximum_number_of_points<basis>; ++n) {
+       n <= maximum_number_of_points<basis, quadrature>; ++n) {
     CAPTURE(n);
     // If target points are source points, matrix should be identity
     const DataVector xi = collocation_points<basis, quadrature>(n);
@@ -68,7 +68,8 @@ void test_zernike_b1(const DataVector& target_pts) {
   constexpr Quadrature quadrature = Quadrature::GaussRadauUpper;
   const size_t num_target_pts = target_pts.size();
   for (size_t num_points = minimum_number_of_points<basis, quadrature>;
-       num_points <= maximum_number_of_points<basis>; ++num_points) {
+       num_points <= maximum_number_of_points<basis, quadrature>;
+       ++num_points) {
     CAPTURE(num_points);
     const Approx custom_approx = Approx::custom().epsilon(5.0e-13).scale(1.0);
     const DataVector& xi = collocation_points<basis, quadrature>(num_points);

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_IsValidDgMesh.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_IsValidDgMesh.cpp
@@ -1,0 +1,412 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <random>
+#include <utility>
+#include <vector>
+
+#include "Framework/TestHelpers.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/IsValidDgMesh.hpp"
+#include "NumericalAlgorithms/Spectral/Limits.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Literals.hpp"
+
+namespace Spectral {
+namespace {
+constexpr auto i1_bases = std::array{Basis::Legendre, Basis::Chebyshev};
+constexpr auto i1_quadratures =
+    std::array{Quadrature::Gauss, Quadrature::GaussLobatto};
+
+size_t low_extent(const Basis basis, const Quadrature quadrature) {
+  return limits::min(basis, quadrature) - 1;
+}
+
+size_t high_extent(const Basis basis, const Quadrature quadrature) {
+  return limits::max(basis, quadrature) + 1;
+}
+
+size_t random_extent(const gsl::not_null<std::mt19937*> generator,
+                     const Basis basis, const Quadrature quadrature) {
+  const auto min = limits::min(basis, quadrature);
+  const auto max = limits::max(basis, quadrature);
+  if (max < min) {
+    // This could happen for an invalid basis and quadrature, so return max
+    // Otherwise the distribution will be invalid and, either throw, or
+    // return a value higher than 255 which triggers an ASSERT in Mesh
+    return max;
+  }
+  std::uniform_int_distribution<size_t> distrib(min, max);
+  if (quadrature == Quadrature::Equiangular and basis == Basis::Fourier) {
+    const size_t result = distrib(*generator);
+    return result % 2 == 0 ? result + 1 : result;
+  }
+  return distrib(*generator);
+}
+
+void test_1d(const gsl::not_null<std::mt19937*> generator) {
+  std::vector<std::pair<Basis, Quadrature>> valid_basis_and_quadratures;
+  valid_basis_and_quadratures.reserve(5);
+  valid_basis_and_quadratures.emplace_back(Basis::Fourier,
+                                           Quadrature::Equiangular);
+  for (const auto basis : i1_bases) {
+    for (const auto quadrature : i1_quadratures) {
+      valid_basis_and_quadratures.emplace_back(basis, quadrature);
+    }
+  }
+
+  for (const auto basis : all_bases()) {
+    if (basis == Basis::Uninitialized) {
+      continue;
+    }
+    CAPTURE(basis);
+    for (const auto quadrature : all_quadratures()) {
+      if (quadrature == Quadrature::Uninitialized) {
+        continue;
+      }
+      CAPTURE(quadrature);
+      CHECK_FALSE(is_valid_dg_mesh(
+          Mesh<1>(low_extent(basis, quadrature), basis, quadrature)));
+      CHECK_FALSE(is_valid_dg_mesh(
+          Mesh<1>(high_extent(basis, quadrature), basis, quadrature)));
+      if (alg::found(valid_basis_and_quadratures,
+                     std::pair{basis, quadrature})) {
+        CHECK(is_valid_dg_mesh(Mesh<1>(
+            random_extent(generator, basis, quadrature), basis, quadrature)));
+      } else {
+        CHECK_FALSE(is_valid_dg_mesh(Mesh<1>(
+            random_extent(generator, basis, quadrature), basis, quadrature)));
+      }
+    }
+  }
+  CHECK_FALSE(
+      is_valid_dg_mesh(Mesh<1>{4, Basis::Fourier, Quadrature::Equiangular}));
+}
+
+void test_2d(const gsl::not_null<std::mt19937*> generator) {
+  std::vector<std::pair<std::array<Basis, 2>, std::array<Quadrature, 2>>>
+      valid_basis_and_quadratures;
+  valid_basis_and_quadratures.reserve(27);
+  valid_basis_and_quadratures.emplace_back(bases::hypertorus<2>,
+                                           quadratures::hypertorus<2>);
+  valid_basis_and_quadratures.emplace_back(bases::spherical_surface,
+                                           quadratures::spherical_surface);
+  valid_basis_and_quadratures.emplace_back(bases::disk, quadratures::disk);
+  for (const auto i1_basis : i1_bases) {
+    for (const auto i1_quadrature : i1_quadratures) {
+      for (const auto another_i1_basis : i1_bases) {
+        for (const auto another_i1_quadrature : i1_quadratures) {
+          valid_basis_and_quadratures.emplace_back(
+              std::array{i1_basis, another_i1_basis},
+              std::array{i1_quadrature, another_i1_quadrature});
+        }
+      }
+      valid_basis_and_quadratures.emplace_back(
+          std::array{i1_basis, Basis::Fourier},
+          std::array{i1_quadrature, Quadrature::Equiangular});
+      valid_basis_and_quadratures.emplace_back(
+          std::array{Basis::Fourier, i1_basis},
+          std::array{Quadrature::Equiangular, i1_quadrature});
+    }
+  }
+
+  REQUIRE(valid_basis_and_quadratures.size() == 27);
+
+  std::vector<std::array<Basis, 2>> bases;
+  bases.reserve(100);
+  for (const auto xi_basis : all_bases()) {
+    if (xi_basis == Basis::Uninitialized) {
+      continue;
+    }
+    for (const auto eta_basis : all_bases()) {
+      if (eta_basis == Basis::Uninitialized) {
+        continue;
+      }
+      bases.emplace_back(std::array{xi_basis, eta_basis});
+    }
+  }
+  REQUIRE(bases.size() == 100);
+
+  std::vector<std::array<Quadrature, 2>> quadratures;
+  quadratures.reserve(81);
+  for (const auto xi_quadrature : all_quadratures()) {
+    if (xi_quadrature == Quadrature::Uninitialized) {
+      continue;
+    }
+    for (const auto eta_quadrature : all_quadratures()) {
+      if (eta_quadrature == Quadrature::Uninitialized) {
+        continue;
+      }
+      quadratures.emplace_back(std::array{xi_quadrature, eta_quadrature});
+    }
+  }
+  REQUIRE(quadratures.size() == 81);
+
+  for (const auto basis : bases) {
+    CAPTURE(basis);
+    for (const auto quadrature : quadratures) {
+      CAPTURE(quadrature);
+      CHECK_FALSE(is_valid_dg_mesh(
+          Mesh<2>(std::array{low_extent(basis[0], quadrature[0]), 5_st}, basis,
+                  quadrature)));
+      CHECK_FALSE(is_valid_dg_mesh(
+          Mesh<2>(std::array{5_st, high_extent(basis[1], quadrature[1])}, basis,
+                  quadrature)));
+      if (alg::found(valid_basis_and_quadratures,
+                     std::pair{basis, quadrature})) {
+        if (basis == bases::spherical_surface) {
+          const size_t nth = random_extent(generator, basis[0], quadrature[0]);
+          CHECK(is_valid_dg_mesh(
+              Mesh<2>(std::array{nth, 2 * nth - 1}, basis, quadrature)));
+        } else if (basis == bases::disk) {
+          const size_t nr = random_extent(generator, basis[0], quadrature[0]);
+          CHECK(is_valid_dg_mesh(
+              Mesh<2>(std::array{nr, 4 * nr - 3}, basis, quadrature)));
+        } else {
+          CHECK(is_valid_dg_mesh(Mesh<2>(
+              std::array{random_extent(generator, basis[0], quadrature[0]),
+                         random_extent(generator, basis[1], quadrature[1])},
+              basis, quadrature)));
+        }
+      } else {
+        CHECK_FALSE(is_valid_dg_mesh(Mesh<2>(
+            std::array{random_extent(generator, basis[0], quadrature[0]),
+                       random_extent(generator, basis[1], quadrature[1])},
+            basis, quadrature)));
+      }
+    }
+  }
+  CHECK_FALSE(
+      is_valid_dg_mesh(Mesh<2>{4, Basis::Fourier, Quadrature::Equiangular}));
+  CHECK_FALSE(is_valid_dg_mesh(Mesh<2>{
+      {4_st, 9_st}, bases::spherical_surface, quadratures::spherical_surface}));
+  CHECK_FALSE(
+      is_valid_dg_mesh(Mesh<2>{{4_st, 9_st}, bases::disk, quadratures::disk}));
+}
+
+void test_3d(const gsl::not_null<std::mt19937*> generator) {
+  std::vector<std::pair<std::array<Basis, 3>, std::array<Quadrature, 3>>>
+      valid_basis_and_quadratures;
+  valid_basis_and_quadratures.reserve(164);
+  valid_basis_and_quadratures.emplace_back(bases::hypertorus<3>,
+                                           quadratures::hypertorus<3>);
+  valid_basis_and_quadratures.emplace_back(bases::full_sphere,
+                                           quadratures::full_sphere);
+  valid_basis_and_quadratures.emplace_back(bases::cartoon_sphere_inner,
+                                           quadratures::cartoon_sphere_inner);
+  valid_basis_and_quadratures.emplace_back(
+      std::array{Basis::ZernikeB1, Basis::HalfFourier, Basis::Cartoon},
+      std::array{Quadrature::GaussRadauUpper, Quadrature::Equiangular,
+                 Quadrature::AxialSymmetry});
+  for (const auto i1_basis : i1_bases) {
+    for (const auto i1_quadrature : i1_quadratures) {
+      for (const auto another_i1_basis : i1_bases) {
+        for (const auto another_i1_quadrature : i1_quadratures) {
+          for (const auto yet_another_i1_basis : i1_bases) {
+            for (const auto yet_another_i1_quadrature : i1_quadratures) {
+              valid_basis_and_quadratures.emplace_back(
+                  std::array{i1_basis, another_i1_basis, yet_another_i1_basis},
+                  std::array{i1_quadrature, another_i1_quadrature,
+                             yet_another_i1_quadrature});
+            }
+          }
+          valid_basis_and_quadratures.emplace_back(
+              std::array{i1_basis, another_i1_basis, Basis::Fourier},
+              std::array{i1_quadrature, another_i1_quadrature,
+                         Quadrature::Equiangular});
+          valid_basis_and_quadratures.emplace_back(
+              std::array{i1_basis, another_i1_basis, Basis::Cartoon},
+              std::array{i1_quadrature, another_i1_quadrature,
+                         Quadrature::AxialSymmetry});
+          valid_basis_and_quadratures.emplace_back(
+              std::array{i1_basis, Basis::Fourier, another_i1_basis},
+              std::array{i1_quadrature, Quadrature::Equiangular,
+                         another_i1_quadrature});
+          valid_basis_and_quadratures.emplace_back(
+              std::array{Basis::Fourier, i1_basis, another_i1_basis},
+              std::array{Quadrature::Equiangular, i1_quadrature,
+                         another_i1_quadrature});
+        }
+      }
+      valid_basis_and_quadratures.emplace_back(
+          std::array{i1_basis, Basis::Fourier, Basis::Fourier},
+          std::array{i1_quadrature, Quadrature::Equiangular,
+                     Quadrature::Equiangular});
+      valid_basis_and_quadratures.emplace_back(
+          std::array{Basis::Fourier, i1_basis, Basis::Fourier},
+          std::array{Quadrature::Equiangular, i1_quadrature,
+                     Quadrature::Equiangular});
+      valid_basis_and_quadratures.emplace_back(
+          std::array{Basis::Fourier, Basis::Fourier, i1_basis},
+          std::array{Quadrature::Equiangular, Quadrature::Equiangular,
+                     i1_quadrature});
+      valid_basis_and_quadratures.emplace_back(
+          std::array{i1_basis, Basis::SphericalHarmonic,
+                     Basis::SphericalHarmonic},
+          std::array{i1_quadrature, Quadrature::Gauss,
+                     Quadrature::Equiangular});
+      valid_basis_and_quadratures.emplace_back(
+          std::array{i1_basis, Basis::Cartoon, Basis::Cartoon},
+          std::array{i1_quadrature, Quadrature::SphericalSymmetry,
+                     Quadrature::SphericalSymmetry});
+      valid_basis_and_quadratures.emplace_back(
+          std::array{Basis::ZernikeB2, Basis::ZernikeB2, i1_basis},
+          std::array{Quadrature::GaussRadauUpper, Quadrature::Equiangular,
+                     i1_quadrature});
+      valid_basis_and_quadratures.emplace_back(
+          std::array{Basis::ZernikeB1, i1_basis, Basis::Cartoon},
+          std::array{Quadrature::GaussRadauUpper, i1_quadrature,
+                     Quadrature::AxialSymmetry});
+      valid_basis_and_quadratures.emplace_back(
+          std::array{i1_basis, Basis::HalfFourier, Basis::Cartoon},
+          std::array{i1_quadrature, Quadrature::Equiangular,
+                     Quadrature::AxialSymmetry});
+    }
+  }
+
+  REQUIRE(valid_basis_and_quadratures.size() == 164);
+
+  std::vector<std::array<Basis, 3>> bases;
+  bases.reserve(729);
+  for (const auto xi_basis : all_bases()) {
+    if (xi_basis == Basis::Uninitialized) {
+      continue;
+    }
+    for (const auto eta_basis : all_bases()) {
+      if (eta_basis == Basis::Uninitialized) {
+        continue;
+      }
+      for (const auto zeta_basis : all_bases()) {
+        if (zeta_basis == Basis::Uninitialized) {
+          continue;
+        }
+        bases.emplace_back(std::array{xi_basis, eta_basis, zeta_basis});
+      }
+    }
+  }
+  REQUIRE(bases.size() == 1000);
+
+  std::vector<std::array<Quadrature, 3>> quadratures;
+  quadratures.reserve(729);
+  for (const auto xi_quadrature : all_quadratures()) {
+    if (xi_quadrature == Quadrature::Uninitialized) {
+      continue;
+    }
+    for (const auto eta_quadrature : all_quadratures()) {
+      if (eta_quadrature == Quadrature::Uninitialized) {
+        continue;
+      }
+      for (const auto zeta_quadrature : all_quadratures()) {
+        if (zeta_quadrature == Quadrature::Uninitialized) {
+          continue;
+        }
+        quadratures.emplace_back(
+            std::array{xi_quadrature, eta_quadrature, zeta_quadrature});
+      }
+    }
+  }
+  REQUIRE(quadratures.size() == 729);
+
+  for (const auto basis : bases) {
+    CAPTURE(basis);
+    for (const auto quadrature : quadratures) {
+      CAPTURE(quadrature);
+      CHECK_FALSE(is_valid_dg_mesh(
+          Mesh<3>(std::array{low_extent(basis[0], quadrature[0]), 5_st, 5_st},
+                  basis, quadrature)));
+      CHECK_FALSE(is_valid_dg_mesh(
+          Mesh<3>(std::array{5_st, 5_st, high_extent(basis[1], quadrature[1])},
+                  basis, quadrature)));
+      if (alg::found(valid_basis_and_quadratures,
+                     std::pair{basis, quadrature})) {
+        if (basis[1] == Basis::SphericalHarmonic) {
+          const size_t nth = random_extent(generator, basis[1], quadrature[1]);
+          CHECK(is_valid_dg_mesh(Mesh<3>(
+              std::array{random_extent(generator, basis[0], quadrature[0]), nth,
+                         2 * nth - 1},
+              basis, quadrature)));
+        } else if (basis == bases::full_sphere) {
+          const size_t nr = random_extent(generator, basis[0], quadrature[0]);
+          CHECK(is_valid_dg_mesh(Mesh<3>(std::array{nr, 2 * nr - 1, 4 * nr - 3},
+                                         basis, quadrature)));
+        } else if (basis[0] == Basis::ZernikeB2) {
+          const size_t nr = random_extent(generator, basis[0], quadrature[0]);
+          CHECK(is_valid_dg_mesh(Mesh<3>(
+              std::array{nr, 4 * nr - 3,
+                         random_extent(generator, basis[2], quadrature[2])},
+              basis, quadrature)));
+        } else if (basis[2] == Basis::Cartoon) {
+          if (basis[1] == Basis::Cartoon) {
+            CHECK(is_valid_dg_mesh(Mesh<3>(
+                std::array{random_extent(generator, basis[0], quadrature[0]),
+                           1_st, 1_st},
+                basis, quadrature)));
+          } else {
+            CHECK(is_valid_dg_mesh(Mesh<3>(
+                std::array{random_extent(generator, basis[0], quadrature[0]),
+                           random_extent(generator, basis[1], quadrature[1]),
+                           1_st},
+                basis, quadrature)));
+          }
+        } else {
+          CHECK(is_valid_dg_mesh(Mesh<3>(
+              std::array{random_extent(generator, basis[0], quadrature[0]),
+                         random_extent(generator, basis[1], quadrature[1]),
+                         random_extent(generator, basis[2], quadrature[2])},
+              basis, quadrature)));
+        }
+      } else {
+        CHECK_FALSE(is_valid_dg_mesh(Mesh<3>(
+            std::array{random_extent(generator, basis[0], quadrature[0]),
+                       random_extent(generator, basis[1], quadrature[1]),
+                       random_extent(generator, basis[2], quadrature[2])},
+            basis, quadrature)));
+      }
+    }
+  }
+  CHECK_FALSE(
+      is_valid_dg_mesh(Mesh<3>{4_st, Basis::Fourier, Quadrature::Equiangular}));
+  CHECK_FALSE(is_valid_dg_mesh(
+      Mesh<3>{{4_st, 4_st, 9_st},
+              bases::spherical_shell<Basis::Legendre>,
+              quadratures::spherical_shell<Quadrature::GaussLobatto>}));
+  CHECK_FALSE(is_valid_dg_mesh(
+      Mesh<3>{{4_st, 9_st, 5_st},
+              bases::full_cylinder<Basis::Legendre>,
+              quadratures::full_cylinder<Quadrature::GaussLobatto>}));
+  CHECK_FALSE(is_valid_dg_mesh(Mesh<3>{
+      {4_st, 5_st, 9_st}, bases::full_sphere, quadratures::full_sphere}));
+  CHECK_FALSE(is_valid_dg_mesh(Mesh<3>{
+      {4_st, 7_st, 15_st}, bases::full_sphere, quadratures::full_sphere}));
+  CHECK_FALSE(is_valid_dg_mesh(
+      Mesh<3>{{4_st, 4_st, 4_st},
+              bases::cartoon_cylinder<Basis::Legendre>,
+              quadratures::cartoon_cylinder<Quadrature::GaussLobatto>}));
+  CHECK_FALSE(is_valid_dg_mesh(
+      Mesh<3>{{4_st, 4_st, 4_st},
+              bases::cartoon_cylinder_inner<Basis::Legendre>,
+              quadratures::cartoon_cylinder_inner<Quadrature::GaussLobatto>}));
+  CHECK_FALSE(is_valid_dg_mesh(
+      Mesh<3>{{4_st, 4_st, 1_st},
+              bases::cartoon_sphere<Basis::Legendre>,
+              quadratures::cartoon_sphere<Quadrature::GaussLobatto>}));
+  CHECK_FALSE(is_valid_dg_mesh(Mesh<3>{{4_st, 4_st, 1_st},
+                                       bases::cartoon_sphere_inner,
+                                       quadratures::cartoon_sphere_inner}));
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Spectral.IsValidDgMesh",
+                  "[NumericalAlgorithms][Unit]") {
+  MAKE_GENERATOR(generator);
+  test_1d(make_not_null(&generator));
+  test_2d(make_not_null(&generator));
+  test_3d(make_not_null(&generator));
+}
+}  // namespace Spectral

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_LegendreGaussLobatto.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_LegendreGaussLobatto.cpp
@@ -112,7 +112,9 @@ SPECTRE_TEST_CASE(
                    0.292042683679680, 0.224889342063126, 0.133305990851071,
                    1.0 / 45.0});
   }
-  if (Spectral::maximum_number_of_points<Spectral::Basis::Legendre> >= 20) {
+  if (Spectral::maximum_number_of_points<Spectral::Basis::Legendre,
+                                         Spectral::Quadrature::GaussLobatto> >=
+      20) {
     SECTION("Check 20 points") {
       test_points_and_weights(
           20,

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_Limits.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_Limits.cpp
@@ -1,0 +1,116 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/Limits.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+
+namespace Spectral {
+namespace {
+void test() {
+  static_assert(limits::min_spherical_harmonic_mode == 2);
+  static_assert(limits::max_spherical_harmonic_mode == 40);
+  static_assert(limits::max_fourier_mode == 40);
+  static_assert(limits::max_i1_polynomial_mode == 20);
+
+  static_assert(limits::max(Basis::Chebyshev, Quadrature::GaussLobatto) == 21);
+  static_assert(limits::max(Basis::Chebyshev, Quadrature::Gauss) == 21);
+  static_assert(limits::max(Basis::Legendre, Quadrature::GaussLobatto) == 21);
+  static_assert(limits::max(Basis::Legendre, Quadrature::Gauss) == 21);
+  static_assert(
+      limits::max(Basis::FiniteDifference, Quadrature::CellCentered) == 42);
+  static_assert(
+      limits::max(Basis::FiniteDifference, Quadrature::FaceCentered) == 42);
+  static_assert(limits::max(Basis::SphericalHarmonic, Quadrature::Gauss) == 41);
+  static_assert(
+      limits::max(Basis::SphericalHarmonic, Quadrature::Equiangular) == 81);
+  static_assert(limits::max(Basis::Fourier, Quadrature::Equiangular) == 81);
+  static_assert(limits::max(Basis::HalfFourier, Quadrature::Equiangular) == 41);
+  static_assert(limits::max(Basis::ZernikeB1, Quadrature::GaussRadauUpper) ==
+                21);
+  static_assert(limits::max(Basis::ZernikeB2, Quadrature::GaussRadauUpper) ==
+                21);
+  static_assert(limits::max(Basis::ZernikeB2, Quadrature::Equiangular) == 81);
+  static_assert(limits::max(Basis::ZernikeB3, Quadrature::GaussRadauUpper) ==
+                21);
+  static_assert(limits::max(Basis::ZernikeB3, Quadrature::Gauss) == 41);
+  static_assert(limits::max(Basis::ZernikeB3, Quadrature::Equiangular) == 81);
+  static_assert(limits::max(Basis::Cartoon, Quadrature::AxialSymmetry) == 1);
+  static_assert(limits::max(Basis::Cartoon, Quadrature::SphericalSymmetry) ==
+                1);
+  // Some invalid pairs should have a limit of 0
+  static_assert(
+      limits::max(Basis::SphericalHarmonic, Quadrature::GaussLobatto) == 0);
+
+  CHECK(limits::max(Basis::Chebyshev, Quadrature::GaussLobatto) == 21);
+  CHECK(limits::max(Basis::Chebyshev, Quadrature::Gauss) == 21);
+  CHECK(limits::max(Basis::Legendre, Quadrature::GaussLobatto) == 21);
+  CHECK(limits::max(Basis::Legendre, Quadrature::Gauss) == 21);
+  CHECK(limits::max(Basis::FiniteDifference, Quadrature::CellCentered) == 42);
+  CHECK(limits::max(Basis::FiniteDifference, Quadrature::FaceCentered) == 42);
+  CHECK(limits::max(Basis::SphericalHarmonic, Quadrature::Gauss) == 41);
+  CHECK(limits::max(Basis::SphericalHarmonic, Quadrature::Equiangular) == 81);
+  CHECK(limits::max(Basis::Fourier, Quadrature::Equiangular) == 81);
+  CHECK(limits::max(Basis::ZernikeB1, Quadrature::GaussRadauUpper) == 21);
+  CHECK(limits::max(Basis::ZernikeB2, Quadrature::GaussRadauUpper) == 21);
+  CHECK(limits::max(Basis::ZernikeB2, Quadrature::Equiangular) == 81);
+  CHECK(limits::max(Basis::ZernikeB3, Quadrature::GaussRadauUpper) == 21);
+  CHECK(limits::max(Basis::ZernikeB3, Quadrature::Gauss) == 41);
+  CHECK(limits::max(Basis::ZernikeB3, Quadrature::Equiangular) == 81);
+  CHECK(limits::max(Basis::Cartoon, Quadrature::AxialSymmetry) == 1);
+  CHECK(limits::max(Basis::Cartoon, Quadrature::SphericalSymmetry) == 1);
+  // Some invalid pairs should have a limit of 0
+  CHECK(limits::max(Basis::SphericalHarmonic, Quadrature::GaussLobatto) == 0);
+
+  static_assert(limits::min(Basis::Chebyshev, Quadrature::GaussLobatto) == 2);
+  static_assert(limits::min(Basis::Chebyshev, Quadrature::Gauss) == 1);
+  static_assert(limits::min(Basis::Legendre, Quadrature::GaussLobatto) == 2);
+  static_assert(limits::min(Basis::Legendre, Quadrature::Gauss) == 1);
+  static_assert(
+      limits::min(Basis::FiniteDifference, Quadrature::CellCentered) == 1);
+  static_assert(
+      limits::min(Basis::FiniteDifference, Quadrature::FaceCentered) == 2);
+  static_assert(limits::min(Basis::SphericalHarmonic, Quadrature::Gauss) == 3);
+  static_assert(
+      limits::min(Basis::SphericalHarmonic, Quadrature::Equiangular) == 5);
+  static_assert(limits::min(Basis::Fourier, Quadrature::Equiangular) == 1);
+  static_assert(limits::min(Basis::HalfFourier, Quadrature::Equiangular) == 1);
+  static_assert(limits::min(Basis::ZernikeB1, Quadrature::GaussRadauUpper) ==
+                1);
+  static_assert(limits::min(Basis::ZernikeB2, Quadrature::GaussRadauUpper) ==
+                1);
+  static_assert(limits::min(Basis::ZernikeB2, Quadrature::Equiangular) == 1);
+  static_assert(limits::min(Basis::ZernikeB3, Quadrature::GaussRadauUpper) ==
+                2);
+  static_assert(limits::min(Basis::ZernikeB3, Quadrature::Gauss) == 3);
+  static_assert(limits::min(Basis::ZernikeB3, Quadrature::Equiangular) == 5);
+  static_assert(limits::min(Basis::Cartoon, Quadrature::AxialSymmetry) == 1);
+  static_assert(limits::min(Basis::Cartoon, Quadrature::SphericalSymmetry) ==
+                1);
+
+  CHECK(limits::min(Basis::Chebyshev, Quadrature::GaussLobatto) == 2);
+  CHECK(limits::min(Basis::Chebyshev, Quadrature::Gauss) == 1);
+  CHECK(limits::min(Basis::Legendre, Quadrature::GaussLobatto) == 2);
+  CHECK(limits::min(Basis::Legendre, Quadrature::Gauss) == 1);
+  CHECK(limits::min(Basis::FiniteDifference, Quadrature::CellCentered) == 1);
+  CHECK(limits::min(Basis::FiniteDifference, Quadrature::FaceCentered) == 2);
+  CHECK(limits::min(Basis::SphericalHarmonic, Quadrature::Gauss) == 3);
+  CHECK(limits::min(Basis::SphericalHarmonic, Quadrature::Equiangular) == 5);
+  CHECK(limits::min(Basis::Fourier, Quadrature::Equiangular) == 1);
+  CHECK(limits::min(Basis::ZernikeB1, Quadrature::GaussRadauUpper) == 1);
+  CHECK(limits::min(Basis::ZernikeB2, Quadrature::GaussRadauUpper) == 1);
+  CHECK(limits::min(Basis::ZernikeB2, Quadrature::Equiangular) == 1);
+  CHECK(limits::min(Basis::ZernikeB3, Quadrature::GaussRadauUpper) == 2);
+  CHECK(limits::min(Basis::ZernikeB3, Quadrature::Gauss) == 3);
+  CHECK(limits::min(Basis::ZernikeB3, Quadrature::Equiangular) == 5);
+  CHECK(limits::min(Basis::Cartoon, Quadrature::AxialSymmetry) == 1);
+  CHECK(limits::min(Basis::Cartoon, Quadrature::SphericalSymmetry) == 1);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Spectral.Limits", "[NumericalAlgorithms][Unit]") {
+  test();
+}
+}  // namespace Spectral

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_LinearFilterMatrix.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_LinearFilterMatrix.cpp
@@ -23,7 +23,7 @@ void test() {
   CAPTURE(basis);
   CAPTURE(quadrature);
   for (size_t n = minimum_number_of_points<basis, quadrature>;
-       n <= maximum_number_of_points<basis>; ++n) {
+       n <= maximum_number_of_points<basis, quadrature>; ++n) {
     CAPTURE(n);
     const DataVector xi = collocation_points<basis, quadrature>(n);
     const Matrix m = linear_filter_matrix<basis, quadrature>(n);

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_LogicalCoordinates.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_LogicalCoordinates.cpp
@@ -9,6 +9,7 @@
 #include <string>
 
 #include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Slice.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
@@ -20,6 +21,7 @@
 #include "Domain/Tags.hpp"
 #include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
 #include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/Limits.hpp"
 #include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
@@ -41,24 +43,29 @@ void test_spherical_logical_coords() {
     const auto xi_expected = ylm.theta_phi_points();
     CHECK(get<0>(xi_s2) == xi_expected[0]);
     CHECK(get<1>(xi_s2) == xi_expected[1]);
+    const size_t nr = l / 2 + 1;
     const Mesh<3> mesh_b3{
-        {1, nth, nph},
+        {nr, nth, nph},
         {Spectral::Basis::ZernikeB3, Spectral::Basis::ZernikeB3,
          Spectral::Basis::ZernikeB3},
         {Spectral::Quadrature::GaussRadauUpper, Spectral::Quadrature::Gauss,
          Spectral::Quadrature::Equiangular}};
     const auto xi_b3 = logical_coordinates(mesh_b3);
-    CHECK(get<1>(xi_b3) == xi_expected[0]);
-    CHECK(get<2>(xi_b3) == xi_expected[1]);
+    const auto sliced_xi_b3 = data_on_slice(xi_b3, mesh_b3.extents(), 0, 0);
+    CHECK(get<1>(sliced_xi_b3) == xi_expected[0]);
+    CHECK(get<2>(sliced_xi_b3) == xi_expected[1]);
   }
 }
 
 void test_radial_zernike_logical_coords() {
+  const auto quadrature = Spectral::Quadrature::GaussRadauUpper;
   for (const auto& basis :
        {Spectral::Basis::ZernikeB1, Spectral::Basis::ZernikeB2,
         Spectral::Basis::ZernikeB3}) {
-    for (size_t n = 2; n < 5; ++n) {
-      const Mesh<1> mesh{n, basis, Spectral::Quadrature::GaussRadauUpper};
+    CAPTURE(basis);
+    for (size_t n = Spectral::limits::min(basis, quadrature); n < 5; ++n) {
+      CAPTURE(n);
+      const Mesh<1> mesh{n, basis, quadrature};
       const auto xi = logical_coordinates(mesh);
       CHECK(get<0>(xi)[n - 1] == approx(1.0));
       if (n >= 4) {

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_ModalToNodalMatrix.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_ModalToNodalMatrix.cpp
@@ -25,7 +25,7 @@ void test() {
   CAPTURE(basis);
   CAPTURE(quadrature);
   for (size_t n = minimum_number_of_points<basis, quadrature>;
-       n <= maximum_number_of_points<basis>; ++n) {
+       n <= maximum_number_of_points<basis, quadrature>; ++n) {
     CAPTURE(n);
     const DataVector xi = collocation_points<basis, quadrature>(n);
     const Matrix m = modal_to_nodal_matrix<basis, quadrature>(n);
@@ -47,7 +47,7 @@ void test_two_indexed() {
   CAPTURE(basis);
   CAPTURE(quadrature);
   for (size_t n = minimum_number_of_points<basis, quadrature>;
-       n <= maximum_number_of_points<basis>; ++n) {
+       n <= maximum_number_of_points<basis, quadrature>; ++n) {
     CAPTURE(n);
     const DataVector xi = collocation_points<basis, quadrature>(n);
     for (size_t N = 0; N < 2 * n - 1; ++N) {

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_NodalToModalMatrix.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_NodalToModalMatrix.cpp
@@ -22,8 +22,9 @@ template <Basis basis, Quadrature quadrature>
 void test() {
   CAPTURE(basis);
   CAPTURE(quadrature);
+  const Approx custom_approx = Approx::custom().epsilon(1.0e-13).scale(1.0);
   for (size_t n = minimum_number_of_points<basis, quadrature>;
-       n <= maximum_number_of_points<basis>; ++n) {
+       n <= maximum_number_of_points<basis, quadrature>; ++n) {
     CAPTURE(n);
     const DataVector xi = collocation_points<basis, quadrature>(n);
     const Matrix m = nodal_to_modal_matrix<basis, quadrature>(n);
@@ -33,7 +34,7 @@ void test() {
       const auto f_k = apply_matrix(m, f);
       DataVector f_k_expected{n, 0.0};
       f_k_expected[k] = 1.0;
-      CHECK_ITERABLE_APPROX(f_k, f_k_expected);
+      CHECK_ITERABLE_CUSTOM_APPROX(f_k, f_k_expected, custom_approx);
     }
   }
 }
@@ -46,7 +47,7 @@ void test_two_indexed() {
   CAPTURE(quadrature);
   const Approx custom_approx = Approx::custom().epsilon(1.0e-13).scale(1.0);
   for (size_t n = minimum_number_of_points<basis, quadrature>;
-       n <= maximum_number_of_points<basis>; ++n) {
+       n <= maximum_number_of_points<basis, quadrature>; ++n) {
     CAPTURE(n);
     const DataVector xi = collocation_points<basis, quadrature>(n);
     for (size_t N = 0; N < 2 * n - 1; ++N) {

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_Projection.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_Projection.cpp
@@ -98,7 +98,8 @@ void test_p_mortar_to_element() {
   for (const auto& quadrature_dest : quadratures) {
     for (size_t num_points_dest = 2;
          num_points_dest <=
-         Spectral::maximum_number_of_points<Spectral::Basis::Legendre>;
+         Spectral::maximum_number_of_points<Spectral::Basis::Legendre,
+                                            Spectral::Quadrature::GaussLobatto>;
          ++num_points_dest) {
       const Mesh<1> mesh_dest(num_points_dest, Spectral::Basis::Legendre,
                               quadrature_dest);
@@ -107,7 +108,8 @@ void test_p_mortar_to_element() {
       for (const auto& quadrature_source : quadratures) {
         for (size_t num_points_source = 2;
              num_points_source <=
-             Spectral::maximum_number_of_points<Spectral::Basis::Legendre>;
+             Spectral::maximum_number_of_points<
+                 Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto>;
              ++num_points_source) {
           const Mesh<1> mesh_source(
               num_points_source, Spectral::Basis::Legendre, quadrature_source);
@@ -166,7 +168,8 @@ void test_p_element_to_mortar() {
   for (const auto& quadrature_dest : quadratures) {
     for (size_t num_points_dest = 2;
          num_points_dest <=
-         Spectral::maximum_number_of_points<Spectral::Basis::Legendre>;
+         Spectral::maximum_number_of_points<Spectral::Basis::Legendre,
+                                            Spectral::Quadrature::GaussLobatto>;
          ++num_points_dest) {
       const Mesh<1> mesh_dest(num_points_dest, Spectral::Basis::Legendre,
                               quadrature_dest);
@@ -295,15 +298,19 @@ void test_h_mortar_to_element() {
     for (size_t num_points_dest = 2;
          // We need one extra point to do the quadrature later.
          num_points_dest <=
-         Spectral::maximum_number_of_points<Spectral::Basis::Legendre> - 1;
+         Spectral::maximum_number_of_points<
+             Spectral::Basis::Legendre, Spectral::Quadrature::GaussLobatto> -
+             1;
          ++num_points_dest) {
       const Mesh<1> mesh_dest(num_points_dest, Spectral::Basis::Legendre,
                               quadrature_dest);
       CAPTURE(mesh_dest);
       for (const auto& quadrature_source : quadratures) {
         for (size_t num_points_source = 2;
-             num_points_source <=
-             Spectral::maximum_number_of_points<Spectral::Basis::Legendre> - 1;
+             num_points_source <= Spectral::maximum_number_of_points<
+                                      Spectral::Basis::Legendre,
+                                      Spectral::Quadrature::GaussLobatto> -
+                                      1;
              ++num_points_source) {
           const Mesh<1> mesh_source(
               num_points_source, Spectral::Basis::Legendre, quadrature_source);
@@ -325,7 +332,8 @@ void test_h_element_to_mortar() {
   for (const auto& quadrature_dest : quadratures) {
     for (size_t num_points_dest = 2;
          num_points_dest <=
-         Spectral::maximum_number_of_points<Spectral::Basis::Legendre>;
+         Spectral::maximum_number_of_points<Spectral::Basis::Legendre,
+                                            Spectral::Quadrature::GaussLobatto>;
          ++num_points_dest) {
       const Mesh<1> mesh_dest(num_points_dest, Spectral::Basis::Legendre,
                               quadrature_dest);
@@ -411,7 +419,7 @@ void test_massive_restriction(const size_t parent_num_points,
                                           true);
     const auto rhs =
         apply_matrix(restriction_operator_massive, massive_child_data);
-    Approx local_approx = Approx::custom().epsilon(1.0e-9);
+    const Approx local_approx = Approx::custom().epsilon(1.0e-8);
     CHECK_ITERABLE_CUSTOM_APPROX(lhs, rhs, local_approx);
   }
 }
@@ -630,7 +638,8 @@ void test_fourier_p_projections() {
   INFO("Fourier p-projections");
   const auto local_approx = Approx::custom().scale(1.0).epsilon(1.0e-14);
   constexpr size_t max_points_f =
-      Spectral::maximum_number_of_points<Spectral::Basis::Fourier>;
+      Spectral::maximum_number_of_points<Spectral::Basis::Fourier,
+                                         Spectral::Quadrature::Equiangular>;
   const std::vector<std::pair<unsigned, unsigned>> test_funcs = {
       {1_st, 0_st}, {0_st, 1_st}, {1_st, 1_st}, {5_st, 4_st}, {13_st, 15_st}};
 
@@ -1169,7 +1178,9 @@ SPECTRE_TEST_CASE("Unit.Numerical.Spectral.Projection",
   test_h_mortar_to_element();
   test_h_element_to_mortar();
   for (size_t child_num_points = 4;
-       child_num_points <= maximum_number_of_points<Spectral::Basis::Legendre>;
+       child_num_points <=
+       maximum_number_of_points<Spectral::Basis::Legendre,
+                                Spectral::Quadrature::GaussLobatto>;
        ++child_num_points) {
     for (size_t parent_num_points = 3; parent_num_points < child_num_points;
          ++parent_num_points) {

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_QuadratureWeights.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_QuadratureWeights.cpp
@@ -20,7 +20,7 @@ void test() {
   CAPTURE(basis);
   CAPTURE(quadrature);
   // Cannot represent the integral of a constant with a single point
-  for (size_t n = 2; n <= maximum_number_of_points<basis>; ++n) {
+  for (size_t n = 2; n <= maximum_number_of_points<basis, quadrature>; ++n) {
     const DataVector& weights_n = quadrature_weights<basis, quadrature>(n);
     const Mesh<1> mesh{n, basis, quadrature};
     const DataVector& weights_m = quadrature_weights(mesh);

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_Spectral.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_Spectral.cpp
@@ -65,7 +65,8 @@ void test_exact_differentiation_impl(const Function& max_poly_deg) {
   CAPTURE(BasisType);
   CAPTURE(QuadratureType);
   for (size_t n = Spectral::minimum_number_of_points<BasisType, QuadratureType>;
-       n <= Spectral ::maximum_number_of_points<BasisType>; n++) {
+       n <= Spectral ::maximum_number_of_points<BasisType, QuadratureType>;
+       n++) {
     CAPTURE(n);
     for (size_t p = 0; p <= max_poly_deg(n); p++) {
       CAPTURE(p);
@@ -104,7 +105,8 @@ void test_weak_differentiation() {
   CAPTURE(QuadratureType);
 
   for (size_t n = Spectral::minimum_number_of_points<BasisType, QuadratureType>;
-       n <= Spectral::maximum_number_of_points<BasisType>; n++) {
+       n <= Spectral::maximum_number_of_points<BasisType, QuadratureType>;
+       n++) {
     CAPTURE(n);
     const DataVector& quad_weights =
         Spectral::quadrature_weights<BasisType, QuadratureType>(n);
@@ -182,7 +184,8 @@ void test_linear_filter_impl() {
   CAPTURE(BasisType);
   CAPTURE(QuadratureType);
   for (size_t n = Spectral::minimum_number_of_points<BasisType, QuadratureType>;
-       n <= Spectral::maximum_number_of_points<BasisType>; n++) {
+       n <= Spectral::maximum_number_of_points<BasisType, QuadratureType>;
+       n++) {
     const auto& filter_matrix =
         Spectral::linear_filter_matrix<BasisType, QuadratureType>(n);
     const auto& nodal_to_modal_matrix =
@@ -224,7 +227,9 @@ void test_interpolation_matrix(const DataVector& target_points,
                                const double eps = 0.) {
   DataVector interpolated_u(target_points.size(), 0.);
   for (size_t n = Spectral::minimum_number_of_points<BasisType, QuadratureType>;
-       n <= std::min(Spectral::maximum_number_of_points<BasisType>, 12_st);
+       n <=
+       std::min(Spectral::maximum_number_of_points<BasisType, QuadratureType>,
+                12_st);
        n++) {
     const auto& collocation_pts =
         Spectral::collocation_points<BasisType, QuadratureType>(n);
@@ -339,7 +344,8 @@ template <Spectral::Basis BasisType, Spectral::Quadrature QuadratureType,
           typename Function>
 void test_exact_unit_weight_quadrature(const Function& max_poly_deg) {
   for (size_t n = Spectral::minimum_number_of_points<BasisType, QuadratureType>;
-       n <= Spectral::maximum_number_of_points<BasisType>; n++) {
+       n <= Spectral::maximum_number_of_points<BasisType, QuadratureType>;
+       n++) {
     for (size_t p = 0; p <= max_poly_deg(n); p++) {
       const double analytic_quadrature = unit_polynomial_integral(p);
       test_exact_quadrature<BasisType, QuadratureType>(n, p,
@@ -463,7 +469,7 @@ void test_gauss_points_boundary_interpolation_and_lifting() {
   DataVector interpolated_u_lower(1, 0.);
   DataVector interpolated_u_upper(1, 0.);
   for (size_t n = Spectral::minimum_number_of_points<BasisType, QuadratureType>;
-       n < Spectral::maximum_number_of_points<BasisType>; n++) {
+       n < Spectral::maximum_number_of_points<BasisType, QuadratureType>; n++) {
     CAPTURE(n);
     const auto& collocation_pts =
         Spectral::collocation_points<BasisType, QuadratureType>(n);

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_ZernikeGaussRadauUpper.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_ZernikeGaussRadauUpper.cpp
@@ -21,8 +21,8 @@
 #include "NumericalAlgorithms/Spectral/CollocationPoints.hpp"
 #include "NumericalAlgorithms/Spectral/CollocationPointsAndWeights.hpp"
 #include "NumericalAlgorithms/Spectral/DifferentiationMatrix.hpp"
+#include "NumericalAlgorithms/Spectral/Limits.hpp"
 #include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
-#include "NumericalAlgorithms/Spectral/MaximumNumberOfPoints.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/ModalToNodalMatrix.hpp"
 #include "NumericalAlgorithms/Spectral/NodalToModalMatrix.hpp"
@@ -32,53 +32,62 @@
 
 namespace {
 template <size_t Dim>
-void test_derivatives(const size_t num_points) {
-  const Approx custom_approx =
-      num_points > 9 ? Approx::custom().epsilon(1.0e-12).scale(1.0)
-                     : Approx::custom().epsilon(1.0e-13).scale(1.0);
-  // Testing differeniation for polynomials exactly representable, so
-  // up to power = num_points
+void test_derivatives() {
   constexpr Spectral::Basis basis = Dim == 1   ? Spectral::Basis::ZernikeB1
                                     : Dim == 2 ? Spectral::Basis::ZernikeB2
                                                : Spectral::Basis::ZernikeB3;
   CAPTURE(basis);
-  CAPTURE(num_points);
-  const Mesh<1> mesh{num_points, basis, Spectral::Quadrature::GaussRadauUpper};
-  const auto coords = logical_coordinates(mesh);
-  const DataVector r = 0.5 * (get<0>(coords) + 1.0);
-  const auto f = [](const size_t power, const DataVector& x) {
-    return integer_pow(x, static_cast<int>(power));
-  };
-  const auto d_f = [](const size_t power, const DataVector& x) {
-    return static_cast<double>(power) *
-           integer_pow(x, static_cast<int>(power) - 1);
-  };
-  auto& diff_matrix_even =
-      Spectral::differentiation_matrix<basis,
-                                       Spectral::Quadrature::GaussRadauUpper>(
-          num_points, Spectral::Parity::Even);
-  auto& diff_matrix_odd =
-      Spectral::differentiation_matrix<basis,
-                                       Spectral::Quadrature::GaussRadauUpper>(
-          num_points, Spectral::Parity::Odd);
-  for (size_t power = 0; power <= num_points; ++power) {
-    CAPTURE(power);
+  const auto quadrature = Spectral::Quadrature::GaussRadauUpper;
+  // Being unaware of tabulated points and weights for Zernike
+  // basis functions specifically with Gauss-Radau quadrature, we
+  // test whether the basis can correctly take the derivatives of exactly
+  // representable function
+  for (size_t num_points = Spectral::limits::min(basis, quadrature);
+       num_points <= Spectral::limits::max(basis, quadrature); ++num_points) {
+    const Approx custom_approx =
+        num_points > 9 ? Approx::custom().epsilon(1.0e-12).scale(1.0)
+                       : Approx::custom().epsilon(1.0e-13).scale(1.0);
+    // Testing differeniation for polynomials exactly representable, so
+    // up to power = num_points
+    CAPTURE(num_points);
+    const Mesh<1> mesh{num_points, basis,
+                       Spectral::Quadrature::GaussRadauUpper};
+    const auto coords = logical_coordinates(mesh);
+    const DataVector r = 0.5 * (get<0>(coords) + 1.0);
+    const auto f = [](const size_t power, const DataVector& x) {
+      return integer_pow(x, static_cast<int>(power));
+    };
+    const auto d_f = [](const size_t power, const DataVector& x) {
+      return static_cast<double>(power) *
+             integer_pow(x, static_cast<int>(power) - 1);
+    };
+    auto& diff_matrix_even =
+        Spectral::differentiation_matrix<basis,
+                                         Spectral::Quadrature::GaussRadauUpper>(
+            num_points, Spectral::Parity::Even);
+    auto& diff_matrix_odd =
+        Spectral::differentiation_matrix<basis,
+                                         Spectral::Quadrature::GaussRadauUpper>(
+            num_points, Spectral::Parity::Odd);
+    for (size_t power = 0; power <= num_points; ++power) {
+      CAPTURE(power);
 
-    DataVector my_function(num_points);
-    my_function = f(power, r);
+      DataVector my_function(num_points);
+      my_function = f(power, r);
 
-    DataVector expected_derivative(num_points);
-    expected_derivative =
-        power > 0 ? d_f(power, r) : DataVector(num_points, 0.0);
+      DataVector expected_derivative(num_points);
+      expected_derivative =
+          power > 0 ? d_f(power, r) : DataVector(num_points, 0.0);
 
-    DataVector evaluated_derivative(num_points);
-    // manually inserting 2 from above affine map (handled automatically
-    // in partial_derivatives())
-    evaluated_derivative =
-        2.0 * (power % 2 == 0 ? apply_matrix(diff_matrix_even, my_function)
-                              : apply_matrix(diff_matrix_odd, my_function));
-    CHECK_ITERABLE_CUSTOM_APPROX(evaluated_derivative, expected_derivative,
-                                 custom_approx);
+      DataVector evaluated_derivative(num_points);
+      // manually inserting 2 from above affine map (handled automatically
+      // in partial_derivatives())
+      evaluated_derivative =
+          2.0 * (power % 2 == 0 ? apply_matrix(diff_matrix_even, my_function)
+                                : apply_matrix(diff_matrix_odd, my_function));
+      CHECK_ITERABLE_CUSTOM_APPROX(evaluated_derivative, expected_derivative,
+                                   custom_approx);
+    }
   }
 }
 
@@ -91,7 +100,8 @@ void test_transform_identity() {
                                                : Spectral::Basis::ZernikeB3;
   CAPTURE(basis);
   const Approx custom_approx = Approx::custom().epsilon(2.0e-12).scale(1.0);
-  for (size_t n = 2; n <= Spectral::maximum_number_of_points<basis> / 2; ++n) {
+  for (size_t n = Spectral::limits::min(basis, quadrature);
+       n <= Spectral::limits::max(basis, quadrature) / 2; ++n) {
     for (size_t N = 0; N < 2 * n - 1; ++N) {
       CAPTURE(N);
       const DataVector xi = Spectral::collocation_points<basis, quadrature>(n);
@@ -145,7 +155,8 @@ void test_weight_at_upper() {
     }
   };
 
-  for (size_t n = 2; n < Spectral::maximum_number_of_points<basis>; ++n) {
+  for (size_t n = Spectral::limits::min(basis, quadrature);
+       n < Spectral::limits::max(basis, quadrature); ++n) {
     CAPTURE(n);
     const DataVector& weights =
         Spectral::quadrature_weights<basis, quadrature>(n);
@@ -157,17 +168,9 @@ void test_weight_at_upper() {
 SPECTRE_TEST_CASE(
     "Unit.Numerical.Spectral.ZernikeGaussRadauUpper.PointsAndWeights",
     "[NumericalAlgorithms][Spectral][Unit]") {
-  // Being unaware of tabulated points and weights for Zernike
-  // basis functions specifically with Gauss-Radau quadrature, we
-  // test whether the basis can correctly take the derivatives of exactly
-  // representable function
-  for (size_t i = 1;
-       i <= Spectral::maximum_number_of_points<Spectral::Basis::ZernikeB2>;
-       ++i) {
-    test_derivatives<1>(i);
-    test_derivatives<2>(i);
-    test_derivatives<3>(i);
-  }
+  test_derivatives<1>();
+  test_derivatives<2>();
+  test_derivatives<3>();
   test_weight_at_upper<1>();
   test_weight_at_upper<2>();
   test_weight_at_upper<3>();

--- a/tests/Unit/ParallelAlgorithms/Amr/Events/Test_RefineMesh.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Events/Test_RefineMesh.cpp
@@ -192,8 +192,10 @@ void test(const Event& event, const Event& observe_event) {
   const Element<1> element{element_id, neighbors};
   const Mesh<1> mesh{std::array{3_st}, Spectral::Basis::Legendre,
                      Spectral::Quadrature::GaussLobatto};
-  const amr::Policies policies{amr::Isotropy::Anisotropic,
-                               amr::Limits{0, 0, 3, 5}, true, true};
+  const amr::Policies policies{
+      amr::Isotropy::Anisotropic,
+      amr::Limits{{{0, 0}}, {{2, 4}}, std::nullopt, std::nullopt, false}, true,
+      true};
   const Slab slab(3.4, 6.7);
   const TimeStepId time_step_id(true, 5, slab.start());
   const auto later_time_step_id =
@@ -279,9 +281,10 @@ void test(const Event& event, const Event& observe_event) {
                                          domain::Tags::Element<1>>(
               runner, element_id) == element);
 
-    const amr::Policies error_policies{amr::Isotropy::Anisotropic,
-                                       amr::Limits{{{0, 0}}, {{3, 5}}, true},
-                                       true, true};
+    const amr::Policies error_policies{
+        amr::Isotropy::Anisotropic,
+        amr::Limits{{{0, 0}}, {{2, 4}}, std::nullopt, std::nullopt, true}, true,
+        true};
     db::mutate<amr::Tags::Policies>(
         [&](const gsl::not_null<amr::Policies*> box_policies) {
           *box_policies = error_policies;

--- a/tests/Unit/ParallelAlgorithms/Amr/Policies/Test_EnforcePolicies.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Policies/Test_EnforcePolicies.cpp
@@ -55,15 +55,17 @@ void test_1d() {
   const ElementId<1> element_id{0, {{{1, 0}}}};
   const Mesh<1> mesh{3, Spectral::Basis::Legendre, Spectral::Quadrature::Gauss};
   for (const auto flags : all_flags) {
-    for (const auto policy : policies) {
+    for (const auto& policy : policies) {
       test_decision(flags, policy, element_id, mesh, flags);
     }
   }
 
   {
     INFO("Limits");
-    const amr::Policies policy{amr::Isotropy::Anisotropic,
-                               amr::Limits{0, 5, 1, 12}, true, true};
+    const amr::Policies policy{
+        amr::Isotropy::Anisotropic,
+        amr::Limits{{{0, 5}}, {{0, 11}}, std::nullopt, std::nullopt, false},
+        true, true};
     test_decision(join, policy, ElementId<1>{0}, mesh, stay);
     test_decision(split, policy, ElementId<1>{0, {{{5, 2}}}}, mesh, stay);
     test_decision(
@@ -217,11 +219,14 @@ void test_3d() {
                 split_split_split);
 
   // Test error beyond limits
-  isotropic = amr::Policies{amr::Isotropy::Isotropic,
-                            amr::Limits{{{0, 0}}, {{2, 8}}, true}, true, true};
-  anisotropic =
-      amr::Policies{amr::Isotropy::Anisotropic,
-                    amr::Limits{{{0, 0}}, {{2, 8}}, true}, true, true};
+  isotropic = amr::Policies{
+      amr::Isotropy::Isotropic,
+      amr::Limits{{{0, 0}}, {{1, 7}}, std::nullopt, std::nullopt, true}, true,
+      true};
+  anisotropic = amr::Policies{
+      amr::Isotropy::Anisotropic,
+      amr::Limits{{{0, 0}}, {{1, 7}}, std::nullopt, std::nullopt, true}, true,
+      true};
   element_id = ElementId<3>{0};
   test_decision(stay_split_split, anisotropic, element_id, mesh,
                 stay_split_split, true);

--- a/tests/Unit/ParallelAlgorithms/Amr/Policies/Test_Limits.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Policies/Test_Limits.cpp
@@ -57,10 +57,10 @@ void test_option_parsing() {
         "ErrorBeyondLimits: False\n";
     const auto limits =
         TestHelpers::test_creation<amr::Limits>(creation_string_3);
-    CHECK(limits ==
-          amr::Limits{
-              0, 3, 1,
-              Spectral::maximum_number_of_points<Spectral::Basis::Legendre>});
+    CHECK(limits == amr::Limits{0, 3, 1,
+                                Spectral::maximum_number_of_points<
+                                    Spectral::Basis::Legendre,
+                                    Spectral::Quadrature::GaussLobatto>});
   }
 
   {

--- a/tests/Unit/ParallelAlgorithms/Amr/Policies/Test_Limits.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Policies/Test_Limits.cpp
@@ -10,22 +10,59 @@
 #include "Framework/TestCreation.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "NumericalAlgorithms/Spectral/Basis.hpp"
-#include "NumericalAlgorithms/Spectral/MaximumNumberOfPoints.hpp"
+#include "NumericalAlgorithms/Spectral/Limits.hpp"
 #include "ParallelAlgorithms/Amr/Policies/Limits.hpp"
 
 namespace {
+constexpr size_t p_max = Spectral::limits::max_i1_polynomial_mode;
+constexpr size_t l_min = Spectral::limits::min_spherical_harmonic_mode;
+constexpr size_t l_max = Spectral::limits::max_spherical_harmonic_mode;
+constexpr size_t m_max = Spectral::limits::max_fourier_mode;
+
 void test_equality() {
   INFO("Equality");
-  CHECK(amr::Limits{0, 3, 1, 5} == amr::Limits{0, 3, 1, 5});
-  CHECK(amr::Limits{0, 3, 1, 5} != amr::Limits{1, 3, 1, 5});
-  CHECK(amr::Limits{0, 3, 1, 5} != amr::Limits{0, 4, 1, 5});
-  CHECK(amr::Limits{0, 3, 1, 5} != amr::Limits{0, 3, 2, 5});
-  CHECK(amr::Limits{0, 3, 1, 5} != amr::Limits{0, 3, 1, 6});
+  const amr::Limits limits{};
+  CHECK(limits ==
+        amr::Limits{
+            {{0, 15}}, {{0, p_max}}, {{0, m_max}}, {{l_min, l_max}}, false});
+  CHECK_FALSE(
+      limits ==
+      amr::Limits{
+          {{4, 15}}, {{0, p_max}}, {{0, m_max}}, {{l_min, l_max}}, false});
+  CHECK_FALSE(
+      limits ==
+      amr::Limits{
+          {{0, 8}}, {{0, p_max}}, {{0, m_max}}, {{l_min, l_max}}, false});
+  CHECK_FALSE(
+      limits ==
+      amr::Limits{
+          {{0, 15}}, {{6, p_max}}, {{0, m_max}}, {{l_min, l_max}}, false});
+  CHECK_FALSE(
+      limits ==
+      amr::Limits{{{0, 15}}, {{0, 6}}, {{0, m_max}}, {{l_min, l_max}}, false});
+  CHECK_FALSE(
+      limits ==
+      amr::Limits{
+          {{0, 15}}, {{0, p_max}}, {{6, m_max}}, {{l_min, l_max}}, false});
+  CHECK_FALSE(
+      limits ==
+      amr::Limits{{{0, 15}}, {{0, p_max}}, {{0, 6}}, {{l_min, l_max}}, false});
+  CHECK_FALSE(
+      limits ==
+      amr::Limits{{{0, 15}}, {{0, p_max}}, {{0, m_max}}, {{6, l_max}}, false});
+  CHECK_FALSE(
+      limits ==
+      amr::Limits{{{0, 15}}, {{0, p_max}}, {{0, m_max}}, {{l_min, 6}}, false});
+  CHECK_FALSE(
+      limits ==
+      amr::Limits{
+          {{0, 15}}, {{0, p_max}}, {{0, m_max}}, {{l_min, l_max}}, true});
 }
 
 void test_pup() {
   INFO("Serialization");
-  test_serialization(amr::Limits{0, 3, 1, 5});
+  test_serialization(amr::Limits{});
+  test_serialization(amr::Limits{{{0, 5}}, {{0, 4}}, {{0, 6}}, {{4, 7}}, true});
 }
 
 void test_option_parsing() {
@@ -33,111 +70,186 @@ void test_option_parsing() {
   {
     const std::string creation_string_1 =
         "RefinementLevel: [0, 3]\n"
-        "NumGridPoints: [1, 5]\n"
+        "NumPolynomialModes: [1, 5]\n"
+        "FourierM: [3, 9]\n"
+        "SphericalHarmonicL: [4, 8]\n"
         "ErrorBeyondLimits: False\n";
     const auto limits =
         TestHelpers::test_creation<amr::Limits>(creation_string_1);
-    CHECK(limits == amr::Limits{0, 3, 1, 5});
+    CHECK(limits == amr::Limits{{{0, 3}}, {{1, 5}}, {{3, 9}}, {{4, 8}}, false});
   }
 
   {
     const std::string creation_string_2 =
         "RefinementLevel: Auto\n"
-        "NumGridPoints: [1, 5]\n"
+        "NumPolynomialModes: [1, 5]\n"
+        "FourierM: [3, 9]\n"
+        "SphericalHarmonicL: [4, 8]\n"
         "ErrorBeyondLimits: False\n";
     const auto limits =
         TestHelpers::test_creation<amr::Limits>(creation_string_2);
-    CHECK(limits == amr::Limits{0, ElementId<1>::max_refinement_level, 1, 5});
+    CHECK(limits == amr::Limits{{{0, ElementId<1>::max_refinement_level}},
+                                {{1, 5}},
+                                {{3, 9}},
+                                {{4, 8}},
+                                false});
   }
 
   {
     const std::string creation_string_3 =
         "RefinementLevel: [0, 3]\n"
-        "NumGridPoints: Auto\n"
+        "NumPolynomialModes: Auto\n"
+        "FourierM: [3, 9]\n"
+        "SphericalHarmonicL: [4, 8]\n"
         "ErrorBeyondLimits: False\n";
     const auto limits =
         TestHelpers::test_creation<amr::Limits>(creation_string_3);
-    CHECK(limits == amr::Limits{0, 3, 1,
-                                Spectral::maximum_number_of_points<
-                                    Spectral::Basis::Legendre,
-                                    Spectral::Quadrature::GaussLobatto>});
+    CHECK(limits == amr::Limits{{{0, 3}},
+                                {{0, Spectral::limits::max_i1_polynomial_mode}},
+                                {{3, 9}},
+                                {{4, 8}},
+                                false});
   }
 
   {
     const std::string creation_string_4 =
-        "RefinementLevel: Auto\n"
-        "NumGridPoints: Auto\n"
+        "RefinementLevel: [0, 3]\n"
+        "NumPolynomialModes: [3, 9]\n"
+        "FourierM: Auto\n"
+        "SphericalHarmonicL: [4, 8]\n"
         "ErrorBeyondLimits: False\n";
     const auto limits =
         TestHelpers::test_creation<amr::Limits>(creation_string_4);
-    CHECK(limits == amr::Limits{});
+    CHECK(limits == amr::Limits{{{0, 3}},
+                                {{3, 9}},
+                                {{0, Spectral::limits::max_fourier_mode}},
+                                {{4, 8}},
+                                false});
   }
 
   {
     const std::string creation_string_5 =
         "RefinementLevel: [0, 3]\n"
-        "NumGridPoints: [1, 5]\n"
+        "NumPolynomialModes: [3, 9]\n"
+        "FourierM: [4, 8]\n"
+        "SphericalHarmonicL: Auto\n"
         "ErrorBeyondLimits: True\n";
     const auto limits =
         TestHelpers::test_creation<amr::Limits>(creation_string_5);
-    CHECK(limits == amr::Limits{{{0, 3}}, {{1, 5}}, true});
+    CHECK(limits ==
+          amr::Limits{{{0, 3}},
+                      {{3, 9}},
+                      {{4, 8}},
+                      {{Spectral::limits::min_spherical_harmonic_mode,
+                        Spectral::limits::max_spherical_harmonic_mode}},
+                      true});
+  }
+
+  {
+    const std::string creation_string_6 =
+        "RefinementLevel: Auto\n"
+        "NumPolynomialModes: Auto\n"
+        "FourierM: Auto\n"
+        "SphericalHarmonicL: Auto\n"
+        "ErrorBeyondLimits: False\n";
+    const auto limits =
+        TestHelpers::test_creation<amr::Limits>(creation_string_6);
+    CHECK(limits == amr::Limits{});
   }
 
   const std::string bad_creation_string_1 =
       "RefinementLevel: [255, 3]\n"
-      "NumGridPoints: [1, 5]\n"
+      "NumPolynomialModes: Auto\n"
+      "FourierM: Auto\n"
+      "SphericalHarmonicL: Auto\n"
       "ErrorBeyondLimits: False\n";
   CHECK_THROWS_WITH(
       TestHelpers::test_creation<amr::Limits>(bad_creation_string_1),
-      Catch::Matchers::ContainsSubstring(
-          "RefinementLevel lower bound '255' cannot be larger than '"));
+      Catch::Matchers::ContainsSubstring("RefinementLevel lower bound '255' "
+                                         "cannot be larger than upper bound"));
 
   const std::string bad_creation_string_2 =
-      "RefinementLevel: [1, 255]\n"
-      "NumGridPoints: [1, 5]\n"
+      "RefinementLevel: [3, 255]\n"
+      "NumPolynomialModes: Auto\n"
+      "FourierM: Auto\n"
+      "SphericalHarmonicL: Auto\n"
       "ErrorBeyondLimits: False\n";
   CHECK_THROWS_WITH(
       TestHelpers::test_creation<amr::Limits>(bad_creation_string_2),
       Catch::Matchers::ContainsSubstring(
-          "RefinementLevel upper bound '255' cannot be larger than '"));
+          "RefinementLevel upper bound '255' "
+          "cannot be larger than refinement limit"));
 
   const std::string bad_creation_string_3 =
-      "RefinementLevel: [0, 3]\n"
-      "NumGridPoints: [0, 5]\n"
+      "RefinementLevel: Auto\n"
+      "NumPolynomialModes: [255, 3]\n"
+      "FourierM: Auto\n"
+      "SphericalHarmonicL: Auto\n"
       "ErrorBeyondLimits: False\n";
   CHECK_THROWS_WITH(
       TestHelpers::test_creation<amr::Limits>(bad_creation_string_3),
-      Catch::Matchers::ContainsSubstring(
-          "NumGridPoints lower bound '0' cannot be smaller than '1'."));
+      Catch::Matchers::ContainsSubstring("NumPolynomialModes lower bound '255' "
+                                         "cannot be larger than upper bound"));
 
   const std::string bad_creation_string_4 =
-      "RefinementLevel: [1, 3]\n"
-      "NumGridPoints: [255, 5]\n"
+      "RefinementLevel: Auto\n"
+      "NumPolynomialModes: [3, 255]\n"
+      "FourierM: Auto\n"
+      "SphericalHarmonicL: Auto\n"
       "ErrorBeyondLimits: False\n";
   CHECK_THROWS_WITH(
       TestHelpers::test_creation<amr::Limits>(bad_creation_string_4),
       Catch::Matchers::ContainsSubstring(
-          "NumGridPoints lower bound '255' cannot be larger than '"));
+          "NumPolynomialModes upper bound '255' "
+          "cannot be larger than Spectral::limits::max_i1_polynomial_mode"));
 
   const std::string bad_creation_string_5 =
-      "RefinementLevel: [1, 3]\n"
-      "NumGridPoints: [1, 0]\n"
+      "RefinementLevel: Auto\n"
+      "NumPolynomialModes: Auto\n"
+      "FourierM: [255, 3]\n"
+      "SphericalHarmonicL: Auto\n"
       "ErrorBeyondLimits: False\n";
   CHECK_THROWS_WITH(
       TestHelpers::test_creation<amr::Limits>(bad_creation_string_5),
-      Catch::Matchers::ContainsSubstring(
-          "NumGridPoints upper bound '0' cannot be smaller than '1'."));
+      Catch::Matchers::ContainsSubstring("FourierM lower bound '255' "
+                                         "cannot be larger than upper bound"));
 
   const std::string bad_creation_string_6 =
-      "RefinementLevel: [1, 3]\n"
-      "NumGridPoints: [1, 255]\n"
+      "RefinementLevel: Auto\n"
+      "NumPolynomialModes: Auto\n"
+      "FourierM: [3, 255]\n"
+      "SphericalHarmonicL: Auto\n"
       "ErrorBeyondLimits: False\n";
   CHECK_THROWS_WITH(
       TestHelpers::test_creation<amr::Limits>(bad_creation_string_6),
       Catch::Matchers::ContainsSubstring(
-          "NumGridPoints upper bound '255' cannot be larger than '"));
-}
+          "FourierM upper bound '255' "
+          "cannot be larger than Spectral::limits::max_fourier_mode"));
 
+  const std::string bad_creation_string_7 =
+      "RefinementLevel: Auto\n"
+      "NumPolynomialModes: Auto\n"
+      "FourierM: Auto\n"
+      "SphericalHarmonicL: [255, 3]\n"
+      "ErrorBeyondLimits: False\n";
+  CHECK_THROWS_WITH(
+      TestHelpers::test_creation<amr::Limits>(bad_creation_string_7),
+      Catch::Matchers::ContainsSubstring("SphericalHarmonicL lower bound '255' "
+                                         "cannot be larger than upper bound"));
+
+  const std::string bad_creation_string_8 =
+      "RefinementLevel: Auto\n"
+      "NumPolynomialModes: Auto\n"
+      "FourierM: Auto\n"
+      "SphericalHarmonicL: [3, 255]\n"
+      "ErrorBeyondLimits: False\n";
+  CHECK_THROWS_WITH(
+      TestHelpers::test_creation<amr::Limits>(bad_creation_string_8),
+      Catch::Matchers::ContainsSubstring(
+          "SphericalHarmonicL upper bound '255' "
+          "cannot be larger than "
+          "Spectral::limits::max_spherical_harmonic_mode"));
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.ParallelAlgorithms.Amr.Limits",
@@ -145,19 +257,4 @@ SPECTRE_TEST_CASE("Unit.ParallelAlgorithms.Amr.Limits",
   test_equality();
   test_pup();
   test_option_parsing();
-#ifdef SPECTRE_DEBUG
-  CHECK_THROWS_WITH(
-      ([]() {
-        amr::Limits limits{2, 1, 1, 5};
-      }()),
-      Catch::Matchers::ContainsSubstring(
-          "The minimum refinement level '2' cannot be larger than "
-          "the maximum refinement level '1'"));
-  CHECK_THROWS_WITH(([]() {
-                      amr::Limits limits{0, 3, 6, 4};
-                    }()),
-                    Catch::Matchers::ContainsSubstring(
-                        "The minimum resolution '6' cannot be larger than the "
-                        "maximum resolution '4'"));
-#endif  // SPECTRE_DEBUG
 }

--- a/tests/Unit/ParallelAlgorithms/Amr/Policies/Test_Policies.cpp
+++ b/tests/Unit/ParallelAlgorithms/Amr/Policies/Test_Policies.cpp
@@ -37,7 +37,8 @@ void test_option_parsing() {
   const auto isotropies =
       std::array{amr::Isotropy::Anisotropic, amr::Isotropy::Isotropic};
   const amr::Limits default_limits{};
-  const amr::Limits specified_limits{1, 5, 3, 7};
+  const amr::Limits specified_limits{
+      {{1, 5}}, {{2, 6}}, std::nullopt, std::nullopt, false};
   for (const auto& [isotropy, enforce_two_to_one, allow_coarsening] :
        cartesian_product(isotropies, std::array{true, false},
                          std::array{true, false})) {
@@ -50,7 +51,9 @@ void test_option_parsing() {
       creation_string << "Isotropy: " << isotropy << "\n";
       creation_string << "Limits:\n"
                       << "  RefinementLevel: [1, 5]\n"
-                      << "  NumGridPoints: [3, 7]\n"
+                      << "  NumPolynomialModes: [2, 6]\n"
+                      << "  FourierM: Auto\n"
+                      << "  SphericalHarmonicL: Auto\n"
                       << "  ErrorBeyondLimits: False\n";
       creation_string << "EnforceTwoToOneBalanceInNormalDirection: "
                       << std::boolalpha << enforce_two_to_one << "\n";
@@ -67,7 +70,9 @@ void test_option_parsing() {
       creation_string << "Isotropy: " << isotropy << "\n";
       creation_string << "Limits:\n"
                       << "  RefinementLevel: Auto\n"
-                      << "  NumGridPoints: Auto\n"
+                      << "  NumPolynomialModes: Auto\n"
+                      << "  FourierM: Auto\n"
+                      << "  SphericalHarmonicL: Auto\n"
                       << "  ErrorBeyondLimits: False\n";
       creation_string << "EnforceTwoToOneBalanceInNormalDirection: "
                       << std::boolalpha << enforce_two_to_one << "\n";

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridAlgorithm.yaml
@@ -91,7 +91,9 @@ Amr:
     EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic
     Limits:
-      NumGridPoints: Auto
+      NumPolynomialModes: Auto
+      FourierM: Auto
+      SphericalHarmonicL: Auto
       RefinementLevel: Auto
       ErrorBeyondLimits: False
     AllowCoarsening: False

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridAlgorithmMassive.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridAlgorithmMassive.yaml
@@ -82,7 +82,9 @@ Amr:
     EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic
     Limits:
-      NumGridPoints: Auto
+      NumPolynomialModes: Auto
+      FourierM: Auto
+      SphericalHarmonicL: Auto
       RefinementLevel: Auto
       ErrorBeyondLimits: False
     AllowCoarsening: False

--- a/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridPreconditionedGmresAlgorithm.yaml
+++ b/tests/Unit/ParallelAlgorithms/LinearSolver/Multigrid/Test_MultigridPreconditionedGmresAlgorithm.yaml
@@ -98,7 +98,9 @@ Amr:
     EnforceTwoToOneBalanceInNormalDirection: true
     Isotropy: Anisotropic
     Limits:
-      NumGridPoints: Auto
+      NumPolynomialModes: Auto
+      FourierM: Auto
+      SphericalHarmonicL: Auto
       RefinementLevel: Auto
       ErrorBeyondLimits: False
     AllowCoarsening: False


### PR DESCRIPTION
## Proposed changes

- Set code limits on resolution based on number of modes instead of extents as non-hypercube topologies are more naturally described in terms of a maximum resolved mode
- Add functions that check the validity of a Mesh for a given Element.  These checks include:
  - The quadrature is valid for the basis
  - The basis is valid for the topology of the Element
  - The extents are within the bounds of the code limits
  - The extents are odd for a Fourier series
  - The extents of multidimensional topologies (i.e. B2, S2, B3) obey certain relationships so that their coupled modes are fully resolved
  - The extents are one in Cartoon dimensions.
- Replace the input file option NumGridPoints (in Amr:Policies:Limits:) with the three options NumPolynomialModes, FourierM, and SphericalHarmonicL

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
Within the input file options for 

 Amr:
    Policies:
       Limits:

replace the option

        NumGridPoints: Auto

with the options

        NumPolynomialModes: Auto
        FourierM: Auto
        SphericalHarmonicL: Auto

If you specified bounds for NumGridPoints, use those bounds for NumPolynomialModes decreasing each bound by 1

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent was used, have a co-author trailer of the form
      "Co-Authored-By: <agent name> <agent email>" as the last line of the
      commit, e.g. "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>".

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
