### PR TITLE
Add ZernikeB2 support to power monitors

### DIFF
--- a/src/NumericalAlgorithms/LinearOperators/PowerMonitors.cpp
+++ b/src/NumericalAlgorithms/LinearOperators/PowerMonitors.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <array>
 #include <cmath>
+#include <cstddef>
 #include <limits>
 #include <vector>
 #include <type_traits>
@@ -21,6 +22,7 @@
 #include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "NumericalAlgorithms/Spectral/BasisFunctions/Fourier.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/ZernikeB2.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/SpherepackIterator.hpp"
 #include "Utilities/ConstantExpressions.hpp"
 #include "Utilities/EqualWithinRoundoff.hpp"
@@ -40,6 +42,45 @@ void power_monitors(const gsl::not_null<std::array<DataVector, Dim>*> result,
              << ") must match the size of the "
                 "vector ("
              << u.size() << ").");
+  if (mesh.basis(0) == Spectral::Basis::ZernikeB2) {
+    if constexpr (std::is_same_v<VectorType, DataVector>) {
+      if constexpr (Dim > 1) {
+        Spectral::b2_power_monitor_radial(make_not_null(&(*result)[0]), u,
+                                          mesh);
+        Spectral::b2_power_monitor_angular(make_not_null(&(*result)[1]), u,
+                                           mesh);
+        if (Dim == 3) {
+          // Compute the z power monitor directly: for each disk point, extract
+          // and transform the z-strip using a 1D mesh for the z-dimension only.
+          const size_t n_disk = mesh.extents(0) * mesh.extents(1);
+          const size_t n_z = mesh.extents(2);
+          const Mesh<1> z_mesh{n_z, mesh.basis(2), mesh.quadrature(2)};
+          DataVector z_slice(n_z);
+          gsl::at(*result, 2).destructive_resize(n_z);
+          gsl::at(*result, 2) = 0.0;
+          for (size_t i_disk = 0; i_disk < n_disk; ++i_disk) {
+            for (size_t j_z = 0; j_z < n_z; ++j_z) {
+              z_slice[j_z] = u[i_disk + n_disk * j_z];
+            }
+            const auto z_modal = to_modal_coefficients(z_slice, z_mesh);
+            for (size_t k = 0; k < n_z; ++k) {
+              gsl::at(*result, 2)[k] += square(z_modal[k]);
+            }
+          }
+          gsl::at(*result, 2) =
+              sqrt(gsl::at(*result, 2) / static_cast<double>(n_disk));
+        }
+        return;
+      } else {
+        ERROR("Passed mesh is using ZernikeB2 for Dim == 1");
+      }
+    } else {
+      ERROR(
+          "Support for complex numbers with ZernikeB2 power monitor has not "
+          "been tested yet");
+    }
+  }
+
   // Get modal coefficients
   const auto modal_coefficients = to_modal_coefficients(u, mesh);
 

