### PR TITLE
Apply FixToAtmosphere to ValenciaDivClean reconstruction

### DIFF
--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/MonotonicityPreserving5.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/MonotonicityPreserving5.cpp
@@ -65,7 +65,8 @@ void MonotonicityPreserving5Prim::reconstruct(
     const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
     const Element<dim>& element,
     const DirectionalIdMap<dim, evolution::dg::subcell::GhostData>& ghost_data,
-    const Mesh<dim>& subcell_mesh) const {
+    const Mesh<dim>& subcell_mesh,
+    const VariableFixing::FixToAtmosphere<dim>& fix_to_atmosphere) const {
   DirectionalIdMap<dim, Variables<prims_to_reconstruct_tags>>
       neighbor_variables_data{};
   ::fd::neighbor_data_as_variables<dim>(make_not_null(&neighbor_variables_data),
@@ -83,7 +84,8 @@ void MonotonicityPreserving5Prim::reconstruct(
             epsilon_);
       },
       volume_prims, eos, element, neighbor_variables_data, subcell_mesh,
-      ghost_zone_size(), true, reconstruct_rho_times_temperature());
+      ghost_zone_size(), true, reconstruct_rho_times_temperature(),
+      &fix_to_atmosphere);
 }
 
 template <size_t ThermodynamicDim>
