### PR TITLE
Start of BinaryWithGravitationalWaves class for XCTS

### DIFF
--- a/docs/References.bib
+++ b/docs/References.bib
@@ -507,6 +507,20 @@ eprint = {https://doi.org/10.1137/0916035}
     year = "2012"
 }
 
+@article{Buonanno2005xu,
+    author = "Buonanno, Alessandra and Chen, Yanbei and Damour, Thibault",
+    title = "{Transition from inspiral to plunge in precessing binaries of
+              spinning black holes}",
+    eprint = "gr-qc/0508067",
+    archivePrefix = "arXiv",
+    doi = "10.1103/PhysRevD.74.104005",
+    journal = "Phys. Rev. D",
+    volume = "74",
+    pages = "104005",
+    year = "2006",
+    url = "https://doi.org/10.1103/PhysRevD.74.104005"
+}
+
 @article{Casoni2012,
   author  = {Casoni, E. and Peraire, J. and Huerta, A.},
   title   = {One-dimensional shock-capturing for high-order discontinuous
@@ -1495,6 +1509,21 @@ archivePrefix = {arXiv},
   url     = "https://doi.org/10.1007/s10915-006-9105-9"
 }
 
+@article{Jaranowski1997ky,
+    author = "{Jaranowski, Piotr and Sch\"afer, Gerhard}",
+    title = "{Third postNewtonian higher order ADM Hamilton dynamics for
+             two-body point-mass systems}",
+    eprint = "gr-qc/9712075",
+    archivePrefix = "arXiv",
+    doi = "10.1103/PhysRevD.57.7274",
+    url = "https://doi.org/10.1103/PhysRevD.57.7274",
+    journal = "Phys. Rev. D",
+    volume = "57",
+    pages = "7274--7291",
+    year = "1998",
+    note = "[Erratum: Phys.Rev.D 63, 029902 (2001)]"
+}
+
 @article{Jiang1996,
   author  = {Guang-Shan Jiang and Chi-Wang Shu},
   doi     = {https://doi.org/10.1006/jcph.1996.0130},
@@ -1523,6 +1552,22 @@ archivePrefix = {arXiv},
   number =       2,
   pages =        023018,
   year =         2021
+}
+
+@article{Kelly2007uc,
+    author = "Kelly, Bernard J. and Tichy, Wolfgang and Campanelli,
+             Manuela and Whiting, Bernard F.",
+    title = "{Black hole puncture initial data with realistic gravitational
+             wave content}",
+    eprint = "0704.0628",
+    archivePrefix = "arXiv",
+    primaryClass = "gr-qc",
+    doi = "10.1103/PhysRevD.76.024008",
+    url = "https://doi.org/10.1103/PhysRevD.76.024008",
+    journal = "Phys. Rev. D",
+    volume = "76",
+    pages = "024008",
+    year = "2007"
 }
 
 @article{Kennedy2003,
@@ -2196,6 +2241,22 @@ journal = {The Astrophysical Journal}
   year =         2014
 }
 
+@article{Mundim2010hu,
+    author = "Mundim, Bruno C. and Kelly, Bernard J. and Zlochower,
+              Yosef and Nakano, Hiroyuki and Campanelli, Manuela",
+    editor = "Lehner, Luis and Pfeiffer, Harald P. and Poisson, E.",
+    title = "{Hybrid black-hole binary initial data}",
+    eprint = "1012.0886",
+    archivePrefix = "arXiv",
+    primaryClass = "gr-qc",
+    doi = "10.1088/0264-9381/28/13/134003",
+    url = "https://doi.org/10.1088/0264-9381/28/13/134003",
+    journal = "Class. Quant. Grav.",
+    volume = "28",
+    pages = "134003",
+    year = "2011"
+}
+
 @article{Nee2024bur,
   author = {Nee, Peter James and Lara, Guillermo and Pfeiffer, Harald P. and
             Vu, Nils L.},
@@ -2741,6 +2802,20 @@ archivePrefix = {arXiv},
   volume   = "79",
 }
 
