### PR TITLE
Support LDG infrastructure part six

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/Actions/CMakeLists.txt
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/CMakeLists.txt
@@ -12,6 +12,7 @@ spectre_target_headers(
   InternalMortarDataImpl.hpp
   NormalCovectorAndMagnitude.hpp
   PackageDataImpl.hpp
+  SendAuxiliaryData.hpp
   VolumeTermsImpl.hpp
   VolumeTermsImpl.tpp
   )

--- a/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp
@@ -107,12 +107,67 @@ template <typename T>
 struct get_dg_package_field_tags {
   using type = typename T::dg_package_field_tags;
 };
+template <typename T>
+struct get_dg_auxiliary_package_temporary_tags {
+  using type =
+      get_dg_auxiliary_package_data_temporary_tags_or_default_t<T,
+                                                                tmpl::list<>>;
+};
+template <typename T>
+struct get_dg_auxiliary_package_field_tags {
+  using type =
+      get_dg_auxiliary_package_field_tags_or_default_t<T, tmpl::list<>>;
+};
 template <typename System, typename T>
 struct get_primitive_tags_for_face {
   using type = typename get_primitive_vars<
       System::has_primitive_and_conservative_vars>::template f<T>;
 };
 }  // namespace detail
+
+namespace ComputeTimeDerivative_detail {
+// Shared implementation of the `ComputeTimeDerivative` action
+// (`IsAuxiliary == false`) and the `SendAuxiliaryData` action
+// (`IsAuxiliary == true`). `IsAuxiliary` selects the LDG auxiliary pass: the
+// volume time derivative and timestep-size adjustment are skipped, the boundary
+// data is packaged with the boundary correction's auxiliary package-data
+// interface, and the data is sent on the auxiliary inbox channel. See the
+// documentation of the two public actions.
+template <size_t Dim, typename EvolutionSystem, typename DgStepChoosers,
+          bool UseNodegroupDgElements, bool IsAuxiliary,
+          typename VariablesTag = typename EvolutionSystem::variables_tag>
+struct Impl {
+  using inbox_tags =
+      tmpl::list<evolution::dg::Tags::BoundaryCorrectionAndGhostCellsInbox<
+          Dim, UseNodegroupDgElements, IsAuxiliary>>;
+  using const_global_cache_tags = tmpl::append<
+      tmpl::list<::dg::Tags::Formulation, evolution::Tags::BoundaryCorrection,
+                 domain::Tags::ExternalBoundaryConditions<Dim>>,
+      tmpl::conditional_t<
+          IsAuxiliary, tmpl::list<>,
+          typename ChangeStepSize<DgStepChoosers>::const_global_cache_tags>>;
+
+  template <typename DbTagsList, typename... InboxTags, typename ArrayIndex,
+            typename ActionList, typename ParallelComponent,
+            typename Metavariables>
+  static Parallel::iterable_action_return_t apply(
+      db::DataBox<DbTagsList>& box,
+      tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
+      Parallel::GlobalCache<Metavariables>& cache,
+      const ArrayIndex& /*array_index*/, ActionList /*meta*/,
+      const ParallelComponent* /*meta*/);  // NOLINT const
+
+ private:
+  template <typename ParallelComponent, typename DbTagsList,
+            typename Metavariables>
+  static void send_data_for_fluxes(
+      gsl::not_null<Parallel::GlobalCache<Metavariables>*> cache,
+      gsl::not_null<db::DataBox<DbTagsList>*> box,
+      [[maybe_unused]] const Variables<db::wrap_tags_in<
+          ::Tags::Flux, typename EvolutionSystem::flux_variables,
+          tmpl::size_t<Dim>, Frame::Inertial>>& volume_fluxes);
+};
+}  // namespace ComputeTimeDerivative_detail
 
 /*!
  * \brief Computes the time derivative for a DG time step.
@@ -356,56 +411,31 @@ struct get_primitive_tags_for_face {
 template <size_t Dim, typename EvolutionSystem, typename DgStepChoosers,
           bool UseNodegroupDgElements,
           typename VariablesTag = typename EvolutionSystem::variables_tag>
-struct ComputeTimeDerivative {
-  using inbox_tags =
-      tmpl::list<evolution::dg::Tags::BoundaryCorrectionAndGhostCellsInbox<
-          Dim, UseNodegroupDgElements>>;
-  using const_global_cache_tags = tmpl::append<
-      tmpl::list<::dg::Tags::Formulation, evolution::Tags::BoundaryCorrection,
-                 domain::Tags::ExternalBoundaryConditions<Dim>>,
-      typename ChangeStepSize<DgStepChoosers>::const_global_cache_tags>;
-
-  template <typename DbTagsList, typename... InboxTags, typename ArrayIndex,
-            typename ActionList, typename ParallelComponent,
-            typename Metavariables>
-  static Parallel::iterable_action_return_t apply(
-      db::DataBox<DbTagsList>& box,
-      tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
-      Parallel::GlobalCache<Metavariables>& cache,
-      const ArrayIndex& /*array_index*/, ActionList /*meta*/,
-      const ParallelComponent* /*meta*/);  // NOLINT const
-
- private:
-  template <typename ParallelComponent, typename DbTagsList,
-            typename Metavariables>
-  static void send_data_for_fluxes(
-      gsl::not_null<Parallel::GlobalCache<Metavariables>*> cache,
-      gsl::not_null<db::DataBox<DbTagsList>*> box,
-      [[maybe_unused]] const Variables<db::wrap_tags_in<
-          ::Tags::Flux, typename EvolutionSystem::flux_variables,
-          tmpl::size_t<Dim>, Frame::Inertial>>& volume_fluxes);
-};
+struct ComputeTimeDerivative
+    : ComputeTimeDerivative_detail::Impl<Dim, EvolutionSystem, DgStepChoosers,
+                                         UseNodegroupDgElements, false,
+                                         VariablesTag> {};
 
 template <size_t Dim, typename EvolutionSystem, typename DgStepChoosers,
-          bool UseNodegroupDgElements, typename VariablesTag>
+          bool UseNodegroupDgElements, bool IsAuxiliary, typename VariablesTag>
 template <typename DbTagsList, typename... InboxTags, typename ArrayIndex,
           typename ActionList, typename ParallelComponent,
           typename Metavariables>
-Parallel::iterable_action_return_t ComputeTimeDerivative<
-    Dim, EvolutionSystem, DgStepChoosers, UseNodegroupDgElements,
+Parallel::iterable_action_return_t ComputeTimeDerivative_detail::Impl<
+    Dim, EvolutionSystem, DgStepChoosers, UseNodegroupDgElements, IsAuxiliary,
     VariablesTag>::apply(db::DataBox<DbTagsList>& box,
                          tuples::TaggedTuple<InboxTags...>& /*inboxes*/,
                          Parallel::GlobalCache<Metavariables>& cache,
                          const ArrayIndex& /*array_index*/, ActionList /*meta*/,
-                         const ParallelComponent* const /*meta*/) {
+                         const ParallelComponent* const /*meta*/) {  // NOLINT
   static_assert(UseNodegroupDgElements ==
                     Parallel::is_dg_element_collection_v<ParallelComponent>,
-                "The action ComputeTimeDerivative is told by the "
-                "template parameter UseNodegroupDgElements that it is being "
-                "used with a DgElementCollection, but the ParallelComponent "
-                "is not a DgElementCollection. You need to change the "
-                "template parameter on the ComputeTimeDerivative action "
-                "in your action list.");
+                "The ComputeTimeDerivative or SendAuxiliaryData action is "
+                "told by the template parameter UseNodegroupDgElements that "
+                "it is being used with a DgElementCollection, but the "
+                "ParallelComponent is not a DgElementCollection. You need to "
+                "change the template parameter on the action in your action "
+                "list.");
 
   using variables_tag = VariablesTag;
   using dt_variables_tag = db::add_tag_prefix<::Tags::dt, variables_tag>;
@@ -456,17 +486,28 @@ Parallel::iterable_action_return_t ComputeTimeDerivative<
   // runtime, we just gather all possible tags from all possible boundary
   // corrections and lump them into the allocation. This may result in a
   // larger-than-necessary allocation, but it won't be that much larger.
-  using all_dg_package_temporary_tags =
+  using all_dg_package_temporary_tags = tmpl::conditional_t<
+      IsAuxiliary,
+      tmpl::transform<
+          derived_boundary_corrections,
+          detail::get_dg_auxiliary_package_temporary_tags<tmpl::_1>>,
       tmpl::transform<derived_boundary_corrections,
-                      detail::get_dg_package_temporary_tags<tmpl::_1>>;
+                      detail::get_dg_package_temporary_tags<tmpl::_1>>>;
   using all_primitive_tags_for_face =
       tmpl::transform<derived_boundary_corrections,
                       detail::get_primitive_tags_for_face<
                           tmpl::pin<EvolutionSystem>, tmpl::_1>>;
   using fluxes_tags = db::wrap_tags_in<::Tags::Flux, flux_variables,
                                        tmpl::size_t<Dim>, Frame::Inertial>;
+  // The physical boundary correction reads the evolved variables and, for LDG
+  // systems, the auxiliary variables (projected to the face); size the face
+  // buffer accordingly. The auxiliary pass computes the auxiliary variables
+  // but does not read them, so they are not projected there.
+  using projected_auxiliary_vars_tags =
+      tmpl::conditional_t<IsAuxiliary, tmpl::list<>, auxiliary_variables>;
   using dg_package_data_projected_tags =