@@ -94,6 +96,7 @@ void MonotonicityPreserving5Prim::reconstruct_fd_neighbor(
     const Element<dim>& element,
     const DirectionalIdMap<dim, evolution::dg::subcell::GhostData>& ghost_data,
     const Mesh<dim>& subcell_mesh,
+    const VariableFixing::FixToAtmosphere<dim>& fix_to_atmosphere,
     const Direction<dim> direction_to_reconstruct) const {
   reconstruct_fd_neighbor_work<prims_to_reconstruct_tags,
                                prims_to_reconstruct_tags>(
@@ -126,7 +129,7 @@ void MonotonicityPreserving5Prim::reconstruct_fd_neighbor(
       },
       subcell_volume_prims, eos, element, ghost_data, subcell_mesh,
       direction_to_reconstruct, ghost_zone_size(), true,
-      reconstruct_rho_times_temperature());
+      reconstruct_rho_times_temperature(), &fix_to_atmosphere);
 }
 
 bool MonotonicityPreserving5Prim::reconstruct_rho_times_temperature() const {
@@ -158,7 +161,8 @@ bool operator!=(const MonotonicityPreserving5Prim& lhs,
       const Element<3>& element,                                            \
       const DirectionalIdMap<3, evolution::dg::subcell::GhostData>&         \
           ghost_data,                                                       \
-      const Mesh<3>& subcell_mesh) const;                                   \
+      const Mesh<3>& subcell_mesh,                                          \
+      const VariableFixing::FixToAtmosphere<3>& fix_to_atmosphere) const;   \
   template void MonotonicityPreserving5Prim::reconstruct_fd_neighbor(       \
       gsl::not_null<Variables<tags_list_for_reconstruct>*> vars_on_face,    \
       const Variables<hydro::grmhd_tags<DataVector>>& subcell_volume_prims, \
@@ -167,6 +171,7 @@ bool operator!=(const MonotonicityPreserving5Prim& lhs,
       const DirectionalIdMap<3, evolution::dg::subcell::GhostData>&         \
           ghost_data,                                                       \
       const Mesh<3>& subcell_mesh,                                          \
+      const VariableFixing::FixToAtmosphere<3>& fix_to_atmosphere,          \
       const Direction<3> direction_to_reconstruct) const;
 
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/MonotonicityPreserving5.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/MonotonicityPreserving5.hpp
@@ -20,6 +20,8 @@
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/ReconstructWork.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Reconstructor.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
+#include "Evolution/VariableFixing/FixToAtmosphere.hpp"
+#include "Evolution/VariableFixing/Tags.hpp"
 #include "Options/String.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"
@@ -128,7 +130,8 @@ class MonotonicityPreserving5Prim : public Reconstructor {
       tmpl::list<::Tags::Variables<hydro::grmhd_tags<DataVector>>,
                  hydro::Tags::GrmhdEquationOfState, domain::Tags::Element<dim>,
                  evolution::dg::subcell::Tags::GhostDataForReconstruction<dim>,
-                 evolution::dg::subcell::Tags::Mesh<dim>>;
+                 evolution::dg::subcell::Tags::Mesh<dim>,
+                 ::Tags::VariableFixer<VariableFixing::FixToAtmosphere<dim>>>;
 
   template <size_t ThermodynamicDim>
   void reconstruct(
@@ -141,7 +144,8 @@ class MonotonicityPreserving5Prim : public Reconstructor {
       const Element<dim>& element,
       const DirectionalIdMap<dim, evolution::dg::subcell::GhostData>&
           ghost_data,
-      const Mesh<dim>& subcell_mesh) const;
+      const Mesh<dim>& subcell_mesh,
+      const VariableFixing::FixToAtmosphere<dim>& fix_to_atmosphere) const;
 
   template <size_t ThermodynamicDim>
   void reconstruct_fd_neighbor(
@@ -152,6 +156,7 @@ class MonotonicityPreserving5Prim : public Reconstructor {
       const DirectionalIdMap<dim, evolution::dg::subcell::GhostData>&
           ghost_data,
       const Mesh<dim>& subcell_mesh,
+      const VariableFixing::FixToAtmosphere<dim>& fix_to_atmosphere,
       Direction<dim> direction_to_reconstruct) const;
 
   bool reconstruct_rho_times_temperature() const override;

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/MonotonisedCentral.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/MonotonisedCentral.cpp
@@ -58,7 +58,8 @@ void MonotonisedCentralPrim::reconstruct(
     const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
     const Element<dim>& element,
     const DirectionalIdMap<dim, evolution::dg::subcell::GhostData>& ghost_data,
-    const Mesh<dim>& subcell_mesh) const {
+    const Mesh<dim>& subcell_mesh,
+    const VariableFixing::FixToAtmosphere<dim>& fix_to_atmosphere) const {
   DirectionalIdMap<dim, Variables<prims_to_reconstruct_tags>>
       neighbor_variables_data{};
   ::fd::neighbor_data_as_variables<dim>(make_not_null(&neighbor_variables_data),
@@ -74,7 +75,8 @@ void MonotonisedCentralPrim::reconstruct(
             ghost_cell_vars, subcell_extents, number_of_variables);
       },
       volume_prims, eos, element, neighbor_variables_data, subcell_mesh,
-      ghost_zone_size(), true, reconstruct_rho_times_temperature());
+      ghost_zone_size(), true, reconstruct_rho_times_temperature(),
+      &fix_to_atmosphere);
 }
 
 template <size_t ThermodynamicDim>
@@ -85,6 +87,7 @@ void MonotonisedCentralPrim::reconstruct_fd_neighbor(
     const Element<dim>& element,
     const DirectionalIdMap<dim, evolution::dg::subcell::GhostData>& ghost_data,
     const Mesh<dim>& subcell_mesh,
+    const VariableFixing::FixToAtmosphere<dim>& fix_to_atmosphere,
     const Direction<dim> direction_to_reconstruct) const {
   reconstruct_fd_neighbor_work<prims_to_reconstruct_tags,
                                prims_to_reconstruct_tags>(
@@ -117,7 +120,7 @@ void MonotonisedCentralPrim::reconstruct_fd_neighbor(
       },
       subcell_volume_prims, eos, element, ghost_data, subcell_mesh,
       direction_to_reconstruct, ghost_zone_size(), true,
-      reconstruct_rho_times_temperature());
+      reconstruct_rho_times_temperature(), &fix_to_atmosphere);
 }
 
 bool MonotonisedCentralPrim::reconstruct_rho_times_temperature() const {
@@ -148,7 +151,8 @@ bool operator!=(const MonotonisedCentralPrim& lhs,
       const Element<3>& element,                                            \
       const DirectionalIdMap<3, evolution::dg::subcell::GhostData>&         \
           ghost_data,                                                       \
-      const Mesh<3>& subcell_mesh) const;                                   \
+      const Mesh<3>& subcell_mesh,                                          \
+      const VariableFixing::FixToAtmosphere<3>& fix_to_atmosphere) const;   \
   template void MonotonisedCentralPrim::reconstruct_fd_neighbor(            \
       gsl::not_null<Variables<tags_list_for_reconstruct>*> vars_on_face,    \
       const Variables<hydro::grmhd_tags<DataVector>>& subcell_volume_prims, \
@@ -157,6 +161,7 @@ bool operator!=(const MonotonisedCentralPrim& lhs,
       const DirectionalIdMap<3, evolution::dg::subcell::GhostData>&         \
           ghost_data,                                                       \
       const Mesh<3>& subcell_mesh,                                          \
+      const VariableFixing::FixToAtmosphere<3>& fix_to_atmosphere,          \
       const Direction<3> direction_to_reconstruct) const;
 
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/MonotonisedCentral.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/MonotonisedCentral.hpp
@@ -18,6 +18,8 @@
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/ReconstructWork.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Reconstructor.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
+#include "Evolution/VariableFixing/FixToAtmosphere.hpp"
+#include "Evolution/VariableFixing/Tags.hpp"
 #include "Options/String.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"
@@ -107,7 +109,8 @@ class MonotonisedCentralPrim : public Reconstructor {
       tmpl::list<::Tags::Variables<hydro::grmhd_tags<DataVector>>,
                  hydro::Tags::GrmhdEquationOfState, domain::Tags::Element<dim>,
                  evolution::dg::subcell::Tags::GhostDataForReconstruction<dim>,
-                 evolution::dg::subcell::Tags::Mesh<dim>>;
+                 evolution::dg::subcell::Tags::Mesh<dim>,
+                 ::Tags::VariableFixer<VariableFixing::FixToAtmosphere<dim>>>;
 
   template <size_t ThermodynamicDim>
   void reconstruct(
@@ -120,7 +123,8 @@ class MonotonisedCentralPrim : public Reconstructor {
       const Element<dim>& element,
       const DirectionalIdMap<dim, evolution::dg::subcell::GhostData>&
           ghost_data,
-      const Mesh<dim>& subcell_mesh) const;
+      const Mesh<dim>& subcell_mesh,
+      const VariableFixing::FixToAtmosphere<dim>& fix_to_atmosphere) const;
 
   /// Called by an element doing DG when the neighbor is doing subcell.
   template <size_t ThermodynamicDim>
@@ -132,6 +136,7 @@ class MonotonisedCentralPrim : public Reconstructor {
       const DirectionalIdMap<dim, evolution::dg::subcell::GhostData>&
           ghost_data,
       const Mesh<dim>& subcell_mesh,
+      const VariableFixing::FixToAtmosphere<dim>& fix_to_atmosphere,
       Direction<dim> direction_to_reconstruct) const;
 
   bool reconstruct_rho_times_temperature() const override;

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/PositivityPreservingAdaptiveOrder.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/PositivityPreservingAdaptiveOrder.cpp
@@ -109,7 +109,8 @@ void PositivityPreservingAdaptiveOrderPrim::reconstruct(
     const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
     const Element<3>& element,
     const DirectionalIdMap<3, evolution::dg::subcell::GhostData>& ghost_data,
-    const Mesh<3>& subcell_mesh) const {
+    const Mesh<3>& subcell_mesh,
+    const VariableFixing::FixToAtmosphere<3>& fix_to_atmosphere) const {
   DirectionalIdMap<dim, Variables<prims_to_reconstruct_tags>>
       neighbor_variables_data{};
   ::fd::neighbor_data_as_variables<dim>(make_not_null(&neighbor_variables_data),
@@ -132,7 +133,8 @@ void PositivityPreservingAdaptiveOrderPrim::reconstruct(
                             std::numeric_limits<double>::signaling_NaN()));
       },
       volume_prims, eos, element, neighbor_variables_data, subcell_mesh,
-      ghost_zone_size(), false, reconstruct_rho_times_temperature());
+      ghost_zone_size(), false, reconstruct_rho_times_temperature(),
+      &fix_to_atmosphere);
   reconstruct_prims_work<non_positive_tags>(
       vars_on_lower_face, vars_on_upper_face,
       [this](auto upper_face_vars_ptr, auto lower_face_vars_ptr,
@@ -147,7 +149,8 @@ void PositivityPreservingAdaptiveOrderPrim::reconstruct(
                          std::numeric_limits<double>::signaling_NaN()));
       },
       volume_prims, eos, element, neighbor_variables_data, subcell_mesh,
-      ghost_zone_size(), true, reconstruct_rho_times_temperature());
+      ghost_zone_size(), true, reconstruct_rho_times_temperature(),
+      &fix_to_atmosphere);
 }
 
 template <size_t ThermodynamicDim>