--- a/src/NumericalAlgorithms/Spectral/CMakeLists.txt
+++ b/src/NumericalAlgorithms/Spectral/CMakeLists.txt
@@ -32,6 +32,7 @@ spectre_target_sources(
   Quadrature.cpp
   QuadratureWeights.cpp
   SegmentSize.cpp
+  ZernikeB2.cpp
   )
 
 spectre_target_headers(
@@ -78,6 +79,7 @@ spectre_target_headers(
   QuadratureWeights.hpp
   SegmentSize.hpp
   SpectralQuantityForMesh.hpp
+  ZernikeB2.hpp
   )
 
 target_link_libraries(

--- a/src/NumericalAlgorithms/Spectral/ZernikeB2.cpp
+++ b/src/NumericalAlgorithms/Spectral/ZernikeB2.cpp
@@ -1,0 +1,248 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "NumericalAlgorithms/Spectral/ZernikeB2.hpp"
+
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Matrix.hpp"
+#include "DataStructures/Transpose.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/NodalToModalMatrix.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "Utilities/Blas.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace Spectral {
+
+namespace {
+template <size_t Dim>
+std::tuple<size_t, size_t, size_t> check_b2_mesh(const DataVector& u,
+                                                 const Mesh<Dim>& mesh) {
+  const size_t n_r = mesh.extents(0);
+  const size_t n_phi = mesh.extents(1);
+  const size_t n_z = Dim == 3 ? mesh.extents(2) : 1_st;
+  const size_t n_r_max = 2 * n_r - 2;
+  const size_t M = n_phi / 2;
+  ASSERT(
+      mesh.basis(0) == Spectral::Basis::ZernikeB2,
+      "First mesh dimension must use ZernikeB2 basis, got " << mesh.basis(0));
+  ASSERT(mesh.quadrature(0) == Spectral::Quadrature::GaussRadauUpper,
+         "First mesh dimension must use GaussRadauUpper quadrature, got "
+             << mesh.quadrature(0));
+  ASSERT(mesh.quadrature(1) == Spectral::Quadrature::Equiangular,
+         "Second mesh dimension must use Equiangular quadrature, got "
+             << mesh.quadrature(1));
+  ASSERT(n_r > 1,
+         "At least 2 radial grid points are required for the B2 power "
+         "monitor, got n_r = "
+             << n_r);
+  ASSERT(
+      n_phi % 2 == 1,
+      "The number of azimuthal grid points must be odd, got n_phi = " << n_phi);
+  ASSERT(M <= n_r_max,
+         "The number of Fourier modes M=" << M
+                                          << " exceeds the maximum Zernike "
+                                             "angular capability n_r_max="
+                                          << n_r_max);
+  ASSERT(u.size() == mesh.number_of_grid_points(),
+         "Size mismatch: u.size()=" << u.size()
+                                    << " != mesh.number_of_grid_points()="
+                                    << mesh.number_of_grid_points());
+  return {n_r_max, M, n_z};
+}
+
+size_t zernike_b2_disk_spectral_size(const size_t n_r_max, const size_t M) {
+  // m=0 contributes (n_r_max + 2) / 2 modes.
+  // Each m >= 1 contributes 2 * ((n_r_max - m + 2) / 2) modes (cos + sin).
+  size_t size = (n_r_max + 2) / 2;
+  for (size_t m = 1; m <= M; ++m) {
+    size += 2 * ((n_r_max - m + 2) / 2);
+  }
+  return size;
+}
+
+// Accumulate squared spectral coefficients and slot counts from one disk slice.
+// If radial is true, index by radial level ell = (n+1)/2; otherwise by m.
+// sum_sq and counts must each have size (n_r for radial, M+1 for angular).
+// Counts are always accumulated so the caller can normalize as sum_sq/counts.
+void accumulate_b2_spectral_sums(const gsl::not_null<DataVector*> sum_sq,
+                                 const gsl::not_null<DataVector*> counts,
+                                 const DataVector& spec, const size_t n_r_max,
+                                 const size_t M, const bool radial) {
+  const size_t spectral_size_m0 = (n_r_max + 2) / 2;
+  // m=0: Zernike degrees n = 0, 2, ..., n_r_max.  ell = (n+1)/2 = k.
+  for (size_t k = 0; k < spectral_size_m0; ++k) {
+    const size_t idx = radial ? k : 0_st;
+    (*sum_sq)[idx] += square(spec[k]);
+    (*counts)[idx] += 1.0;
+  }
+  // m>=1: Zernike degrees n = m, m+2, ..., n_r_max.
+  // ell = (m + 2k + 1) / 2  (integer division, where k is the sub-index).
+  size_t offset = spectral_size_m0;
+  for (size_t m = 1; m <= M; ++m) {
+    const size_t spectral_size_m = (n_r_max - m + 2) / 2;
+    for (size_t k = 0; k < spectral_size_m; ++k) {
+      // cos at spec[offset + k], sin at spec[offset + spectral_size_m + k]
+      const size_t idx = radial ? (m + 2 * k + 1) / 2 : m;
+      (*sum_sq)[idx] +=
+          square(spec[offset + k]) + square(spec[offset + spectral_size_m + k]);
+      (*counts)[idx] += 2.0;
+    }
+    offset += 2 * spectral_size_m;
+  }
+}
+}  // namespace
+
+void zernike_b2_disk_nodal_to_modal(const gsl::not_null<DataVector*> modal,
+                                    const gsl::not_null<DataVector*> buf,
+                                    const DataVector& u, const size_t n_r,
+                                    const size_t n_phi, const size_t n_r_max,
+                                    const size_t num_components) {
+  const size_t M = n_phi / 2;
+  const size_t n_disk = n_r * n_phi;
+  const size_t spectral_size = zernike_b2_disk_spectral_size(n_r_max, M);
+  // buf is split into two halves of size num_components * n_disk each.
+  if (UNLIKELY(buf->size() < 2 * num_components * n_disk)) {
+    buf->destructive_resize(2 * num_components * n_disk);
+  }
+  double* const buf_a = buf->data();
+  double* const buf_b = buf->data() + num_components * n_disk;
+
+  // Fourier NTM for all components simultaneously.
+  const Matrix& ntm_phi =
+      nodal_to_modal_matrix<Basis::Fourier, Quadrature::Equiangular>(n_phi);
+  raw_transpose(make_not_null(buf_b), u.data(), n_r, num_components * n_phi);
+  dgemm_<true>('N', 'N', n_phi, num_components * n_r, n_phi, 1.0,
+               ntm_phi.data(), ntm_phi.spacing(), buf_b, n_phi, 0.0, buf_a,
+               n_phi);
+  raw_transpose(make_not_null(buf_b), buf_a, num_components * n_phi, n_r);
+
+  // Zernike NTM for each azimuthal wavenumber m, looping over
+  // components.
+  const size_t spectral_size_m0 = (n_r_max + 2) / 2;
+  const Matrix& ntm_m0 =
+      nodal_to_modal_matrix<Basis::ZernikeB2, Quadrature::GaussRadauUpper>(
+          n_r, 0, n_r_max);
+  for (size_t comp = 0; comp < num_components; ++comp) {
+    dgemv_('N', spectral_size_m0, n_r, 1.0, ntm_m0.data(), ntm_m0.spacing(),
+           buf_b + comp * n_disk,  // NOLINT
+           1, 0.0, modal->data() + comp * spectral_size, 1);
+  }
+  size_t offset = spectral_size_m0;
+  for (size_t m = 1, j = 1; m <= M; ++m, j += 2) {
+    const size_t spectral_size_m = (n_r_max - m + 2) / 2;
+    const Matrix& ntm_mm =
+        nodal_to_modal_matrix<Basis::ZernikeB2, Quadrature::GaussRadauUpper>(
+            n_r, m, n_r_max);
+    for (size_t comp = 0; comp < num_components; ++comp) {
+      // Process cos (column j) and sin (column j+1) jointly.
+      dgemm_<true>('N', 'N', spectral_size_m, 2, n_r, 1.0, ntm_mm.data(),
+                   ntm_mm.spacing(),
+                   buf_b + comp * n_disk + j * n_r,  // NOLINT
+                   n_r, 0.0, modal->data() + comp * spectral_size + offset,
+                   spectral_size_m);
+    }
+    offset += 2 * spectral_size_m;
+  }
+}
+
+void b2_power_monitor_radial(const gsl::not_null<DataVector*> result,
+                             const DataVector& u, const Mesh<2>& mesh) {
+  const auto [n_r_max, M, n_z] = check_b2_mesh(u, mesh);
+  const size_t n_r = mesh.extents(0);
+  const size_t n_phi = mesh.extents(1);
+  const size_t spectral_size = zernike_b2_disk_spectral_size(n_r_max, M);
+  result->destructive_resize(n_r);
+  DataVector sum_sq(n_r, 0.0);
+  DataVector counts(n_r, 0.0);
+  DataVector spec(spectral_size);
+  DataVector scratch(2 * n_r * n_phi);
+  Spectral::zernike_b2_disk_nodal_to_modal(
+      make_not_null(&spec), make_not_null(&scratch), u, n_r, n_phi, n_r_max);
+  accumulate_b2_spectral_sums(make_not_null(&sum_sq), make_not_null(&counts),
+                              spec, n_r_max, M, true);
+  for (size_t ell = 0; ell < n_r; ++ell) {
+    (*result)[ell] = sqrt(sum_sq[ell] / counts[ell]);
+  }
+}
+
+void b2_power_monitor_radial(const gsl::not_null<DataVector*> result,
+                             const DataVector& u, const Mesh<3>& mesh) {
+  const auto [n_r_max, M, n_z] = check_b2_mesh(u, mesh);
+  const size_t n_r = mesh.extents(0);
+  const size_t n_phi = mesh.extents(1);
+  const size_t n_disk = n_r * n_phi;
+  const size_t spectral_size = zernike_b2_disk_spectral_size(n_r_max, M);
+  result->destructive_resize(n_r);
+  DataVector sum_sq(n_r, 0.0);
+  DataVector counts(n_r, 0.0);
+  DataVector spec(spectral_size);
+  DataVector scratch(2 * n_disk);
+  for (size_t k_z = 0; k_z < n_z; ++k_z) {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+    auto* const u_data = const_cast<double*>(u.data());
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    const DataVector u_slice(u_data + k_z * n_disk, n_disk);
+    Spectral::zernike_b2_disk_nodal_to_modal(make_not_null(&spec),
+                                             make_not_null(&scratch), u_slice,
+                                             n_r, n_phi, n_r_max);
+    accumulate_b2_spectral_sums(make_not_null(&sum_sq), make_not_null(&counts),
+                                spec, n_r_max, M, true);
+  }
+  for (size_t ell = 0; ell < n_r; ++ell) {
+    (*result)[ell] = sqrt(sum_sq[ell] / counts[ell]);
+  }
+}
+
+void b2_power_monitor_angular(const gsl::not_null<DataVector*> result,
+                              const DataVector& u, const Mesh<2>& mesh) {
+  const auto [n_r_max, M, n_z] = check_b2_mesh(u, mesh);
+  const size_t n_r = mesh.extents(0);
+  const size_t n_phi = mesh.extents(1);
+  const size_t spectral_size = zernike_b2_disk_spectral_size(n_r_max, M);
+  result->destructive_resize(M + 1);
+  DataVector sum_sq(M + 1, 0.0);
+  DataVector counts(M + 1, 0.0);
+  DataVector spec(spectral_size);
+  DataVector scratch(2 * n_r * n_phi);
+  Spectral::zernike_b2_disk_nodal_to_modal(
+      make_not_null(&spec), make_not_null(&scratch), u, n_r, n_phi, n_r_max);
+  accumulate_b2_spectral_sums(make_not_null(&sum_sq), make_not_null(&counts),
+                              spec, n_r_max, M, false);
+  for (size_t m = 0; m <= M; ++m) {
+    (*result)[m] = sqrt(sum_sq[m] / counts[m]);
+  }
+}
+
+void b2_power_monitor_angular(const gsl::not_null<DataVector*> result,
+                              const DataVector& u, const Mesh<3>& mesh) {
+  const auto [n_r_max, M, n_z] = check_b2_mesh(u, mesh);
+  const size_t n_r = mesh.extents(0);
+  const size_t n_phi = mesh.extents(1);
+  const size_t n_disk = n_r * n_phi;
+  const size_t spectral_size = zernike_b2_disk_spectral_size(n_r_max, M);
+  result->destructive_resize(M + 1);
+  DataVector sum_sq(M + 1, 0.0);
+  DataVector counts(M + 1, 0.0);
+  DataVector spec(spectral_size);
+  DataVector scratch(2 * n_disk);
+  for (size_t k_z = 0; k_z < n_z; ++k_z) {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+    auto* const u_data = const_cast<double*>(u.data());
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    const DataVector u_slice(u_data + k_z * n_disk, n_disk);
+    Spectral::zernike_b2_disk_nodal_to_modal(make_not_null(&spec),
+                                             make_not_null(&scratch), u_slice,
+                                             n_r, n_phi, n_r_max);
+    accumulate_b2_spectral_sums(make_not_null(&sum_sq), make_not_null(&counts),
+                                spec, n_r_max, M, false);
+  }
+  for (size_t m = 0; m <= M; ++m) {
+    (*result)[m] = sqrt(sum_sq[m] / counts[m]);
+  }
+}
+}  // namespace Spectral

--- a/src/NumericalAlgorithms/Spectral/ZernikeB2.hpp
+++ b/src/NumericalAlgorithms/Spectral/ZernikeB2.hpp
@@ -1,0 +1,113 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "Utilities/Gsl.hpp"
+
+/// \cond
+class DataVector;
+template <size_t Dim>
+class Mesh;
+/// \endcond
+
+namespace Spectral {
+
+/*!
+ * \ingroup SpectralGroup
+ * \brief Transform nodal ZernikeB2 data on a disk to modal space.
+ *
+ * Transforms \p num_components independent disk slices simultaneously. This
+ * is the same operation as done in the disk filtering, while cylinder
+ * filtering batches more optimally so we choose not to refactor them to use
+ * this looped version. The Fourier nodal-to-modal step is applied to all
+ * components in a single batched DGEMM while the Zernike nodal-to-modal
+ * step loops over components.
+ *
+ * \param modal Output spectral coefficients.
+ *   Size: `num_components * zernike_b2_disk_spectral_size(n_r_max, n_phi/2)`.
+ *   Layout: `modal[comp * spectral_size + spec_index]`.
+ * \param buf Scratch buffer. Size: `>= 2 * num_components * n_r * n_phi`.
+ * \param u Input nodal values.
+ *   Size: `num_components * n_r * n_phi`.
+ *   Layout: `u[comp * n_r * n_phi + i_r + n_r * j_phi]`.
+ * \param n_r Number of radial grid points.
+ * \param n_phi Number of azimuthal grid points (must be odd).
+ * \param n_r_max Maximum Zernike degree.
+ * \param num_components Number of independent disk slices to transform.
+ */
+void zernike_b2_disk_nodal_to_modal(gsl::not_null<DataVector*> modal,
+                                    gsl::not_null<DataVector*> buf,
+                                    const DataVector& u, size_t n_r,
+                                    size_t n_phi, size_t n_r_max,
+                                    size_t num_components = 1);
+
+/// @{
+/*!
+ * \ingroup SpectralGroup
+ * \brief Returns the radial B2 power monitor indexed by radial spectral level
+ * \f$\ell = (n+1)/2\f$ for a function on a ZernikeB2 disk or cylinder mesh.
+ *
+ * \details For functions represented on a filled disk by ZernikeB2 basis
+ * functions, the radial and angular spectral spaces are coupled. This function
+ * transforms to the combined ZernikeB2 spectral space and groups based on
+ * spectral level, meaning all spectral modes \f$(n, m)\f$ satisfying \f$(n+1)/2
+ * = \ell\f$ (using integer division), across all \f$m\f$ and both cosine and
+ * sine components, are pooled together.
+ *
+ * The returned DataVector has \f$N_r\f$ entries \f$(\ell = 0, 1, \ldots,
+ * N_r - 1)\f$. The \f$\ell\f$-th entry is
+ *
+ * \f{align*}{
+ *   P_\ell[\psi] = \sqrt{ \frac{1}{S_\ell}
+ *     \sum_{\substack{n,m: \\ (n+1)/2 = \ell}} \left| c_{n,m} \right|^2 },
+ * \f}
+ *
+ * where \f$c_{n,m}\f$ are the ZernikeB2 spectral coefficients summing over
+ * both cosine and sine components for \f$m \geq 1\f$, and \f$S_\ell\f$ is
+ * the total number of spectral coefficient slots at level \f$\ell\f$
+ * (including slots that are zero).
+ *
+ * For the 3D (cylinder) overload, coefficients are pooled across all
+ * \f$z\f$-slices: \f$S_\ell\f$ is multiplied by the number of \f$z\f$ points.
+ */
+void b2_power_monitor_radial(gsl::not_null<DataVector*> result,
+                             const DataVector& u, const Mesh<2>& mesh);
+void b2_power_monitor_radial(gsl::not_null<DataVector*> result,
+                             const DataVector& u, const Mesh<3>& mesh);
+/// @}
+
+/// @{
+/*!
+ * \ingroup SpectralGroup
+ * \brief Returns the B2 power monitor indexed by azimuthal wavenumber \f$m\f$
+ * for a function on a ZernikeB2 disk or cylinder mesh.
+ *
+ * \details For functions represented on a filled disk by ZernikeB2 basis
+ * functions, the radial and angular spectral spaces are coupled. This function
+ * transforms to the combined ZernikeB2 spectral space and returns the
+ * root-mean-square of the spectral coefficients at each azimuthal wavenumber
+ * \f$m = 0, 1, \ldots, M\f$, where \f$M = N_\phi / 2\f$ and \f$N_\phi\f$ is the
+ * number of azimuthal grid points.
+ *
+ * The returned DataVector has \f$M + 1\f$ entries. The \f$m\f$-th entry is
+ *
+ * \f{align*}{
+ *   P_m[\psi] = \sqrt{ \frac{1}{S_m} \sum_n \left| c_{n,m} \right|^2 },
+ * \f}
+ *
+ * where \f$c_{n,m}\f$ are the ZernikeB2 spectral coefficients of \f$\psi\f$
+ * at angular wavenumber \f$m\f$ (summing over both cosine and sine components
+ * for \f$m \geq 1\f$), and \f$S_m\f$ is the number of terms in the sum.
+ *
+ * For the 3D (cylinder) overload, coefficients are pooled across all
+ * \f$z\f$-slices: \f$S_m\f$ is multiplied by the number of \f$z\f$ points.
+ */
+void b2_power_monitor_angular(gsl::not_null<DataVector*> result,
+                              const DataVector& u, const Mesh<2>& mesh);
+void b2_power_monitor_angular(gsl::not_null<DataVector*> result,
+                              const DataVector& u, const Mesh<3>& mesh);
+/// @}
+}  // namespace Spectral

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PowerMonitors.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PowerMonitors.cpp
@@ -587,6 +587,34 @@ void test_power_monitors_fourier_multidim(
     CHECK_ITERABLE_APPROX(pm[2], expected_z);
   }
 }