+@article{Steinhoff2008zr,
+    author = "{Steinhoff, Jan and Sch\"afer, Gerhard and Hergt, Steven}",
+    title = "{ADM canonical formalism for gravitating spinning objects}",
+    eprint = "0805.3136",
+    archivePrefix = "arXiv",
+    primaryClass = "gr-qc",
+    doi = "10.1103/PhysRevD.77.104018",
+    url = "https://doi.org/10.1103/PhysRevD.77.104018",
+    journal = "Phys. Rev. D",
+    volume = "77",
+    pages = "104018",
+    year = "2008"
+}
+
 @article{Stiller2016a,
   author        = "Stiller, Jörg",
   title         = "Robust multigrid for high-order discontinuous {Galerkin}
@@ -2878,6 +2953,22 @@ archivePrefix = {arXiv},
   year       = "2017",
   url        = "https://press.princeton.edu/titles/10157.html",
   publisher  = "Princeton University Press",
+}
+
+@article{Tichy2002ec,
+    author = "{Tichy, Wolfgang and Br\"ugmann, Bernd and Campanelli, Manuela
+             and Diener, Peter}",
+    title = "{Binary black hole initial data for numerical general relativity
+             based on post-Newtonian data}",
+    eprint = "gr-qc/0207011",
+    archivePrefix = "arXiv",
+    reportNumber = "UTBRG-2002-06, AEI-2002-048",
+    doi = "10.1103/PhysRevD.67.064008",
+    url = {https://link.aps.org/doi/10.1103/PhysRevD.67.064008},
+    journal = "Phys. Rev. D",
+    volume = "67",
+    pages = "064008",
+    year = "2003"
 }
 
 @article{Toro1994,

--- a/src/Elliptic/Executables/Xcts/SolveXcts.hpp
+++ b/src/Elliptic/Executables/Xcts/SolveXcts.hpp
@@ -43,6 +43,7 @@
 #include "ParallelAlgorithms/LinearSolver/Multigrid/ElementsAllocator.hpp"
 #include "ParallelAlgorithms/LinearSolver/Multigrid/Tags.hpp"
 #include "PointwiseFunctions/AnalyticData/Xcts/Binary.hpp"
+#include "PointwiseFunctions/AnalyticData/Xcts/BinaryWithGravitationalWaves.hpp"
 #include "PointwiseFunctions/AnalyticData/Xcts/KerrSchildTeukolsky.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/Xcts/Factory.hpp"
 #include "PointwiseFunctions/Hydro/LowerSpatialFourVelocity.hpp"
@@ -127,6 +128,9 @@ struct Metavariables {
         Xcts::AnalyticData::KerrSchildTeukolsky,
         Xcts::AnalyticData::Binary<elliptic::analytic_data::AnalyticSolution,
                                    Xcts::Solutions::all_analytic_solutions>,
+        Xcts::AnalyticData::BinaryWithGravitationalWaves<
+            elliptic::analytic_data::AnalyticSolution,
+            Xcts::Solutions::all_analytic_solutions>,
         elliptic::analytic_data::NumericData>;
 
     using factory_classes = tmpl::map<

--- a/src/Elliptic/Systems/Xcts/BoundaryConditions/Factory.hpp
+++ b/src/Elliptic/Systems/Xcts/BoundaryConditions/Factory.hpp
@@ -15,5 +15,5 @@ using standard_boundary_conditions =
     tmpl::list<elliptic::BoundaryConditions::AnalyticSolution<System>,
                Flatness<System::enabled_equations>,
                Robin<System::enabled_equations>,
-               ApparentHorizon<System::conformal_geometry>>;
+               ApparentHorizon<System::conformal_geometry> >;
 }

--- a/src/PointwiseFunctions/AnalyticData/Xcts/BinaryWithGravitationalWaves.cpp
+++ b/src/PointwiseFunctions/AnalyticData/Xcts/BinaryWithGravitationalWaves.cpp
@@ -1,0 +1,163 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "PointwiseFunctions/AnalyticData/Xcts/BinaryWithGravitationalWaves.hpp"
+
+#include <array>
+#include <cstddef>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/EagerMath/DeterminantAndInverse.hpp"
+#include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
+#include "DataStructures/Tensor/EagerMath/RaiseOrLowerIndex.hpp"
+#include "DataStructures/Tensor/EagerMath/Trace.hpp"
+#include "DataStructures/Tensor/Expressions/TensorIndex.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Elliptic/Systems/Xcts/Tags.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "PointwiseFunctions/AnalyticData/Xcts/CommonVariables.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Christoffel.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Lapse.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Shift.hpp"
+#include "PointwiseFunctions/GeneralRelativity/SpacetimeMetric.hpp"
+#include "PointwiseFunctions/GeneralRelativity/SpatialMetric.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/ContainerHelpers.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace Xcts::AnalyticData::detail {
+
+template <typename DataType>
+void BinaryWithGravitationalWavesVariables<DataType>::operator()(
+    const gsl::not_null<tnsr::ii<DataType, 3>*> conformal_metric,
+    const gsl::not_null<Cache*> /*cache*/,
+    Xcts::Tags::ConformalMetric<DataType, 3, Frame::Inertial> /*meta*/) const {
+  const auto& conformal_metric_aux = get_t_conformal_metric(present_time);
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = 0; j <= i; ++j) {
+      conformal_metric->get(i, j) = conformal_metric_aux.get(i, j);
+    }
+  }
+}
+
+template <typename DataType>
+void BinaryWithGravitationalWavesVariables<DataType>::operator()(
+    const gsl::not_null<tnsr::ijj<DataType, 3>*> deriv_conformal_metric,
+    const gsl::not_null<Cache*> /*cache*/,
+    ::Tags::deriv<Xcts::Tags::ConformalMetric<DataType, 3, Frame::Inertial>,
+                  tmpl::size_t<Dim>, Frame::Inertial> /*meta*/) const {
+  std::fill(deriv_conformal_metric->begin(), deriv_conformal_metric->end(), 0.);
+}
+
+template <typename DataType>
+void BinaryWithGravitationalWavesVariables<DataType>::operator()(
+    const gsl::not_null<Scalar<DataType>*> trace_extrinsic_curvature,
+    const gsl::not_null<Cache*> /*cache*/,
+    gr::Tags::TraceExtrinsicCurvature<DataType> /*meta*/) const {
+  get(*trace_extrinsic_curvature) = get(get_t_trace_extrinsic_curvature(
+      present_time, mesh->get(), inv_jacobian->get()));
+}
+
+template <typename DataType>
+void BinaryWithGravitationalWavesVariables<DataType>::operator()(
+    const gsl::not_null<Scalar<DataType>*> dt_trace_extrinsic_curvature,
+    const gsl::not_null<Cache*> /*cache*/,
+    ::Tags::dt<gr::Tags::TraceExtrinsicCurvature<DataType>> /*meta*/) const {
+  get(*dt_trace_extrinsic_curvature) = 0. * time_displacement;
+}
+
+template <typename DataType>
+void BinaryWithGravitationalWavesVariables<DataType>::operator()(
+    const gsl::not_null<tnsr::II<DataType, 3, Frame::Inertial>*>
+        longitudinal_shift_background_minus_dt_conformal_metric,
+    const gsl::not_null<Cache*> /*cache*/,
+    Xcts::Tags::LongitudinalShiftBackgroundMinusDtConformalMetric<
+        DataType, 3, Frame::Inertial> /*meta*/) const {
+  std::fill(longitudinal_shift_background_minus_dt_conformal_metric->begin(),
+            longitudinal_shift_background_minus_dt_conformal_metric->end(), 0.);
+}
+
+template <typename DataType>
+void BinaryWithGravitationalWavesVariables<DataType>::operator()(
+    const gsl::not_null<Scalar<DataType>*> conformal_factor_minus_one,
+    const gsl::not_null<Cache*> /*cache*/,
+    Xcts::Tags::ConformalFactorMinusOne<DataType> /*meta*/) const {
+  get(*conformal_factor_minus_one) = 0.;
+}
+
+template <typename DataType>
+void BinaryWithGravitationalWavesVariables<DataType>::operator()(
+    const gsl::not_null<Scalar<DataType>*>
+        lapse_times_conformal_factor_minus_one,
+    const gsl::not_null<Cache*> cache,
+    Xcts::Tags::LapseTimesConformalFactorMinusOne<DataType> /*meta*/) const {
+  const auto& conformal_factor_minus_one =
+      cache->get_var(*this, Xcts::Tags::ConformalFactorMinusOne<DataType>{});
+  const auto lapse = get_t_lapse(present_time);
+  get(*lapse_times_conformal_factor_minus_one) =
+      get(lapse) * (get(conformal_factor_minus_one) + 1.) - 1.;
+}
+
+template <typename DataType>
+void BinaryWithGravitationalWavesVariables<DataType>::operator()(
+    const gsl::not_null<tnsr::I<DataType, Dim>*> shift_excess,
+    const gsl::not_null<Cache*> /*cache*/,
+    Xcts::Tags::ShiftExcess<DataType, Dim, Frame::Inertial> /*meta*/) const {
+  std::fill(shift_excess->begin(), shift_excess->end(), 0.);
+}
+
+// Private functions
+
+template <typename DataType>
+Scalar<DataType> BinaryWithGravitationalWavesVariables<DataType>::
+    get_t_trace_extrinsic_curvature(
+        DataType t, Mesh<3> /*local_mesh*/,
+        InverseJacobian<DataType, 3, Frame::ElementLogical, Frame::Inertial>
+        /*local_inv_jacobian*/) const {
+  tnsr::ii<DataType, 3> extrinsic_curvature{t.size()};
+  std::fill(extrinsic_curvature.begin(), extrinsic_curvature.end(), 0.);
+
+  const auto conformal_metric = get_t_conformal_metric(t);
+  const auto inv_conformal_metric =
+      determinant_and_inverse(conformal_metric).second;
+  return trace(extrinsic_curvature, inv_conformal_metric);
+}
+
+template <typename DataType>
+tnsr::ii<DataType, 3>
+BinaryWithGravitationalWavesVariables<DataType>::get_t_conformal_metric(
+    DataType t) const {
+  tnsr::ii<DataType, Dim> conformal_metric(make_with_value<DataType>(t, 0.));
+  for (size_t i = 0; i < Dim; ++i) {
+    conformal_metric.get(i, i) = 1.;
+  }
+  return conformal_metric;
+}
+
+template <typename DataType>
+Scalar<DataType> BinaryWithGravitationalWavesVariables<DataType>::get_t_lapse(
+    DataType t) const {
+  Scalar<DataType> lapse_t{t.size()};
+  std::fill(lapse_t.begin(), lapse_t.end(), 1.);
+  return lapse_t;
+}
+
+template <typename DataType>
+tnsr::I<DataType, 3>
+BinaryWithGravitationalWavesVariables<DataType>::get_t_shift(DataType t) const {
+  tnsr::I<DataType, 3> shift_t{t.size()};
+  std::fill(shift_t.begin(), shift_t.end(), 0.);
+  return shift_t;
+}
+
+template class BinaryWithGravitationalWavesVariables<DataVector>;
+
+}  // namespace Xcts::AnalyticData::detail
+
+template class Xcts::AnalyticData::CommonVariables<
+    DataVector, typename Xcts::AnalyticData::detail::
+                    BinaryWithGravitationalWavesVariables<DataVector>::Cache>;