@@ -158,6 +161,7 @@ void PositivityPreservingAdaptiveOrderPrim::reconstruct_fd_neighbor(
     const Element<3>& element,
     const DirectionalIdMap<3, evolution::dg::subcell::GhostData>& ghost_data,
     const Mesh<3>& subcell_mesh,
+    const VariableFixing::FixToAtmosphere<3>& fix_to_atmosphere,
     const Direction<3> direction_to_reconstruct) const {
   reconstruct_fd_neighbor_work<positivity_preserving_tags,
                                prims_to_reconstruct_tags>(
@@ -194,7 +198,7 @@ void PositivityPreservingAdaptiveOrderPrim::reconstruct_fd_neighbor(
       },
       subcell_volume_prims, eos, element, ghost_data, subcell_mesh,
       direction_to_reconstruct, ghost_zone_size(), false,
-      reconstruct_rho_times_temperature());
+      reconstruct_rho_times_temperature(), &fix_to_atmosphere);
   reconstruct_fd_neighbor_work<non_positive_tags, prims_to_reconstruct_tags>(
       vars_on_face,
       [this](const auto tensor_component_on_face_ptr,
@@ -229,7 +233,7 @@ void PositivityPreservingAdaptiveOrderPrim::reconstruct_fd_neighbor(
       },
       subcell_volume_prims, eos, element, ghost_data, subcell_mesh,
       direction_to_reconstruct, ghost_zone_size(), true,
-      reconstruct_rho_times_temperature());
+      reconstruct_rho_times_temperature(), &fix_to_atmosphere);
 }
 
 bool PositivityPreservingAdaptiveOrderPrim::reconstruct_rho_times_temperature()
