### PR TITLE
Add BMS frame fixing for CCE output

### DIFF
--- a/docs/Tutorials/CCE.md
+++ b/docs/Tutorials/CCE.md
@@ -655,8 +655,30 @@ because the data at future null infinity is in the wrong Bondi-Metzner-Sachs
 (BMS) frame. In order to put this data into the correct BMS frame, the
 [SXS Collaboration](https://github.com/sxs-collaboration) offers a python/numba
 code called [scri](https://github.com/moble/scri) to do these transformations.
-See their documentation for how to install/run/plot a waveform at future null
-infinity in the correct BMS frame.
+
+We wrap scri in a CLI that maps the CCE output to the superrest frame and writes
+the result in the same format as the raw CCE output:
+
+```
+spectre bbh frame-fix CharacteristicExtractReduction.h5
+```
+
+This writes `CharacteristicExtractReductionFrameFixed.h5`, which you can plot
+with `spectre plot cce` just like the raw output. Run
+`spectre bbh frame-fix -h` to see the available options. The two that matter
+most are `--t-0-superrest` and `--padding-time`, which select the time window
+that determines the BMS transformation. **That window must not contain junk
+radiation**, so check the defaults against your simulation. If a run is slow,
+`--superrest-dt` determines the transformation from data that is sampled more
+coarsely in time, which doesn't change the resolution of the output.
+
+The BBH pipeline (`spectre bbh run-cce`) runs the frame fixing automatically
+once CCE completes, as part of the same job. Note that the job's wallclock limit has
+to cover the frame fixing as well as the CCE evolution.
+
+\note The `EthInertialRetardedTime` dataset is a diagnostic of the coordinate
+transformation that CCE itself performed. The frame fixing supersedes that
+transformation, so the dataset is filled with NaN in the frame-fixed output.
 
 Below is a plot of the imaginary part of the 2,2 component for the strain when
 plotted using the raw output from SpECTRE CCE and BMS frame-fixing with scri.
@@ -665,9 +687,9 @@ doesn't decay back down to zero during the ringdown. This is because of the
 improper BMS frame that the SpECTRE CCE waveform is in. A supertranslation must
 be applied to transform the waveform into the correct BMS frame. See
 \cite Mitman2024review for a review of BMS transformations and gravitational
-memory. To perform the frame fixing, see
+memory, and
 [this tutorial](https://scri.readthedocs.io/en/latest/tutorial_abd.html#loading-cce-data-and-adjusting-the-bms-frame)
-in scri.
+in scri for the transformation that `spectre bbh frame-fix` performs.
 
 \image html im_h22.png "Imaginary part of 2,2 component of the strain"
 

--- a/support/Pipelines/Bbh/CMakeLists.txt
+++ b/support/Pipelines/Bbh/CMakeLists.txt
@@ -11,6 +11,7 @@ spectre_python_add_module(
   ControlId.py
   EccentricityControl.py
   FindHorizon.py
+  FrameFix.py
   InitialData.py
   InitialData.yaml
   Inspiral.py

--- a/support/Pipelines/Bbh/Cce.py
+++ b/support/Pipelines/Bbh/Cce.py
@@ -36,6 +36,10 @@ def run_cce(
     options are forwarded to the 'schedule' command. See 'schedule' docs for
     details.
 
+    Once CCE is done, the waveforms are transformed into the correct BMS frame
+    with 'spectre bbh frame-fix'. This runs in the same job, so the wallclock
+    limit ('--time-limit' / '-t') must cover it as well.
+
     Arguments:
         bondi_sachs_data: Path to one or more files containing Bondi-Sachs data
         pipeline_dir: Directory where steps in the pipeline are created.

--- a/support/Pipelines/Bbh/Cce.yaml
+++ b/support/Pipelines/Bbh/Cce.yaml
@@ -11,6 +11,13 @@ BondiSachsData: "{{ BondiSachsData }}"
 FilesCombined: |
 {{ FilesCombined | indent(2, true) }}
 
+# Transform the waveforms into the correct BMS frame once CCE is done. This runs
+# in the same job as CCE, so make sure the wallclock limit covers it as well.
+Next:
+  Run: spectre.Pipelines.Bbh.FrameFix:frame_fix
+  With:
+    cce_reduction_file: ./CharacteristicExtractReduction.h5
+
 ---
 # Start of the input file that controls the CCE evolution.
 

--- a/support/Pipelines/Bbh/FrameFix.py
+++ b/support/Pipelines/Bbh/FrameFix.py
@@ -1,0 +1,357 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import logging
+import re
+from pathlib import Path
+from typing import Optional, Union
+
+import click
+import h5py
+import numpy as np
+import scri
+
+import spectre.IO.H5 as spectre_h5
+from spectre.IO.H5 import available_subfiles
+
+logger = logging.getLogger(__name__)
+
+# scri requires this format for the CCE subfile name
+SUBFILE_PATTERN = re.compile(r"SpectreR(\d{4})\.cce$")
+
+# Extra time on either side of the padding window that scri slices out of the
+# data to determine the BMS transformation, see
+# 'scri.asymptotic_bondi_data.map_to_superrest_frame'
+SCRI_EXTRA_PADDING_TIME = 200.0
+
+
+def _resolve_subfile(cce_reduction_file: Path):
+    """Find the Cce subfile to transform and its extraction radius.
+
+    Note that scri picks the subfile itself when it reads the file, so we can't
+    offer a choice here: it takes the first one whose name contains "Spectre".
+    """
+    with h5py.File(cce_reduction_file, "r") as open_h5_file:
+        cce_subfiles = available_subfiles(open_h5_file, extension=".cce")
+    if not cce_subfiles:
+        raise click.UsageError(
+            f"Could not find any Cce subfiles in H5 file {cce_reduction_file}."
+            " Cce subfiles must end with the extension '.cce'."
+        )
+    if len(cce_subfiles) > 1:
+        raise click.UsageError(
+            f"The H5 file {cce_reduction_file} has {len(cce_subfiles)} Cce"
+            f" subfiles ({', '.join(cce_subfiles)}), but scri only"
+            " supports one extraction radius per file. Split them into"
+            " separate files first."
+        )
+    subfile_name = cce_subfiles[0]
+    match = re.search(SUBFILE_PATTERN, subfile_name)
+    if not match:
+        raise click.UsageError(
+            f"The Cce subfile '{subfile_name}' is not named 'SpectreRXXXX.cce',"
+            " so the extraction radius can't be determined. scri requires this"
+            " format."
+        )
+    return subfile_name, float(match.group(1))
+
+
+def _spectre_waveforms(abd):
+    """Waveform quantities in SpECTRE's conventions vs. scri's conventions.
+
+    Internally scri uses the Moreschi-Boyle conventions, so undo the conversion
+    that 'scri.SpEC.file_io.create_abd_from_h5' applied when it loaded the data
+    with 'convention="SpEC"'. The factors here are the inverse of scri's
+    'conversion_factor["spec"] = [2, -sqrt(2), 1, -1/sqrt(2), 0.5, 0.5]' for
+    '[Psi0, Psi1, Psi2, Psi3, Psi4, h]'.
+    """
+    # 'abd.sigma' holds the conjugate of half the strain, so this is the strain
+    # in SpECTRE's conventions (the same as scri's 'abd.h', but keeping the
+    # l = 0, 1 modes that SpECTRE always writes out).
+    sigma_bar = abd.sigma.bar
+    return {
+        "Strain": 2.0 * sigma_bar,
+        # SpECTRE's News is the first time derivative of the strain
+        "News": 2.0 * sigma_bar.dot,
+        "Psi0": abd.psi0 / 2.0,
+        "Psi1": abd.psi1 / (-np.sqrt(2.0)),
+        "Psi2": abd.psi2,
+        "Psi3": -np.sqrt(2.0) * abd.psi3,
+        "Psi4": 2.0 * abd.psi4,
+    }
+
+
+def _write_cce_file(
+    output_file: Path,
+    subfile_name: str,
+    times,
+    waveforms: dict,
+    extraction_radius,
+):
+    """Write frame-fixed waveforms in SpECTRE's Cce format.
+
+    The layout matches the output of the CCE executable, so tools like
+    'spectre plot cce' work on the result.
+    """
+    num_modes = next(iter(waveforms.values())).shape[1]
+    l_max = int(round(np.sqrt(num_modes))) - 1
+    # scri works in retarded time, so it subtracts the extraction radius when it
+    # reads a Cce subfile. Add it back so the time column of a Cce subfile
+    # always means the same thing and the data round-trips through scri.
+    time_column = np.asarray(times) + extraction_radius
+    # Interleave real and imaginary parts of the modes, matching the legend that
+    # 'h5::Cce' generates: 'time, Real Y_0,0, Imag Y_0,0, Real Y_1,-1, ...'
+    rows = {}
+    for name, modes in waveforms.items():
+        modes = np.asarray(modes)
+        row = np.empty((len(time_column), 1 + 2 * num_modes))
+        row[:, 0] = time_column
+        row[:, 1::2] = modes.real
+        row[:, 2::2] = modes.imag
+        rows[name] = row
+    # CCE writes "EthInertialRetardedTime" alongside the waveform quantities to
+    # diagnose the coordinate transformation it performed at future null
+    # infinity. The frame fixing supersedes that transformation, so we have
+    # nothing meaningful to put here, but the Cce file format requires the
+    # dataset. Fill it with NaN.
+    rows["EthInertialRetardedTime"] = np.full(
+        (len(time_column), 1 + 2 * num_modes), np.nan
+    )
+    rows["EthInertialRetardedTime"][:, 0] = time_column
+
+    with spectre_h5.H5File(file_name=str(output_file), mode="a") as h5file:
+        cce_file = h5file.insert_cce(path=subfile_name, l_max=l_max, version=1)
+        for i in range(len(time_column)):
+            cce_file.append({name: row[i] for name, row in rows.items()})
+
+
+def frame_fix(
+    cce_reduction_file: Union[str, Path],
+    output_file: Optional[Union[str, Path]] = None,
+    t_0_superrest: Optional[float] = None,
+    padding_time: float = 200.0,
+    junk_time: float = 500.0,
+    ch_mass: Optional[float] = None,
+    superrest_dt: Optional[float] = 5.0,
+    force: bool = False,
+) -> Path:
+    """Transform CCE output into the correct BMS frame.
+
+    Waveforms that the CCE executable writes at future null infinity are in the
+    wrong Bondi-Metzner-Sachs (BMS) frame, which shows up as an offset in the
+    strain that doesn't decay during ringdown. This maps the data to the
+    superrest frame using scri, following
+    https://scri.readthedocs.io/en/latest/tutorial_abd.html
+
+    The result is written in the same format as the raw CCE output, so it can be
+    plotted with 'spectre plot cce'. Note that 'EthInertialRetardedTime' is a
+    diagnostic of the transformation that CCE performed, which the frame fixing
+    supersedes, so it is filled with NaN in the output.
+
+    See arXiv:2405.08868 for a review of BMS transformations and gravitational
+    memory, and cite scri (https://github.com/moble/scri) if you use this.
+
+    \f
+    Arguments:
+      cce_reduction_file: The CCE reduction file to transform, e.g.
+        'CharacteristicExtractReduction.h5'.
+      output_file: Where to write the frame-fixed data. Defaults to the input
+        file name with 'FrameFixed' appended, next to the input file.
+      t_0_superrest: Retarded time at which to map to the superrest frame.
+        Defaults to 'junk_time' plus 'padding_time' after the start of the data.
+      padding_time: Length of the time window around 't_0_superrest' used to
+        determine the BMS transformation. A few hundred M, or a couple of
+        orbits, is usually sufficient.
+      junk_time: How long the CCE junk radiation lasts. Only used to choose a
+        default for 't_0_superrest'.
+      ch_mass: Total Christodoulou mass of the system, used to make the
+        waveforms dimensionless. Defaults to no rescaling, which is what you
+        want when the simulation already has unit total mass (as the BBH
+        pipeline sets up).
+      superrest_dt: Time spacing of the data used to determine the BMS
+        transformation. The transformation is applied to the full data, so this
+        only trades accuracy of the transformation against runtime, not the
+        resolution of the output. Pass None to use the full data.
+      force: Overwrite the output file if it already exists.
+    """
+    cce_reduction_file = Path(cce_reduction_file).resolve()
+    if output_file is None:
+        output_file = cce_reduction_file.with_name(
+            cce_reduction_file.stem + "FrameFixed" + cce_reduction_file.suffix
+        )
+    output_file = Path(output_file)
+    if output_file.exists():
+        if output_file.samefile(cce_reduction_file):
+            raise click.UsageError(
+                f"The output file {output_file} is the CCE output that we read"
+                " from. Write the frame-fixed data to a different file, so the"
+                " raw CCE output is preserved."
+            )
+        if not force:
+            raise click.UsageError(
+                f"The output file {output_file} already exists. Use '--force' /"
+                " '-f' to overwrite it."
+            )
+        output_file.unlink()
+
+    subfile_name, extraction_radius = _resolve_subfile(cce_reduction_file)
+
+    # scri works in retarded time, i.e. it subtracts the extraction radius from
+    # the time column of the CCE output, so choose the transformation times in
+    # that convention as well
+    with h5py.File(cce_reduction_file, "r") as open_h5_file:
+        times = open_h5_file[subfile_name]["Strain"][:, 0] - extraction_radius
+
+    if t_0_superrest is None:
+        # The BMS transformation must be determined from a window that is free
+        # of junk radiation, so skip 'junk_time' plus the padding.
+        # The junk radiation time is a crude heuristic. It should be replaced by
+        # a relaxation time determined from the data.
+        t_0_superrest = times[0] + junk_time + padding_time
+    if t_0_superrest - padding_time < times[0] or t_0_superrest > times[-1]:
+        raise click.UsageError(
+            f"The frame-fixing window [{t_0_superrest - padding_time},"
+            f" {t_0_superrest}] is not contained in the data, which covers"
+            f" [{times[0]}, {times[-1]}] in retarded time. Adjust"
+            " '--t-0-superrest' and '--padding-time'."
+        )
+    logger.info(
+        f"Mapping to the superrest frame at t = {t_0_superrest:g} over a window"
+        f" of {padding_time:g}, both in retarded time (the data covers"
+        f" [{times[0]:g}, {times[-1]:g}]). Make sure this window is free of"
+        " junk radiation."
+    )
+    # scri determines the transformation from a window that is wider than
+    # 'padding_time' (see 'map_to_superrest_frame'), and silently uses whatever
+    # data it finds there, so point out when that's less than it asked for
+    scri_window = padding_time + SCRI_EXTRA_PADDING_TIME
+    if (
+        t_0_superrest - scri_window < times[0]
+        or t_0_superrest + scri_window > times[-1]
+    ):
+        logger.warning(
+            f"scri determines the transformation from t = {t_0_superrest:g} +/-"
+            f" {scri_window:g}, but the data only covers [{times[0]:g},"
+            f" {times[-1]:g}]. It will use the data it has, so the"
+            " transformation is determined from a shorter window than intended."
+        )
+
+    abd = scri.SpEC.file_io.create_abd_from_h5(
+        file_format="SpECTRECCE_v1",
+        file_name=str(cce_reduction_file),
+        ch_mass=ch_mass,
+    )
+
+    # Determine the BMS transformation from data that is sampled coarsely in
+    # time, then apply it to the full data. CCE output is often sampled far more
+    # densely than the iterative solve needs, and this keeps the solve from
+    # taking hours without throwing away any of the output. See
+    # https://scri.readthedocs.io/en/latest/tutorial_abd.html
+    if superrest_dt is not None:
+        abd_for_bms = abd.interpolate(
+            np.arange(abd.t[0], abd.t[-1], superrest_dt)
+        )
+    else:
+        abd_for_bms = abd
+    _, bms_transformation, _ = abd_for_bms.map_to_superrest_frame(
+        t_0=t_0_superrest, padding_time=padding_time
+    )
+    logger.info(f"BMS transformation: {bms_transformation}")
+    abd = abd.transform(
+        supertranslation=bms_transformation.supertranslation,
+        frame_rotation=bms_transformation.frame_rotation.components,
+        boost_velocity=bms_transformation.boost_velocity,
+    )
+
+    _write_cce_file(
+        output_file=output_file,
+        subfile_name=subfile_name,
+        times=abd.t,
+        waveforms=_spectre_waveforms(abd),
+        extraction_radius=extraction_radius,
+    )
+    logger.info(f"Frame-fixed waveforms written to {output_file}")
+    return output_file
+
+
+@click.command(name="frame-fix", help=frame_fix.__doc__)
+@click.argument(
+    "cce_reduction_file",
+    type=click.Path(
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        readable=True,
+        path_type=Path,
+    ),
+)
+@click.option(
+    "--output-file",
+    "-o",
+    type=click.Path(file_okay=True, dir_okay=False, path_type=Path),
+    help=(
+        "Where to write the frame-fixed data. Defaults to the input file name"
+        " with 'FrameFixed' appended."
+    ),
+)
+@click.option(
+    "--t-0-superrest",
+    type=float,
+    help=(
+        "Retarded time at which to map to the superrest frame."
+        " [default: 'junk-time' plus 'padding-time' after the start of the"
+        " data]"
+    ),
+)
+@click.option(
+    "--padding-time",
+    type=float,
+    default=200.0,
+    show_default=True,
+    help=(
+        "Length of the time window around 't-0-superrest' used to determine the"
+        " BMS transformation."
+    ),
+)
+@click.option(
+    "--junk-time",
+    type=float,
+    default=500.0,
+    show_default=True,
+    help=(
+        "How long the CCE junk radiation lasts. Only used to choose a default"
+        " for 't-0-superrest'."
+    ),
+)
+@click.option(
+    "--ch-mass",
+    type=float,
+    help=(
+        "Total Christodoulou mass of the system, used to make the waveforms"
+        " dimensionless. [default: no rescaling]"
+    ),
+)
+@click.option(
+    "--superrest-dt",
+    type=float,
+    default=5.0,
+    show_default=True,
+    help=(
+        "Time spacing of the data used to determine the BMS transformation. The"
+        " transformation is applied to the full data, so this doesn't change"
+        " the resolution of the output."
+    ),
+)
+@click.option(
+    "--force",
+    "-f",
+    is_flag=True,
+    help="Overwrite the output file if it already exists.",
+)
+def frame_fix_command(**kwargs):
+    _rich_traceback_guard = True  # Hide traceback until here
+    frame_fix(**kwargs)
+
+
+if __name__ == "__main__":
+    frame_fix_command(help_option_names=["-h", "--help"])

--- a/support/Pipelines/Bbh/__init__.py
+++ b/support/Pipelines/Bbh/__init__.py
@@ -13,6 +13,7 @@ class Bbh(click.Group):
         return [
             "eccentricity-control",
             "find-horizon",
+            "frame-fix",
             "generate-id",
             "postprocess-id",
             "start-inspiral",
@@ -29,6 +30,10 @@ class Bbh(click.Group):
             from .FindHorizon import find_horizon_command
 
             return find_horizon_command
+        elif name == "frame-fix":
+            from .FrameFix import frame_fix_command
+
+            return frame_fix_command
         elif name == "generate-id":
             from .InitialData import generate_id_command
 

--- a/support/Python/requirements.txt
+++ b/support/Python/requirements.txt
@@ -30,4 +30,7 @@ pybind11 >= 2.7.0
 pyyaml
 # Rich: to format CLI output and tracebacks
 rich >= 12.0.0
+# Scri: to transform CCE waveforms at future null infinity into the correct
+# Bondi-Metzner-Sachs (BMS) frame. See 'spectre bbh frame-fix'.
+scri
 scipy

--- a/tests/support/Pipelines/Bbh/CMakeLists.txt
+++ b/tests/support/Pipelines/Bbh/CMakeLists.txt
@@ -25,6 +25,13 @@ spectre_add_python_bindings_test(
   TIMEOUT 20)
 
 spectre_add_python_bindings_test(
+  "support.Pipelines.Bbh.FrameFix"
+  Test_FrameFix.py
+  "Python"
+  None
+  TIMEOUT 60)
+
+spectre_add_python_bindings_test(
   "support.Pipelines.Bbh.InitialData"
   Test_InitialData.py
   "Python"

--- a/tests/support/Pipelines/Bbh/Test_Cce.py
+++ b/tests/support/Pipelines/Bbh/Test_Cce.py
@@ -7,6 +7,7 @@ import unittest
 from pathlib import Path
 
 import numpy as np
+import yaml
 
 import spectre.IO.H5 as spectre_h5
 from spectre.Informer import unit_test_build_path
@@ -163,6 +164,18 @@ class TestCce(unittest.TestCase):
         self.assertTrue((self.test_dir / "01_Output/Cce.yaml").exists())
         self.assertTrue(
             (self.test_dir / "01_Output/combinedBondiSachsCceR0200.h5").exists()
+        )
+        # Frame fixing runs in the same job once CCE is done
+        with open(self.test_dir / "01_Output/Cce.yaml") as open_input_file:
+            metadata = next(yaml.safe_load_all(open_input_file))
+        self.assertEqual(
+            metadata["Next"],
+            {
+                "Run": "spectre.Pipelines.Bbh.FrameFix:frame_fix",
+                "With": {
+                    "cce_reduction_file": "./CharacteristicExtractReduction.h5",
+                },
+            },
         )
         run_cce_command.main(
             args=[

--- a/tests/support/Pipelines/Bbh/Test_FrameFix.py
+++ b/tests/support/Pipelines/Bbh/Test_FrameFix.py
@@ -1,0 +1,225 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import shutil
+import unittest
+from pathlib import Path
+
+import click
+import h5py
+import numpy as np
+import scri
+
+import spectre.IO.H5 as spectre_h5
+from spectre.Informer import unit_test_build_path
+from spectre.IO.H5 import available_subfiles
+from spectre.Pipelines.Bbh.FrameFix import (
+    _spectre_waveforms,
+    _write_cce_file,
+    frame_fix,
+    frame_fix_command,
+)
+from spectre.Visualization.PlotCce import plot_cce
+
+# Keep this small so the iterative BMS solve stays fast. Real CCE output uses
+# an observation l_max of 8.
+L_MAX = 4
+EXTRACTION_RADIUS = 200.0
+SUBFILE_NAME = f"SpectreR{int(EXTRACTION_RADIUS):04d}.cce"
+QUANTITIES = [
+    "EthInertialRetardedTime",
+    "News",
+    "Psi0",
+    "Psi1",
+    "Psi2",
+    "Psi3",
+    "Psi4",
+    "Strain",
+]
+
+
+def _mode_index(ell, m):
+    """Index of the (ell, m) mode in m-varies-fastest ordering from ell = 0."""
+    return ell**2 + ell + m
+
+
+def write_test_cce_file(file_name: Path, num_times: int = 150):
+    """Write a crude inspiral-like waveform in the SpECTRE Cce format.
+
+    Only modes with ell >= |spin weight| are populated, since the others vanish
+    identically for spin-weighted quantities.
+    """
+    num_modes = (L_MAX + 1) ** 2
+    times = np.linspace(0.0, 3000.0, num_times)
+    phase = 0.02 * (1.0 + times / times[-1]) * times
+    amplitude = 0.1 * (1.0 + times / times[-1])
+    strain = np.zeros((num_times, num_modes), dtype=complex)
+    strain[:, _mode_index(2, 2)] = amplitude * np.exp(1j * phase)
+    strain[:, _mode_index(2, -2)] = amplitude * np.exp(-1j * phase)
+    # A constant offset in the memory mode, which the frame fixing acts on
+    strain[:, _mode_index(2, 0)] = 0.01
+    news = np.gradient(strain, times[1] - times[0], axis=0)
+    psi2 = np.zeros((num_times, num_modes), dtype=complex)
+    # Psi2 has spin weight zero, and its (0, 0) mode is minus the Bondi mass
+    psi2[:, _mode_index(0, 0)] = -1.0
+    data = {
+        "Strain": strain,
+        "News": news,
+        "Psi4": np.gradient(news, times[1] - times[0], axis=0),
+        "Psi3": 0.01 * news,
+        "Psi2": psi2,
+        "Psi1": 0.001 * strain,
+        "Psi0": 0.001 * strain,
+        "EthInertialRetardedTime": np.zeros_like(strain),
+    }
+    with spectre_h5.H5File(file_name=str(file_name), mode="a") as h5file:
+        cce_file = h5file.insert_cce(path=SUBFILE_NAME, l_max=L_MAX, version=1)
+        for i in range(num_times):
+            row = {}
+            for name, modes in data.items():
+                values = np.empty(1 + 2 * num_modes)
+                # CCE writes the time at the extraction radius, not the
+                # retarded time
+                values[0] = times[i] + EXTRACTION_RADIUS
+                values[1::2] = modes[i].real
+                values[2::2] = modes[i].imag
+                row[name] = values
+            cce_file.append(row)
+
+
+class TestFrameFix(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = Path(
+            unit_test_build_path(), "support/Pipelines/Bbh/FrameFix"
+        )
+        shutil.rmtree(self.test_dir, ignore_errors=True)
+        self.test_dir.mkdir(parents=True, exist_ok=True)
+        self.cce_reduction_file = (
+            self.test_dir / "CharacteristicExtractReduction.h5"
+        )
+        write_test_cce_file(self.cce_reduction_file)
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir, ignore_errors=True)
+
+    def test_conventions(self):
+        # Loading with scri and writing back out without any BMS transformation
+        # must reproduce the input, which tests the conversion between scri's
+        # Moreschi-Boyle conventions and SpECTRE's conventions.
+        abd = scri.SpEC.file_io.create_abd_from_h5(
+            file_format="SpECTRECCE_v1", file_name=str(self.cce_reduction_file)
+        )
+        output_file = self.test_dir / "RoundTrip.h5"
+        _write_cce_file(
+            output_file=output_file,
+            subfile_name=SUBFILE_NAME,
+            times=abd.t,
+            waveforms=_spectre_waveforms(abd),
+            extraction_radius=EXTRACTION_RADIUS,
+        )
+        with (
+            h5py.File(self.cce_reduction_file, "r") as original,
+            h5py.File(output_file, "r") as roundtrip,
+        ):
+            original_data = original[SUBFILE_NAME]
+            roundtrip_data = roundtrip[SUBFILE_NAME]
+            self.assertEqual(
+                list(original_data["Strain"].attrs["Legend"]),
+                list(roundtrip_data["Strain"].attrs["Legend"]),
+            )
+            for name in ["Strain", "Psi0", "Psi1", "Psi2", "Psi3", "Psi4"]:
+                np.testing.assert_allclose(
+                    roundtrip_data[name][()],
+                    original_data[name][()],
+                    atol=1e-14,
+                    err_msg=f"'{name}' does not round-trip through scri",
+                )
+            # The News is recomputed as a spectral time derivative of the
+            # strain, so it only agrees with the finite-difference News in the
+            # test data to the accuracy of that derivative
+            np.testing.assert_allclose(
+                roundtrip_data["News"][()],
+                original_data["News"][()],
+                atol=1e-2,
+            )
+
+    def test_cli(self):
+        # Not using `CliRunner.invoke()` because it runs in an isolated
+        # environment and doesn't work with MPI in the container.
+        frame_fix_command.main(
+            args=[
+                str(self.cce_reduction_file),
+                "--t-0-superrest",
+                "1000",
+                "--padding-time",
+                "200",
+            ],
+            standalone_mode=False,
+        )
+        output_file = (
+            self.test_dir / "CharacteristicExtractReductionFrameFixed.h5"
+        )
+        self.assertTrue(output_file.exists())
+
+        with h5py.File(output_file, "r") as open_h5_file:
+            self.assertEqual(
+                available_subfiles(open_h5_file, extension=".cce"),
+                [SUBFILE_NAME],
+            )
+            frame_fixed = open_h5_file[SUBFILE_NAME]
+            self.assertEqual(sorted(frame_fixed.keys()), QUANTITIES)
+            # The diagnostic that the frame fixing supersedes is NaN, not zero
+            diagnostic = frame_fixed["EthInertialRetardedTime"][()]
+            self.assertTrue(np.isfinite(diagnostic[:, 0]).all())
+            self.assertTrue(np.isnan(diagnostic[:, 1:]).all())
+            self.assertEqual(
+                list(frame_fixed["Strain"].attrs["Legend"][:3]),
+                ["time", "Real Y_0,0", "Imag Y_0,0"],
+            )
+            strain = frame_fixed["Strain"][()]
+            self.assertEqual(strain.shape[1], 1 + 2 * (L_MAX + 1) ** 2)
+            self.assertTrue(np.isfinite(strain).all())
+            # Times are written in the same convention as the raw CCE output,
+            # i.e. offset by the extraction radius
+            self.assertGreater(strain[0, 0], EXTRACTION_RADIUS)
+
+        # The output is in the same format as the raw CCE output, so it can be
+        # plotted with the same tooling
+        plot_cce(str(output_file), modes=["Real Y_2,2", "Imag Y_2,2"])
+
+        # Refuse to overwrite the output unless '--force' is given
+        with self.assertRaises(click.UsageError):
+            frame_fix(self.cce_reduction_file, t_0_superrest=1000.0)
+
+    def test_frame_fixing_window(self):
+        with self.assertRaises(click.UsageError):
+            frame_fix(self.cce_reduction_file, t_0_superrest=1.0e10)
+        # scri uses a wider window than 'padding_time', and silently makes do
+        # with less data, so point that out. This t_0 is inside the data, so it
+        # passes the check above, but the wider window is not.
+        with self.assertLogs(
+            "spectre.Pipelines.Bbh.FrameFix", level="WARNING"
+        ) as logs:
+            frame_fix(
+                self.cce_reduction_file,
+                output_file=self.test_dir / "NearTheEnd.h5",
+                t_0_superrest=2900.0,
+                padding_time=200.0,
+            )
+        self.assertIn("shorter window than intended", logs.output[0])
+
+    def test_refuses_to_overwrite_input(self):
+        # Writing the output over the input would destroy the CCE data
+        with self.assertRaisesRegex(
+            click.UsageError, "CCE output that we read"
+        ):
+            frame_fix(
+                self.cce_reduction_file,
+                output_file=self.cce_reduction_file,
+                force=True,
+            )
+        self.assertTrue(self.cce_reduction_file.exists())
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Proposed changes

Add `spectre bbh frame-fix` CLI endpoint to take CCE output and perform frame-fixing, just like our docs and the scri tutorial https://scri.readthedocs.io/en/latest/tutorial_abd.html recommend. Then wire it into the pipeline so frame-fixing runs automatically after the CCE step.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent was used, have a co-author trailer of the form
      "Co-Authored-By: <agent name> <agent email>" as the last line of the
      commit, e.g. "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>".

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
