### PR TITLE
Make Cartoon BC not factory creatable

### DIFF
--- a/src/Domain/BoundaryConditions/Cartoon.hpp
+++ b/src/Domain/BoundaryConditions/Cartoon.hpp
@@ -54,12 +54,7 @@ template <typename SystemBoundaryConditionBaseClass>
 struct Cartoon final : public SystemBoundaryConditionBaseClass,
                        public MarkAsCartoon {
  public:
-  using options = tmpl::list<>;
-  static constexpr Options::String help{
-      "Cartoon boundary condition, to be used in systems that do not implement "
-      "Subcell.\n\nNote: This should never be used as an external boundary, it "
-      "is only used on specific cartoon-system boundaries that are "
-      "automatically handled in the domain creators."};
+  static constexpr bool factory_creatable = false;
   static std::string name() { return "Cartoon"; }
 
   Cartoon() = default;


### PR DESCRIPTION
## Proposed changes

This BC should never be specified as an external boundary condition from an input file; it is automatically handled by the cartoon domain creators.

Will told me to make this edit in another PR a few weeks ago and it is also appropriate here.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent was used, have a co-author trailer of the form
      "Co-Authored-By: <agent name> <agent email>" as the last line of the
      commit, e.g. "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>".

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