@@ -270,7 +274,8 @@ bool operator!=(const PositivityPreservingAdaptiveOrderPrim& lhs,
       const Element<3>& element,                                            \
       const DirectionalIdMap<3, evolution::dg::subcell::GhostData>&         \
           ghost_data,                                                       \
-      const Mesh<3>& subcell_mesh) const;                                   \
+      const Mesh<3>& subcell_mesh,                                          \
+      const VariableFixing::FixToAtmosphere<3>& fix_to_atmosphere) const;   \
   template void                                                             \
   PositivityPreservingAdaptiveOrderPrim::reconstruct_fd_neighbor(           \
       gsl::not_null<Variables<tags_list_for_reconstruct>*> vars_on_face,    \
@@ -280,6 +285,7 @@ bool operator!=(const PositivityPreservingAdaptiveOrderPrim& lhs,
       const DirectionalIdMap<3, evolution::dg::subcell::GhostData>&         \
           ghost_data,                                                       \
       const Mesh<3>& subcell_mesh,                                          \
+      const VariableFixing::FixToAtmosphere<3>& fix_to_atmosphere,          \
       const Direction<3> direction_to_reconstruct) const;
 
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/PositivityPreservingAdaptiveOrder.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/PositivityPreservingAdaptiveOrder.hpp
@@ -16,6 +16,8 @@
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/ReconstructWork.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Reconstructor.hpp"
+#include "Evolution/VariableFixing/FixToAtmosphere.hpp"
+#include "Evolution/VariableFixing/Tags.hpp"
 #include "NumericalAlgorithms/FiniteDifference/FallbackReconstructorType.hpp"
 #include "Options/Auto.hpp"
 #include "Options/Context.hpp"
@@ -165,7 +167,8 @@ class PositivityPreservingAdaptiveOrderPrim : public Reconstructor {
       tmpl::list<::Tags::Variables<hydro::grmhd_tags<DataVector>>,
                  hydro::Tags::GrmhdEquationOfState, domain::Tags::Element<dim>,
                  evolution::dg::subcell::Tags::GhostDataForReconstruction<dim>,
-                 evolution::dg::subcell::Tags::Mesh<dim>>;
+                 evolution::dg::subcell::Tags::Mesh<dim>,
+                 ::Tags::VariableFixer<VariableFixing::FixToAtmosphere<dim>>>;
 
   template <size_t ThermodynamicDim>
   void reconstruct(
@@ -180,7 +183,8 @@ class PositivityPreservingAdaptiveOrderPrim : public Reconstructor {
       const Element<dim>& element,
       const DirectionalIdMap<dim, evolution::dg::subcell::GhostData>&
           ghost_data,
-      const Mesh<dim>& subcell_mesh) const;
+      const Mesh<dim>& subcell_mesh,
+      const VariableFixing::FixToAtmosphere<dim>& fix_to_atmosphere) const;
 
   template <size_t ThermodynamicDim>
   void reconstruct_fd_neighbor(
@@ -191,6 +195,7 @@ class PositivityPreservingAdaptiveOrderPrim : public Reconstructor {
       const DirectionalIdMap<dim, evolution::dg::subcell::GhostData>&
           ghost_data,
       const Mesh<dim>& subcell_mesh,
+      const VariableFixing::FixToAtmosphere<dim>& fix_to_atmosphere,
       Direction<dim> direction_to_reconstruct) const;
 
   bool reconstruct_rho_times_temperature() const override;

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/ReconstructWork.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/ReconstructWork.hpp
@@ -11,6 +11,7 @@
 #include "DataStructures/Tensor/TypeAliases.hpp"
 #include "Domain/Structure/DirectionalIdMap.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/TagsDeclarations.hpp"
+#include "Evolution/VariableFixing/FixToAtmosphere.hpp"
 #include "PointwiseFunctions/GeneralRelativity/TagsDeclarations.hpp"
 #include "PointwiseFunctions/Hydro/TagsDeclarations.hpp"
 #include "Utilities/TMPL.hpp"
@@ -107,7 +108,8 @@ void reconstruct_prims_work(
     const DirectionalIdMap<3, Variables<PrimsTagsSentByNeighbor>>&
         neighbor_data,
     const Mesh<3>& subcell_mesh, size_t ghost_zone_size,
-    bool compute_conservatives, bool reconstruct_density_times_temperature);
+    bool compute_conservatives, bool reconstruct_density_times_temperature,
+    const VariableFixing::FixToAtmosphere<3>* fix_to_atmosphere);
 
 /*!
  * \brief Reconstructs the `PrimTagsForReconstruction` and if
@@ -135,5 +137,6 @@ void reconstruct_fd_neighbor_work(
     const DirectionalIdMap<3, evolution::dg::subcell::GhostData>& ghost_data,
     const Mesh<3>& subcell_mesh, const Direction<3>& direction_to_reconstruct,
     size_t ghost_zone_size, bool compute_conservatives,
-    bool reconstruct_density_times_temperature);
+    bool reconstruct_density_times_temperature,
+    const VariableFixing::FixToAtmosphere<3>* fix_to_atmosphere);
 }  // namespace grmhd::ValenciaDivClean::fd

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/ReconstructWork.tpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/ReconstructWork.tpp
@@ -107,8 +107,7 @@ void compute_conservatives_for_reconstruction(
   // EoS calls based on reconstructed primitives
   if constexpr (ThermodynamicDim == 1) {
     specific_internal_energy =
-        eos.specific_internal_energy_from_density(
-            rest_mass_density);
+        eos.specific_internal_energy_from_density(rest_mass_density);
     pressure = eos.pressure_from_density(rest_mass_density);
   } else if constexpr (ThermodynamicDim == 2) {
     specific_internal_energy =
@@ -158,7 +157,8 @@ void reconstruct_prims_work(
         neighbor_data,
     const Mesh<3>& subcell_mesh, const size_t ghost_zone_size,
     const bool compute_conservatives,
-    const bool reconstruct_density_times_temperature) {
+    const bool reconstruct_density_times_temperature,
+    const VariableFixing::FixToAtmosphere<3>* const fix_to_atmosphere) {
   // computation dimension accounts for "skipped" cartoon bases
   const size_t comp_dim =
       evolution::dg::subcell::fd::get_computational_dim(subcell_mesh);
@@ -316,9 +316,11 @@ void reconstruct_prims_work(
 
   for (size_t i = 0; compute_conservatives and i < comp_dim; ++i) {
     compute_conservatives_for_reconstruction(
-        make_not_null(&gsl::at(*vars_on_lower_face, i)), eos, nullptr);
+        make_not_null(&gsl::at(*vars_on_lower_face, i)), eos,
+        fix_to_atmosphere);
     compute_conservatives_for_reconstruction(
-        make_not_null(&gsl::at(*vars_on_upper_face, i)), eos, nullptr);
+        make_not_null(&gsl::at(*vars_on_upper_face, i)), eos,
+        fix_to_atmosphere);
   }
 }
 
@@ -333,7 +335,8 @@ void reconstruct_fd_neighbor_work(
     const DirectionalIdMap<3, evolution::dg::subcell::GhostData>& ghost_data,
     const Mesh<3>& subcell_mesh, const Direction<3>& direction_to_reconstruct,
     const size_t ghost_zone_size, const bool compute_conservatives,
-    const bool reconstruct_density_times_temperature) {
+    const bool reconstruct_density_times_temperature,
+    const VariableFixing::FixToAtmosphere<3>* const fix_to_atmosphere) {
   const DirectionalId<3> mortar_id{
       direction_to_reconstruct,
       *element.neighbors().at(direction_to_reconstruct).begin()};
@@ -355,114 +358,116 @@ void reconstruct_fd_neighbor_work(
   DataVector buffer{3 * subcell_volume_prims.number_of_grid_points() +
                     ghost_data_extents.product()};
   Scalar<DataVector> rho_times_temperature_neighbor{};
-  tmpl::for_each<PrimTagsForReconstruction>(
-      [&buffer, &direction_to_reconstruct, &ghost_data_extents, &neighbor_prims,
-       reconstruct_density_times_temperature, &reconstruct_lower_neighbor,
-       &reconstruct_upper_neighbor, &rho_times_temperature_neighbor,
-       &subcell_mesh, &subcell_volume_prims, &vars_on_face](auto tag_v) {
-        using tag = tmpl::type_from<decltype(tag_v)>;
-        const typename tag::type* volume_tensor_ptr = nullptr;
-        typename tag::type volume_tensor{};
-        if constexpr (std::is_same_v<
-                          tag, hydro::Tags::LorentzFactorTimesSpatialVelocity<
-                                   DataVector, 3>>) {
-          // we need to handle the Wv^i reconstruction separately since we need
-          // to first compute Wv^i in the volume (it's not one of our primitives
-          // from the recovery). The components need to be stored contiguously,
-          // which is why we have the Variables `lorentz_factor_times_v_I`
-          const auto& spatial_velocity =
-              get<hydro::Tags::SpatialVelocity<DataVector, 3>>(
-                  subcell_volume_prims);
-          const auto& lorentz_factor =
-              get<hydro::Tags::LorentzFactor<DataVector>>(subcell_volume_prims);
-          for (size_t i = 0; i < 3; ++i) {
-            volume_tensor.get(i).set_data_ref(
-                &buffer[i * subcell_volume_prims.number_of_grid_points()],
-                subcell_volume_prims.number_of_grid_points());
-          }
-          volume_tensor = spatial_velocity;
-          for (size_t i = 0; i < 3; ++i) {
-            volume_tensor.get(i) *= get(lorentz_factor);
-          }
+  tmpl::for_each<
+      PrimTagsForReconstruction>([&buffer, &direction_to_reconstruct,
+                                  &ghost_data_extents, &neighbor_prims,
+                                  reconstruct_density_times_temperature,
+                                  &reconstruct_lower_neighbor,
+                                  &reconstruct_upper_neighbor,
+                                  &rho_times_temperature_neighbor,
+                                  &subcell_mesh, &subcell_volume_prims,
+                                  &vars_on_face](auto tag_v) {
+    using tag = tmpl::type_from<decltype(tag_v)>;
+    const typename tag::type* volume_tensor_ptr = nullptr;
+    typename tag::type volume_tensor{};
+    if constexpr (std::is_same_v<tag,
+                                 hydro::Tags::LorentzFactorTimesSpatialVelocity<
+                                     DataVector, 3>>) {
+      // we need to handle the Wv^i reconstruction separately since we need
+      // to first compute Wv^i in the volume (it's not one of our primitives
+      // from the recovery). The components need to be stored contiguously,
+      // which is why we have the Variables `lorentz_factor_times_v_I`
+      const auto& spatial_velocity =
+          get<hydro::Tags::SpatialVelocity<DataVector, 3>>(
+              subcell_volume_prims);
+      const auto& lorentz_factor =
+          get<hydro::Tags::LorentzFactor<DataVector>>(subcell_volume_prims);
+      for (size_t i = 0; i < 3; ++i) {
+        volume_tensor.get(i).set_data_ref(
+            &buffer[i * subcell_volume_prims.number_of_grid_points()],
+            subcell_volume_prims.number_of_grid_points());
+      }
+      volume_tensor = spatial_velocity;
+      for (size_t i = 0; i < 3; ++i) {
+        volume_tensor.get(i) *= get(lorentz_factor);
+      }
+      volume_tensor_ptr = &volume_tensor;
+    } else {
+      if constexpr (std::is_same_v<tag, hydro::Tags::Temperature<DataVector>>) {
+        if (reconstruct_density_times_temperature) {
+          get(volume_tensor)
+              .set_data_ref(buffer.data(),
+                            subcell_volume_prims.number_of_grid_points());
+          get(volume_tensor) =
+              get(get<hydro::Tags::RestMassDensity<DataVector>>(
+                  subcell_volume_prims)) *
+              get(get<tag>(subcell_volume_prims));
           volume_tensor_ptr = &volume_tensor;
         } else {
-          if constexpr (std::is_same_v<tag,
-                                       hydro::Tags::Temperature<DataVector>>) {
-            if (reconstruct_density_times_temperature) {
-              get(volume_tensor)
-                  .set_data_ref(buffer.data(),
-                                subcell_volume_prims.number_of_grid_points());
-              get(volume_tensor) =
-                  get(get<hydro::Tags::RestMassDensity<DataVector>>(
-                      subcell_volume_prims)) *
-                  get(get<tag>(subcell_volume_prims));
-              volume_tensor_ptr = &volume_tensor;
-            } else {
-              volume_tensor_ptr = &get<tag>(subcell_volume_prims);
-            }
-          } else {
-            volume_tensor_ptr = &get<tag>(subcell_volume_prims);
-          }
+          volume_tensor_ptr = &get<tag>(subcell_volume_prims);
         }
+      } else {
+        volume_tensor_ptr = &get<tag>(subcell_volume_prims);
+      }
+    }
 
-        const auto& tensor_neighbor =
-            [&buffer, &neighbor_prims, reconstruct_density_times_temperature,
-             &rho_times_temperature_neighbor,
-             &subcell_volume_prims]() -> typename tag::type& {
-          if constexpr (std::is_same_v<tag,
-                                       hydro::Tags::Temperature<DataVector>>) {
-            if (reconstruct_density_times_temperature) {
-              get(rho_times_temperature_neighbor)
-                  .set_data_ref(
-                      &buffer[subcell_volume_prims.number_of_grid_points()],
-                      get(get<tag>(neighbor_prims)).size());
-              get(rho_times_temperature_neighbor) =
-                  get(get<hydro::Tags::RestMassDensity<DataVector>>(
-                      neighbor_prims)) *
-                  get(get<tag>(neighbor_prims));
-              return rho_times_temperature_neighbor;
-            } else {
-              (void)buffer, (void)reconstruct_density_times_temperature;
-              (void)rho_times_temperature_neighbor, (void)subcell_volume_prims;
-              return get<tag>(neighbor_prims);
-            }
-          } else {
-            (void)buffer, (void)reconstruct_density_times_temperature;
-            (void)rho_times_temperature_neighbor, (void)subcell_volume_prims;
-            return get<tag>(neighbor_prims);
-          }
-        }();
-        auto& tensor_on_face = get<tag>(*vars_on_face);
-        if (direction_to_reconstruct.side() == Side::Upper) {
-          for (size_t tensor_index = 0; tensor_index < tensor_on_face.size();
-               ++tensor_index) {
-            reconstruct_upper_neighbor(
-                make_not_null(&tensor_on_face[tensor_index]),
-                (*volume_tensor_ptr)[tensor_index],
-                tensor_neighbor[tensor_index], subcell_mesh.extents(),
-                ghost_data_extents, direction_to_reconstruct);
-          }
+    const auto& tensor_neighbor =
+        [&buffer, &neighbor_prims, reconstruct_density_times_temperature,
+         &rho_times_temperature_neighbor,
+         &subcell_volume_prims]() -> typename tag::type& {
+      if constexpr (std::is_same_v<tag, hydro::Tags::Temperature<DataVector>>) {
+        if (reconstruct_density_times_temperature) {
+          get(rho_times_temperature_neighbor)
+              .set_data_ref(
+                  &buffer[subcell_volume_prims.number_of_grid_points()],
+                  get(get<tag>(neighbor_prims)).size());
+          get(rho_times_temperature_neighbor) =
+              get(get<hydro::Tags::RestMassDensity<DataVector>>(
+                  neighbor_prims)) *
+              get(get<tag>(neighbor_prims));
+          return rho_times_temperature_neighbor;
         } else {
-          for (size_t tensor_index = 0; tensor_index < tensor_on_face.size();
-               ++tensor_index) {
-            reconstruct_lower_neighbor(
-                make_not_null(&tensor_on_face[tensor_index]),
-                (*volume_tensor_ptr)[tensor_index],
-                tensor_neighbor[tensor_index], subcell_mesh.extents(),
-                ghost_data_extents, direction_to_reconstruct);
-          }
+          (void)buffer, (void)reconstruct_density_times_temperature;
+          (void)rho_times_temperature_neighbor, (void)subcell_volume_prims;
+          return get<tag>(neighbor_prims);
         }
-        if constexpr (std::is_same_v<tag,
-                                     hydro::Tags::Temperature<DataVector>>) {
-          if (reconstruct_density_times_temperature) {
-            get(tensor_on_face) /= get(
-                get<hydro::Tags::RestMassDensity<DataVector>>(*vars_on_face));
-          }
-        }
-      });
+      } else {
+        (void)buffer, (void)reconstruct_density_times_temperature;
+        (void)rho_times_temperature_neighbor, (void)subcell_volume_prims;
+        return get<tag>(neighbor_prims);
+      }
+    }();
+    auto& tensor_on_face = get<tag>(*vars_on_face);
+    if (direction_to_reconstruct.side() == Side::Upper) {
+      for (size_t tensor_index = 0; tensor_index < tensor_on_face.size();
+           ++tensor_index) {
+        reconstruct_upper_neighbor(make_not_null(&tensor_on_face[tensor_index]),
+                                   (*volume_tensor_ptr)[tensor_index],
+                                   tensor_neighbor[tensor_index],
+                                   subcell_mesh.extents(), ghost_data_extents,
+                                   direction_to_reconstruct);
+      }
+    } else {
+      for (size_t tensor_index = 0; tensor_index < tensor_on_face.size();
+           ++tensor_index) {
+        reconstruct_lower_neighbor(make_not_null(&tensor_on_face[tensor_index]),
+                                   (*volume_tensor_ptr)[tensor_index],
+                                   tensor_neighbor[tensor_index],
+                                   subcell_mesh.extents(), ghost_data_extents,
+                                   direction_to_reconstruct);
+      }
+    }
+    if constexpr (std::is_same_v<tag, hydro::Tags::Temperature<DataVector>>) {
+      if (reconstruct_density_times_temperature) {
+        get(tensor_on_face) /=
+            get(get<hydro::Tags::RestMassDensity<DataVector>>(*vars_on_face));
+      }
+    }
+  });
 
   if (compute_conservatives) {
-    compute_conservatives_for_reconstruction(vars_on_face, eos, nullptr);
+    compute_conservatives_for_reconstruction(vars_on_face, eos,
+                                             fix_to_atmosphere);
   }
 }
 }  // namespace grmhd::ValenciaDivClean::fd

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Wcns5z.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Wcns5z.cpp
@@ -87,7 +87,8 @@ void Wcns5zPrim::reconstruct(
     const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
     const Element<3>& element,
     const DirectionalIdMap<3, evolution::dg::subcell::GhostData>& ghost_data,
-    const Mesh<3>& subcell_mesh) const {
+    const Mesh<3>& subcell_mesh,
+    const VariableFixing::FixToAtmosphere<3>& fix_to_atmosphere) const {
   DirectionalIdMap<dim, Variables<prims_to_reconstruct_tags>>
       neighbor_variables_data{};
   ::fd::neighbor_data_as_variables<dim>(make_not_null(&neighbor_variables_data),
@@ -104,7 +105,8 @@ void Wcns5zPrim::reconstruct(
                      epsilon_, max_number_of_extrema_);
       },
       volume_prims, eos, element, neighbor_variables_data, subcell_mesh,
-      ghost_zone_size(), true, reconstruct_rho_times_temperature());
+      ghost_zone_size(), true, reconstruct_rho_times_temperature(),
+      &fix_to_atmosphere);
 }
 
 template <size_t ThermodynamicDim>
@@ -115,6 +117,7 @@ void Wcns5zPrim::reconstruct_fd_neighbor(
     const Element<3>& element,
     const DirectionalIdMap<3, evolution::dg::subcell::GhostData>& ghost_data,
     const Mesh<3>& subcell_mesh,
+    const VariableFixing::FixToAtmosphere<3>& fix_to_atmosphere,
     const Direction<3> direction_to_reconstruct) const {
   reconstruct_fd_neighbor_work<prims_to_reconstruct_tags,
                                prims_to_reconstruct_tags>(
@@ -143,7 +146,7 @@ void Wcns5zPrim::reconstruct_fd_neighbor(
       },
       subcell_volume_prims, eos, element, ghost_data, subcell_mesh,
       direction_to_reconstruct, ghost_zone_size(), true,
-      reconstruct_rho_times_temperature());
+      reconstruct_rho_times_temperature(), &fix_to_atmosphere);
 }
 
 bool Wcns5zPrim::reconstruct_rho_times_temperature() const {
@@ -178,7 +181,8 @@ bool operator!=(const Wcns5zPrim& lhs, const Wcns5zPrim& rhs) {
       const Element<3>& element,                                            \
       const DirectionalIdMap<3, evolution::dg::subcell::GhostData>&         \
           ghost_data,                                                       \
-      const Mesh<3>& subcell_mesh) const;                                   \
+      const Mesh<3>& subcell_mesh,                                          \
+      const VariableFixing::FixToAtmosphere<3>& fix_to_atmosphere) const;   \
   template void Wcns5zPrim::reconstruct_fd_neighbor(                        \
       gsl::not_null<Variables<tags_list_for_reconstruct>*> vars_on_face,    \
       const Variables<hydro::grmhd_tags<DataVector>>& subcell_volume_prims, \
@@ -187,6 +191,7 @@ bool operator!=(const Wcns5zPrim& lhs, const Wcns5zPrim& rhs) {
       const DirectionalIdMap<3, evolution::dg::subcell::GhostData>&         \
           ghost_data,                                                       \
       const Mesh<3>& subcell_mesh,                                          \
+      const VariableFixing::FixToAtmosphere<3>& fix_to_atmosphere,          \
       const Direction<3> direction_to_reconstruct) const;
 
 GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Wcns5z.hpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Wcns5z.hpp
@@ -16,6 +16,8 @@
 #include "Evolution/DgSubcell/Tags/Mesh.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/ReconstructWork.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Reconstructor.hpp"
+#include "Evolution/VariableFixing/FixToAtmosphere.hpp"
+#include "Evolution/VariableFixing/Tags.hpp"
 #include "NumericalAlgorithms/FiniteDifference/FallbackReconstructorType.hpp"
 #include "Options/String.hpp"
 #include "PointwiseFunctions/Hydro/Tags.hpp"
@@ -139,7 +141,8 @@ class Wcns5zPrim : public Reconstructor {
       tmpl::list<::Tags::Variables<hydro::grmhd_tags<DataVector>>,
                  hydro::Tags::GrmhdEquationOfState, domain::Tags::Element<dim>,
                  evolution::dg::subcell::Tags::GhostDataForReconstruction<dim>,
-                 evolution::dg::subcell::Tags::Mesh<dim>>;
+                 evolution::dg::subcell::Tags::Mesh<dim>,
+                 ::Tags::VariableFixer<VariableFixing::FixToAtmosphere<dim>>>;
 
   template <size_t ThermodynamicDim>
   void reconstruct(
@@ -152,7 +155,8 @@ class Wcns5zPrim : public Reconstructor {
       const Element<dim>& element,
       const DirectionalIdMap<dim, evolution::dg::subcell::GhostData>&
           ghost_data,
-      const Mesh<dim>& subcell_mesh) const;
+      const Mesh<dim>& subcell_mesh,
+      const VariableFixing::FixToAtmosphere<dim>& fix_to_atmosphere) const;
 
   template <size_t ThermodynamicDim>
   void reconstruct_fd_neighbor(
@@ -163,6 +167,7 @@ class Wcns5zPrim : public Reconstructor {
       const DirectionalIdMap<dim, evolution::dg::subcell::GhostData>&
           ghost_data,
       const Mesh<dim>& subcell_mesh,
+      const VariableFixing::FixToAtmosphere<dim>& fix_to_atmosphere,
       Direction<dim> direction_to_reconstruct) const;
 
   bool reconstruct_rho_times_temperature() const override;

--- a/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/NeighborPackagedData.cpp
+++ b/src/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/NeighborPackagedData.cpp
@@ -41,6 +41,8 @@
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Tag.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/ComputeFluxes.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp"
+#include "Evolution/VariableFixing/FixToAtmosphere.hpp"
+#include "Evolution/VariableFixing/Tags.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/Parity.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
@@ -107,6 +109,9 @@ DirectionalIdMap<3, DataVector> NeighborPackagedData::apply(
 
       const auto& element = db::get<domain::Tags::Element<3>>(box);
       const auto& eos = get<hydro::Tags::GrmhdEquationOfState>(box);
+      const auto& fix_to_atmosphere =
+          db::get<::Tags::VariableFixer<VariableFixing::FixToAtmosphere<3>>>(
+              box);
 
       using dg_package_field_tags =
           typename DerivedCorrection::dg_package_field_tags;
@@ -152,12 +157,13 @@ DirectionalIdMap<3, DataVector> NeighborPackagedData::apply(
 
         call_with_dynamic_type<void, typename grmhd::ValenciaDivClean::fd::
                                          Reconstructor::creatable_classes>(
-            &recons,
-            [&element, &eos, &mortar_id, &ghost_subcell_data, &subcell_mesh,
-             &vars_on_face, &volume_prims](const auto& reconstructor) {
+            &recons, [&element, &eos, &fix_to_atmosphere, &mortar_id,
+                      &ghost_subcell_data, &subcell_mesh, &vars_on_face,
+                      &volume_prims](const auto& reconstructor) {
               reconstructor->reconstruct_fd_neighbor(
                   make_not_null(&vars_on_face), volume_prims, eos, element,
-                  ghost_subcell_data, subcell_mesh, mortar_id.direction());
+                  ghost_subcell_data, subcell_mesh, fix_to_atmosphere,
+                  mortar_id.direction());
             });
 
         // Get the mesh velocity if needed

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_NeighborPackagedData.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_NeighborPackagedData.cpp
@@ -49,6 +49,8 @@
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/NeighborPackagedData.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
+#include "Evolution/VariableFixing/FixToAtmosphere.hpp"
+#include "Evolution/VariableFixing/Tags.hpp"
 #include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GrMhd/BondiMichel.hpp"
@@ -101,8 +103,8 @@ double test(const size_t num_dg_pts) {
   const Affine affine_map{-1.0, 1.0, 2.0, 3.0};
   const ElementId<3> element_id{
       0, {SegmentId{3, 4}, SegmentId{3, 4}, SegmentId{3, 4}}};
-  std::unordered_map<std::string,
-                     std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+  const std::unordered_map<
+      std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
       functions_of_time{};
   std::vector<Block<3>> blocks;
   blocks.emplace_back(Block<3>(
@@ -110,7 +112,7 @@ double test(const size_t num_dg_pts) {
           Affine3D{affine_map, affine_map, affine_map}),
       0, {}));
   const auto& block = blocks[0];
-  ElementMap<3, Frame::Grid> element_map{
+  const ElementMap<3, Frame::Grid> element_map{
       element_id, block.is_time_dependent()
                       ? block.moving_mesh_logical_to_grid_map().get_clone()
                       : block.stationary_map().get_to_grid_frame()};
@@ -258,7 +260,8 @@ double test(const size_t num_dg_pts) {
           Tags::ConstraintDampingParameter, evolution::dg::Tags::MortarData<3>,
           domain::Tags::MeshVelocity<3>,
           evolution::dg::Tags::NormalCovectorAndMagnitude<3>,
-          evolution::dg::subcell::Tags::SubcellOptions<3>>,
+          evolution::dg::subcell::Tags::SubcellOptions<3>,
+          ::Tags::VariableFixer<VariableFixing::FixToAtmosphere<3>>>,
       db::AddComputeTags<
           evolution::dg::subcell::Tags::LogicalCoordinatesCompute<3>>>(
       element, dg_mesh, subcell_mesh,
@@ -278,13 +281,14 @@ double test(const size_t num_dg_pts) {
       evolution::dg::subcell::SubcellOptions{
           4.0, 1_st, 1.0e-3, 1.0e-4, false, false,
           evolution::dg::subcell::fd::ReconstructionMethod::DimByDim, false,
-          std::nullopt, ::fd::DerivativeOrder::Two, 1, 1, 1});
+          std::nullopt, ::fd::DerivativeOrder::Two, 1, 1, 1},
+      VariableFixing::FixToAtmosphere<3>{1.0e-30, 1.0e-30, std::nullopt,
+                                         std::nullopt});
   db::mutate_apply<ConservativeFromPrimitive>(make_not_null(&box));
 
   std::vector<DirectionalId<3>> mortars_to_reconstruct_to{};
   for (const auto& [direction, neighbors] : element.neighbors()) {
-    mortars_to_reconstruct_to.emplace_back(
-        DirectionalId<3>{direction, *neighbors.begin()});
+    mortars_to_reconstruct_to.emplace_back(direction, *neighbors.begin());
   }
 
   const auto all_packaged_data =
@@ -292,7 +296,7 @@ double test(const size_t num_dg_pts) {
 
   // Parse out evolved vars, since those are easiest to check for correctness,
   // then return absolute difference between analytic and reconstructed values.
-  DirectionalIdMap<3, typename variables_tag::type> evolved_vars_errors{};
+  const DirectionalIdMap<3, typename variables_tag::type> evolved_vars_errors{};
   double max_rel_error = 0.0;
   for (const auto& [direction_and_id, data] : all_packaged_data) {
     const auto& direction = direction_and_id.direction();

--- a/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TimeDerivative.cpp
+++ b/tests/Unit/Evolution/Systems/GrMhd/ValenciaDivClean/Subcell/Test_TimeDerivative.cpp
@@ -63,6 +63,8 @@
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
 #include "Evolution/TagsDomain.hpp"
+#include "Evolution/VariableFixing/FixToAtmosphere.hpp"
+#include "Evolution/VariableFixing/Tags.hpp"
 #include "NumericalAlgorithms/FiniteDifference/FallbackReconstructorType.hpp"
 #include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
 #include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
@@ -443,7 +445,8 @@ std::array<double, 5> test(const size_t num_dg_pts,
           CellCenteredFluxesTag,
           evolution::dg::subcell::Tags::SubcellOptions<3>,
           evolution::dg::subcell::Tags::ReconstructionOrder<3>,
-          evolution::dg::subcell::Tags::GhostZoneInverseJacobian<3>>,
+          evolution::dg::subcell::Tags::GhostZoneInverseJacobian<3>,
+          ::Tags::VariableFixer<VariableFixing::FixToAtmosphere<3>>>,
       db::AddComputeTags<
           ::domain::Tags::LogicalCoordinates<3>,
           // Compute tags for Frame::Grid quantities
@@ -511,7 +514,9 @@ std::array<double, 5> test(const size_t num_dg_pts,
           evolution::dg::subcell::fd::ReconstructionMethod::DimByDim, false,
           std::nullopt, fd_derivative_order, 1, 1, 1},
       typename evolution::dg::subcell::Tags::ReconstructionOrder<3>::type{},
-      ghost_zone_inv_jac);
+      ghost_zone_inv_jac,
+      VariableFixing::FixToAtmosphere<3>{1.0e-30, 1.0e-30, std::nullopt,
+                                         std::nullopt});
 
   db::mutate_apply<ConservativeFromPrimitive>(make_not_null(&box));
 

--- a/tests/Unit/Helpers/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/PrimReconstructor.hpp
+++ b/tests/Unit/Helpers/Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/PrimReconstructor.hpp
@@ -7,6 +7,7 @@
 
 #include <array>
 #include <cstddef>
+#include <optional>
 #include <unordered_set>
 #include <utility>
 
@@ -32,6 +33,7 @@
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/FiniteDifference/Reconstructor.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/System.hpp"
 #include "Evolution/Systems/GrMhd/ValenciaDivClean/Tags.hpp"
+#include "Evolution/VariableFixing/FixToAtmosphere.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "NumericalAlgorithms/Spectral/Basis.hpp"
 #include "NumericalAlgorithms/Spectral/LogicalCoordinates.hpp"
@@ -83,7 +85,8 @@ template <size_t ThermodynamicDim, typename Reconstructor>
 void test_prim_reconstructor_impl(
     const size_t points_per_dimension,
     const Reconstructor& derived_reconstructor,
-    const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos) {
+    const EquationsOfState::EquationOfState<true, ThermodynamicDim>& eos,
+    const VariableFixing::FixToAtmosphere<3>& fix_to_atmosphere) {
   // 1. Create linear prims to reconstruct
   // 2. send through reconstruction
   // 3. check prims and cons were computed correctly
@@ -235,7 +238,7 @@ void test_prim_reconstructor_impl(
         .reconstruct(make_not_null(&vars_on_lower_face),
                      make_not_null(&vars_on_upper_face),
                      make_not_null(&reconstruction_order), volume_prims, eos,
-                     element, ghost_data, subcell_mesh);
+                     element, ghost_data, subcell_mesh, fix_to_atmosphere);
     for (size_t d = 0; d < 3; ++d) {
       CAPTURE(d);
       for (size_t i = 0; i < gsl::at(reconstruction_order_storage, d).size();
@@ -249,7 +252,7 @@ void test_prim_reconstructor_impl(
     dynamic_cast<const Reconstructor&>(reconstructor)
         .reconstruct(make_not_null(&vars_on_lower_face),
                      make_not_null(&vars_on_upper_face), volume_prims, eos,
-                     element, ghost_data, subcell_mesh);
+                     element, ghost_data, subcell_mesh, fix_to_atmosphere);
   }
 
   for (size_t dim = 0; dim < 3; ++dim) {
@@ -385,7 +388,8 @@ void test_prim_reconstructor_impl(
     dynamic_cast<const Reconstructor&>(reconstructor)
         .reconstruct_fd_neighbor(make_not_null(&upper_side_vars_on_mortar),
                                  volume_prims, eos, element, ghost_data,
-                                 subcell_mesh, Direction<3>{dim, Side::Upper});
+                                 subcell_mesh, fix_to_atmosphere,
+                                 Direction<3>{dim, Side::Upper});
 
     Variables<dg_package_data_argument_tags> lower_side_vars_on_mortar{
         num_pts_on_mortar};
@@ -405,7 +409,8 @@ void test_prim_reconstructor_impl(
     dynamic_cast<const Reconstructor&>(reconstructor)
         .reconstruct_fd_neighbor(make_not_null(&lower_side_vars_on_mortar),
                                  volume_prims, eos, element, ghost_data,
-                                 subcell_mesh, Direction<3>{dim, Side::Lower});
+                                 subcell_mesh, fix_to_atmosphere,
+                                 Direction<3>{dim, Side::Lower});
 
     tmpl::for_each<tmpl::append<cons_tags, prims_tags>>(
         [dim, &expected_lower_face_values, &expected_upper_face_values,
@@ -436,11 +441,13 @@ void test_prim_reconstructor(const size_t points_per_dimension,
   const auto& derived_reconstructor =
       dynamic_cast<const Reconstructor&>(*base_recons);
 
-  detail::test_prim_reconstructor_impl(points_per_dimension,
-                                       derived_reconstructor,
-                                       EquationsOfState::IdealFluid<true>{1.4});
+  const VariableFixing::FixToAtmosphere<3> fix_to_atmosphere{
+      1.0e-30, 1.0e-30, std::nullopt, std::nullopt};
   detail::test_prim_reconstructor_impl(
       points_per_dimension, derived_reconstructor,
-      EquationsOfState::PolytropicFluid<true>{1.0, 2.0});
+      EquationsOfState::IdealFluid<true>{1.4}, fix_to_atmosphere);
+  detail::test_prim_reconstructor_impl(
+      points_per_dimension, derived_reconstructor,
+      EquationsOfState::PolytropicFluid<true>{1.0, 2.0}, fix_to_atmosphere);
 }
 }  // namespace TestHelpers::grmhd::ValenciaDivClean::fd


### PR DESCRIPTION
## Proposed changes


This PR passes a real `FixToAtmosphere<3>` instead of `nullptr` to `ValenciaDivClean` subcell reconstructors. Related files and tests are also updated. Mirrors what Nils Deppe did on #6440 for `GhValenciaDivClean`.


### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent was used, have a co-author trailer of the form
      "Co-Authored-By: <agent name> <agent email>" as the last line of the
      commit, e.g. "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>".

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