+
+void test_power_monitors_b2_cylinder() {
+  // Regression test: exact analytical values for u = r * cos(phi) * z.
+  // Test of underlying implementation is in ../Spectral/Test_ZernikeB2.cpp
+    const size_t n_r = 3;
+    const size_t n_phi = 5;
+    const size_t n_z = 4;
+    const size_t M = n_phi / 2;
+    const Mesh<3> mesh{{n_r, n_phi, n_z},
+                       {Spectral::Basis::ZernikeB2, Spectral::Basis::ZernikeB2,
+                        Spectral::Basis::Legendre},
+                       {Spectral::Quadrature::GaussRadauUpper,
+                        Spectral::Quadrature::Equiangular,
+                        Spectral::Quadrature::GaussLobatto}};
+    const auto coords = logical_coordinates(mesh);
+    const DataVector r = 0.5 * (get<0>(coords) + 1.0);
+    const DataVector& phi = get<1>(coords);
+    const DataVector& z = get<2>(coords);
+    const DataVector u = r * cos(phi) * z;
+    const auto pm = PowerMonitors::power_monitors(u, mesh);
+    CHECK(pm[0].size() == n_r);
+    CHECK_ITERABLE_APPROX(pm[0], (DataVector{0.0, sqrt(3.0) / 10.0, 0.0}));
+    CHECK(pm[1].size() == M + 1);
+    CHECK_ITERABLE_APPROX(pm[1], (DataVector{0.0, sqrt(15.0) / 20.0, 0.0}));
+    CHECK(pm[2].size() == n_z);
+    CHECK_ITERABLE_APPROX(pm[2],
+                          (DataVector{0.0, sqrt(30.0) / 10.0, 0.0, 0.0}));
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.PowerMonitors",
@@ -603,4 +631,5 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.PowerMonitors",
   test_spherical_shell_angular_power_monitor();
   test_power_monitors_fourier(make_not_null(&gen));
   test_power_monitors_fourier_multidim(make_not_null(&gen));
+  test_power_monitors_b2_cylinder();
 }

