### PR TITLE
Enable AhA/B adaptive angular resolution in BBH pipeline

### DIFF
--- a/support/Pipelines/Bbh/Inspiral.py
+++ b/support/Pipelines/Bbh/Inspiral.py
@@ -109,6 +109,28 @@ def _constraint_damping_params(
     }
 
 
+def _ah_ab_adaptivity_params() -> dict:
+    """Parameters for adaptive AhA/B resolution.
+
+    These values use the SpEC BBH DoMultipleRuns.input horizon-adaptivity
+    tolerances with the currently fixed representative medium level k = 2.
+    SpECTRE currently supports the Residual and Shape criteria, but not SpEC's
+    SurfaceAreaElement selector.
+    """
+
+    spec_medium_level = 2
+    truncation_error_max = 0.000216536 * 4 ** (-spec_medium_level)
+
+    return {
+        "AhABMaxResidual": truncation_error_max,
+        "AhABMinResidual": truncation_error_max / 10.0,
+        "AhABMaxTruncationError": truncation_error_max,
+        "AhABMinTruncationError": truncation_error_max / 100.0,
+        "AhABMinResolutionL": 6,
+        "AhABMaxPileUpModes": 4,
+    }
+
+
 def inspiral_parameters(
     id_input_file: dict,
     id_metadata: dict,
@@ -295,6 +317,9 @@ def inspiral_parameters(
         )
     )
 
+    # AhA/B apparent horizon adaptivity
+    params.update(_ah_ab_adaptivity_params())
+
     # Store target parameters in the input file
     params["TargetParams"] = yaml.safe_dump(
         {"TargetParams": target_params}
@@ -405,6 +430,9 @@ def inspiral_parameters_spec(
             spin_magnitude_right=spin_magnitude_right,
         )
     )
+
+    # AhA/B apparent horizon adaptivity
+    params.update(_ah_ab_adaptivity_params())
 
     # Store target parameters in the input file
     params["TargetParams"] = yaml.safe_dump(

--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -537,6 +537,15 @@ ApparentHorizons:
   LMax: 33
   ObservationAhA: &AhA
     Criteria:
+      - Residual:
+          MinResidual: {{ AhABMinResidual }}
+          MaxResidual: {{ AhABMaxResidual }}
+          MinResolutionL: {{ AhABMinResolutionL }}
+      - Shape:
+          MinTruncationError: {{ AhABMinTruncationError }}
+          MaxTruncationError: {{ AhABMaxTruncationError }}
+          MaxPileUpModes: {{ AhABMaxPileUpModes }}
+          MinResolutionL: {{ AhABMinResolutionL }}
     InitialGuess:
       InitialL: &ObsLMax 10
       InitialShape:
@@ -557,6 +566,15 @@ ApparentHorizons:
     BlocksForHorizonFind: ["ObjectAShell", "ObjectACube"]
   ObservationAhB: &AhB
     Criteria:
+      - Residual:
+          MinResidual: {{ AhABMinResidual }}
+          MaxResidual: {{ AhABMaxResidual }}
+          MinResolutionL: {{ AhABMinResolutionL }}
+      - Shape:
+          MinTruncationError: {{ AhABMinTruncationError }}
+          MaxTruncationError: {{ AhABMaxTruncationError }}
+          MaxPileUpModes: {{ AhABMaxPileUpModes }}
+          MinResolutionL: {{ AhABMinResolutionL }}
     InitialGuess:
       InitialL: *ObsLMax
       InitialShape:

--- a/tests/support/Pipelines/Bbh/Test_Inspiral.py
+++ b/tests/support/Pipelines/Bbh/Test_Inspiral.py
@@ -117,6 +117,21 @@ class TestInspiral(unittest.TestCase):
         self.assertEqual(params["Gamma0OriginWidth"], 50.0)
         self.assertEqual(params["Gamma1Width"], 200.0)
 
+        # AhA/B apparent horizon adaptivity
+        ah_ab_max_tolerance = 0.000216536 * 4 ** (-2)
+        self.assertAlmostEqual(params["AhABMaxResidual"], ah_ab_max_tolerance)
+        self.assertAlmostEqual(
+            params["AhABMinResidual"], ah_ab_max_tolerance / 10.0
+        )
+        self.assertAlmostEqual(
+            params["AhABMaxTruncationError"], ah_ab_max_tolerance
+        )
+        self.assertAlmostEqual(
+            params["AhABMinTruncationError"], ah_ab_max_tolerance / 100.0
+        )
+        self.assertEqual(params["AhABMinResolutionL"], 6)
+        self.assertEqual(params["AhABMaxPileUpModes"], 4)
+
     def test_cli(self):
         common_args = [
             str(self.id_dir / "InitialData.yaml"),
@@ -150,6 +165,40 @@ class TestInspiral(unittest.TestCase):
         self.assertTrue(
             (self.test_dir / "Inspiral/Segment_0000/Inspiral.yaml").exists()
         )
+
+        with open(
+            self.test_dir / "Inspiral/Segment_0000/Inspiral.yaml", "r"
+        ) as open_input_file:
+            _, input_file = yaml.safe_load_all(open_input_file)
+        ah_ab_max_tolerance = 0.000216536 * 4 ** (-2)
+        ah_ab_min_residual = ah_ab_max_tolerance / 10.0
+        ah_ab_min_truncation_error = ah_ab_max_tolerance / 100.0
+        expected_ah_ab_criteria = [
+            {
+                "Residual": {
+                    "MinResidual": ah_ab_min_residual,
+                    "MaxResidual": ah_ab_max_tolerance,
+                    "MinResolutionL": 6,
+                }
+            },
+            {
+                "Shape": {
+                    "MinTruncationError": ah_ab_min_truncation_error,
+                    "MaxTruncationError": ah_ab_max_tolerance,
+                    "MaxPileUpModes": 4,
+                    "MinResolutionL": 6,
+                }
+            },
+        ]
+        self.assertEqual(
+            input_file["ApparentHorizons"]["ObservationAhA"]["Criteria"],
+            expected_ah_ab_criteria,
+        )
+        self.assertEqual(
+            input_file["ApparentHorizons"]["ObservationAhB"]["Criteria"],
+            expected_ah_ab_criteria,
+        )
+
         # Test with pipeline directory and lev specified
         try:
             start_inspiral_command(


### PR DESCRIPTION
Add SpEC-inspired adaptive angular resolution for AhA and AhB in the BBH inspiral pipeline. The tolerances use the currently fixed representative medium SpEC level `k = 2`.
## Proposed changes

- Add Residual and Shape apparent-horizon adaptivity criteria for AhA and AhB
- Use a currently fixed representative medium SpEC level `k = 2` for the AhA/B adaptivity tolerances
- Enable AhA/B adaptivity by default in the generated inspiral input file
- Add pipeline tests for default criteria generation

### Upgrade instructions

<!-- UPGRADE INSTRUCTIONS -->

AhA/B horizon adaptivity is now enabled by default in generated BBH inspiral input files. 
To disable it manually, edit the generated input file and remove the `Criteria` entries under `ApparentHorizons: ObservationAhA` and `ObservationAhB`.

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [x] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [x] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [x] If a coding agent was used, have a co-author trailer of the form
      "Co-Authored-By: <agent name> <agent email>" as the last line of the
      commit, e.g. "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>".

### Further comments

Testing:

- `ctest -R support.Pipelines.Bbh.Inspiral --output-on-failure`