--- a/src/PointwiseFunctions/AnalyticData/Xcts/BinaryWithGravitationalWaves.hpp
+++ b/src/PointwiseFunctions/AnalyticData/Xcts/BinaryWithGravitationalWaves.hpp
@@ -1,0 +1,647 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <array>
+#include <functional>
+#include <optional>
+#include <utility>
+
+#include "DataStructures/CachedTempBuffer.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/TaggedTuple.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Elliptic/Systems/Xcts/Tags.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "Options/Context.hpp"
+#include "Options/ParseError.hpp"
+#include "Options/String.hpp"
+#include "PointwiseFunctions/AnalyticData/Xcts/CommonVariables.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Xcts/Flatness.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/Xcts/Schwarzschild.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
+#include "PointwiseFunctions/GeneralRelativity/Tags/Conformal.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/Background.hpp"
+#include "PointwiseFunctions/InitialDataUtilities/InitialGuess.hpp"
+#include "PointwiseFunctions/SpecialRelativity/LorentzBoostMatrix.hpp"
+#include "Utilities/CallWithDynamicType.hpp"
+#include "Utilities/Requires.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace Xcts::AnalyticData {
+
+namespace detail {
+
+template <typename DataType>
+using BinaryWithGravitationalWavesVariablesCache =
+    cached_temp_buffer_from_typelist<tmpl::append<
+        common_tags<DataType>,
+        tmpl::list<
+            // ::Tags::deriv<
+            //    Xcts::Tags::ShiftBackground<DataType, 3, Frame::Inertial>,
+            //    tmpl::size_t<3>, Frame::Inertial>,
+            gr::Tags::Conformal<gr::Tags::EnergyDensity<DataType>, 0>,
+            gr::Tags::Conformal<gr::Tags::StressTrace<DataType>, 0>,
+            gr::Tags::Conformal<gr::Tags::MomentumDensity<DataType, 3>, 0>,
+            // For initial guesses
+            Xcts::Tags::ConformalFactorMinusOne<DataType>,
+            Xcts::Tags::LapseTimesConformalFactorMinusOne<DataType>,
+            Xcts::Tags::ShiftExcess<DataType, 3, Frame::Inertial>>,
+        hydro_tags<DataType>>>;
+
+template <typename DataType>
+struct BinaryWithGravitationalWavesVariables
+    : CommonVariables<DataType,
+                      BinaryWithGravitationalWavesVariablesCache<DataType>> {
+  static constexpr size_t Dim = 3;
+  using Cache = BinaryWithGravitationalWavesVariablesCache<DataType>;
+  using Base =
+      CommonVariables<DataType,
+                      BinaryWithGravitationalWavesVariablesCache<DataType>>;
+  using Base::operator();
+
+  using superposed_tags = tmpl::append<
+      tmpl::list<
+          Xcts::Tags::ConformalMetric<DataType, Dim, Frame::Inertial>,
+          gr::Tags::Conformal<gr::Tags::EnergyDensity<DataType>, 0>,
+          gr::Tags::Conformal<gr::Tags::StressTrace<DataType>, 0>,
+          gr::Tags::Conformal<gr::Tags::MomentumDensity<DataType, Dim>, 0>>,
+      hydro_tags<DataType>>;
+
+  using boost_tags = tmpl::append<
+      tmpl::list<Xcts::Tags::ConformalMetric<DataType, Dim, Frame::Inertial>,
+                 Xcts::Tags::ConformalFactorMinusOne<DataType>,
+                 Xcts::Tags::LapseTimesConformalFactorMinusOne<DataType>,
+                 Xcts::Tags::ShiftExcess<DataType, Dim, Frame::Inertial>>>;
+
+  BinaryWithGravitationalWavesVariables(
+      std::optional<std::reference_wrapper<const Mesh<Dim>>> local_mesh,
+      std::optional<std::reference_wrapper<const InverseJacobian<
+          DataType, Dim, Frame::ElementLogical, Frame::Inertial>>>
+          local_inv_jacobian,
+      const tnsr::I<DataVector, Dim>& local_x,
+      const std::array<double, 2>& local_masses,
+      const std::array<double, 2>& local_xcoords,
+      const std::array<double, 3>& local_momentum_left,
+      const std::array<double, 3>& local_momentum_right,
+      const double local_y_offset, const double local_z_offset,
+      std::array<tnsr::I<DataVector, Dim>, 2> local_x_isolated,
+      tuples::tagged_tuple_from_typelist<superposed_tags> local_flat_vars,
+      std::array<tuples::tagged_tuple_from_typelist<superposed_tags>, 2>
+          local_isolated_vars,
+      std::array<tuples::tagged_tuple_from_typelist<boost_tags>, 2>
+          local_boost_vars)
+      : Base(std::move(local_mesh), std::move(local_inv_jacobian)),
+        mesh(std::move(local_mesh)),
+        inv_jacobian(std::move(local_inv_jacobian)),
+        x(local_x),
+        mass_left(local_masses[0]),
+        mass_right(local_masses[1]),
+        xcoords(local_xcoords),
+        momentum_left(local_momentum_left),
+        momentum_right(local_momentum_right),
+        offset({local_y_offset, local_z_offset}),
+        x_isolated(std::move(local_x_isolated)),
+        flat_vars(std::move(local_flat_vars)),
+        isolated_vars(std::move(local_isolated_vars)),
+        boost_vars(std::move(local_boost_vars)) {}
+
+  std::optional<std::reference_wrapper<const Mesh<Dim>>> mesh;
+  std::optional<std::reference_wrapper<const InverseJacobian<
+      DataType, Dim, Frame::ElementLogical, Frame::Inertial>>>
+      inv_jacobian;
+
+  tnsr::I<DataVector, Dim> x;
+  double mass_left;
+  double mass_right;
+  std::array<double, 2> xcoords;
+  std::array<double, 3> momentum_left;
+  std::array<double, 3> momentum_right;
+  std::array<double, 2> offset;
+  std::array<tnsr::I<DataVector, Dim>, 2> x_isolated;
+  tuples::tagged_tuple_from_typelist<superposed_tags> flat_vars;
+  std::array<tuples::tagged_tuple_from_typelist<superposed_tags>, 2>
+      isolated_vars;
+  std::array<tuples::tagged_tuple_from_typelist<boost_tags>, 2> boost_vars;
+
+  double time_displacement = 0.01;
+  DataType present_time = make_with_value<DataVector>(x, 1.);
+
+  template <typename Tag,
+            Requires<tmpl::list_contains_v<superposed_tags, Tag>> = nullptr>
+  void superposition(gsl::not_null<typename Tag::type*> superposed_var,
+                     gsl::not_null<Cache*> /*cache*/, Tag /*meta*/) const {
+    for (size_t i = 0; i < superposed_var->size(); ++i) {
+      (*superposed_var)[i] = get<Tag>(isolated_vars[0])[i] +
+                             get<Tag>(isolated_vars[1])[i] -
+                             get<Tag>(flat_vars)[i];
+    }
+  }
+
+  void operator()(gsl::not_null<tnsr::ii<DataType, Dim>*> conformal_metric,
+                  gsl::not_null<Cache*> cache,
+                  Xcts::Tags::ConformalMetric<DataType, Dim, Frame::Inertial>
+                      meta) const override;
+  void operator()(
+      gsl::not_null<tnsr::ijj<DataType, Dim>*> deriv_conformal_metric,
+      gsl::not_null<Cache*> cache,
+      ::Tags::deriv<Xcts::Tags::ConformalMetric<DataType, Dim, Frame::Inertial>,
+                    tmpl::size_t<Dim>, Frame::Inertial>
+          meta) const override;
+  void operator()(
+      gsl::not_null<Scalar<DataType>*> trace_extrinsic_curvature,
+      gsl::not_null<Cache*> cache,
+      gr::Tags::TraceExtrinsicCurvature<DataType> meta) const override;
+  void operator()(gsl::not_null<Scalar<DataType>*> dt_trace_extrinsic_curvature,
+                  gsl::not_null<Cache*> cache,
+                  ::Tags::dt<gr::Tags::TraceExtrinsicCurvature<DataType>> meta)
+      const override;
+  void operator()(
+      gsl::not_null<tnsr::I<DataType, Dim>*> shift_background,
+      gsl::not_null<Cache*> /*cache*/,
+      Xcts::Tags::ShiftBackground<DataType, Dim, Frame::Inertial> /*meta*/)
+      const override {
+    std::fill(shift_background->begin(), shift_background->end(), 0.);
+  }
+  void operator()(
+      gsl::not_null<tnsr::iJ<DataType, Dim>*> deriv_shift_background,
+      gsl::not_null<Cache*> /*cache*/,
+      ::Tags::deriv<Xcts::Tags::ShiftBackground<DataType, Dim, Frame::Inertial>,
+                    tmpl::size_t<Dim>, Frame::Inertial> /*meta*/)
+      const override {
+    std::fill(deriv_shift_background->begin(), deriv_shift_background->end(),
+              0.);
+  }
+  void operator()(gsl::not_null<tnsr::II<DataType, Dim, Frame::Inertial>*>
+                      longitudinal_shift_background_minus_dt_conformal_metric,
+                  gsl::not_null<Cache*> cache,
+                  Xcts::Tags::LongitudinalShiftBackgroundMinusDtConformalMetric<
+                      DataType, Dim, Frame::Inertial> /*meta*/) const override;
+  void operator()(
+      const gsl::not_null<Scalar<DataType>*> conformal_energy_density,
+      const gsl::not_null<Cache*> cache,
+      gr::Tags::Conformal<gr::Tags::EnergyDensity<DataType>, 0> meta) const {
+    superposition(conformal_energy_density, cache, meta);
+  }
+  void operator()(
+      const gsl::not_null<Scalar<DataType>*> conformal_stress_trace,
+      const gsl::not_null<Cache*> cache,
+      gr::Tags::Conformal<gr::Tags::StressTrace<DataType>, 0> meta) const {
+    superposition(conformal_stress_trace, cache, meta);
+  }
+  void operator()(
+      const gsl::not_null<tnsr::I<DataType, Dim>*> conformal_momentum_density,
+      const gsl::not_null<Cache*> cache,
+      gr::Tags::Conformal<gr::Tags::MomentumDensity<DataType, Dim>, 0> meta)
+      const {
+    superposition(conformal_momentum_density, cache, meta);
+  }
+  void operator()(gsl::not_null<Scalar<DataType>*> conformal_factor_minus_one,
+                  gsl::not_null<Cache*> cache,
+                  Xcts::Tags::ConformalFactorMinusOne<DataType> meta) const;
+  void operator()(
+      gsl::not_null<Scalar<DataType>*> lapse_times_conformal_factor_minus_one,
+      gsl::not_null<Cache*> cache,
+      Xcts::Tags::LapseTimesConformalFactorMinusOne<DataType> meta) const;
+  void operator()(
+      gsl::not_null<tnsr::I<DataType, Dim>*> shift_excess,
+      gsl::not_null<Cache*> cache,
+      Xcts::Tags::ShiftExcess<DataType, Dim, Frame::Inertial> meta) const;
+  void operator()(const gsl::not_null<Scalar<DataType>*> rest_mass_density,
+                  const gsl::not_null<Cache*> cache,
+                  hydro::Tags::RestMassDensity<DataType> meta) const {
+    superposition(rest_mass_density, cache, meta);
+  }
+  void operator()(const gsl::not_null<Scalar<DataType>*> specific_enthalpy,
+                  const gsl::not_null<Cache*> cache,
+                  hydro::Tags::SpecificEnthalpy<DataType> meta) const {
+    superposition(specific_enthalpy, cache, meta);
+  }
+  void operator()(const gsl::not_null<Scalar<DataType>*> pressure,
+                  const gsl::not_null<Cache*> cache,
+                  hydro::Tags::Pressure<DataType> meta) const {
+    superposition(pressure, cache, meta);
+  }
+  void operator()(const gsl::not_null<tnsr::I<DataType, 3>*> spatial_velocity,
+                  const gsl::not_null<Cache*> cache,
+                  hydro::Tags::SpatialVelocity<DataType, 3> meta) const {
+    superposition(spatial_velocity, cache, meta);
+  }
+  void operator()(const gsl::not_null<Scalar<DataType>*> lorentz_factor,
+                  const gsl::not_null<Cache*> cache,
+                  hydro::Tags::LorentzFactor<DataType> meta) const {
+    superposition(lorentz_factor, cache, meta);
+  }
+  void operator()(const gsl::not_null<tnsr::I<DataType, 3>*> magnetic_field,
+                  const gsl::not_null<Cache*> cache,
+                  hydro::Tags::MagneticField<DataType, 3> meta) const {
+    superposition(magnetic_field, cache, meta);
+  }
+
+ private:
+  // DataType integrate_term(DataType t, size_t i, size_t j, int left_right,
+  // double t0) const;
+  Scalar<DataType> get_t_trace_extrinsic_curvature(
+      DataType t, Mesh<3> local_mesh,
+      InverseJacobian<DataType, 3, Frame::ElementLogical, Frame::Inertial>
+          local_inv_jacobian) const;
+  tnsr::ii<DataType, 3> get_t_conformal_metric(DataType t) const;
+  Scalar<DataType> get_t_lapse(DataType t) const;
+  tnsr::I<DataType, 3> get_t_shift(DataType t) const;
+};
+}  // namespace detail
+
+/*!
+ * \brief   Binary initial data with realistic wave background,
+ * constructed in Post-Newtonian approximations.
+ *
+ * The main goal of this implementation is to improve the extracted
+ * wave forms, for example, by minimizing junk radiation.
+ * The data is only valid for black holes without spin. Even so, there is some
+ * work done to describe such systems that could later be implemented
+ * \cite Steinhoff2008zr. The objects are constructed from a superposition of
+ * two isolated objects that are boosted with respect to each other. The
+ * radiative data is constructed from Post-Newtonian expansions for the
+ * inspiral phase, in orders of \f$\epsilon = 1/c\f$, in \cite Jaranowski1997ky.
+ * In ADMTT gauge it is possible to get the 3-metric as
+ * \f$\gamma^{PN}_{ij} = \psi^{4}_{PN} \delta_{ij} + h^{TT}_{ij}\f$ where
+ * \f$h^{TT}_{ij}\f$ is the radiative part and the non-radiative Post-Newtonian
+ * conformal factor is given by
+ *
+ * \f{equation}{
+ * \psi_{PN} = 1 + \sum_{a=1}^{2} \frac{E_a}{2 r_a} + O(\epsilon^6)
+ * \f}
+ *
+ * and
+ *
+ * \f{equation}{E_a = (\epsilon^2) m_a + (\epsilon^4) \Bigr(\frac{p_a^2}{2 m_a}
+ * - \frac{m_1 m_2}{2 r_{12}}\Bigr) \f}
+ *
+ * with \f$\vec{p}_a\f$ the linear momentum, \f$r_a\f$ the distance to each
+ * black hole center of mass from the point of calculation and \f$r_{12}\f$
+ * separation between the two black holes and \f$m_a\f$ is the mass of each
+ * black hole. Near each black hole, the 3-metric can be approximated by the
+ * Schwarzschild 3-metric in isotropic coordinates.
+ *
+ * In \cite Mundim2010hu, the radiative term \f$h^{TT}_{ij}\f$ is decomposed
+ * into two parts, a near-zone that is only valid close to the black holes and a
+ * remainder that makes corrections far from the black holes, \f$h^{TT}_{ij} =
+ * h^{TT\ (NZ)}_{ij} + h^{TT\ (remainder)}_{ij} + O(\epsilon^5)\f$. The
+ * near-zone term is given by $h^{TT\ (NZ)}_{ij} = (\epsilon^4) h^{TT}_{(4)ij} +
+ * (\epsilon^5) h^{TT}_{(5)ij}$, with
+ *
+ * \f{align}{
+ * h^{TT\ i j}_{(4)} &= \frac{1}{4} \sum_a \frac{1}{m_a r_a} \Bigr\{
+ * [p_a^2-5(\hat{n}_a \cdot \vec{p}_a)^2] \delta^{i j}+2 p_a^i p_a^j
+ * +[3(\hat{n}_a \cdot \vec{p}_a)^2-5p_a^2] n_a^i n_a^j +12(\hat{n}_a \cdot
+ * \vec{p}_a) n_a^{(i} p_a^{j)} \Bigr\} \nonumber \\
+ *  &+\frac{1}{8} \sum_a \sum_{b \neq a} m_a m_b \Bigr\{-\frac{32}{s_{a
+ * b}}(\frac{1}{r_{a b}}+\frac{1}{s_{a b}}) n_{a b}^i n_{a
+ * b}^j+2(\frac{r_a+r_b}{r_{a b}^3}+\frac{12}{s_{a b}^2}) n_a^i
+ * n_b^j+32(\frac{2}{s_{a b}^2}-\frac{1}{r_{a b}^2}) n_a^{(i} n_{a b}^{j)}
+ * \label{eq:near_zone_term} \\
+ *  &+[\frac{5}{r_{a b} r_a}-\frac{1}{r_{a b}^3}(\frac{r_b^2}{r_a}+3
+ * r_a)-\frac{8}{s_{a b}}(\frac{1}{r_a}+\frac{1}{s_{a b}})] n_a^i n_a^j+[5
+ * \frac{r_a}{r_{a b}^3}(\frac{r_a}{r_b}-1)-\frac{17}{r_{a b} r_a}+\frac{4}{r_a
+ * r_b}+\frac{8}{s_{a b}}(\frac{1}{r_a}+\frac{4}{r_{a b}})] \delta^{i j}\Bigr\},
+ * \nonumber \f}
+ *
+ * where \f$\hat{n}_a\f$ is the unit normal vector pointing to the black hole
+ * center of mass, \f$\hat{n}_{ab}\f$ is the unit normal vector pointing from
+ * black hole \f$a\f$ to black hole \f$b\f$ and \f$s_{ab} = r_a + r_b +
+ * r_{ab}\f$. The term \f$h^{TT}_{(5)ij}\f$ is a spatially constant field that
+ * just varies in time, for initial data we can choose an initial time such that
+ * \f$h^{TT}_{(5)ij} = 0\f$.
+ *
+ * Looking at \cite Kelly2007uc, the remainder term in itself is decomposed in
+ * general computations for specific vectors as
+ *
+ * \f{equation}{
+ * h^{TT\ (remainder)}_{ij} = H^{TT\ 1}_{ij} \Bigr[
+ * \frac{\vec{p_1}}{\sqrt{m_1}}\Bigr] + H^{TT\ 2}_{ij} \Bigr[
+ * \frac{\vec{p_2}}{\sqrt{m_2}}\Bigr] - H^{TT\ 1}_{ij} \Bigr[ \sqrt{\frac{m_1
+ * m_2}{2 r_{12}}}  \hat{n_{12}} \Bigr] - H^{TT\ 2}_{ij} \Bigr[ \sqrt{\frac{m_1
+ * m_2}{2 r_{12}}}  \hat{n_{12}} \Bigr], \f}
+ *
+ * each of this is composed of three different computations: one computed at
+ * present time \f$t\f$, other at retarded time \f$t_{a}^{r}\f$ defined by \f$t
+ * - t_{a}^{r} - r_a(t_{a}^{r}) = 0\f$ and the last is an integral between the
+ * two times:
+ *
+ * \f{equation}{
+ * H^{TT\ a}_{ij} [ \vec{u} ] = H^{TT\ a}_{ij} [ \vec{u} ; t] + H^{TT\ a}_{ij} [
+ * \vec{u} ; t^{r}_a] + H^{TT\ a}_{ij} [ \vec{u} ; t_{a}^{r} \to t]. \f}
+ *
+ * Explicitly they are
+ *
+ * \f{equation}{
+ * H^{TT\ a}_{ij} [ \vec{u} ; t] = -\frac{1}{4 r_a(t)} \Bigr\{ [u^2 - 5(\vec{u}
+ * \cdot \hat{n}_a)^2] \delta_{ij} + 2 u^iu^j + 3(\vec{u}\cdot\hat{n}_a)^2 - 5
+ * u^2] n_a^i n_a^j + 12 (\vec{u} \cdot \hat{n}_a) u^{(i}n_a^{j)}\Bigr\}_t,
+ * \label{eq:present_term} \f}
+ *
+ * \f{equation}{
+ * H^{TT\ a}_{ij} [ \vec{u} ; t^{r}_a] = \frac{1}{r_a(t^{r}_a)} \Bigr\{ [-2u^2
+ * + 2(\vec{u} \cdot \hat{n}_a)^2] \delta^{ij} + 4u^iu^j + [2 u^2 + 2 (\vec{u}
+ * \cdot \hat{n}_a)^2 ] n_a^i n_a^j - 8(\vec{u}\cdot\hat{n}_a) u^{(i}n_a^{j)}
+ * \Bigr\}_{t^{r}_a},
+ * \label{eq:retarded_term} \f}
+ *
+ * and
+ *
+ * \f{align}{
+ * H^{TT\ a}_{ij} [ \vec{u} ; t^{r}_a \to t] &= \nonumber \\
+ *  &- \int^t_{t^{r}_a} d\tau \frac{(t-\tau)}{r_a(\tau)^3}  \Bigr\{ [-5u^2 +
+ * 9(\vec{u} \cdot \hat{n}_a)^2] \delta^{ij} + 6u^iu^j - 12
+ * (\vec{u}\cdot\hat{n}_a) u^{(i}n_a^{j)} + [9 u^2 - 15(\vec{u} \cdot
+ * \hat{n}_a)^2 ]  n_a^i n_a^j\Bigr\} \label{eq:integral_term} \\
+ *  &- \int^t_{t^{r}_a} d\tau \frac{(t-\tau)^3}{r_a(\tau)^5}  \Bigr\{ [u^2 -
+ * 5(\vec{u} \cdot \hat{n}_a)^2] \delta^{ij} + 2 u^iu^j - 20
+ * (\vec{u}\cdot\hat{n}_a) u^{(i}n_a^{j)} + [-5 u^2 + 35(\vec{u} \cdot
+ * \hat{n}_a)^2 ]  n_a^i n_a^j\Bigr\}. \nonumber \f}
+ *
+ * \warning The radiative terms, equations \f$\eqref{eq:near_zone_term}\f$,
+ * \f$\eqref{eq:present_term}\f$, \f$\eqref{eq:retarded_term}\f$ and
+ * \f$\eqref{eq:integral_term}\f$, are not implemented yet. Instead these terms
+ * are set to zero.
+ *
+ * With this the whole spatial metric is computed up to \f$2PN\f$ order and the
+ * radiative term agrees well with quadrupole predictions. In \cite Tichy2002ec,
+ * the extrinsic curvature is given up to \f$2.5PN\f$ order by
+ *
+ * \f{equation}{
+ * K^{ij}_{PN} = - \psi^{-10}_{PN} \Bigr[ (\epsilon^3) \tilde{\pi}_{(3)}^{ij} +
+ * (\epsilon^5) \frac{1}{2} \dot{h}^{TT}_{(4)ij} + (\epsilon^5) (\phi_{(2)}
+ * \tilde{\pi}_{(3)}^{ij})^{TT} \Bigr] + O(\epsilon^6). \f}
+ *
+ * where
+ *
+ * \f{equation}{
+ *  \tilde{\pi}_{(3)}^{i j}=\frac{1}{16 \pi} \sum_a p_{a}^k\{-\delta_{i
+ * j}(\frac{1}{r_a})_{, k}+2[\delta_{i k}(\frac{1}{r_a})_{, j}+\delta_{j
+ * k}(\frac{1}{r_a})_{, i}]-\frac{1}{2} r_{a, i j k}\}. \f}
+ *
+ *
+ * To be able to calculate equations \f$\eqref{eq:retarded_term}\f$ and
+ * \f$\eqref{eq:integral_term}\f$ we need to look into the past history
+ * of the binary at least up to the time were the generated wave can reach the
+ * furthest point on the grid. To do so we must evolve the binary backward in
+ * time. Because we are only looking into the inspiral phase we can follow a
+ * simple Hamiltonian evolution computed in Post-Newtonian orders. The
+ * equations to be solved are
+ *
+ * \f{equation}{
+ * \frac{d X^i}{d t}=\frac{\partial H}{\partial P_i}
+ * \f}
+ *
+ * and
+ *
+ * \f{equation}{
+ * \frac{d P_i}{d t}=-\frac{\partial H}{\partial X^i}+F_i,
+ * \f}
+ *
+ * where $H$ is the Post-Newtonian Hamiltonian, $X^i$ is the separation
+ * vector between the two particles, $P_i$ is the momentum of one particle
+ * in the center of mass frame and $F_i$ is the radiation-reaction flux term.
+ * The Post-Newtonian Hamiltonian is given in \cite Buonanno2005xu.
+ */
+template <typename IsolatedObjectBase, typename IsolatedObjectClasses>
+class BinaryWithGravitationalWaves
+    : public elliptic::analytic_data::Background,
+      public elliptic::analytic_data::InitialGuess {
+ public:
+  template <typename DataType>
+  using tags = typename detail::BinaryWithGravitationalWavesVariablesCache<
+      DataType>::tags_list;
+
+  struct XCoords {
+    static constexpr Options::String help =
+        "The coordinates on the x-axis where the two objects are placed.";
+    using type = std::array<double, 2>;
+  };
+  struct Masses {
+    static constexpr Options::String help =
+        "The mass of each object, first left and second right.";
+    using type = std::array<double, 2>;
+  };
+  struct MomentumLeft {
+    static constexpr Options::String help =
+        "The momentum assigned to the left object.";
+    using type = std::array<double, 3>;
+  };
+  struct MomentumRight {
+    static constexpr Options::String help =
+        "The momentum assigned to the right object.";
+    using type = std::array<double, 3>;
+  };
+  struct CenterOfMassOffset {
+    static constexpr Options::String help = {
+        "Offset in the y and z axes applied to both objects in order to "
+        "control the center of mass."};
+    using type = std::array<double, 2>;
+  };
+  struct ObjectLeft {
+    static constexpr Options::String help =
+        "The object placed on the negative x-axis.";
+    using type = std::unique_ptr<IsolatedObjectBase>;
+  };
+  struct ObjectRight {
+    static constexpr Options::String help =
+        "The object placed on the positive x-axis.";
+    using type = std::unique_ptr<IsolatedObjectBase>;
+  };
+
+  using options = tmpl::list<XCoords, Masses, MomentumLeft, MomentumRight,
+                             CenterOfMassOffset, ObjectLeft, ObjectRight>;
+  static constexpr Options::String help =
+      "Binary black hole initial data with realistic wave background, "
+      "constructed in Post-Newtonian approximations. ";
+
+  BinaryWithGravitationalWaves() = default;
+  BinaryWithGravitationalWaves(const BinaryWithGravitationalWaves&) = delete;
+  BinaryWithGravitationalWaves& operator=(const BinaryWithGravitationalWaves&) =
+      delete;
+  BinaryWithGravitationalWaves(BinaryWithGravitationalWaves&&) = default;
+  BinaryWithGravitationalWaves& operator=(BinaryWithGravitationalWaves&&) =
+      default;
+  ~BinaryWithGravitationalWaves() override = default;
+
+  BinaryWithGravitationalWaves(
+      const std::array<double, 2> xcoords, const std::array<double, 2> masses,
+      const std::array<double, 3> momentum_left,
+      const std::array<double, 3> momentum_right,
+      const std::array<double, 2> center_of_mass_offset,
+      std::unique_ptr<IsolatedObjectBase> object_left,
+      std::unique_ptr<IsolatedObjectBase> object_right,
+      const Options::Context& context = {})
+      : xcoords_(xcoords),
+        masses_(masses),
+        momentum_left_(momentum_left),
+        momentum_right_(momentum_right),
+        y_offset_(center_of_mass_offset[0]),
+        z_offset_(center_of_mass_offset[1]),
+        superposed_objects_({std::move(object_left), std::move(object_right)}) {
+    if (masses_[0] <= 0. || masses_[1] <= 0.) {
+      PARSE_ERROR(context, "The masses must be positive.");
+    }
+    if (xcoords_[0] >= xcoords_[1]) {
+      PARSE_ERROR(context, "Specify 'XCoords' ascending from left to right.");
+    }
+  }
+
+  explicit BinaryWithGravitationalWaves(CkMigrateMessage* m)
+      : elliptic::analytic_data::Background(m),
+        elliptic::analytic_data::InitialGuess(m) {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(BinaryWithGravitationalWaves);
+
+  template <typename DataType, typename... RequestedTags,
+            Requires<tmpl2::flat_all_v<tmpl::list_contains_v<
+                tags<DataType>, RequestedTags>...>> = nullptr>
+  tuples::TaggedTuple<RequestedTags...> variables(
+      const tnsr::I<DataType, 3, Frame::Inertial>& x,
+      tmpl::list<RequestedTags...> /*meta*/) const {
+    return variables_impl<DataType>(x, std::nullopt, std::nullopt,
+                                    tmpl::list<RequestedTags...>{});
+  }
+  template <typename... RequestedTags,
+            Requires<tmpl2::flat_all_v<tmpl::list_contains_v<
+                tags<DataVector>, RequestedTags>...>> = nullptr>
+  tuples::TaggedTuple<RequestedTags...> variables(
+      const tnsr::I<DataVector, 3, Frame::Inertial>& x, const Mesh<3>& mesh,
+      const InverseJacobian<DataVector, 3, Frame::ElementLogical,
+                            Frame::Inertial>& inv_jacobian,
+      tmpl::list<RequestedTags...> /*meta*/) const {
+    return variables_impl<DataVector>(x, mesh, inv_jacobian,
+                                      tmpl::list<RequestedTags...>{});
+  }
+
+  // NOLINTNEXTLINE
+  void pup(PUP::er& p) override {
+    elliptic::analytic_data::Background::pup(p);
+    elliptic::analytic_data::InitialGuess::pup(p);
+    p | xcoords_;
+    p | masses_;
+    p | y_offset_;
+    p | z_offset_;
+    p | momentum_left_;
+    p | momentum_right_;
+    p | superposed_objects_;
+  }
+
+  /// Coordinates of the objects, ascending left to right
+  const std::array<double, 2>& x_coords() const { return xcoords_; }
+  /// The momentum of the left object.
+  const std::array<double, 3>& momentum_left() const { return momentum_left_; }
+  /// The momentum of the right object.
+  const std::array<double, 3>& momentum_right() const {
+    return momentum_right_;
+  }
+  /// Offset in y and z coordinates of the objects
+  double y_offset() const { return y_offset_; }
+  double z_offset() const { return z_offset_; }
+  /// The two objects. First entry is the left object, second entry is the right
+  /// object.
+  const std::array<std::unique_ptr<IsolatedObjectBase>, 2>& superposed_objects()
+      const {
+    return superposed_objects_;
+  }
+
+ private:
+  std::array<double, 2> xcoords_{};
+  std::array<double, 2> masses_{};
+  std::array<double, 3> momentum_left_{};
+  std::array<double, 3> momentum_right_{};
+  double y_offset_{};
+  double z_offset_{};
+  std::array<std::unique_ptr<IsolatedObjectBase>, 2> superposed_objects_{};
+  Xcts::Solutions::Flatness flatness_{};
+
+  template <typename DataType, typename... RequestedTags,
+            Requires<tmpl2::flat_all_v<tmpl::list_contains_v<
+                tags<DataType>, RequestedTags>...>> = nullptr>
+  tuples::TaggedTuple<RequestedTags...> variables_impl(
+      const tnsr::I<DataType, 3, Frame::Inertial>& x,
+      std::optional<std::reference_wrapper<const Mesh<3>>> mesh,
+      std::optional<std::reference_wrapper<const InverseJacobian<
+          DataType, 3, Frame::ElementLogical, Frame::Inertial>>>
+          inv_jacobian,
+      tmpl::list<RequestedTags...> /*meta*/) const {
+    std::array<tnsr::I<DataVector, 3>, 2> x_isolated{{x, x}};
+    const std::array<std::array<double, 3>, 2> coords_isolated{
+        {{{xcoords_[0], y_offset_, z_offset_}},
+         {{xcoords_[1], y_offset_, z_offset_}}}};
+    // Possible optimization: Only retrieve those superposed tags from the
+    // isolated solutions that are actually needed. This needs some dependency
+    // logic, because some of the non-superposed tags depend on superposed tags.
+    using VarsComputer =
+        detail::BinaryWithGravitationalWavesVariables<DataType>;
+    using requested_superposed_tags = typename VarsComputer::superposed_tags;
+    std::array<tuples::tagged_tuple_from_typelist<requested_superposed_tags>, 2>
+        isolated_vars;
+    for (size_t i = 0; i < 2; ++i) {
+      for (size_t dim = 0; dim < 3; dim++) {
+        gsl::at(x_isolated, i).get(dim) -= gsl::at(coords_isolated, i)[dim];
+      }
+      gsl::at(isolated_vars, i) = get_isolated_vars<requested_superposed_tags>(
+          *gsl::at(superposed_objects_, i), gsl::at(x_isolated, i));
+    }
+    auto flat_vars = flatness_.variables(x, requested_superposed_tags{});
+    using requested_boost_tags = typename VarsComputer::boost_tags;
+    std::array<tuples::tagged_tuple_from_typelist<requested_boost_tags>, 2>
+        boost_vars;
+    std::array<tnsr::I<DataVector, 3>, 2> x_unboosted{{x, x}};
+    sr::lorentz_boost(make_not_null(&(gsl::at(x_unboosted, 0))),
+                      gsl::at(x_isolated, 0), 0., momentum_left_ / masses_[0]);
+    sr::lorentz_boost(make_not_null(&(gsl::at(x_unboosted, 1))),
+                      gsl::at(x_isolated, 1), 0., momentum_right_ / masses_[1]);
+    for (size_t i = 0; i < 2; ++i) {
+      gsl::at(boost_vars, i) = get_isolated_vars<requested_boost_tags>(
+          *gsl::at(superposed_objects_, i), gsl::at(x_unboosted, i));
+    }
+
+    typename VarsComputer::Cache cache{get_size(*x.begin())};
+    const VarsComputer computer{std::move(mesh),
+                                std::move(inv_jacobian),
+                                x,
+                                masses_,
+                                xcoords_,
+                                momentum_left_,
+                                momentum_right_,
+                                y_offset_,
+                                z_offset_,
+                                std::move(x_isolated),
+                                std::move(flat_vars),
+                                std::move(isolated_vars),
+                                std::move(boost_vars)};
+    return {cache.get_var(computer, RequestedTags{})...};
+  }
+
+  template <typename TagsList, typename... Args>
+  tuples::tagged_tuple_from_typelist<TagsList> get_isolated_vars(
+      const IsolatedObjectBase& isolated_object, const Args&... args) const {
+    return call_with_dynamic_type<tuples::tagged_tuple_from_typelist<TagsList>,
+                                  IsolatedObjectClasses>(
+        &isolated_object, [&args...](const auto* const derived) {
+          return derived->variables(args..., TagsList{});
+        });
+  }
+};
+
+/// \cond
+template <typename IsolatedObjectBase, typename IsolatedObjectClasses>
+PUP::able::PUP_ID BinaryWithGravitationalWaves<
+    IsolatedObjectBase, IsolatedObjectClasses>::my_PUP_ID = 0;  // NOLINT
+/// \endcond
+
+}  // namespace Xcts::AnalyticData