-      tmpl::list<typename variables_tag::tags_list, fluxes_tags,
+      tmpl::list<typename variables_tag::tags_list,
+                 projected_auxiliary_vars_tags, fluxes_tags,
                  all_dg_package_temporary_tags, all_primitive_tags_for_face>;
   using all_face_temporary_tags =
       tmpl::remove_duplicates<tmpl::flatten<tmpl::push_back<
@@ -476,9 +517,14 @@ Parallel::iterable_action_return_t ComputeTimeDerivative<
   // To avoid additional allocations in internal_mortar_data, we provide a
   // buffer used to compute the packaged data before it has to be projected to
   // the mortar. We get all mortar tags for similar reasons as described above
-  using all_mortar_tags = tmpl::remove_duplicates<tmpl::flatten<
-      tmpl::transform<derived_boundary_corrections,
-                      detail::get_dg_package_field_tags<tmpl::_1>>>>;
+  using all_mortar_tags =
+      tmpl::remove_duplicates<tmpl::flatten<tmpl::conditional_t<
+          IsAuxiliary,
+          tmpl::transform<
+              derived_boundary_corrections,
+              detail::get_dg_auxiliary_package_field_tags<tmpl::_1>>,
+          tmpl::transform<derived_boundary_corrections,
+                          detail::get_dg_package_field_tags<tmpl::_1>>>>>;
 
   // We also don't use the number of volume mesh grid points. We instead use the
   // max number of grid points from each face. That way, our allocation will be
@@ -497,6 +543,10 @@ Parallel::iterable_action_return_t ComputeTimeDerivative<
 
   // Allocate the Variables classes needed for the time derivative
   // computation.
+  //
+  // On the auxiliary pass (`IsAuxiliary==true`) the volume time derivative is
+  // NOT computed, so the volume buffers below are allocated but left
+  // uninitialized.
   //
   // This is factored out so that we will be able to do ADER-DG/CG where a
   // spacetime polynomial is constructed by solving implicit equations in time
@@ -579,84 +629,88 @@ Parallel::iterable_action_return_t ComputeTimeDerivative<
       DgPackagedDataVarsOnFace::number_of_independent_components *
           num_face_temporary_grid_points);
 
-  const Scalar<DataVector>* det_inverse_jacobian = nullptr;
-  if constexpr (tmpl::size<flux_variables>::value != 0) {
-    if (dg_formulation == ::dg::Formulation::WeakInertial) {
-      det_inverse_jacobian = &db::get<
-          domain::Tags::DetInvJacobian<Frame::ElementLogical, Frame::Inertial>>(
-          box);
+  // The auxiliary pass sends boundary data before the volume time
+  // derivative is computed; it does not compute the volume terms.
+  if constexpr (not IsAuxiliary) {
+    const Scalar<DataVector>* det_inverse_jacobian = nullptr;
+    if constexpr (tmpl::size<flux_variables>::value != 0) {
+      if (dg_formulation == ::dg::Formulation::WeakInertial) {
+        det_inverse_jacobian =
+            &db::get<domain::Tags::DetInvJacobian<Frame::ElementLogical,
+                                                  Frame::Inertial>>(box);
+      }
     }
-  }
-  if constexpr (tmpl::size<auxiliary_variables>::value != 0) {
-    static_assert(
-        tmpl::size<tmpl::list_difference<
-                partial_derivative_tags,
-                tmpl::append<typename variables_tag::tags_list,
-                             auxiliary_variables>>>::value == 0,
-        "Every gradient variable must be an evolved variable (in "
-        "variables_tag) or an auxiliary variable (in auxiliary_variables); "
-        "otherwise it is not populated in the combined differentiation "
-        "source.");
-    Variables<detail::evolved_and_auxiliary_vars_tags<EvolutionSystem>>
-        evolved_and_auxiliary_vars{mesh.number_of_grid_points()};
-    evolved_and_auxiliary_vars.assign_subset(db::get<variables_tag>(box));
-    evolved_and_auxiliary_vars.assign_subset(
-        db::get<::Tags::Variables<auxiliary_variables>>(box));
-    db::mutate_apply<
-        tmpl::list<dt_variables_tag>,
-        typename compute_volume_time_derivative_terms::argument_tags>(
-        [&dg_formulation, &div_fluxes, &det_inverse_jacobian,
-         &div_mesh_velocity = db::get<::domain::Tags::DivMeshVelocity>(box),
-         &evolved_and_auxiliary_vars,
-         &inertial_coordinates =
-             db::get<domain::Tags::Coordinates<Dim, Frame::Inertial>>(box),
-         &logical_to_inertial_inv_jacobian =
-             db::get<::domain::Tags::InverseJacobian<Dim, Frame::ElementLogical,
-                                                     Frame::Inertial>>(box),
-         &mesh,
-         &mesh_velocity = db::get<::domain::Tags::MeshVelocity<Dim>>(box),
-         &partial_derivs, &temporaries,
-         &volume_fluxes](const gsl::not_null<Variables<db::wrap_tags_in<
-                             ::Tags::dt, typename variables_tag::tags_list>>*>
-                             dt_vars_ptr,
-                         const auto&... time_derivative_args) {
-          detail::volume_terms<compute_volume_time_derivative_terms>(
-              dt_vars_ptr, make_not_null(&volume_fluxes),
-              make_not_null(&partial_derivs), make_not_null(&temporaries),
-              make_not_null(&div_fluxes), evolved_and_auxiliary_vars,
-              dg_formulation, mesh, inertial_coordinates,
-              logical_to_inertial_inv_jacobian, det_inverse_jacobian,
-              mesh_velocity, div_mesh_velocity, time_derivative_args...);
-        },
-        make_not_null(&box));
-  } else {
-    db::mutate_apply<
-        tmpl::list<dt_variables_tag>,
-        typename compute_volume_time_derivative_terms::argument_tags>(
-        [&dg_formulation, &div_fluxes, &det_inverse_jacobian,
-         &div_mesh_velocity = db::get<::domain::Tags::DivMeshVelocity>(box),
-         &evolved_variables = db::get<variables_tag>(box),
-         &inertial_coordinates =
-             db::get<domain::Tags::Coordinates<Dim, Frame::Inertial>>(box),
-         &logical_to_inertial_inv_jacobian =
-             db::get<::domain::Tags::InverseJacobian<Dim, Frame::ElementLogical,
-                                                     Frame::Inertial>>(box),
-         &mesh,
-         &mesh_velocity = db::get<::domain::Tags::MeshVelocity<Dim>>(box),
-         &partial_derivs, &temporaries,
-         &volume_fluxes](const gsl::not_null<Variables<db::wrap_tags_in<
-                             ::Tags::dt, typename variables_tag::tags_list>>*>
-                             dt_vars_ptr,
-                         const auto&... time_derivative_args) {
-          detail::volume_terms<compute_volume_time_derivative_terms>(
-              dt_vars_ptr, make_not_null(&volume_fluxes),
-              make_not_null(&partial_derivs), make_not_null(&temporaries),
-              make_not_null(&div_fluxes), evolved_variables, dg_formulation,
-              mesh, inertial_coordinates, logical_to_inertial_inv_jacobian,
-              det_inverse_jacobian, mesh_velocity, div_mesh_velocity,
-              time_derivative_args...);
-        },
-        make_not_null(&box));
+    if constexpr (tmpl::size<auxiliary_variables>::value != 0) {
+      static_assert(
+          tmpl::size<tmpl::list_difference<
+                  partial_derivative_tags,
+                  tmpl::append<typename variables_tag::tags_list,
+                               auxiliary_variables>>>::value == 0,
+          "Every gradient variable must be an evolved variable (in "
+          "variables_tag) or an auxiliary variable (in auxiliary_variables); "
+          "otherwise it is not populated in the combined differentiation "
+          "source.");
+      Variables<detail::evolved_and_auxiliary_vars_tags<EvolutionSystem>>
+          evolved_and_auxiliary_vars{mesh.number_of_grid_points()};
+      evolved_and_auxiliary_vars.assign_subset(db::get<variables_tag>(box));
+      evolved_and_auxiliary_vars.assign_subset(
+          db::get<::Tags::Variables<auxiliary_variables>>(box));
+      db::mutate_apply<
+          tmpl::list<dt_variables_tag>,
+          typename compute_volume_time_derivative_terms::argument_tags>(
+          [&dg_formulation, &div_fluxes, &det_inverse_jacobian,
+           &div_mesh_velocity = db::get<::domain::Tags::DivMeshVelocity>(box),
+           &evolved_and_auxiliary_vars,
+           &inertial_coordinates =
+               db::get<domain::Tags::Coordinates<Dim, Frame::Inertial>>(box),
+           &logical_to_inertial_inv_jacobian =
+               db::get<::domain::Tags::InverseJacobian<
+                   Dim, Frame::ElementLogical, Frame::Inertial>>(box),
+           &mesh,
+           &mesh_velocity = db::get<::domain::Tags::MeshVelocity<Dim>>(box),
+           &partial_derivs, &temporaries,
+           &volume_fluxes](const gsl::not_null<Variables<db::wrap_tags_in<
+                               ::Tags::dt, typename variables_tag::tags_list>>*>
+                               dt_vars_ptr,
+                           const auto&... time_derivative_args) {
+            detail::volume_terms<compute_volume_time_derivative_terms>(
+                dt_vars_ptr, make_not_null(&volume_fluxes),
+                make_not_null(&partial_derivs), make_not_null(&temporaries),
+                make_not_null(&div_fluxes), evolved_and_auxiliary_vars,
+                dg_formulation, mesh, inertial_coordinates,
+                logical_to_inertial_inv_jacobian, det_inverse_jacobian,
+                mesh_velocity, div_mesh_velocity, time_derivative_args...);
+          },
+          make_not_null(&box));
+    } else {
+      db::mutate_apply<
+          tmpl::list<dt_variables_tag>,
+          typename compute_volume_time_derivative_terms::argument_tags>(
+          [&dg_formulation, &div_fluxes, &det_inverse_jacobian,
+           &div_mesh_velocity = db::get<::domain::Tags::DivMeshVelocity>(box),
+           &evolved_variables = db::get<variables_tag>(box),
+           &inertial_coordinates =
+               db::get<domain::Tags::Coordinates<Dim, Frame::Inertial>>(box),
+           &logical_to_inertial_inv_jacobian =
+               db::get<::domain::Tags::InverseJacobian<
+                   Dim, Frame::ElementLogical, Frame::Inertial>>(box),
+           &mesh,
+           &mesh_velocity = db::get<::domain::Tags::MeshVelocity<Dim>>(box),
+           &partial_derivs, &temporaries,
+           &volume_fluxes](const gsl::not_null<Variables<db::wrap_tags_in<
+                               ::Tags::dt, typename variables_tag::tags_list>>*>
+                               dt_vars_ptr,
+                           const auto&... time_derivative_args) {
+            detail::volume_terms<compute_volume_time_derivative_terms>(
+                dt_vars_ptr, make_not_null(&volume_fluxes),
+                make_not_null(&partial_derivs), make_not_null(&temporaries),
+                make_not_null(&div_fluxes), evolved_variables, dg_formulation,
+                mesh, inertial_coordinates, logical_to_inertial_inv_jacobian,
+                det_inverse_jacobian, mesh_velocity, div_mesh_velocity,
+                time_derivative_args...);
+          },
+          make_not_null(&box));
+    }
   }
 
   const Variables<detail::get_primitive_vars_tags_from_system<EvolutionSystem>>*
@@ -683,23 +737,37 @@ Parallel::iterable_action_return_t ComputeTimeDerivative<
           // Note: this call mutates:
           //  - evolution::dg::Tags::NormalCovectorAndMagnitude<Dim>,
           //  - evolution::dg::Tags::MortarData<Dim>
-          detail::internal_mortar_data<EvolutionSystem, Dim>(
-              make_not_null(&box), make_not_null(&face_temporaries),
-              make_not_null(&packaged_data_buffer),
-              dynamic_cast<const DerivedCorrection&>(boundary_correction),
-              db::get<variables_tag>(box), volume_fluxes, temporaries,
-              primitive_vars,
-              typename DerivedCorrection::dg_package_data_volume_tags{});
+          if constexpr (IsAuxiliary) {
+            detail::internal_mortar_data<EvolutionSystem, Dim,
+                                         /*ComputeAuxiliary=*/true>(
+                make_not_null(&box), make_not_null(&face_temporaries),
+                make_not_null(&packaged_data_buffer),
+                dynamic_cast<const DerivedCorrection&>(boundary_correction),
+                db::get<variables_tag>(box), volume_fluxes, temporaries,
+                primitive_vars,
+                detail::get_dg_auxiliary_package_data_volume_tags_or_default_t<
+                    DerivedCorrection, tmpl::list<>>{});
+          } else {
+            detail::internal_mortar_data<EvolutionSystem, Dim>(
+                make_not_null(&box), make_not_null(&face_temporaries),
+                make_not_null(&packaged_data_buffer),
+                dynamic_cast<const DerivedCorrection&>(boundary_correction),
+                db::get<variables_tag>(box), volume_fluxes, temporaries,
+                primitive_vars,
+                typename DerivedCorrection::dg_package_data_volume_tags{});
+          }
 
           detail::apply_boundary_conditions_on_all_external_faces<
-              EvolutionSystem, Dim, variables_tag>(
+              EvolutionSystem, Dim, variables_tag, IsAuxiliary>(
               make_not_null(&box),
               dynamic_cast<const DerivedCorrection&>(boundary_correction),
               temporaries, volume_fluxes, partial_derivs, primitive_vars);
         }
       });
 
