### PR TITLE
Add SecondOrderScalarWave characteristics

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -1282,6 +1282,21 @@ eprint = {https://doi.org/10.1137/0916035}
   primaryClass   = "gr-qc",
 }
 
+@article{Gundlach2005ta,
+  author         = "Gundlach, Carsten and Martin-Garcia, Jose M.",
+  title          = "Hyperbolicity of second-order in space systems of
+                    evolution equations",
+  journal        = "Class. Quant. Grav.",
+  volume         = "23",
+  year           = "2006",
+  pages          = "S387-S404",
+  doi            = "10.1088/0264-9381/23/16/S06",
+  url            = "https://doi.org/10.1088/0264-9381/23/16/S06",
+  eprint         = "gr-qc/0506037",
+  archivePrefix  = "arXiv",
+  primaryClass   = "gr-qc",
+}
+
 @book{Hairer1993,
   address = {Berlin},
   author = {Hairer, E. and N{\o}rsett, S.P. and Wanner, G.},

--- a/src/Evolution/Systems/SecondOrderScalarWave/CMakeLists.txt
+++ b/src/Evolution/Systems/SecondOrderScalarWave/CMakeLists.txt
@@ -8,6 +8,7 @@ add_spectre_library(${LIBRARY})
 spectre_target_sources(
   ${LIBRARY}
   PRIVATE
+  Characteristics.cpp
   TimeDerivative.cpp
   )
 
@@ -15,6 +16,7 @@ spectre_target_headers(
   ${LIBRARY}
   INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   HEADERS
+  Characteristics.hpp
   System.hpp
   Tags.hpp
   TagsDeclarations.hpp
@@ -26,5 +28,6 @@ target_link_libraries(
   PUBLIC
   DataStructures
   DiscontinuousGalerkin
+  Domain
   Utilities
   )

--- a/src/Evolution/Systems/SecondOrderScalarWave/Characteristics.cpp
+++ b/src/Evolution/Systems/SecondOrderScalarWave/Characteristics.cpp
@@ -1,0 +1,161 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/SecondOrderScalarWave/Characteristics.hpp"
+
+#include <array>
+
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/SetNumberOfGridPoints.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace SecondOrderScalarWave {
+template <size_t Dim>
+void characteristic_speeds(
+    const gsl::not_null<std::array<DataVector, 3>*> char_speeds,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& unit_normal_one_form) {
+  set_number_of_grid_points(char_speeds, unit_normal_one_form);
+  (*char_speeds)[0] = 0.;   // VZero
+  (*char_speeds)[1] = 1.;   // VPlus
+  (*char_speeds)[2] = -1.;  // VMinus
+}
+
+template <size_t Dim>
+std::array<DataVector, 3> characteristic_speeds(
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& unit_normal_one_form) {
+  auto char_speeds = make_with_value<std::array<DataVector, 3>>(
+      get<0>(unit_normal_one_form), 0.);
+  characteristic_speeds(make_not_null(&char_speeds), unit_normal_one_form);
+  return char_speeds;
+}
+
+template <size_t Dim>
+void characteristic_fields(
+    const gsl::not_null<
+        Variables<tmpl::list<Tags::VZero<Dim>, Tags::VPlus, Tags::VMinus>>*>
+        char_fields,
+    const Scalar<DataVector>& pi,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& phi,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& unit_normal_one_form) {
+  if (UNLIKELY(char_fields->number_of_grid_points() != get(pi).size())) {
+    char_fields->initialize(get(pi).size());
+  }
+  const auto phi_dot_normal = dot_product(unit_normal_one_form, phi);
+
+  for (size_t i = 0; i < Dim; ++i) {
+    get<Tags::VZero<Dim>>(*char_fields).get(i) =
+        phi.get(i) - unit_normal_one_form.get(i) * get(phi_dot_normal);
+  }
+
+  get(get<Tags::VPlus>(*char_fields)) = get(pi) + get(phi_dot_normal);
+  get(get<Tags::VMinus>(*char_fields)) = get(pi) - get(phi_dot_normal);
+}
+
+template <size_t Dim>
+Variables<tmpl::list<Tags::VZero<Dim>, Tags::VPlus, Tags::VMinus>>
+characteristic_fields(
+    const Scalar<DataVector>& pi,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& phi,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& unit_normal_one_form) {
+  Variables<tmpl::list<Tags::VZero<Dim>, Tags::VPlus, Tags::VMinus>>
+      char_fields(get_size(get(pi)));
+  characteristic_fields(make_not_null(&char_fields), pi, phi,
+                        unit_normal_one_form);
+  return char_fields;
+}
+
+template <size_t Dim>
+void fields_from_inverse_characteristic_transform(
+    const gsl::not_null<Variables<tmpl::list<Tags::Pi, Tags::Phi<Dim>>>*>
+        evolved_fields,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& v_zero,
+    const Scalar<DataVector>& v_plus, const Scalar<DataVector>& v_minus,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& unit_normal_one_form) {
+  if (UNLIKELY(evolved_fields->number_of_grid_points() != get(v_plus).size())) {
+    evolved_fields->initialize(get(v_plus).size());
+  }
+  get(get<Tags::Pi>(*evolved_fields)) = 0.5 * (get(v_plus) + get(v_minus));
+  for (size_t i = 0; i < Dim; ++i) {
+    get<Tags::Phi<Dim>>(*evolved_fields).get(i) =
+        0.5 * (get(v_plus) - get(v_minus)) * unit_normal_one_form.get(i) +
+        v_zero.get(i);
+  }
+}
+
+template <size_t Dim>
+Variables<tmpl::list<Tags::Pi, Tags::Phi<Dim>>>
+fields_from_inverse_characteristic_transform(
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& v_zero,
+    const Scalar<DataVector>& v_plus, const Scalar<DataVector>& v_minus,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& unit_normal_one_form) {
+  Variables<tmpl::list<Tags::Pi, Tags::Phi<Dim>>> evolved_fields(
+      get_size(get(v_plus)));
+  fields_from_inverse_characteristic_transform(make_not_null(&evolved_fields),
+                                               v_zero, v_plus, v_minus,
+                                               unit_normal_one_form);
+  return evolved_fields;
+}
+}  // namespace SecondOrderScalarWave
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                                                   \
+  template void SecondOrderScalarWave::characteristic_speeds(                  \
+      const gsl::not_null<std::array<DataVector, 3>*> char_speeds,             \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>&                   \
+          unit_normal_one_form);                                               \
+  template std::array<DataVector, 3>                                           \
+  SecondOrderScalarWave::characteristic_speeds(                                \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>&                   \
+          unit_normal_one_form);                                               \
+  template struct SecondOrderScalarWave::Tags::CharacteristicSpeedsCompute<    \
+      DIM(data)>;                                                              \
+  template void SecondOrderScalarWave::characteristic_fields(                  \
+      const gsl::not_null<                                                     \
+          Variables<tmpl::list<SecondOrderScalarWave::Tags::VZero<DIM(data)>,  \
+                               SecondOrderScalarWave::Tags::VPlus,             \
+                               SecondOrderScalarWave::Tags::VMinus>>*>         \
+          char_fields,                                                         \
+      const Scalar<DataVector>& pi,                                            \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>& phi,              \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>&                   \
+          unit_normal_one_form);                                               \
+  template Variables<tmpl::list<SecondOrderScalarWave::Tags::VZero<DIM(data)>, \
+                                SecondOrderScalarWave::Tags::VPlus,            \
+                                SecondOrderScalarWave::Tags::VMinus>>          \
+  SecondOrderScalarWave::characteristic_fields(                                \
+      const Scalar<DataVector>& pi,                                            \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>& phi,              \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>&                   \
+          unit_normal_one_form);                                               \
+  template struct SecondOrderScalarWave::Tags::CharacteristicFieldsCompute<    \
+      DIM(data)>;                                                              \
+  template void                                                                \
+  SecondOrderScalarWave::fields_from_inverse_characteristic_transform(         \
+      const gsl::not_null<                                                     \
+          Variables<tmpl::list<SecondOrderScalarWave::Tags::Pi,                \
+                               SecondOrderScalarWave::Tags::Phi<DIM(data)>>>*> \
+          evolved_fields,                                                      \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>& v_zero,           \
+      const Scalar<DataVector>& v_plus, const Scalar<DataVector>& v_minus,     \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>&                   \
+          unit_normal_one_form);                                               \
+  template Variables<tmpl::list<SecondOrderScalarWave::Tags::Pi,               \
+                                SecondOrderScalarWave::Tags::Phi<DIM(data)>>>  \
+  SecondOrderScalarWave::fields_from_inverse_characteristic_transform(         \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>& v_zero,           \
+      const Scalar<DataVector>& v_plus, const Scalar<DataVector>& v_minus,     \
+      const tnsr::i<DataVector, DIM(data), Frame::Inertial>&                   \
+          unit_normal_one_form);                                               \
+  template struct SecondOrderScalarWave::Tags::                                \
+      FieldsFromInverseCharacteristicTransformCompute<DIM(data)>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#undef INSTANTIATE
+#undef DIM

--- a/src/Evolution/Systems/SecondOrderScalarWave/Characteristics.hpp
+++ b/src/Evolution/Systems/SecondOrderScalarWave/Characteristics.hpp
@@ -1,0 +1,194 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/FaceNormal.hpp"
+#include "Evolution/Systems/SecondOrderScalarWave/Tags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/MakeWithValue.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+template <typename>
+class Variables;
+
+namespace Tags {
+template <typename Tag>
+struct Normalized;
+}  // namespace Tags
+/// \endcond
+
+namespace SecondOrderScalarWave {
+/// @{
+/*!
+ * \brief Compute the characteristic speeds for the second-order scalar wave
+ * system.
+ *
+ * The characteristic fields are, in order, \f$v^0_i\f$ (`Tags::VZero`),
+ * \f$v^+\f$ (`Tags::VPlus`), and \f$v^-\f$ (`Tags::VMinus`). Their
+ * characteristic speeds are 0, +1, and -1, respectively.
+ */
+template <size_t Dim>
+std::array<DataVector, 3> characteristic_speeds(
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& unit_normal_one_form);
+
+template <size_t Dim>
+void characteristic_speeds(
+    gsl::not_null<std::array<DataVector, 3>*> char_speeds,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& unit_normal_one_form);
+
+namespace Tags {
+template <size_t Dim>
+struct CharacteristicSpeedsCompute : Tags::CharacteristicSpeeds<Dim>,
+                                     db::ComputeTag {
+  using base = Tags::CharacteristicSpeeds<Dim>;
+  using return_type = typename base::type;
+  using argument_tags =
+      tmpl::list<::Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<Dim>>>;
+
+  static void function(
+      gsl::not_null<return_type*> char_speeds,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& unit_normal_one_form) {
+    characteristic_speeds(char_speeds, unit_normal_one_form);
+  }
+};
+}  // namespace Tags
+/// @}
+
+/// @{
+/*!
+ * \brief Computes characteristic fields from evolved fields for the
+ * second-order scalar wave system.
+ *
+ * The characteristic fields are given in terms of the evolved fields by:
+ *
+ * \f{align*}
+ * v^0_{i} =& (\delta^k_i - n_i n^k) \Phi_{k} \\
+ * v^{\pm} =& \Pi \pm n^i \Phi_{i}
+ * \f}
+ *
+ * where \f$n_i\f$ is the unit normal along which the characteristic fields
+ * are defined. Note that, unlike the first-order scalar wave system, there is
+ * no characteristic field corresponding to \f$\Psi\f$
+ * (see \cite Gundlach2005ta).
+ *
+ * The corresponding characteristic speeds are
+ * computed by \ref Tags::CharacteristicSpeedsCompute . The inverse
+ * transform, reconstructing \f$(\Pi, \Phi_i)\f$ from the characteristic fields,
+ * is computed by
+ * \ref Tags::FieldsFromInverseCharacteristicTransformCompute .
+ */
+template <size_t Dim>
+Variables<tmpl::list<Tags::VZero<Dim>, Tags::VPlus, Tags::VMinus>>
+characteristic_fields(
+    const Scalar<DataVector>& pi,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& phi,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& unit_normal_one_form);
+
+template <size_t Dim>
+void characteristic_fields(
+    gsl::not_null<
+        Variables<tmpl::list<Tags::VZero<Dim>, Tags::VPlus, Tags::VMinus>>*>
+        char_fields,
+    const Scalar<DataVector>& pi,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& phi,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& unit_normal_one_form);
+
+namespace Tags {
+template <size_t Dim>
+struct CharacteristicFieldsCompute : Tags::CharacteristicFields<Dim>,
+                                     db::ComputeTag {
+  using base = Tags::CharacteristicFields<Dim>;
+  using return_type = typename base::type;
+  using argument_tags =
+      tmpl::list<Pi, Phi<Dim>,
+                 ::Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<Dim>>>;
+
+  static void function(
+      const gsl::not_null<return_type*> char_fields,
+      const Scalar<DataVector>& pi,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& phi,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& unit_normal_one_form) {
+    characteristic_fields(char_fields, pi, phi, unit_normal_one_form);
+  };
+};
+}  // namespace Tags
+/// @}
+
+/// @{
+/*!
+ * \brief Reconstruct the fields \f$(\Pi, \Phi_i)\f$ from the characteristic
+ * fields.
+ *
+ * This uses the inverse of the relations in
+ * \ref Tags::CharacteristicFieldsCompute :
+ *
+ * \f{align*}
+ * \Pi =& \frac{1}{2}(v^+ + v^-), \\
+ * \Phi_{i} =& \frac{1}{2}(v^+ - v^-) n_i + v^0_{i}.
+ * \f}
+ *
+ * The scalar field \f$\Psi\f$ is not reconstructed because it is not part of
+ * the characteristic decomposition of the second-order scalar wave system.
+ */
+template <size_t Dim>
+Variables<tmpl::list<Tags::Pi, Tags::Phi<Dim>>>
+fields_from_inverse_characteristic_transform(
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& v_zero,
+    const Scalar<DataVector>& v_plus, const Scalar<DataVector>& v_minus,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& unit_normal_one_form);
+
+template <size_t Dim>
+void fields_from_inverse_characteristic_transform(
+    gsl::not_null<Variables<tmpl::list<Tags::Pi, Tags::Phi<Dim>>>*>
+        evolved_fields,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& v_zero,
+    const Scalar<DataVector>& v_plus, const Scalar<DataVector>& v_minus,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& unit_normal_one_form);
+
+namespace Tags {
+template <size_t Dim>
+struct FieldsFromInverseCharacteristicTransformCompute
+    : Tags::FieldsFromInverseCharacteristicTransform<Dim>,
+      db::ComputeTag {
+  using base = Tags::FieldsFromInverseCharacteristicTransform<Dim>;
+  using return_type = typename base::type;
+  using argument_tags =
+      tmpl::list<Tags::VZero<Dim>, Tags::VPlus, Tags::VMinus,
+                 ::Tags::Normalized<domain::Tags::UnnormalizedFaceNormal<Dim>>>;
+
+  static void function(
+      const gsl::not_null<return_type*> evolved_fields,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& v_zero,
+      const Scalar<DataVector>& v_plus, const Scalar<DataVector>& v_minus,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& unit_normal_one_form) {
+    fields_from_inverse_characteristic_transform(evolved_fields, v_zero, v_plus,
+                                                 v_minus, unit_normal_one_form);
+  };
+};
+
+struct LargestCharacteristicSpeed : db::SimpleTag {
+  using type = double;
+};
+
+/// Compute the maximum magnitude of the characteristic speeds.
+struct ComputeLargestCharacteristicSpeed : LargestCharacteristicSpeed,
+                                           db::ComputeTag {
+  using argument_tags = tmpl::list<>;
+  using return_type = double;
+  using base = LargestCharacteristicSpeed;
+  SPECTRE_ALWAYS_INLINE static constexpr void function(
+      const gsl::not_null<double*> speed) {
+    *speed = 1.0;
+  }
+};
+}  // namespace Tags
+/// @}
+}  // namespace SecondOrderScalarWave

--- a/src/Evolution/Systems/SecondOrderScalarWave/System.hpp
+++ b/src/Evolution/Systems/SecondOrderScalarWave/System.hpp
@@ -7,6 +7,7 @@
 #include <string>
 
 #include "DataStructures/VariablesTag.hpp"
+#include "Evolution/Systems/SecondOrderScalarWave/Characteristics.hpp"
 #include "Evolution/Systems/SecondOrderScalarWave/Tags.hpp"
 #include "Evolution/Systems/SecondOrderScalarWave/TimeDerivative.hpp"
 #include "Utilities/TMPL.hpp"
@@ -41,5 +42,8 @@ struct System {
   using gradient_variables = tmpl::list<Tags::Psi, Tags::Pi, Tags::Phi<Dim>>;
 
   using compute_volume_time_derivative_terms = TimeDerivative<Dim>;
+
+  using compute_largest_characteristic_speed =
+      Tags::ComputeLargestCharacteristicSpeed;
 };
 }  // namespace SecondOrderScalarWave

--- a/tests/Unit/Evolution/Systems/SecondOrderScalarWave/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/SecondOrderScalarWave/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(LIBRARY Test_SecondOrderScalarWave)
 
 set(LIBRARY_SOURCES
+  Test_Characteristics.cpp
   Test_System.cpp
   Test_Tags.cpp
   Test_TimeDerivative.cpp
@@ -15,6 +16,10 @@ target_link_libraries(
   ${LIBRARY}
   PRIVATE
   DataStructures
+  Domain
+  MathFunctions
   SecondOrderScalarWave
+  Spectral
   Utilities
+  WaveEquationSolutions
   )

--- a/tests/Unit/Evolution/Systems/SecondOrderScalarWave/Characteristics.py
+++ b/tests/Unit/Evolution/Systems/SecondOrderScalarWave/Characteristics.py
@@ -1,0 +1,53 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+# Test functions for characteristic speeds
+def char_speed_vzero(unit_normal):
+    return 0.0
+
+
+def char_speed_vplus(unit_normal):
+    return 1.0
+
+
+def char_speed_vminus(unit_normal):
+    return -1.0
+
+
+# Test functions for characteristic fields
+def char_field_vzero(pi, phi, normal_one_form):
+    normal_vector = normal_one_form
+    projection_tensor = np.identity(len(normal_vector)) - np.einsum(
+        "i,j", normal_one_form, normal_vector
+    )
+    return np.einsum("ij,j->i", projection_tensor, phi)
+
+
+def char_field_vplus(pi, phi, normal_one_form):
+    normal_vector = normal_one_form
+    phi_dot_normal = np.einsum("i,i->", normal_vector, phi)
+    return pi + phi_dot_normal
+
+
+def char_field_vminus(pi, phi, normal_one_form):
+    normal_vector = normal_one_form
+    phi_dot_normal = np.einsum("i,i->", normal_vector, phi)
+    return pi - phi_dot_normal
+
+
+# End test functions for characteristic fields
+
+
+# Test functions for the inverse characteristic transform
+def inverse_field_pi(vzero, vplus, vminus, normal_one_form):
+    return 0.5 * (vplus + vminus)
+
+
+def inverse_field_phi(vzero, vplus, vminus, normal_one_form):
+    return 0.5 * (vplus - vminus) * normal_one_form + vzero
+
+
+# End test functions for the inverse characteristic transform

--- a/tests/Unit/Evolution/Systems/SecondOrderScalarWave/Test_Characteristics.cpp
+++ b/tests/Unit/Evolution/Systems/SecondOrderScalarWave/Test_Characteristics.cpp
@@ -1,0 +1,400 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <limits>
+#include <memory>
+#include <pup.h>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/TaggedTuple.hpp"
+#include "DataStructures/Tensor/EagerMath/DotProduct.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
+#include "Evolution/Systems/SecondOrderScalarWave/Characteristics.hpp"
+#include "Evolution/Systems/SecondOrderScalarWave/Tags.hpp"
+#include "Framework/CheckWithRandomValues.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/WaveEquation/SecondOrderWrapper.hpp"
+#include "PointwiseFunctions/MathFunctions/MathFunction.hpp"
+#include "PointwiseFunctions/MathFunctions/PowX.hpp"
+#include "Utilities/MakeWithValue.hpp"
+
+namespace {
+template <size_t Index, size_t Dim>
+Scalar<DataVector> speed_with_index(
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& normal) {
+  return Scalar<DataVector>{
+      SecondOrderScalarWave::characteristic_speeds<Dim>(normal)[Index]};
+}
+
+template <size_t Dim>
+void test_characteristic_speeds() {
+  TestHelpers::db::test_compute_tag<
+      SecondOrderScalarWave::Tags::CharacteristicSpeedsCompute<Dim>>(
+      "CharacteristicSpeeds");
+  const DataVector used_for_size(5);
+  pypp::check_with_random_values<1>(speed_with_index<0, Dim>, "Characteristics",
+                                    "char_speed_vzero", {{{-10.0, 10.0}}},
+                                    used_for_size);
+  pypp::check_with_random_values<1>(speed_with_index<1, Dim>, "Characteristics",
+                                    "char_speed_vplus", {{{-10.0, 10.0}}},
+                                    used_for_size);
+  pypp::check_with_random_values<1>(speed_with_index<2, Dim>, "Characteristics",
+                                    "char_speed_vminus", {{{-10.0, 10.0}}},
+                                    used_for_size);
+}
+
+// Test return-by-reference char speeds through the compute-tag function. The
+// speeds are the exact constants 0, +1, and -1, so no approximate comparison
+// is needed.
+template <size_t Dim>
+void test_characteristic_speeds_constant() {
+  const size_t n_pts = 5;
+  const tnsr::i<DataVector, Dim, Frame::Inertial> unit_normal_one_form{
+      DataVector(n_pts, 1. / sqrt(Dim))};
+
+  std::array<DataVector, 3> char_speeds{};
+  SecondOrderScalarWave::Tags::CharacteristicSpeedsCompute<Dim>::function(
+      &char_speeds, unit_normal_one_form);
+  CHECK(char_speeds[0] == DataVector(n_pts, 0.));   // VZero
+  CHECK(char_speeds[1] == DataVector(n_pts, 1.));   // VPlus
+  CHECK(char_speeds[2] == DataVector(n_pts, -1.));  // VMinus
+}
+
+template <typename Tag, size_t Dim>
+typename Tag::type field_with_tag(
+    const Scalar<DataVector>& pi,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& phi,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_one_form) {
+  Variables<tmpl::list<SecondOrderScalarWave::Tags::VZero<Dim>,
+                       SecondOrderScalarWave::Tags::VPlus,
+                       SecondOrderScalarWave::Tags::VMinus>>
+      char_fields{};
+  SecondOrderScalarWave::Tags::CharacteristicFieldsCompute<Dim>::function(
+      make_not_null(&char_fields), pi, phi, normal_one_form);
+  return get<Tag>(char_fields);
+}
+
+template <size_t Dim>
+void test_characteristic_fields() {
+  TestHelpers::db::test_compute_tag<
+      SecondOrderScalarWave::Tags::CharacteristicFieldsCompute<Dim>>(
+      "CharacteristicFields");
+  const DataVector used_for_size(5);
+  // VZero
+  pypp::check_with_random_values<1>(
+      field_with_tag<SecondOrderScalarWave::Tags::VZero<Dim>, Dim>,
+      "Characteristics", "char_field_vzero", {{{-10., 10.}}}, used_for_size,
+      1.e-11);
+  // VPlus
+  pypp::check_with_random_values<1>(
+      field_with_tag<SecondOrderScalarWave::Tags::VPlus, Dim>,
+      "Characteristics", "char_field_vplus", {{{-10., 10.}}}, used_for_size);
+  // VMinus
+  pypp::check_with_random_values<1>(
+      field_with_tag<SecondOrderScalarWave::Tags::VMinus, Dim>,
+      "Characteristics", "char_field_vminus", {{{-10., 10.}}}, used_for_size);
+}
+
+// Test return-by-reference char fields by comparing to analytic solution
+template <size_t Dim, typename Solution>
+void test_characteristic_fields_analytic(
+    const Solution& solution, const size_t grid_size_each_dimension,
+    const std::array<double, Dim>& lower_bound,
+    const std::array<double, Dim>& upper_bound) {
+  // Set up grid
+  const Mesh<Dim> mesh{grid_size_each_dimension, Spectral::Basis::Legendre,
+                 Spectral::Quadrature::GaussLobatto};
+
+  using Affine = domain::CoordinateMaps::Affine;
+  using Affine3D =
+      domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
+  const auto coord_map =
+      domain::make_coordinate_map<Frame::ElementLogical, Frame::Inertial>(
+          Affine3D{
+              Affine{-1., 1., lower_bound[0], upper_bound[0]},
+              Affine{-1., 1., lower_bound[1], upper_bound[1]},
+              Affine{-1., 1., lower_bound[2], upper_bound[2]},
+          });
+
+  // Set up coordinates
+  const auto x_logical = logical_coordinates(mesh);
+  const auto x = coord_map(x_logical);
+  const double t = 0.;
+
+  // Evaluate analytic solution (Psi is retrieved but not used here)
+  const auto vars =
+      solution.variables(x, t,
+                         tmpl::list<SecondOrderScalarWave::Tags::Psi,
+                                    SecondOrderScalarWave::Tags::Pi,
+                                    SecondOrderScalarWave::Tags::Phi<Dim>>{});
+
+  const size_t n_pts = mesh.number_of_grid_points();
+  const auto& pi = get<SecondOrderScalarWave::Tags::Pi>(vars);
+  const auto& phi = get<SecondOrderScalarWave::Tags::Phi<Dim>>(vars);
+  const auto unit_normal_one_form =
+      make_with_value<tnsr::i<DataVector, Dim, Frame::Inertial>>(
+          x, 1. / sqrt(Dim));
+
+  // Compute characteristic fields locally
+  const auto phi_dot_normal = dot_product(unit_normal_one_form, phi);
+
+  tnsr::i<DataVector, Dim, Frame::Inertial> phi_dot_projection_tensor{
+      DataVector(n_pts)};
+  for (size_t i = 0; i < Dim; ++i) {
+    phi_dot_projection_tensor.get(i) =
+        phi.get(i) - unit_normal_one_form.get(i) * get(phi_dot_normal);
+  }
+
+  const auto& vzero_expected = phi_dot_projection_tensor;
+  const Scalar<DataVector> vplus_expected{get(pi) + get(phi_dot_normal)};
+  const Scalar<DataVector> vminus_expected{get(pi) - get(phi_dot_normal)};
+
+  // Check that locally computed fields match returned ones
+  Variables<tmpl::list<SecondOrderScalarWave::Tags::VZero<Dim>,
+                       SecondOrderScalarWave::Tags::VPlus,
+                       SecondOrderScalarWave::Tags::VMinus>>
+      uvars{};
+  SecondOrderScalarWave::Tags::CharacteristicFieldsCompute<Dim>::function(
+      make_not_null(&uvars), pi, phi, unit_normal_one_form);
+
+  const auto& vzero = get<SecondOrderScalarWave::Tags::VZero<Dim>>(uvars);
+  const auto& vplus = get<SecondOrderScalarWave::Tags::VPlus>(uvars);
+  const auto& vminus = get<SecondOrderScalarWave::Tags::VMinus>(uvars);
+
+  CHECK_ITERABLE_APPROX(vzero_expected, vzero);
+  CHECK_ITERABLE_APPROX(vplus_expected, vplus);
+  CHECK_ITERABLE_APPROX(vminus_expected, vminus);
+}
+
+template <typename Tag, size_t Dim>
+typename Tag::type inverse_field_with_tag(
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& v_zero,
+    const Scalar<DataVector>& v_plus, const Scalar<DataVector>& v_minus,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& unit_normal_one_form) {
+  Variables<tmpl::list<SecondOrderScalarWave::Tags::Pi,
+                       SecondOrderScalarWave::Tags::Phi<Dim>>>
+      evolved_vars{};
+  SecondOrderScalarWave::Tags::FieldsFromInverseCharacteristicTransformCompute<
+      Dim>::function(make_not_null(&evolved_vars), v_zero, v_plus, v_minus,
+                     unit_normal_one_form);
+  return get<Tag>(evolved_vars);
+}
+
+template <size_t Dim>
+void test_fields_from_inverse_characteristic_transform() {
+  TestHelpers::db::test_compute_tag<
+      SecondOrderScalarWave::Tags::
+          FieldsFromInverseCharacteristicTransformCompute<Dim>>(
+      "FieldsFromInverseCharacteristicTransform");
+  const DataVector used_for_size(5);
+  // Pi
+  pypp::check_with_random_values<1>(
+      inverse_field_with_tag<SecondOrderScalarWave::Tags::Pi, Dim>,
+      "Characteristics", "inverse_field_pi", {{{-10., 10.}}}, used_for_size);
+  // Phi
+  pypp::check_with_random_values<1>(
+      inverse_field_with_tag<SecondOrderScalarWave::Tags::Phi<Dim>, Dim>,
+      "Characteristics", "inverse_field_phi", {{{-10., 10.}}}, used_for_size);
+}
+
+// Test return-by-reference inverse-transform fields by comparing to analytic
+// solution
+template <size_t Dim, typename Solution>
+void test_fields_from_inverse_characteristic_transform_analytic(
+    const Solution& solution, const size_t grid_size_each_dimension,
+    const std::array<double, Dim>& lower_bound,
+    const std::array<double, Dim>& upper_bound) {
+  // Set up grid
+  const Mesh<Dim> mesh{grid_size_each_dimension, Spectral::Basis::Legendre,
+                 Spectral::Quadrature::GaussLobatto};
+
+  using Affine = domain::CoordinateMaps::Affine;
+  using Affine3D =
+      domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
+  const auto coord_map =
+      domain::make_coordinate_map<Frame::ElementLogical, Frame::Inertial>(
+          Affine3D{
+              Affine{-1., 1., lower_bound[0], upper_bound[0]},
+              Affine{-1., 1., lower_bound[1], upper_bound[1]},
+              Affine{-1., 1., lower_bound[2], upper_bound[2]},
+          });
+
+  // Set up coordinates
+  const auto x_logical = logical_coordinates(mesh);
+  const auto x = coord_map(x_logical);
+  const double t = 0.;
+
+  // Evaluate analytic solution (Psi is retrieved but not used here)
+  const auto vars =
+      solution.variables(x, t,
+                         tmpl::list<SecondOrderScalarWave::Tags::Psi,
+                                    SecondOrderScalarWave::Tags::Pi,
+                                    SecondOrderScalarWave::Tags::Phi<Dim>>{});
+
+  const size_t n_pts = mesh.number_of_grid_points();
+  const auto& pi_expected = get<SecondOrderScalarWave::Tags::Pi>(vars);
+  const auto& phi_expected = get<SecondOrderScalarWave::Tags::Phi<Dim>>(vars);
+  const auto unit_normal_one_form =
+      make_with_value<tnsr::i<DataVector, Dim, Frame::Inertial>>(
+          x, 1. / sqrt(Dim));
+
+  // Compute characteristic fields locally
+  const auto phi_dot_normal = dot_product(unit_normal_one_form, phi_expected);
+
+  tnsr::i<DataVector, Dim, Frame::Inertial> phi_dot_projection_tensor{
+      DataVector(n_pts)};
+  for (size_t i = 0; i < Dim; ++i) {
+    phi_dot_projection_tensor.get(i) =
+        phi_expected.get(i) - unit_normal_one_form.get(i) * get(phi_dot_normal);
+  }
+
+  const auto& vzero = phi_dot_projection_tensor;
+  const Scalar<DataVector> vplus{get(pi_expected) + get(phi_dot_normal)};
+  const Scalar<DataVector> vminus{get(pi_expected) - get(phi_dot_normal)};
+  // Obtain reconstructed fields using compute tag
+  {
+    Variables<tmpl::list<SecondOrderScalarWave::Tags::Pi,
+                         SecondOrderScalarWave::Tags::Phi<Dim>>>
+        fields{};
+    SecondOrderScalarWave::Tags::
+        FieldsFromInverseCharacteristicTransformCompute<Dim>::function(
+            make_not_null(&fields), vzero, vplus, vminus, unit_normal_one_form);
+    const auto& pi = get<SecondOrderScalarWave::Tags::Pi>(fields);
+    const auto& phi = get<SecondOrderScalarWave::Tags::Phi<Dim>>(fields);
+
+    CHECK_ITERABLE_APPROX(pi_expected, pi);
+    CHECK_ITERABLE_APPROX(phi_expected, phi);
+  }
+  // Obtain reconstructed fields using function
+  {
+    const auto fields =
+        SecondOrderScalarWave::fields_from_inverse_characteristic_transform(
+            vzero, vplus, vminus, unit_normal_one_form);
+    const auto& pi = get<SecondOrderScalarWave::Tags::Pi>(fields);
+    const auto& phi = get<SecondOrderScalarWave::Tags::Phi<Dim>>(fields);
+
+    CHECK_ITERABLE_APPROX(pi_expected, pi);
+    CHECK_ITERABLE_APPROX(phi_expected, phi);
+  }
+}
+
+// Test that characteristic_fields followed by
+// fields_from_inverse_characteristic_transform is the identity on (pi, phi),
+// using random data and a random unit normal.
+template <size_t Dim>
+void test_roundtrip() {
+  CAPTURE(Dim);
+  MAKE_GENERATOR(gen);
+  std::uniform_real_distribution<> dist(-10., 10.);
+  const size_t n_pts = 5;
+
+  // Random evolved fields
+  auto pi = make_with_value<Scalar<DataVector>>(DataVector(n_pts), 0.);
+  auto phi = make_with_value<tnsr::i<DataVector, Dim, Frame::Inertial>>(
+      DataVector(n_pts), 0.);
+  fill_with_random_values(make_not_null(&pi), make_not_null(&gen),
+                          make_not_null(&dist));
+  fill_with_random_values(make_not_null(&phi), make_not_null(&gen),
+                          make_not_null(&dist));
+
+  // Random unit normal: generate random direction, then normalize
+  auto normal = make_with_value<tnsr::i<DataVector, Dim, Frame::Inertial>>(
+      DataVector(n_pts), 0.);
+  fill_with_random_values(make_not_null(&normal), make_not_null(&gen),
+                          make_not_null(&dist));
+  const auto mag = magnitude(normal);
+  for (size_t i = 0; i < Dim; ++i) {
+    normal.get(i) /= get(mag);
+  }
+
+  // Forward: evolved -> characteristic
+  const auto char_fields =
+      SecondOrderScalarWave::characteristic_fields(pi, phi, normal);
+  const auto& v_zero =
+      get<SecondOrderScalarWave::Tags::VZero<Dim>>(char_fields);
+  const auto& v_plus = get<SecondOrderScalarWave::Tags::VPlus>(char_fields);
+  const auto& v_minus = get<SecondOrderScalarWave::Tags::VMinus>(char_fields);
+
+  // Inverse: characteristic -> evolved
+  const auto recovered =
+      SecondOrderScalarWave::fields_from_inverse_characteristic_transform(
+          v_zero, v_plus, v_minus, normal);
+
+  CHECK_ITERABLE_APPROX(pi, get<SecondOrderScalarWave::Tags::Pi>(recovered));
+  CHECK_ITERABLE_APPROX(phi,
+                        get<SecondOrderScalarWave::Tags::Phi<Dim>>(recovered));
+}
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.Evolution.Systems.SecondOrderScalarWave.Characteristics",
+    "[Unit][Evolution]") {
+  const pypp::SetupLocalPythonEnvironment local_python_env{
+      "Evolution/Systems/SecondOrderScalarWave/"};
+
+  test_characteristic_speeds<1>();
+  test_characteristic_speeds<2>();
+  test_characteristic_speeds<3>();
+
+  test_characteristic_fields<1>();
+  test_characteristic_fields<2>();
+  test_characteristic_fields<3>();
+
+  test_fields_from_inverse_characteristic_transform<1>();
+  test_fields_from_inverse_characteristic_transform<2>();
+  test_fields_from_inverse_characteristic_transform<3>();
+
+  test_roundtrip<1>();
+  test_roundtrip<2>();
+  test_roundtrip<3>();
+
+  test_characteristic_speeds_constant<1>();
+  test_characteristic_speeds_constant<2>();
+  test_characteristic_speeds_constant<3>();
+
+  // Test characteristics against 3D plane wave
+  const size_t grid_size = 8;
+  const std::array<double, 3> lower_bound{{0.82, 1.22, 1.32}};
+  const std::array<double, 3> upper_bound{{0.78, 1.18, 1.28}};
+
+  const double kx = 1.5;
+  const double ky = -7.2;
+  const double kz = 2.7;
+  const double center_x = 2.4;
+  const double center_y = -4.8;
+  const double center_z = 8.4;
+  const SecondOrderScalarWave::Solutions::SecondOrderWrapper
+      plane_wave_solution(ScalarWave::Solutions::PlaneWave<3>(
+          {{kx, ky, kz}}, {{center_x, center_y, center_z}},
+          std::make_unique<MathFunctions::PowX<1, Frame::Inertial>>(3)));
+
+  test_characteristic_fields_analytic<3>(plane_wave_solution, grid_size,
+                                         lower_bound, upper_bound);
+  test_fields_from_inverse_characteristic_transform_analytic<3>(
+      plane_wave_solution, grid_size, lower_bound, upper_bound);
+
+  double largest_characteristic_speed =
+      std::numeric_limits<double>::signaling_NaN();
+  SecondOrderScalarWave::Tags::ComputeLargestCharacteristicSpeed::function(
+      make_not_null(&largest_characteristic_speed));
+  CHECK(largest_characteristic_speed == 1.0);
+}


### PR DESCRIPTION
Add the characteristic speeds and fields of the `SecondOrderScalarWave` system and the inverse transformation.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent was used, have a co-author trailer of the form
      "Co-Authored-By: <agent name> <agent email>" as the last line of the
      commit, e.g. "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>".

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