--- a/src/PointwiseFunctions/AnalyticData/Xcts/CMakeLists.txt
+++ b/src/PointwiseFunctions/AnalyticData/Xcts/CMakeLists.txt
@@ -10,6 +10,7 @@ spectre_target_sources(
   PRIVATE
   Binary.cpp
   KerrSchildTeukolsky.cpp
+  BinaryWithGravitationalWaves.cpp
   )
 
 spectre_target_headers(
@@ -18,6 +19,7 @@ spectre_target_headers(
   HEADERS
   AnalyticData.hpp
   Binary.hpp
+  BinaryWithGravitationalWaves.hpp
   CommonVariables.hpp
   CommonVariables.tpp
   KerrSchildTeukolsky.hpp
@@ -36,6 +38,7 @@ target_link_libraries(
   Options
   Parallel
   Serialization
+  SpecialRelativity
   Spectral
   Utilities
   PRIVATE

--- a/tests/InputFiles/Xcts/BinaryWithGravitationalWaves.yaml
+++ b/tests/InputFiles/Xcts/BinaryWithGravitationalWaves.yaml
@@ -1,0 +1,257 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+Executable: SolveXcts
+Testing:
+  Check: parse
+  Timeout: 30
+  Priority: High
+ExpectedOutput:
+  - BwGWReductions.h5
+  - BwGWVolume0.h5
+
+---
+
+Parallelization:
+  ElementDistribution: NumGridPoints
+
+ResourceInfo:
+  AvoidGlobalProc0: false
+  Singletons: Auto
+
+Background: &background
+  BinaryWithGravitationalWaves:
+    Masses: [&mass_left .5, &mass_right .5]
+    XCoords: [&x_left -6.0, &x_right 6.0]
+    MomentumLeft: [0., &momentum_left -0.08, 0.]
+    MomentumRight: [0., &momentum_right 0.08, 0.]
+    CenterOfMassOffset: &center_offset [&y_center 0.0, &z_center 0.0]
+    ObjectLeft: &object_left
+      Flatness
+    ObjectRight: &object_right
+      Flatness
+
+InitialGuess: *background
+
+RandomizeInitialGuess: None
+
+DomainCreator:
+  BinaryCompactObject:
+    ObjectA:
+      InnerRadius: .3
+      OuterRadius: 4.
+      XCoord: *x_right
+      Interior: Auto
+      UseLogarithmicMap: False
+    ObjectB:
+      InnerRadius: .3
+      OuterRadius: 4.
+      XCoord: *x_left
+      Interior: Auto
+      UseLogarithmicMap: False
+    CenterOfMassOffset: *center_offset
+    CubeScale: 1.0
+    Envelope:
+      Radius: &outer_shell_inner_radius 60.
+      RadialDistribution: Logarithmic
+    OuterShell:
+      Radius: &outer_radius 70.
+      RadialPartitioning: []
+      RadialDistribution: &outer_shell_distribution Linear
+      OpeningAngle: 120.0
+      UseSphericalHarmonics: false
+      BoundaryCondition: Robin
+    UseEquiangularMap: True
+    InitialRefinement:
+      ObjectAInterior:            [1, 1, 1]
+      ObjectBInterior:            [1, 1, 1]
+      ObjectAShell:               [1, 1, 1]
+      ObjectBShell:               [1, 1, 1]
+      ObjectACube:                [1, 1, 1]
+      ObjectBCube:                [1, 1, 1]
+      EnvelopeUpperZLeft:         [1, 1, 0]
+      EnvelopeLowerZLeft:         [1, 1, 0]
+      EnvelopeUpperYLeft:         [1, 1, 0]
+      EnvelopeLowerYLeft:         [1, 1, 0]
+      EnvelopeLowerX:             [1, 1, 0]
+      EnvelopeUpperZRight:        [1, 1, 0]
+      EnvelopeLowerZRight:        [1, 1, 0]
+      EnvelopeUpperYRight:        [1, 1, 0]
+      EnvelopeLowerYRight:        [1, 1, 0]
+      EnvelopeUpperX:             [1, 1, 0]
+      OuterShell0UpperZLeft:       [0, 1, 0]
+      OuterShell0LowerZLeft:       [0, 1, 0]
+      OuterShell0UpperYLeft:       [0, 1, 0]
+      OuterShell0LowerYLeft:       [0, 1, 0]
+      OuterShell0LowerX:           [1, 1, 0]
+      OuterShell0UpperZRight:      [0, 1, 0]
+      OuterShell0LowerZRight:      [0, 1, 0]
+      OuterShell0UpperYRight:      [0, 1, 0]
+      OuterShell0LowerYRight:      [0, 1, 0]
+      OuterShell0UpperX:           [1, 1, 0]
+    # This p-refinement represents a crude manual optimization of the domain. We
+    # will need AMR to optimize the domain further.
+    InitialGridPoints:
+      ObjectAInterior: [4, 4, 4]
+      ObjectBInterior: [4, 4, 4]
+      ObjectAShell:    [4, 4, 5]
+      ObjectBShell:    [4, 4, 5]
+      ObjectACube:     [4, 4, 5]
+      ObjectBCube:     [4, 4, 5]
+      Envelope:        [4, 4, 4]
+      OuterShell0:      [4, 4, 3]
+    UseWorldtube: False
+    TimeDependentMaps: None
+
+Amr:
+  Verbosity: Verbose
+  Criteria: []
+  EnableInBlocks: All
+  Policies:
+    EnforceTwoToOneBalanceInNormalDirection: true
+    Isotropy: Anisotropic
+    Limits:
+      NumGridPoints: Auto
+      RefinementLevel: Auto
+      ErrorBeyondLimits: False
+    AllowCoarsening: True
+  MaxCoarseLevels: Auto
+  Iterations: 1
+
+PhaseChangeAndTriggers: []
+
+Discretization:
+  DiscontinuousGalerkin:
+    PenaltyParameter: 1.5
+    Massive: True
+    Quadrature: GaussLobatto
+    Formulation: WeakInertial
+
+Observers:
+  VolumeFileName: "BwGWVolume"
+  ReductionFileName: "BwGWReductions"
+
+NonlinearSolver:
+  NewtonRaphson:
+    ConvergenceCriteria:
+      MaxIterations: 20
+      RelativeResidual: 1.e-10
+      AbsoluteResidual: 1.e-11
+    SufficientDecrease: 1.e-4
+    MaxGlobalizationSteps: 40
+    DampingFactor: 1.
+    Verbosity: Verbose
+
+LinearSolver:
+  Gmres:
+    ConvergenceCriteria:
+      MaxIterations: 100
+      RelativeResidual: 1.e-4
+      AbsoluteResidual: 1.e-14
+    Verbosity: Quiet
+
+  Multigrid:
+    Iterations: 1
+    InitialCoarseLevels: Auto
+    PreSmoothing: True
+    UseBottomSolver: False
+    PostSmoothingAtBottom: True
+    Verbosity: Silent
+    OutputVolumeData: False
+
+  SchwarzSmoother:
+    MaxOverlap: 2
+    Iterations: 3
+    Verbosity: Silent
+    SubdomainSolver:
+      Gmres:
+        ConvergenceCriteria:
+          MaxIterations: 3
+          RelativeResidual: 1.e-4
+          AbsoluteResidual: 1.e-10
+        Verbosity: Silent
+        Restart: None
+        Preconditioner:
+          MinusLaplacian:
+            Solver:
+              ExplicitInverse:
+                WriteMatrixToFile: None
+            BoundaryConditions: Auto
+    SkipResets: True
+    ObservePerCoreReductions: False
+    OutputVolumeData: False
+
+RadiallyCompressedCoordinates:
+  InnerRadius: *outer_shell_inner_radius
+  OuterRadius: *outer_radius
+  Compression: *outer_shell_distribution
+
+EventsAndTriggersAtIterations:
+  - Trigger:
+      EveryNIterations:
+        N: 1000000000
+        Offset: 0
+    Events:
+      - ObserveFields:
+          SubfileName: BackgroundData
+          VariablesToObserve:
+            - Conformal(SpatialMetric)
+            - TraceExtrinsicCurvature
+            - Lapse
+            - Shift
+            - ShiftBackground
+            - LongitudinalShiftBackgroundMinusDtConformalMetric
+            - dt(TraceExtrinsicCurvature)
+            - HamiltonianConstraint
+            - MomentumConstraint
+          BlocksToObserve: All
+          InterpolateToMesh: None
+          ProjectToMesh: None
+          CoordinatesFloatingPointType: Double
+          FloatingPointTypes: [Double]
+  - Trigger: HasConverged
+    Events:
+      - ObserveNorms:
+          SubfileName: Norms
+          TensorsToObserve:
+            - Name: ConformalFactor
+              NormType: Max
+              Components: Individual
+            - Name: Lapse
+              NormType: Min
+              Components: Individual
+            - Name: Magnitude(ShiftExcess)
+              NormType: Max
+              Components: Individual
+            - Name: HamiltonianConstraint
+              NormType: L2Norm
+              Components: Individual
+            - Name: MomentumConstraint
+              NormType: L2Norm
+              Components: Individual
+      - ObserveFields:
+          SubfileName: VolumeData
+          VariablesToObserve:
+            - ConformalFactor
+            - Lapse
+            - Shift
+            - ShiftExcess
+            - SpatialMetric
+            - InverseSpatialMetric
+            - SpatialChristoffelSecondKind
+            - ExtrinsicCurvature
+            - SpatialRicci
+            - RadiallyCompressedCoordinates
+            - HamiltonianConstraint
+            - MomentumConstraint
+          BlocksToObserve: All
+          InterpolateToMesh: None
+          ProjectToMesh: None
+          CoordinatesFloatingPointType: Double
+          FloatingPointTypes: [Double]
+
+BuildMatrix:
+  MatrixSubfileName: None
+  Verbosity: Verbose
+  EnableDirectSolve: True
+  SkipResets: True

--- a/tests/Unit/PointwiseFunctions/AnalyticData/Xcts/BinaryWithGravitationalWaves.py
+++ b/tests/Unit/PointwiseFunctions/AnalyticData/Xcts/BinaryWithGravitationalWaves.py
@@ -1,0 +1,63 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+x_coords = [-5.0, 6.0]
+y_offset = 0.02
+z_offset = 0.01
+
+
+def shift(spacetime_metric):
+    spatial_metric = spacetime_metric[1:, 1:]
+    inverse_spatial_metric = np.linalg.inv(spatial_metric)
+    g_jt = spacetime_metric[1:, 0]
+
+    shift = np.dot(inverse_spatial_metric, g_jt)
+
+    return shift
+
+
+def lapse(spacetime_metric):
+    spatial_metric = spacetime_metric[1:, 1:]
+    inverse_spatial_metric = np.linalg.inv(spatial_metric)
+    g_jt = spacetime_metric[1:, 0]
+    shift = np.dot(inverse_spatial_metric, g_jt)
+    beta_g_it = np.dot(shift, g_jt)
+    g_tt = spacetime_metric[0, 0]
+
+    lapse = np.sqrt(beta_g_it - g_tt)
+
+    return lapse
+
+
+def conformal_metric_bbh_isotropic(x):
+    return np.identity(3)
+
+
+def inv_conformal_metric_bbh_isotropic(x):
+    return np.identity(3)
+
+
+def shift_background(x):
+    return np.zeros(3)
+
+
+def longitudinal_shift_background_bbh_isotropic(x):
+    return np.zeros((3, 3))
+
+
+def conformal_factor_minus_one_bbh_isotropic(x):
+    return 0.0
+
+
+def energy_density_bbh_isotropic(x):
+    return 0.0
+
+
+def stress_trace_bbh_isotropic(x):
+    return 0.0
+
+
+def momentum_density_bbh_isotropic(x):
+    return np.zeros(3)


### PR DESCRIPTION
A reduced version of #6428 for easier peer review. This commit is deliberatly kept simple. It just puts functions and structures in place against which the follow up pull request can be compared to aid peer review.

- adds the class to implement background data
- for now the background is just flat space
- no black holes or radiative content is added for now
- documentation already contains the formulas for the planned implementation

## Proposed changes

Add the BinaryWithGravitationalWaves class.

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent was used, have a co-author trailer of the form
      "Co-Authored-By: <agent name> <agent email>" as the last line of the
      commit, e.g. "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>".