-  db::mutate_apply<ChangeStepSize<DgStepChoosers>>(make_not_null(&box));
+  if constexpr (not IsAuxiliary) {
+    db::mutate_apply<ChangeStepSize<DgStepChoosers>>(make_not_null(&box));
+  }
 
   send_data_for_fluxes<ParallelComponent>(make_not_null(&cache),
                                           make_not_null(&box), volume_fluxes);
@@ -707,11 +775,12 @@ Parallel::iterable_action_return_t ComputeTimeDerivative<
 }
 
 template <size_t Dim, typename EvolutionSystem, typename DgStepChoosers,
-          bool UseNodegroupDgElements, typename VariablesTag>
+          bool UseNodegroupDgElements, bool IsAuxiliary, typename VariablesTag>
 template <typename ParallelComponent, typename DbTagsList,
           typename Metavariables>
-void ComputeTimeDerivative<Dim, EvolutionSystem, DgStepChoosers,
-                           UseNodegroupDgElements, VariablesTag>::
+void ComputeTimeDerivative_detail::Impl<Dim, EvolutionSystem, DgStepChoosers,
+                                        UseNodegroupDgElements, IsAuxiliary,
+                                        VariablesTag>::
     send_data_for_fluxes(
         const gsl::not_null<Parallel::GlobalCache<Metavariables>*> cache,
         const gsl::not_null<db::DataBox<DbTagsList>*> box,
@@ -853,14 +922,14 @@ void ComputeTimeDerivative<Dim, EvolutionSystem, DgStepChoosers,
             Parallel::Actions::SendDataToElement>(
             receiver_proxy, cache,
             evolution::dg::Tags::BoundaryCorrectionAndGhostCellsInbox<
-                Dim, UseNodegroupDgElements>{},
+                Dim, UseNodegroupDgElements, IsAuxiliary>{},
             neighbor, time_step_id,
             std::make_pair(DirectionalId{direction_from_neighbor, element.id()},
                            std::move(data)));
       } else {
         Parallel::receive_data<
             evolution::dg::Tags::BoundaryCorrectionAndGhostCellsInbox<
-                Dim, UseNodegroupDgElements>>(
+                Dim, UseNodegroupDgElements, IsAuxiliary>>(
             receiver_proxy[neighbor], time_step_id,
             std::make_pair(DirectionalId{direction_from_neighbor, element.id()},
                            std::move(data)));

--- a/src/Evolution/DiscontinuousGalerkin/Actions/InternalMortarDataImpl.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/InternalMortarDataImpl.hpp
@@ -14,6 +14,7 @@
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
+#include "DataStructures/VariablesTag.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/FaceNormal.hpp"
 #include "Domain/Structure/Direction.hpp"
@@ -42,9 +43,9 @@ struct TimeStepId;
 /// \endcond
 
 namespace evolution::dg::Actions::detail {
-template <typename System, size_t Dim, typename BoundaryCorrection,
-          typename EvolvedVariablesTags, typename TemporaryTags,
-          typename... PackageDataVolumeArgs>
+template <typename System, size_t Dim, bool ComputeAuxiliary = false,
+          typename BoundaryCorrection, typename EvolvedVariablesTags,
+          typename TemporaryTags, typename... PackageDataVolumeArgs>
 void internal_mortar_data_impl(
     const gsl::not_null<
         DirectionMap<Dim, std::optional<Variables<tmpl::list<
@@ -58,6 +59,13 @@ void internal_mortar_data_impl(
     const gsl::not_null<gsl::span<double>*> packaged_data_buffer,
     const BoundaryCorrection& boundary_correction,
     const Variables<EvolvedVariablesTags>& volume_evolved_vars,
+    // The physical boundary correction may read the auxiliary variables,
+    // so they are projected to the face for the physical pass.
+    // No-op when there are no auxiliary variables or during the
+    // auxiliary pass (which computes them but does not read them).
+    const Variables<
+        get_auxiliary_variables_or_default_t<System, tmpl::list<>>>* const
+        volume_auxiliary_variables,
     const Variables<
         db::wrap_tags_in<::Tags::Flux, typename System::flux_variables,
                          tmpl::size_t<Dim>, Frame::Inertial>>& volume_fluxes,
@@ -74,19 +82,29 @@ void internal_mortar_data_impl(
                           Frame::Inertial>& volume_inverse_jacobian,
     const PackageDataVolumeArgs&... package_data_volume_args) {
   using variables_tags = EvolvedVariablesTags;
+  using auxiliary_variables =
+      get_auxiliary_variables_or_default_t<System, tmpl::list<>>;
   using flux_variables = typename System::flux_variables;
   using fluxes_tags = db::wrap_tags_in<::Tags::Flux, flux_variables,
                                        tmpl::size_t<Dim>, Frame::Inertial>;
-  using temporary_tags_for_face =
-      typename BoundaryCorrection::dg_package_data_temporary_tags;
+  using temporary_tags_for_face = tmpl::conditional_t<
+      ComputeAuxiliary,
+      get_dg_auxiliary_package_data_temporary_tags_or_default_t<
+          BoundaryCorrection, tmpl::list<>>,
+      typename BoundaryCorrection::dg_package_data_temporary_tags>;
   using primitive_tags_for_face = typename detail::get_primitive_vars<
       System::has_primitive_and_conservative_vars>::
       template f<BoundaryCorrection>;
-  using mortar_tags_list = typename BoundaryCorrection::dg_package_field_tags;
-
+  using mortar_tags_list =
+      tmpl::conditional_t<ComputeAuxiliary,
+                          get_dg_auxiliary_package_field_tags_or_default_t<
+                              BoundaryCorrection, tmpl::list<>>,
+                          typename BoundaryCorrection::dg_package_field_tags>;
+  using projected_auxiliary_vars_tags =
+      tmpl::conditional_t<ComputeAuxiliary, tmpl::list<>, auxiliary_variables>;
   using dg_package_data_projected_tags =
-      tmpl::append<variables_tags, fluxes_tags, temporary_tags_for_face,
-                   primitive_tags_for_face>;
+      tmpl::append<variables_tags, projected_auxiliary_vars_tags, fluxes_tags,
+                   temporary_tags_for_face, primitive_tags_for_face>;
   using FieldsOnFace = Variables<tmpl::remove_duplicates<tmpl::push_back<
       tmpl::append<dg_package_data_projected_tags,
                    detail::inverse_spatial_metric_tag<System>>,
@@ -136,6 +154,17 @@ void internal_mortar_data_impl(
     ::dg::project_contiguous_data_to_boundary(make_not_null(&fields_on_face),
                                               volume_evolved_vars, volume_mesh,
                                               direction);
+    if constexpr (not ComputeAuxiliary and
+                  tmpl::size<auxiliary_variables>::value != 0) {
+      ASSERT(volume_auxiliary_variables != nullptr,
+             "The auxiliary variables must be provided to the physical pass "
+             "when the system has auxiliary variables.");
+      ::dg::project_tensors_to_boundary<auxiliary_variables>(
+          make_not_null(&fields_on_face), *volume_auxiliary_variables,
+          volume_mesh, direction);
+    } else {
+      (void)volume_auxiliary_variables;
+    }
     if constexpr (tmpl::size<fluxes_tags>::value != 0) {
       ::dg::project_contiguous_data_to_boundary(make_not_null(&fields_on_face),
                                                 volume_fluxes, volume_mesh,
@@ -284,12 +313,21 @@ void internal_mortar_data_impl(
       packaged_data.set_data_ref(packaged_data_buffer->data(), total_face_size);
     }
 
-    detail::dg_package_data<System>(
-        make_not_null(&packaged_data), boundary_correction, fields_on_face,
-        get<evolution::dg::Tags::NormalCovector<Dim>>(
-            *normal_covector_and_magnitude_ptr->at(direction)),
-        face_mesh_velocity, dg_package_data_projected_tags{},
-        package_data_volume_args...);
+    if constexpr (ComputeAuxiliary) {
+      detail::dg_auxiliary_package_data<System>(
+          make_not_null(&packaged_data), boundary_correction, fields_on_face,
+          get<evolution::dg::Tags::NormalCovector<Dim>>(
+              *normal_covector_and_magnitude_ptr->at(direction)),
+          face_mesh_velocity, dg_package_data_projected_tags{},
+          package_data_volume_args...);
+    } else {
+      detail::dg_package_data<System>(
+          make_not_null(&packaged_data), boundary_correction, fields_on_face,
+          get<evolution::dg::Tags::NormalCovector<Dim>>(
+              *normal_covector_and_magnitude_ptr->at(direction)),
+          face_mesh_velocity, dg_package_data_projected_tags{},
+          package_data_volume_args...);
+    }
 
     // Perform step 3
     // This will only do something if neighbors are conforming and either
@@ -330,9 +368,9 @@ void internal_mortar_data_impl(
   }
 }
 
-template <typename System, size_t Dim, typename BoundaryCorrection,
-          typename DbTagsList, typename EvolvedVariablesTags,
-          typename... PackageDataVolumeTags>
+template <typename System, size_t Dim, bool ComputeAuxiliary = false,
+          typename BoundaryCorrection, typename DbTagsList,
+          typename EvolvedVariablesTags, typename... PackageDataVolumeTags>
 void internal_mortar_data(
     const gsl::not_null<db::DataBox<DbTagsList>*> box,
     const gsl::not_null<gsl::span<double>*> face_temporaries,
@@ -348,10 +386,19 @@ void internal_mortar_data(
     const Variables<get_primitive_vars_tags_from_system<System>>* const
         primitive_vars,
     tmpl::list<PackageDataVolumeTags...> /*meta*/) {
+  using auxiliary_variables =
+      get_auxiliary_variables_or_default_t<System, tmpl::list<>>;
+  const Variables<auxiliary_variables>* volume_auxiliary_variables = nullptr;
+  if constexpr (not ComputeAuxiliary and
+                tmpl::size<auxiliary_variables>::value != 0) {
+    volume_auxiliary_variables =
+        &db::get<::Tags::Variables<auxiliary_variables>>(*box);
+  }
   db::mutate<evolution::dg::Tags::NormalCovectorAndMagnitude<Dim>,
              evolution::dg::Tags::MortarData<Dim>>(
       [&boundary_correction, &face_temporaries, &packaged_data_buffer,
        &element = db::get<domain::Tags::Element<Dim>>(*box), &evolved_variables,
+       volume_auxiliary_variables,
        &logical_to_inertial_inverse_jacobian =
            db::get<domain::Tags::InverseJacobian<Dim, Frame::ElementLogical,
                                                  Frame::Inertial>>(*box),
@@ -364,13 +411,13 @@ void internal_mortar_data(
        &primitive_vars, &temporaries, &volume_fluxes](
           const auto normal_covector_and_magnitude_ptr,
           const auto mortar_data_ptr, const auto&... package_data_volume_args) {
-        detail::internal_mortar_data_impl<System>(
+        detail::internal_mortar_data_impl<System, Dim, ComputeAuxiliary>(
             normal_covector_and_magnitude_ptr, mortar_data_ptr,
             face_temporaries, packaged_data_buffer, boundary_correction,
-            evolved_variables, volume_fluxes, temporaries, primitive_vars,
-            element, mesh, mortar_meshes, mortar_infos, moving_mesh_map,
-            mesh_velocity, logical_to_inertial_inverse_jacobian,
-            package_data_volume_args...);
+            evolved_variables, volume_auxiliary_variables, volume_fluxes,
+            temporaries, primitive_vars, element, mesh, mortar_meshes,
+            mortar_infos, moving_mesh_map, mesh_velocity,
+            logical_to_inertial_inverse_jacobian, package_data_volume_args...);
       },
       box, db::get<PackageDataVolumeTags>(*box)...);
 }

--- a/src/Evolution/DiscontinuousGalerkin/Actions/SendAuxiliaryData.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/Actions/SendAuxiliaryData.hpp
@@ -1,0 +1,215 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <type_traits>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "Domain/BoundaryConditions/Cartoon.hpp"
+#include "Domain/BoundaryConditions/None.hpp"
+#include "Domain/BoundaryConditions/Periodic.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/BoundaryCorrection.hpp"
+#include "Evolution/DiscontinuousGalerkin/Actions/BoundaryConditionsImpl.hpp"
+#include "Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivative.hpp"
+#include "Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeHelpers.hpp"
+#include "Evolution/DiscontinuousGalerkin/UsingSubcell.hpp"
+#include "Parallel/AlgorithmExecution.hpp"
+#include "Parallel/GlobalCache.hpp"
+#include "Time/LtsMode.hpp"
+#include "Time/Tags/LtsMode.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+namespace tuples {
+template <typename...>
+class TaggedTuple;
+}  // namespace tuples
+/// \endcond
+
+namespace evolution::dg::Actions {
+namespace detail {
+// Per-boundary-condition tags projected from the volume temporaries
+// (`dg_interior_temporary_tags`). The inertial coordinates are exempt: the
+// boundary-condition path computes them on the face directly from the
+// coordinate map instead of projecting them from the volume temporaries.
+template <typename DimType, typename BoundaryCondition>
+struct boundary_condition_volume_temporary_tags {
+  using type =
+      tmpl::remove<typename BoundaryCondition::dg_interior_temporary_tags,
+                   domain::Tags::Coordinates<DimType::value, Frame::Inertial>>;
+};
+
+// Per-boundary-condition tags projected from the volume partial derivatives
+// (`dg_interior_deriv_vars_tags`, optional) and from the volume time
+// derivative (`dg_interior_dt_vars_tags`, optional).
+template <typename BoundaryCondition>
+struct boundary_condition_deriv_tags {
+  using type = get_deriv_vars_from_boundary_condition<BoundaryCondition>;
+};
+template <typename BoundaryCondition>
+struct boundary_condition_dt_tags {
+  using type = get_dt_vars_from_boundary_condition<BoundaryCondition>;
+};
+
+// Verify that the LDG auxiliary send reads no uninitialized face data, i.e. it
+// never projects any of the volume time-derivative buffers (volume
+// temporaries, fluxes, partial derivatives), the inverse spatial metric, or
+// the volume time derivative to the boundary.
+template <typename EvolutionSystem, typename Metavariables>
+struct auxiliary_send_projects_no_uninitialized_data_to_face {
+ private:
+  using derived_boundary_corrections =
+      tmpl::at<typename Metavariables::factory_creation::factory_classes,
+               evolution::BoundaryCorrection>;
+
+  // The Cartoon/None/Periodic marker conditions are handled specially and do
+  // not declare the interior-data interface (e.g. dg_interior_temporary_tags),
+  // so they are excluded before inspecting that interface.
+  using derived_boundary_conditions = tmpl::remove_if<
+      tmpl::at<typename Metavariables::factory_creation::factory_classes,
+               typename EvolutionSystem::boundary_conditions_base>,
+      tmpl::or_<
+          std::is_base_of<domain::BoundaryConditions::MarkAsCartoon, tmpl::_1>,
+          std::is_base_of<domain::BoundaryConditions::MarkAsNone, tmpl::_1>,
+          std::is_base_of<domain::BoundaryConditions::MarkAsPeriodic,
+                          tmpl::_1>>>;
+
+  // Volume temporaries the boundary corrections would need on the face, from
+  // either packaging interface.
+  using all_correction_temporary_tags = tmpl::flatten<tmpl::append<
+      tmpl::transform<derived_boundary_corrections,
+                      get_dg_auxiliary_package_temporary_tags<tmpl::_1>>,
+      tmpl::transform<derived_boundary_corrections,
+                      get_dg_package_temporary_tags<tmpl::_1>>>>;
+  // Volume temporaries the boundary conditions would project.
+  using all_condition_volume_temporary_tags = tmpl::flatten<tmpl::transform<
+      derived_boundary_conditions,
+      boundary_condition_volume_temporary_tags<
+          tmpl::pin<tmpl::size_t<EvolutionSystem::volume_dim>>, tmpl::_1>>>;
+  // Partial derivatives the boundary conditions would project.
+  using all_condition_deriv_tags =
+      tmpl::flatten<tmpl::transform<derived_boundary_conditions,
+                                    boundary_condition_deriv_tags<tmpl::_1>>>;
+  // Volume time derivatives the boundary conditions would project.
+  using all_condition_dt_tags =
+      tmpl::flatten<tmpl::transform<derived_boundary_conditions,
+                                    boundary_condition_dt_tags<tmpl::_1>>>;
+
+ public:
+  static constexpr bool value =
+      // (1) No fluxes are projected (system is flux-free).
+      tmpl::size<typename EvolutionSystem::flux_variables>::value == 0 and
+      // (2) The system has no inverse spatial metric to project.
+      not has_inverse_spatial_metric_tag_v<EvolutionSystem> and
+      // (3) No boundary correction declares temporaries in either packaging
+      //     interface.
+      tmpl::size<all_correction_temporary_tags>::value == 0 and
+      // (4) No boundary condition projects volume temporaries.
+      tmpl::size<all_condition_volume_temporary_tags>::value == 0 and
+      // (5) No boundary condition projects partial derivatives.
+      tmpl::size<all_condition_deriv_tags>::value == 0 and
+      // (6) No boundary condition projects the volume time derivative.
+      tmpl::size<all_condition_dt_tags>::value == 0;
+};
+
+template <typename EvolutionSystem, typename Metavariables>
+constexpr bool auxiliary_send_projects_no_uninitialized_data_to_face_v =
+    auxiliary_send_projects_no_uninitialized_data_to_face<EvolutionSystem,
+                                                          Metavariables>::value;
+}  // namespace detail
+
+/*!
+ * \brief Packages and sends the auxiliary-pass data for the local
+ * discontinuous Galerkin (LDG) method for auxiliary boundary corrections.
+ *
+ * This action performs the *send* half of the LDG auxiliary communication. It
+ * mirrors the boundary-data portion of `ComputeTimeDerivative::apply`
+ * (without the time-derivative computation) but uses the auxiliary package-data
+ * interface (`dg_auxiliary_package_field_tags`, `dg_auxiliary_package_data`,
+ * `dg_auxiliary_package_data_volume_tags`) and sends to the auxiliary inbox
+ * channel `evolution::dg::Tags::BoundaryCorrectionAndGhostCellsInbox` with
+ * `IsAuxiliary` set to `true`.
+ *
+ * The action does NOT compute the volume time derivative, fluxes, flux
+ * divergence, or partial derivatives. It only:
+ *
+ * 1. Computes the internal mortar data in auxiliary mode
+ *    (`detail::internal_mortar_data` with `ComputeAuxiliary` set to `true`).
+ * 2. Applies the auxiliary external boundary conditions
+ *    (`detail::apply_boundary_conditions_on_all_external_faces` with
+ *    `ComputeAuxiliary` set to `true`).
+ * 3. Sends the packaged auxiliary mortar data to the neighbors on the auxiliary
+ *    inbox channel by the shared implementation
+ *    (`ComputeTimeDerivative_detail::Impl` with `IsAuxiliary` set to `true`).
+ *
+ * Only pure-DG executables (no DG-FD subcell) and global time stepping are
+ * supported for now. The subcell restriction is enforced by a `static_assert`;
+ * global time stepping is enforced by a runtime error unless `Tags::LtsMode`
+ * is `LtsMode::Off`. Nonconforming meshes flow through the same shared mortar
+ * machinery as the physical pass, but are not yet exercised by tests; until
+ * they are, a runtime error rejects elements with nonconforming neighbors.
+ */
+template <size_t Dim, typename EvolutionSystem, bool UseNodegroupDgElements,
+          typename VariablesTag = typename EvolutionSystem::variables_tag>
+struct SendAuxiliaryData
+    : ComputeTimeDerivative_detail::Impl<Dim, EvolutionSystem, tmpl::list<>,
+                                         UseNodegroupDgElements, true,
+                                         VariablesTag> {
+ private:
+  using base =
+      ComputeTimeDerivative_detail::Impl<Dim, EvolutionSystem, tmpl::list<>,
+                                         UseNodegroupDgElements, true,
+                                         VariablesTag>;
+
+ public:
+  template <typename DbTagsList, typename... InboxTags, typename ArrayIndex,
+            typename ActionList, typename ParallelComponent,
+            typename Metavariables>
+  static Parallel::iterable_action_return_t apply(
+      db::DataBox<DbTagsList>& box, tuples::TaggedTuple<InboxTags...>& inboxes,
+      Parallel::GlobalCache<Metavariables>& cache,
+      const ArrayIndex& array_index, const ActionList action_list_meta,
+      const ParallelComponent* const parallel_component_meta) {
+    static_assert(not evolution::dg::using_subcell_v<Metavariables>,
+                  "The LDG auxiliary pass does not support executables using "
+                  "DG-subcell (the DG-FD hybrid scheme) yet.");
+    static_assert(not EvolutionSystem::has_primitive_and_conservative_vars,
+                  "The LDG auxiliary pass does not support systems with "
+                  "primitive and conservative variables.");
+    static_assert(
+        detail::auxiliary_send_projects_no_uninitialized_data_to_face_v<
+            EvolutionSystem, Metavariables>,
+        "The LDG auxiliary pass does not compute the volume time derivative, "
+        "so it cannot supply volume temporaries, fluxes, partial derivatives, "
+        "an inverse spatial metric, or interior time derivatives to the "
+        "auxiliary boundary corrections/conditions. An auxiliary boundary "
+        "correction or condition "
+        "registered for this system requires one of these on the boundary, "
+        "which the auxiliary send does not support.");
+
+    if (db::get<::Tags::LtsMode>(box) != LtsMode::Off) {
+      ERROR("Local time stepping is not supported for the LDG auxiliary pass.");
+    }
+
+    const Element<Dim>& element = db::get<domain::Tags::Element<Dim>>(box);
+    for (const auto& direction_and_neighbors : element.neighbors()) {
+      if (not direction_and_neighbors.second.are_conforming()) {
+        ERROR(
+            "The LDG auxiliary send has not been tested with nonconforming "
+            "meshes yet. Element "
+            << element.id() << " has nonconforming neighbors in direction "
+            << direction_and_neighbors.first << ".");
+      }
+    }
+    return base::apply(box, inboxes, cache, array_index, action_list_meta,
+                       parallel_component_meta);
+  }
+};
+}  // namespace evolution::dg::Actions

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_SendAuxiliaryData.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_SendAuxiliaryData.cpp
@@ -1,0 +1,516 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <pup.h>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataBox/Tag.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "Domain/Block.hpp"
+#include "Domain/BoundaryConditions/BoundaryCondition.hpp"
+#include "Domain/BoundaryConditions/Periodic.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/Identity.hpp"
+#include "Domain/CoordinateMaps/Tags.hpp"
+#include "Domain/Creators/Tags/Domain.hpp"
+#include "Domain/Creators/Tags/ExternalBoundaryConditions.hpp"
+#include "Domain/Creators/Tags/FunctionsOfTime.hpp"
+#include "Domain/Creators/Tags/InitialExtents.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/ElementMap.hpp"
+#include "Domain/Structure/BlockNeighbors.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Domain/Structure/DirectionalId.hpp"
+#include "Domain/Structure/DirectionalIdMap.hpp"
+#include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/Neighbors.hpp"
+#include "Domain/Structure/OrientationMap.hpp"
+#include "Domain/Tags.hpp"
+#include "Domain/TagsTimeDependent.hpp"
+#include "Evolution/BoundaryConditions/Type.hpp"
+#include "Evolution/BoundaryCorrection.hpp"
+#include "Evolution/BoundaryCorrectionTags.hpp"
+#include "Evolution/DiscontinuousGalerkin/Actions/SendAuxiliaryData.hpp"
+#include "Evolution/DiscontinuousGalerkin/InboxTags.hpp"
+#include "Evolution/DiscontinuousGalerkin/Initialization/Mortars.hpp"
+#include "Evolution/DiscontinuousGalerkin/MortarData.hpp"
+#include "Evolution/DiscontinuousGalerkin/MortarDataHolder.hpp"
+#include "Evolution/DiscontinuousGalerkin/MortarTags.hpp"
+#include "Framework/ActionTesting.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/ProjectToBoundary.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "Options/Protocols/FactoryCreation.hpp"
+#include "Parallel/Phase.hpp"
+#include "Parallel/PhaseDependentActionList.hpp"
+#include "Time/History.hpp"
+#include "Time/LtsMode.hpp"
+#include "Time/Slab.hpp"
+#include "Time/Tags/HistoryEvolvedVariables.hpp"
+#include "Time/Tags/LtsMode.hpp"
+#include "Time/Tags/Time.hpp"
+#include "Time/Tags/TimeStepId.hpp"
+#include "Time/Time.hpp"
+#include "Time/TimeStepId.hpp"
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/CloneUniquePtrs.hpp"
+#include "Utilities/ErrorHandling/Error.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/ProtocolHelpers.hpp"
+#include "Utilities/Serialization/RegisterDerivedClassesWithCharm.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+// Evolved variable for a LDG-like nonconservative system.
+struct Psi : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+// Auxiliary variable for a LDG-like nonconservative system.
+template <size_t Dim>
+struct AuxVar : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+// Variable to be packaged during the auxiliary send.
+struct TwoTimesPsi : db::SimpleTag {
+  using type = Scalar<DataVector>;
+};
+
+// A dummy boundary correction.
+template <size_t Dim>
+struct AuxiliaryCorrection final : public ::evolution::BoundaryCorrection {
+  explicit AuxiliaryCorrection(CkMigrateMessage* /*unused*/) {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(AuxiliaryCorrection);  // NOLINT
+  AuxiliaryCorrection() = default;
+  AuxiliaryCorrection(const AuxiliaryCorrection&) = default;
+  AuxiliaryCorrection& operator=(const AuxiliaryCorrection&) = default;
+  AuxiliaryCorrection(AuxiliaryCorrection&&) = default;
+  AuxiliaryCorrection& operator=(AuxiliaryCorrection&&) = default;
+  ~AuxiliaryCorrection() override = default;
+
+  std::unique_ptr<BoundaryCorrection> get_clone() const override {
+    return std::make_unique<AuxiliaryCorrection>(*this);
+  }
+
+  void pup(PUP::er& p) override {  // NOLINT
+    BoundaryCorrection::pup(p);
+  }
+
+  static constexpr bool need_normal_vector = false;
+
+  using dg_package_field_tags = tmpl::list<>;
+  using dg_package_data_temporary_tags = tmpl::list<>;
+  using dg_package_data_primitive_tags = tmpl::list<>;
+  using dg_package_data_volume_tags = tmpl::list<>;
+  using dg_boundary_terms_volume_tags = tmpl::list<>;
+
+  double dg_package_data(
+      const Scalar<DataVector>& /*psi*/,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& /*normal_covector*/,
+      const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
+      /*mesh_velocity*/,
+      const std::optional<Scalar<DataVector>>& /*normal_dot_mesh_velocity*/)
+      const {
+    // the auxiliary send should not call the physical package-data interface
+    ERROR(
+        "The physical dg_package_data interface must not be called by the "
+        "auxiliary send.");
+  }
+
+  using dg_auxiliary_package_field_tags = tmpl::list<TwoTimesPsi>;
+  using dg_auxiliary_package_data_temporary_tags = tmpl::list<>;
+  using dg_auxiliary_package_data_volume_tags = tmpl::list<>;
+  using dg_auxiliary_boundary_terms_volume_tags = tmpl::list<>;
+
+  double dg_auxiliary_package_data(
+      const gsl::not_null<Scalar<DataVector>*> two_times_psi,
+      const Scalar<DataVector>& psi,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& /*normal_covector*/,
+      const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
+      /*mesh_velocity*/,
+      const std::optional<Scalar<DataVector>>& /*normal_dot_mesh_velocity*/)
+      const {
+    get(*two_times_psi) = 2.0 * get(psi);
+    return 1.0;
+  }
+
+  // Auxiliary boundary correction: half the jump in the packaged field.
+  void dg_auxiliary_boundary_terms(
+      const gsl::not_null<Scalar<DataVector>*> aux_var_correction,
+      const Scalar<DataVector>& two_times_psi_interior,
+      const Scalar<DataVector>& two_times_psi_exterior,
+      const ::dg::Formulation /*dg_formulation*/) const {
+    get(*aux_var_correction) =
+        0.5 * (get(two_times_psi_exterior) - get(two_times_psi_interior));
+  }
+};
+
+template <size_t Dim>
+PUP::able::PUP_ID AuxiliaryCorrection<Dim>::my_PUP_ID = 0;  // NOLINT
+
+template <size_t Dim>
+class BoundaryCondition : public domain::BoundaryConditions::BoundaryCondition {
+ public:
+  BoundaryCondition() = default;
+  BoundaryCondition(BoundaryCondition&&) = default;
+  BoundaryCondition& operator=(BoundaryCondition&&) = default;
+  BoundaryCondition(const BoundaryCondition&) = default;
+  BoundaryCondition& operator=(const BoundaryCondition&) = default;
+  ~BoundaryCondition() override = default;
+  explicit BoundaryCondition(CkMigrateMessage* msg)
+      : domain::BoundaryConditions::BoundaryCondition(msg) {}
+
+  void pup(PUP::er& p) override {
+    domain::BoundaryConditions::BoundaryCondition::pup(p);
+  }
+};
+
+template <size_t Dim>
+class GhostPsi : public BoundaryCondition<Dim> {
+ public:
+  GhostPsi() = default;
+  GhostPsi(GhostPsi&&) = default;
+  GhostPsi& operator=(GhostPsi&&) = default;
+  GhostPsi(const GhostPsi&) = default;
+  GhostPsi& operator=(const GhostPsi&) = default;
+  ~GhostPsi() override = default;
+
+  explicit GhostPsi(CkMigrateMessage* msg) : BoundaryCondition<Dim>(msg) {}
+
+  WRAPPED_PUPable_decl_base_template(
+      domain::BoundaryConditions::BoundaryCondition, GhostPsi);
+
+  auto get_clone() const -> std::unique_ptr<
+      domain::BoundaryConditions::BoundaryCondition> override {
+    return std::make_unique<GhostPsi<Dim>>(*this);
+  }
+
+  static constexpr ::evolution::BoundaryConditions::Type bc_type =
+      ::evolution::BoundaryConditions::Type::Ghost;
+
+  void pup(PUP::er& p) override { BoundaryCondition<Dim>::pup(p); }
+
+  using dg_interior_evolved_variables_tags = tmpl::list<Psi, AuxVar<Dim>>;
+  using dg_interior_primitive_variables_tags = tmpl::list<>;
+  using dg_interior_temporary_tags = tmpl::list<>;
+  using dg_gridless_tags = tmpl::list<>;
+
+  // The exterior data depends on both projected interior fields so that a
+  // wrong projection of either changes the resulting auxiliary variables.
+  std::optional<std::string> dg_ghost(
+      const gsl::not_null<Scalar<DataVector>*> psi_exterior,
+      const gsl::not_null<Scalar<DataVector>*> aux_var_exterior,
+      const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
+      /*face_mesh_velocity*/,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& /*normal_covector*/,
+      const Scalar<DataVector>& psi_interior,
+      const Scalar<DataVector>& aux_var_interior) const {
+    // The projected interior fields on the single-point -xi face
+    CHECK(get(psi_interior) == DataVector{2.0});
+    CHECK(get(aux_var_interior) == DataVector{7.0});
+    get(*psi_exterior) = 2.0 * get(psi_interior) + 3.0 * get(aux_var_interior);
+    get(*aux_var_exterior) = get(aux_var_interior);
+    return std::nullopt;
+  }
+};
+
+template <size_t Dim>
+PUP::able::PUP_ID GhostPsi<Dim>::my_PUP_ID = 0;  // NOLINT
+
+template <size_t Dim>
+struct TimeDerivativeTerms {
+  using temporary_tags = tmpl::list<>;
+};
+
+template <size_t Dim>
+struct System {
+  static constexpr bool has_primitive_and_conservative_vars = false;
+  static constexpr size_t volume_dim = Dim;
+
+  using boundary_conditions_base = BoundaryCondition<Dim>;
+
+  using variables_tag = Tags::Variables<tmpl::list<Psi>>;
+  using auxiliary_variables = tmpl::list<AuxVar<Dim>>;
+  using flux_variables = tmpl::list<>;
+  using gradient_variables = tmpl::list<Psi, AuxVar<Dim>>;
+
+  using compute_volume_time_derivative_terms = TimeDerivativeTerms<Dim>;
+};
+
+constexpr bool use_nodegroup_dg_elements = false;
+
+struct Metavariables;
+
+template <size_t Dim>
+struct component {
+  using metavariables = Metavariables;
+  using chare_type = ActionTesting::MockArrayChare;
+  using array_index = ElementId<Dim>;
+
+  using variables_tag = typename System<Dim>::variables_tag;
+
+  using simple_tags =
+      tmpl::list<::Tags::TimeStepId, ::Tags::Next<::Tags::TimeStepId>,
+                 ::Tags::Time, variables_tag,
+                 ::Tags::Variables<typename System<Dim>::auxiliary_variables>,
+                 ::Tags::HistoryEvolvedVariables<variables_tag>,
+                 domain::Tags::Mesh<Dim>,
+                 ::domain::Tags::FunctionsOfTimeInitialize,
+                 domain::CoordinateMaps::Tags::CoordinateMap<Dim, Frame::Grid,
+                                                             Frame::Inertial>,
+                 domain::Tags::Element<Dim>, domain::Tags::NeighborMesh<Dim>,
+                 domain::Tags::InverseJacobian<Dim, Frame::ElementLogical,
+                                               Frame::Inertial>,
+                 domain::Tags::MeshVelocity<Dim>,
+                 domain::Tags::ElementMap<Dim, Frame::Grid>>;
+
+  using compute_tags =
+      tmpl::list<domain::Tags::DetInvJacobianCompute<Dim, Frame::ElementLogical,
+                                                     Frame::Inertial>>;
+
+  using inbox_tags =
+      tmpl::list<::evolution::dg::Tags::BoundaryCorrectionAndGhostCellsInbox<
+          Dim, use_nodegroup_dg_elements, /*IsAuxiliary=*/false>>;
+
+  using phase_dependent_action_list = tmpl::list<
+      Parallel::PhaseActions<
+          Parallel::Phase::Initialization,
+          tmpl::flatten<tmpl::list<
+              ActionTesting::InitializeDataBox<simple_tags, compute_tags>,
+              ::evolution::dg::Initialization::Mortars<Dim>>>>,
+      Parallel::PhaseActions<
+          Parallel::Phase::Testing,
+          tmpl::list<::evolution::dg::Actions::SendAuxiliaryData<
+              Dim, System<Dim>, use_nodegroup_dg_elements>>>>;
+};
+
+struct Metavariables {
+  using system = System<1>;
+  using const_global_cache_tags =
+      tmpl::list<domain::Tags::InitialExtents<1>, domain::Tags::Domain<1>,
+                 ::Tags::LtsMode>;
+  struct factory_creation
+      : tt::ConformsTo<Options::protocols::FactoryCreation> {
+    using factory_classes =
+        tmpl::map<tmpl::pair<BoundaryCondition<1>, tmpl::list<GhostPsi<1>>>,
+                  tmpl::pair<::evolution::BoundaryCorrection,
+                             tmpl::list<AuxiliaryCorrection<1>>>>;
+  };
+  using component_list = tmpl::list<component<1>>;
+};
+
+void test(const bool nonconforming_neighbors) {
+  constexpr size_t Dim = 1;
+  using metavars = Metavariables;
+  using MockRuntimeSystem = ActionTesting::MockRuntimeSystem<metavars>;
+  register_factory_classes_with_charm<metavars>();
+
+  const Spectral::Quadrature quadrature = Spectral::Quadrature::GaussLobatto;
+  const ::dg::Formulation dg_formulation = ::dg::Formulation::StrongInertial;
+
+  // Two elements in a single block, with a shared internal boundary in +xi.
+  const ElementId<Dim> self_id{0, {{{1, 0}}}};
+  const ElementId<Dim> east_id{0, {{{1, 1}}}};
+  DirectionMap<Dim, Neighbors<Dim>> neighbors{};
+  if (nonconforming_neighbors) {
+    neighbors[Direction<Dim>::upper_xi()] = Neighbors<Dim>{
+        {east_id}, {{0, OrientationMap<Dim>::create_aligned()}}, false};
+  } else {
+    neighbors[Direction<Dim>::upper_xi()] =
+        Neighbors<Dim>{{east_id}, OrientationMap<Dim>::create_aligned()};
+  }
+  const Element<Dim> element{self_id, neighbors};
+
+  const auto grid_to_inertial_map =
+      domain::make_coordinate_map_base<Frame::Grid, Frame::Inertial>(
+          domain::CoordinateMaps::Identity<Dim>{});
+
+  const std::array<size_t, Dim> extents{{2}};
+  const Mesh<Dim> mesh{extents, Spectral::Basis::Legendre, quadrature};
+
+  DirectionalIdMap<Dim, Mesh<Dim>> neighbor_mesh{};
+  for (const auto& [direction, direction_neighbors] : neighbors) {
+    for (const auto& neighbor : direction_neighbors) {
+      const auto& neighbor_orientation =
+          direction_neighbors.orientation(neighbor);
+      neighbor_mesh.emplace(DirectionalId{direction, neighbor},
+                            neighbor_orientation.inverse_map()(mesh));
+    }
+  }
+
+  const Slab time_slab{0.2, 3.4};
+  const TimeDelta time_step{time_slab, {1, 128}};
+  const TimeStepId time_step_id{true, 3, Time{time_slab, {3, 128}}};
+  const TimeStepId next_time_step_id = time_step_id.next_step(time_step);
+
+  MockRuntimeSystem runner = [&dg_formulation, &extents,
+                              &grid_to_inertial_map]() {
+    std::vector<DirectionMap<
+        Dim, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
+        boundary_conditions{1};
+    std::vector<Block<Dim>> blocks{1};
+    for (const auto& direction : Direction<Dim>::all_directions()) {
+      boundary_conditions[0][direction] = std::make_unique<GhostPsi<Dim>>();
+    }
+    blocks[0] = Block<Dim>{
+        domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
+            domain::CoordinateMaps::Identity<Dim>{}),
+        0,
+        {}};
+    Domain<Dim> domain{std::move(blocks)};
+    domain.inject_time_dependent_map_for_block(
+        0, grid_to_inertial_map->get_clone());
+    return MockRuntimeSystem{
+        {std::vector<std::array<size_t, Dim>>{extents, extents},
+         std::move(domain), ::LtsMode::Off, dg_formulation,
+         std::make_unique<AuxiliaryCorrection<Dim>>(),
+         std::move(boundary_conditions)}};
+  }();
+
+  const auto get_tag =
+      [&runner, &self_id]<typename Tag>(Tag /*tag_v*/) -> decltype(auto) {
+    return ActionTesting::get_databox_tag<component<Dim>, Tag>(runner, self_id);
+  };
+
+  ::InverseJacobian<DataVector, Dim, Frame::ElementLogical, Frame::Inertial>
+      inv_jac{mesh.number_of_grid_points(), 0.0};
+  inv_jac.get(0, 0) = 1.0;
+
+  const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>
+      mesh_velocity{};
+
+  Variables<tmpl::list<Psi>> evolved_vars{mesh.number_of_grid_points()};
+  get(get<Psi>(evolved_vars)) = DataVector{2.0, 5.0};
+  Variables<tmpl::list<AuxVar<Dim>>> aux_vars{mesh.number_of_grid_points()};
+  get(get<AuxVar<Dim>>(aux_vars)) = DataVector{7.0, 3.0};
+  const ::TimeSteppers::History<decltype(evolved_vars)> history{1};
+
+  std::unordered_map<std::string,
+                     std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+      functions_of_time{};
+
+  const auto emplace = [&](const ElementId<Dim>& id) {
+    ActionTesting::emplace_component_and_initialize<component<Dim>>(
+        &runner, id,
+        {time_step_id, next_time_step_id, time_step_id.step_time().value(),
+         evolved_vars, aux_vars, history, mesh,
+         clone_unique_ptrs(functions_of_time),
+         grid_to_inertial_map->get_clone(), element, neighbor_mesh, inv_jac,
+         mesh_velocity,
+         ElementMap<Dim, Frame::Grid>{
+             id,
+             domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Grid>(
+                 domain::CoordinateMaps::Identity<Dim>{})}});
+  };
+  emplace(self_id);
+
+  if (nonconforming_neighbors) {
+    ActionTesting::set_phase(make_not_null(&runner), Parallel::Phase::Testing);
+    CHECK_THROWS_WITH(
+        ActionTesting::next_action<component<Dim>>(make_not_null(&runner),
+                                                   self_id),
+        Catch::Matchers::ContainsSubstring(
+            "The LDG auxiliary send has not been tested with nonconforming "
+            "meshes yet."));
+    return;
+  }
+  emplace(east_id);
+
+  ActionTesting::next_action<component<Dim>>(make_not_null(&runner), self_id);
+  ActionTesting::set_phase(make_not_null(&runner), Parallel::Phase::Testing);
+  ActionTesting::next_action<component<Dim>>(make_not_null(&runner), self_id);
+
+  // Compute the expected auxiliary mortar data
+  const DirectionalId<Dim> mortar_id_east{Direction<Dim>::upper_xi(), east_id};
+  const Mesh<Dim - 1> face_mesh =
+      mesh.slice_away(Direction<Dim>::upper_xi().dimension());
+  Variables<tmpl::list<Psi>> psi_on_face{face_mesh.number_of_grid_points()};
+  ::dg::project_contiguous_data_to_boundary(make_not_null(&psi_on_face),
+                                            evolved_vars, mesh,
+                                            Direction<Dim>::upper_xi());
+  Variables<tmpl::list<TwoTimesPsi>> expected_packaged_data{
+      face_mesh.number_of_grid_points()};
+  get(get<TwoTimesPsi>(expected_packaged_data)) =
+      2.0 * get(get<Psi>(psi_on_face));
+  const DataVector expected_mortar_data{
+      get(get<TwoTimesPsi>(expected_packaged_data))};
+
+  CHECK(get_tag(::evolution::dg::Tags::MortarData<Dim>{})
+            .at(mortar_id_east)
+            .local()
+            .mortar_data.value() == expected_mortar_data);
+
+  // The neighbor receives the data on the auxiliary inbox channel.
+  const DirectionalId<Dim> east_neighbor_mortar_id{Direction<Dim>::lower_xi(),
+                                                   self_id};
+  const auto& aux_messages =
+      ActionTesting::get_inbox_tag<
+          component<Dim>,
+          ::evolution::dg::Tags::BoundaryCorrectionAndGhostCellsInbox<
+              Dim, use_nodegroup_dg_elements, /*IsAuxiliary=*/true>>(runner,
+                                                                     east_id)
+          .messages;
+  REQUIRE(aux_messages.count(time_step_id) == 1);
+  const auto& aux_messages_at_time = aux_messages.at(time_step_id);
+  const auto received_entry =
+      alg::find_if(aux_messages_at_time, [&](const auto& entry) {
+        return entry.first == east_neighbor_mortar_id;
+      });
+  REQUIRE(received_entry != aux_messages_at_time.end());
+  const auto& received = received_entry->second;
+  REQUIRE(received.boundary_correction_data.has_value());
+  CHECK(received.boundary_correction_data.value() == expected_mortar_data);
+  CHECK(received.validity_range == next_time_step_id);
+
+  // The physical inbox channel (IsAuxiliary == false) must stay empty.
+  const auto& physical_messages =
+      ActionTesting::get_inbox_tag<
+          component<Dim>,
+          ::evolution::dg::Tags::BoundaryCorrectionAndGhostCellsInbox<
+              Dim, use_nodegroup_dg_elements, /*IsAuxiliary=*/false>>(runner,
+                                                                      east_id)
+          .messages;
+  CHECK(physical_messages.empty());
+
+  // The ghost external boundary condition on the -xi face adds a lifted
+  // auxiliary boundary correction to the auxiliary variables.
+  const DataVector expected_aux_var{-16.0, 3.0};
+  CHECK_ITERABLE_APPROX(get(get<AuxVar<Dim>>(get_tag(
+                            ::Tags::Variables<tmpl::list<AuxVar<Dim>>>{}))),
+                        expected_aux_var);
+}
+
+SPECTRE_TEST_CASE("Unit.Evolution.DG.SendAuxiliaryData",
+                  "[Unit][Evolution][Actions]") {
+  PUPable_reg(
+      SINGLE_ARG(domain::CoordinateMap<Frame::Grid, Frame::Inertial,
+                                       domain::CoordinateMaps::Identity<1>>));
+  PUPable_reg(
+      SINGLE_ARG(domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial,
+                                       domain::CoordinateMaps::Identity<1>>));
+  PUPable_reg(
+      SINGLE_ARG(domain::CoordinateMap<Frame::BlockLogical, Frame::Grid,
+                                       domain::CoordinateMaps::Identity<1>>));
+  test(false);
+  test(true);
+}
+}  // namespace

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/CMakeLists.txt
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
   Actions/Test_BoundaryConditions.cpp
   Actions/Test_ComputeTimeDerivative.cpp
   Actions/Test_NormalCovectorAndMagnitude.cpp
+  Actions/Test_SendAuxiliaryData.cpp
   Initialization/Test_Mortars.cpp
   Initialization/Test_ProjectSpectralFilters.cpp
   Initialization/Test_QuadratureTag.cpp

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeImpl.tpp
@@ -858,6 +858,62 @@ struct BoundaryTerms final : public ::evolution::BoundaryCorrection {
     return max(get(*max_abs_char_speed));
   }
 
+  // Nonconservative system with a LDG auxiliary variable
+  double dg_package_data(
+      const gsl::not_null<Scalar<DataVector>*> out_normal_dot_flux_var1,
+      const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*>
+          out_normal_dot_flux_var2,
+      const gsl::not_null<Scalar<DataVector>*> out_var1,
+      const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> out_var2,
+      const gsl::not_null<Scalar<DataVector>*> max_abs_char_speed,
+
+      const Scalar<DataVector>& var1,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& var2,
+      const Scalar<DataVector>& var_aux,
+
+      const Scalar<DataVector>& var3_squared,
+
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_covector,
+      const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
+          mesh_velocity,
+      const std::optional<Scalar<DataVector>>& normal_dot_mesh_velocity) const {
+    dg_package_data(out_normal_dot_flux_var1, out_normal_dot_flux_var2,
+                    out_var1, out_var2, max_abs_char_speed, var1, var2,
+                    var3_squared, normal_covector, mesh_velocity,
+                    normal_dot_mesh_velocity);
+    get(*out_var1) += get(var_aux);
+    return max(get(*max_abs_char_speed));
+  }
+
+  // Mixed system with a LDG auxiliary variable
+  double dg_package_data(
+      const gsl::not_null<Scalar<DataVector>*> out_normal_dot_flux_var1,
+      const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*>
+          out_normal_dot_flux_var2,
+      const gsl::not_null<Scalar<DataVector>*> out_var1,
+      const gsl::not_null<tnsr::I<DataVector, Dim, Frame::Inertial>*> out_var2,
+      const gsl::not_null<Scalar<DataVector>*> max_abs_char_speed,
+
+      const Scalar<DataVector>& var1,
+      const tnsr::I<DataVector, Dim, Frame::Inertial>& var2,
+      const Scalar<DataVector>& var_aux,
+
+      const tnsr::IJ<DataVector, Dim, Frame::Inertial>& flux_var2,
+
+      const Scalar<DataVector>& var3_squared,
+
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_covector,
+      const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
+          mesh_velocity,
+      const std::optional<Scalar<DataVector>>& normal_dot_mesh_velocity) const {
+    dg_package_data(out_normal_dot_flux_var1, out_normal_dot_flux_var2,
+                    out_var1, out_var2, max_abs_char_speed, var1, var2,
+                    flux_var2, var3_squared, normal_covector, mesh_velocity,
+                    normal_dot_mesh_velocity);
+    get(*out_var1) += get(var_aux);
+    return max(get(*max_abs_char_speed));
+  }
+
   // Mixed system with prims
   /// [bt_mp]
   double dg_package_data(
@@ -1754,6 +1810,8 @@ void test_impl(const Spectral::Quadrature quadrature,
   // interfaces are called. Working out all the numbers explicitly would be
   // tedious.
   using variables_tags = typename variables_tag::tags_list;
+  using aux_tags_for_face =
+      tmpl::conditional_t<HasAux, tmpl::list<VarAux>, tmpl::list<>>;
   using temporary_tags_for_face = tmpl::list<Var3Squared>;
   using primitive_tags_for_face = tmpl::conditional_t<
       system::has_primitive_and_conservative_vars,
@@ -1802,20 +1860,26 @@ void test_impl(const Spectral::Quadrature quadrature,
       mesh.number_of_grid_points()};
   get(get<Var3Squared>(volume_temporaries)) = square(get(var3));
   const auto compute_expected_mortar_data =
-      [&element, &expected_fluxes, &face_normals, &get_tag, &mesh,
+      [&aux_vars, &element, &expected_fluxes, &face_normals, &get_tag, &mesh,
        &mesh_velocity, &mortar_meshes, &mortar_infos, &volume_temporaries,
        &variables_before_compute_time_derivatives](
           const Direction<Dim>& local_direction,
           const ElementId<Dim>& local_neighbor_id, const bool local_data) {
         const auto& face_mesh = mesh.slice_away(local_direction.dimension());
         // First project data to the face in the direction of the mortar
-        Variables<
-            tmpl::append<variables_tags, fluxes_tags, temporary_tags_for_face,
-                         primitive_tags_for_face>>
+        Variables<tmpl::append<variables_tags, aux_tags_for_face, fluxes_tags,
+                               temporary_tags_for_face,
+                               primitive_tags_for_face>>
             fields_on_face{face_mesh.number_of_grid_points()};
         ::dg::project_contiguous_data_to_boundary(
             make_not_null(&fields_on_face),
             variables_before_compute_time_derivatives, mesh, local_direction);
+        if constexpr (HasAux) {
+          ::dg::project_tensors_to_boundary<tmpl::list<VarAux>>(
+              make_not_null(&fields_on_face), aux_vars, mesh, local_direction);
+        } else {
+          (void)aux_vars;
+        }
         if constexpr (tmpl::size<fluxes_tags>::value != 0) {
           ::dg::project_contiguous_data_to_boundary(
               make_not_null(&fields_on_face), expected_fluxes, mesh,


### PR DESCRIPTION
Add the SendAuxiliaryData action: the send half of the LDG auxiliary pass, sharing its implementation with ComputeTimeDerivative through ComputeTimeDerivative_detail::Impl.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent was used, have a co-author trailer of the form
      "Co-Authored-By: <agent name> <agent email>" as the last line of the
      commit, e.g. "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>".

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
