### PR TITLE
Register SecondOrderStandingWave analytic solution

### DIFF
--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/Factory.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/Factory.hpp
@@ -25,5 +25,6 @@ namespace SecondOrderScalarWave::Solutions {
 /// wave system
 template <size_t Dim>
 using all_solutions =
-    tmpl::list<SecondOrderWrapper<ScalarWave::Solutions::PlaneWave<Dim>>>;
+    tmpl::list<SecondOrderWrapper<ScalarWave::Solutions::PlaneWave<Dim>>,
+               SecondOrderWrapper<ScalarWave::Solutions::StandingWave<Dim>>>;
 }  // namespace SecondOrderScalarWave::Solutions

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/SecondOrderWrapper.cpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/SecondOrderWrapper.cpp
@@ -5,9 +5,13 @@
 
 #include "PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/WaveEquation/SecondOrderWrapper.tpp"
+#include "PointwiseFunctions/AnalyticSolutions/WaveEquation/StandingWave.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 
 GENERATE_INSTANTIATIONS(SECOND_ORDER_WRAPPER_INSTANTIATE,
                         (ScalarWave::Solutions::PlaneWave<1>,
                          ScalarWave::Solutions::PlaneWave<2>,
-                         ScalarWave::Solutions::PlaneWave<3>))
+                         ScalarWave::Solutions::PlaneWave<3>,
+                         ScalarWave::Solutions::StandingWave<1>,
+                         ScalarWave::Solutions::StandingWave<2>,
+                         ScalarWave::Solutions::StandingWave<3>))


### PR DESCRIPTION
Instantiate `SecondOrderWrapper` for `ScalarWave::Solutions::StandingWave` and add it to the `SecondOrderScalarWave` factory list, so the wrapped solution is creatable from options as `SecondOrderStandingWave`.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent was used, have a co-author trailer of the form
      "Co-Authored-By: <agent name> <agent email>" as the last line of the
      commit, e.g. "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>".

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