--- a/tests/Unit/NumericalAlgorithms/Spectral/CMakeLists.txt
+++ b/tests/Unit/NumericalAlgorithms/Spectral/CMakeLists.txt
@@ -43,6 +43,7 @@ set(LIBRARY_SOURCES
   Test_QuadratureWeights.cpp
   Test_SegmentSize.cpp
   Test_Spectral.cpp
+  Test_ZernikeB2.cpp
   Test_ZernikeGaussRadauUpper.cpp
   )
 

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_ZernikeB2.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_ZernikeB2.cpp
@@ -1,0 +1,398 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cmath>
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/BasisFunctionValue.hpp"
+#include "NumericalAlgorithms/Spectral/CollocationPoints.hpp"
+#include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "NumericalAlgorithms/Spectral/ZernikeB2.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/Literals.hpp"
+
+namespace {
+
+void test_b2_disk_power_monitors() {
+  // Test structural properties of both angular and radial power monitors on a
+  // 2D disk over several mesh sizes (n_phi odd, M = n_phi/2 <= 2*n_r - 2).
+  // Exact single-mode values are verified by
+  // test_b2_power_monitor_exact_values; here we check properties that require
+  // sin modes or multiple modes:
+  //   (a) sin mode: zero at all slots except the excited one,
+  //   (b) cos and sin carry equal power (Fourier symmetry),
+  //   (c) cos+sin has sqrt(2) times the single-component power,
+  //   (d) Pythagorean addition for distinct modes sharing a radial level.
+  const std::vector<std::pair<size_t, size_t>> mesh_sizes{
+      {2, 3}, {3, 5}, {3, 9}, {4, 5}, {5, 7}};
+
+  for (const auto& [n_r, n_phi] : mesh_sizes) {
+    CAPTURE(n_r);
+    CAPTURE(n_phi);
+    const size_t M = n_phi / 2;
+    const Mesh<2> mesh{{n_r, n_phi},
+                       {Spectral::Basis::ZernikeB2, Spectral::Basis::ZernikeB2},
+                       {Spectral::Quadrature::GaussRadauUpper,
+                        Spectral::Quadrature::Equiangular}};
+    const auto xi = logical_coordinates(mesh);
+    const DataVector r = 0.5 * (get<0>(xi) + 1.0);
+    const DataVector& phi = get<1>(xi);
+
+    for (size_t m_test = 1; m_test <= M; ++m_test) {
+      CAPTURE(m_test);
+      const size_t ell_test = (m_test + 1) / 2;
+      const DataVector r_m = pow(r, static_cast<double>(m_test));
+      const DataVector f_cos = r_m * cos(static_cast<double>(m_test) * phi);
+      const DataVector f_sin = r_m * sin(static_cast<double>(m_test) * phi);
+
+      DataVector pm_ang_cos;
+      DataVector pm_ang_sin;
+      DataVector pm_ang_both;
+      DataVector pm_rad_cos;
+      DataVector pm_rad_sin;
+      DataVector pm_rad_both;
+      Spectral::b2_power_monitor_angular(make_not_null(&pm_ang_cos), f_cos,
+                                         mesh);
+      Spectral::b2_power_monitor_angular(make_not_null(&pm_ang_sin), f_sin,
+                                         mesh);
+      Spectral::b2_power_monitor_angular(make_not_null(&pm_ang_both),
+                                         f_cos + f_sin, mesh);
+      Spectral::b2_power_monitor_radial(make_not_null(&pm_rad_cos), f_cos,
+                                        mesh);
+      Spectral::b2_power_monitor_radial(make_not_null(&pm_rad_sin), f_sin,
+                                        mesh);
+      Spectral::b2_power_monitor_radial(make_not_null(&pm_rad_both),
+                                        f_cos + f_sin, mesh);
+
+      // (a) Sin mode: zero at every slot except the excited one.
+      for (size_t m = 0; m <= M; ++m) {
+        if (m != m_test) {
+          CHECK(pm_ang_sin[m] == approx(0.0));
+        }
+      }
+      for (size_t ell = 0; ell < n_r; ++ell) {
+        if (ell != ell_test) {
+          CHECK(pm_rad_sin[ell] == approx(0.0));
+        }
+      }
+
+      // (b) Cos and sin carry equal power.
+      CHECK(pm_ang_cos[m_test] == approx(pm_ang_sin[m_test]));
+      CHECK(pm_rad_cos[ell_test] == approx(pm_rad_sin[ell_test]));
+
+      // (c) Cos+sin has sqrt(2) times the single-component power.
+      CHECK(pm_ang_both[m_test] == approx(std::sqrt(2.0) * pm_ang_cos[m_test]));
+      CHECK(pm_rad_both[ell_test] ==
+            approx(std::sqrt(2.0) * pm_rad_cos[ell_test]));
+    }
+
+    // (d) Pythagorean addition for modes at the same radial level.
+    // m=1 -> ell=1 and m=2 -> ell=1, so
+    //        |pm(f1+f2)|^2 = |pm(f1)|^2 + |pm(f2)|^2.
+    if (M >= 2) {
+      const DataVector f1 = r * cos(phi);                // (n=1, m=1) -> ell=1
+      const DataVector f2 = square(r) * cos(2.0 * phi);  // (n=2, m=2) -> ell=1
+      DataVector pm1;
+      DataVector pm2;
+      DataVector pm12;
+      Spectral::b2_power_monitor_radial(make_not_null(&pm1), f1, mesh);
+      Spectral::b2_power_monitor_radial(make_not_null(&pm2), f2, mesh);
+      Spectral::b2_power_monitor_radial(make_not_null(&pm12), f1 + f2, mesh);
+      CHECK(square(pm12[1]) == approx(square(pm1[1]) + square(pm2[1])));
+    }
+  }
+}
+
+void test_b2_cylinder_power_monitors() {
+  // Test that the Mesh<3> (cylinder) power monitors agree with the Mesh<2>
+  // (disk) monitors when n_z = 1, and that z-stacking two identical disks
+  // gives the same angular and radial power as a single disk.
+  const std::vector<std::pair<size_t, size_t>> disk_sizes{
+      {2, 3}, {3, 5}, {4, 7}};
+  const std::vector<size_t> z_sizes{1, 2, 3};
+
+  for (const auto& [n_r, n_phi] : disk_sizes) {
+    CAPTURE(n_r);
+    CAPTURE(n_phi);
+    const size_t M = n_phi / 2;
+    const Mesh<2> disk_mesh{
+        {n_r, n_phi},
+        {Spectral::Basis::ZernikeB2, Spectral::Basis::ZernikeB2},
+        {Spectral::Quadrature::GaussRadauUpper,
+         Spectral::Quadrature::Equiangular}};
+    const auto xi = logical_coordinates(disk_mesh);
+    const DataVector r = 0.5 * (get<0>(xi) + 1.0);
+    const DataVector& phi = get<1>(xi);
+    // Use a non-trivial test function with several modes excited.
+    const DataVector u_disk = 1.0 + r * cos(phi) + square(r) * cos(2.0 * phi);
+    DataVector pm_disk;
+    DataVector pm_radial_disk;
+    Spectral::b2_power_monitor_angular(make_not_null(&pm_disk), u_disk,
+                                       disk_mesh);
+    Spectral::b2_power_monitor_radial(make_not_null(&pm_radial_disk), u_disk,
+                                      disk_mesh);
+
+    for (const size_t n_z : z_sizes) {
+      CAPTURE(n_z);
+      const Mesh<3> cyl_mesh{
+          {n_r, n_phi, n_z},
+          {Spectral::Basis::ZernikeB2, Spectral::Basis::ZernikeB2,
+           Spectral::Basis::Legendre},
+          {Spectral::Quadrature::GaussRadauUpper,
+           Spectral::Quadrature::Equiangular,
+           Spectral::Quadrature::GaussLobatto}};
+
+      // Construct cylinder data by repeating u_disk for every z-slice.
+      DataVector u_cyl(cyl_mesh.number_of_grid_points(), 0.0);
+      for (size_t k_z = 0; k_z < n_z; ++k_z) {
+        for (size_t i = 0; i < n_r * n_phi; ++i) {
+          u_cyl[k_z * n_r * n_phi + i] = u_disk[i];
+        }
+      }
+
+      // Angular monitor: cylinder result must equal disk result (same data
+      // repeated in z, so the RMS over z is the same as for one slice).
+      DataVector pm_cyl;
+      Spectral::b2_power_monitor_angular(make_not_null(&pm_cyl), u_cyl,
+                                         cyl_mesh);
+      CHECK(pm_cyl.size() == M + 1_st);
+      CHECK_ITERABLE_APPROX(pm_cyl, pm_disk);
+
+      // Radial monitor: same reasoning.
+      DataVector pm_radial_cyl;
+      Spectral::b2_power_monitor_radial(make_not_null(&pm_radial_cyl), u_cyl,
+                                        cyl_mesh);
+      CHECK(pm_radial_cyl.size() == n_r);
+      CHECK_ITERABLE_APPROX(pm_radial_cyl, pm_radial_disk);
+    }
+
+    // When two *different* z-slices are stacked, the Pythagorean law holds
+    // in z: P_cyl^2 = (P_disk1^2 + P_disk2^2) / 2.
+    {
+      const size_t n_z2 = 2;
+      const Mesh<3> cyl_mesh2{
+          {n_r, n_phi, n_z2},
+          {Spectral::Basis::ZernikeB2, Spectral::Basis::ZernikeB2,
+           Spectral::Basis::Legendre},
+          {Spectral::Quadrature::GaussRadauUpper,
+           Spectral::Quadrature::Equiangular,
+           Spectral::Quadrature::GaussLobatto}};
+
+      const DataVector u2_disk = r * cos(phi);  // different second slice
+      DataVector pm2_disk;
+      DataVector pm2_radial_disk;
+      Spectral::b2_power_monitor_angular(make_not_null(&pm2_disk), u2_disk,
+                                         disk_mesh);
+      Spectral::b2_power_monitor_radial(make_not_null(&pm2_radial_disk),
+                                        u2_disk, disk_mesh);
+
+      DataVector u2_cyl(cyl_mesh2.number_of_grid_points(), 0.0);
+      for (size_t i = 0; i < n_r * n_phi; ++i) {
+        u2_cyl[i] = u_disk[i];
+        u2_cyl[n_r * n_phi + i] = u2_disk[i];
+      }
+
+      DataVector pm2_cyl;
+      DataVector pm2_radial_cyl;
+      Spectral::b2_power_monitor_angular(make_not_null(&pm2_cyl), u2_cyl,
+                                         cyl_mesh2);
+      Spectral::b2_power_monitor_radial(make_not_null(&pm2_radial_cyl), u2_cyl,
+                                        cyl_mesh2);
+
+      for (size_t m = 0; m <= M; ++m) {
+        // P_cyl^2 = (P1^2 + P2^2) / 2
+        CHECK(square(pm2_cyl[m]) ==
+              approx(0.5 * (square(pm_disk[m]) + square(pm2_disk[m]))));
+      }
+      for (size_t ell = 0; ell < n_r; ++ell) {
+        CHECK(square(pm2_radial_cyl[ell]) ==
+              approx(0.5 * (square(pm_radial_disk[ell]) +
+                            square(pm2_radial_disk[ell]))));
+      }
+    }
+  }
+}
+// Count spectral slots at radial level ell_0 for a ZernikeB2 disk.
+// m=0 modes contribute 1 slot each; m>0 modes contribute 2 (cos + sin).
+// Each mode (m, k) maps to ell = (m + 2*k + 1) / 2 (integer division).
+size_t count_b2_radial_slots(const size_t ell_0, const size_t n_r_max,
+                             const size_t M) {
+  const size_t spectral_size_m0 = (n_r_max + 2) / 2;
+  size_t slots = 0;
+  if (ell_0 < spectral_size_m0) {
+    ++slots;  // one m=0 mode at this level
+  }
+  for (size_t m = 1; m <= M; ++m) {
+    const size_t sm = (n_r_max - m + 2) / 2;
+    for (size_t k = 0; k < sm; ++k) {
+      if ((m + 2 * k + 1) / 2 == ell_0) {
+        slots += 2;
+      }
+    }
+  }
+  return slots;
+}
+
+size_t count_b2_angular_slots(const size_t m, const size_t n_r_max) {
+  const size_t spectral_size_m0 = (n_r_max + 2) / 2;
+  return m == 0 ? spectral_size_m0 : 2 * ((n_r_max - m + 2) / 2);
+}
+
+// Test b2_power_monitor_radial and b2_power_monitor_angular on a 2D disk with
+// the pure mode u = phi_n^m(r) * cos(m*phi), where phi_n^m is the orthonormal
+// ZernikeB2 basis function.  By orthonormality, the (n,m,cos) spectral
+// coefficient equals 1 and all others equal 0, so expected power monitor
+// values follow directly from slot counts:
+//   pm_radial[ell_0] = 1 / sqrt(slots_rad),
+//   pm_angular[m]    = 1 / sqrt(slots_ang).
+void test_b2_disk_mode(const size_t n_zernike, const size_t m_zernike,
+                       const size_t n_r, const size_t n_phi) {
+  CAPTURE(n_zernike);
+  CAPTURE(m_zernike);
+  CAPTURE(n_r);
+  CAPTURE(n_phi);
+  const size_t n_r_max = 2 * n_r - 2;
+  const size_t M = n_phi / 2;
+  const Mesh<2> mesh{{n_r, n_phi},
+                     {Spectral::Basis::ZernikeB2, Spectral::Basis::ZernikeB2},
+                     {Spectral::Quadrature::GaussRadauUpper,
+                      Spectral::Quadrature::Equiangular}};
+  const DataVector xi_r = Spectral::collocation_points(mesh.slice_through(0));
+  const DataVector phi_pts =
+      Spectral::collocation_points(mesh.slice_through(1));
+  const DataVector phi_nm_at_r =
+      Spectral::compute_basis_function_value<Spectral::Basis::ZernikeB2>(
+          n_zernike, m_zernike, xi_r);
+  // Build u = phi_n^m(r) * cos(m*phi); index layout u[i_r + n_r*i_phi].
+  DataVector u(mesh.number_of_grid_points());
+  for (size_t i_phi = 0; i_phi < n_phi; ++i_phi) {
+    const double cos_mphi =
+        cos(static_cast<double>(m_zernike) * phi_pts[i_phi]);
+    for (size_t i_r = 0; i_r < n_r; ++i_r) {
+      u[i_r + n_r * i_phi] = phi_nm_at_r[i_r] * cos_mphi;
+    }
+  }
+  const size_t ell_0 = (n_zernike + 1) / 2;
+  DataVector expected_radial(n_r, 0.0);
+  expected_radial[ell_0] =
+      1.0 / sqrt(static_cast<double>(count_b2_radial_slots(ell_0, n_r_max, M)));
+  DataVector expected_angular(M + 1, 0.0);
+  expected_angular[m_zernike] =
+      1.0 /
+      sqrt(static_cast<double>(count_b2_angular_slots(m_zernike, n_r_max)));
+  DataVector pm_radial;
+  DataVector pm_angular;
+  Spectral::b2_power_monitor_radial(make_not_null(&pm_radial), u, mesh);
+  Spectral::b2_power_monitor_angular(make_not_null(&pm_angular), u, mesh);
+  CHECK(pm_radial.size() == n_r);
+  CHECK(pm_angular.size() == M + 1);
+  CHECK_ITERABLE_APPROX(pm_radial, expected_radial);
+  CHECK_ITERABLE_APPROX(pm_angular, expected_angular);
+}
+
+// Same test for Mesh<3> (cylinder) overloads with
+// u = phi_n^m(r) * cos(m*phi) * P_{k'}(z).
+// The disk spectral coefficient equals P_{k'}(z) per z-slice, so the
+// z-averaged power monitor uses sum_Pk_sq = sum_i P_{k'}(z_i)^2:
+//   pm_radial[ell_0] = sqrt(sum_Pk_sq / (n_z * slots_rad)),
+//   pm_angular[m]    = sqrt(sum_Pk_sq / (n_z * slots_ang)).
+void test_b2_cylinder_mode(const size_t n_zernike, const size_t m_zernike,
+                           const size_t k_legendre, const size_t n_r,
+                           const size_t n_phi, const size_t n_z) {
+  CAPTURE(n_zernike);
+  CAPTURE(m_zernike);
+  CAPTURE(k_legendre);
+  CAPTURE(n_r);
+  CAPTURE(n_phi);
+  CAPTURE(n_z);
+  const size_t n_r_max = 2 * n_r - 2;
+  const size_t M = n_phi / 2;
+  const Mesh<3> cyl_mesh{
+      {n_r, n_phi, n_z},
+      {Spectral::Basis::ZernikeB2, Spectral::Basis::ZernikeB2,
+       Spectral::Basis::Legendre},
+      {Spectral::Quadrature::GaussRadauUpper, Spectral::Quadrature::Equiangular,
+       Spectral::Quadrature::GaussLobatto}};
+  const DataVector xi_r =
+      Spectral::collocation_points(cyl_mesh.slice_through(0));
+  const DataVector phi_pts =
+      Spectral::collocation_points(cyl_mesh.slice_through(1));
+  const DataVector z_pts =
+      Spectral::collocation_points(cyl_mesh.slice_through(2));
+  const DataVector phi_nm_at_r =
+      Spectral::compute_basis_function_value<Spectral::Basis::ZernikeB2>(
+          n_zernike, m_zernike, xi_r);
+  const DataVector P_k_at_z =
+      Spectral::compute_basis_function_value<Spectral::Basis::Legendre>(
+          k_legendre, z_pts);
+  DataVector u(cyl_mesh.number_of_grid_points());
+  for (size_t i_z = 0; i_z < n_z; ++i_z) {
+    for (size_t i_phi = 0; i_phi < n_phi; ++i_phi) {
+      const double cos_mphi =
+          cos(static_cast<double>(m_zernike) * phi_pts[i_phi]);
+      for (size_t i_r = 0; i_r < n_r; ++i_r) {
+        u[i_r + n_r * (i_phi + n_phi * i_z)] =
+            phi_nm_at_r[i_r] * cos_mphi * P_k_at_z[i_z];
+      }
+    }
+  }
+  double sum_Pk_sq = 0.0;
+  for (size_t i = 0; i < n_z; ++i) {
+    sum_Pk_sq += square(P_k_at_z[i]);
+  }
+  const size_t ell_0 = (n_zernike + 1) / 2;
+  DataVector expected_radial(n_r, 0.0);
+  expected_radial[ell_0] =
+      sqrt(sum_Pk_sq /
+           (static_cast<double>(n_z) *
+            static_cast<double>(count_b2_radial_slots(ell_0, n_r_max, M))));
+  DataVector expected_angular(M + 1, 0.0);
+  expected_angular[m_zernike] =
+      sqrt(sum_Pk_sq /
+           (static_cast<double>(n_z) *
+            static_cast<double>(count_b2_angular_slots(m_zernike, n_r_max))));
+  DataVector pm_radial;
+  DataVector pm_angular;
+  Spectral::b2_power_monitor_radial(make_not_null(&pm_radial), u, cyl_mesh);
+  Spectral::b2_power_monitor_angular(make_not_null(&pm_angular), u, cyl_mesh);
+  CHECK(pm_radial.size() == n_r);
+  CHECK(pm_angular.size() == M + 1);
+  CHECK_ITERABLE_APPROX(pm_radial, expected_radial);
+  CHECK_ITERABLE_APPROX(pm_angular, expected_angular);
+}
+
+void test_b2_power_monitor_exact_values() {
+  // 2D disk: (n_zernike, m_zernike, n_r, n_phi)
+  test_b2_disk_mode(0, 0, 2, 3);  // monopole (n=m=0)
+  test_b2_disk_mode(1, 1, 2, 3);  // lowest non-trivial mode
+  test_b2_disk_mode(2, 0, 3, 5);  // m=0 second radial level
+  test_b2_disk_mode(2, 2, 3, 5);  // m=2
+  test_b2_disk_mode(3, 1, 3, 5);  // n=3, m=1
+  test_b2_disk_mode(3, 3, 4, 7);  // m=3
+  test_b2_disk_mode(4, 2, 4, 7);  // n=4, m=2
+  // 3D cylinder: (n_zernike, m_zernike, k_legendre, n_r, n_phi, n_z)
+  test_b2_cylinder_mode(1, 1, 0, 3, 5, 4);
+  test_b2_cylinder_mode(2, 0, 1, 3, 5, 4);
+  test_b2_cylinder_mode(2, 2, 2, 3, 5, 4);
+  test_b2_cylinder_mode(3, 1, 0, 4, 7, 3);
+  test_b2_cylinder_mode(3, 3, 2, 4, 7, 4);
+  test_b2_cylinder_mode(4, 2, 1, 4, 7, 5);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE("Unit.Numerical.Spectral.ZernikeB2",
+                  "[NumericalAlgorithms][Spectral][Unit]") {
+  test_b2_disk_power_monitors();
+  test_b2_cylinder_power_monitors();
+  test_b2_power_monitor_exact_values();
+}


### PR DESCRIPTION
## Proposed changes

Creating the `ZernikeB2.hpp` specific file seemed appropriate here as it is quite bulky to add to the power-monitor code.

The `FilteringB2.tpp` was not refactored to use the new ZernikeB2 nodal-to-modal code as the filtering code is optimized to use a passed buffer

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent was used, have a co-author trailer of the form
      "Co-Authored-By: <agent name> <agent email>" as the last line of the
      commit, e.g. "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>".

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
