### PR TITLE
Add filled option to nonconforming sphere

### DIFF
--- a/src/Domain/Creators/ExpandOverBlocks.cpp
+++ b/src/Domain/Creators/ExpandOverBlocks.cpp
@@ -8,6 +8,7 @@
 
 namespace domain {
 
+template class ExpandOverBlocks<size_t>;
 template class ExpandOverBlocks<std::array<size_t, 1>>;
 template class ExpandOverBlocks<std::array<size_t, 2>>;
 template class ExpandOverBlocks<std::array<size_t, 3>>;

--- a/src/Domain/Creators/ExpandOverBlocks.tpp
+++ b/src/Domain/Creators/ExpandOverBlocks.tpp
@@ -42,7 +42,7 @@ std::vector<T> ExpandOverBlocks<T>::operator()(const T& value) const {
     }
     return expanded;
   } else {
-    return {num_blocks_, value};
+    return std::vector<T>(num_blocks_, value);
   }
 }
 

--- a/src/Domain/Creators/NonconformingSphericalShells.cpp
+++ b/src/Domain/Creators/NonconformingSphericalShells.cpp
@@ -4,6 +4,7 @@
 #include "Domain/Creators/NonconformingSphericalShells.hpp"
 
 #include <array>
+#include <cmath>
 #include <cstddef>
 #include <memory>
 #include <optional>
@@ -18,8 +19,10 @@
 #include "Domain/BoundaryConditions/None.hpp"
 #include "Domain/BoundaryConditions/Periodic.hpp"
 #include "Domain/CoordinateMaps/Affine.hpp"
+#include "Domain/CoordinateMaps/BulgedCube.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/Equiangular.hpp"
 #include "Domain/CoordinateMaps/Identity.hpp"
 #include "Domain/CoordinateMaps/Interval.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
@@ -27,6 +30,8 @@
 #include "Domain/CoordinateMaps/SphericalToCartesianPfaffian.hpp"
 #include "Domain/CoordinateMaps/Wedge.hpp"
 #include "Domain/Creators/DomainCreator.hpp"
+#include "Domain/Creators/ExpandOverBlocks.hpp"
+#include "Domain/Creators/ShellDistribution.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/DomainHelpers.hpp"
 #include "Domain/Structure/BlockNeighbors.hpp"
@@ -36,42 +41,40 @@
 #include "Domain/Structure/Topology.hpp"
 #include "Options/Context.hpp"
 #include "Options/ParseError.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/Gsl.hpp"
+
+namespace Frame {
+struct Inertial;
+struct BlockLogical;
+}  // namespace Frame
 
 namespace domain::creators {
 
 NonconformingSphericalShells::NonconformingSphericalShells(
     const double inner_radius, const double interface_radius,
-    const double outer_radius, const size_t initial_radial_refinement,
-    const size_t initial_angular_refinement,
-    const size_t initial_number_of_radial_grid_points,
-    const size_t initial_spherical_harmonic_l,
-    const size_t initial_number_of_angular_grid_points_of_wedges,
-    std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
-        inner_boundary_condition,
+    const double outer_radius, std::variant<Excision, InnerCube> interior,
+    const typename InitialCubeRefinement::type& initial_cube_refinement,
+    const typename InitialSHRefinement::type& initial_sh_refinement,
+    const typename InitialCubeGridPoints::type& initial_cube_grid_points,
+    const typename InitialSHGridPoints::type& initial_sh_grid_points,
+    std::array<std::vector<double>, 2> radial_partitioning,
+    std::array<std::vector<domain::CoordinateMaps::Distribution>, 2>
+        radial_distribution,
+    const bool use_equiangular_map,
+    std::optional<TimeDepOptionType> time_dependent_options,
     std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
         outer_boundary_condition,
     const Options::Context& context)
     : inner_radius_(inner_radius),
       interface_radius_(interface_radius),
       outer_radius_(outer_radius),
-      initial_radial_refinement_(initial_radial_refinement),
-      initial_angular_refinement_(initial_angular_refinement),
-      initial_number_of_radial_grid_points_(
-          initial_number_of_radial_grid_points),
-      initial_spherical_harmonic_l_(initial_spherical_harmonic_l),
-      initial_number_of_angular_grid_points_of_wedges_(
-          initial_number_of_angular_grid_points_of_wedges),
-      initial_refinement_levels_{
-          7,
-          {{initial_angular_refinement_, initial_angular_refinement_,
-            initial_radial_refinement_}}},
-      initial_number_of_grid_points_{
-          7,
-          {{initial_number_of_angular_grid_points_of_wedges_,
-            initial_number_of_angular_grid_points_of_wedges_,
-            initial_number_of_radial_grid_points_}}},
-      inner_boundary_condition_(std::move(inner_boundary_condition)),
+      interior_(std::move(interior)),
+      fill_interior_(std::holds_alternative<InnerCube>(interior_)),
+      radial_partitioning_(std::move(radial_partitioning)),
+      radial_distribution_{},
+      use_equiangular_map_(use_equiangular_map),
+      time_dependent_options_(std::move(time_dependent_options)),
       outer_boundary_condition_(std::move(outer_boundary_condition)),
       grid_anchors_{{{"Center", tnsr::I<double, 3, Frame::Grid>{
                                     std::array{0.0, 0.0, 0.0}}}}} {
@@ -83,7 +86,6 @@ NonconformingSphericalShells::NonconformingSphericalShells(
                     " and interface radius is " +
                     std::to_string(interface_radius_) + ".");
   }
-
   if (interface_radius_ > outer_radius_) {
     PARSE_ERROR(
         context,
@@ -95,83 +97,415 @@ NonconformingSphericalShells::NonconformingSphericalShells(
 
   // Validate boundary conditions
   using domain::BoundaryConditions::is_none;
-  if (is_none(inner_boundary_condition_) or
-      is_none(outer_boundary_condition_)) {
-    PARSE_ERROR(
-        context,
-        "None boundary condition is not supported. If you would like an "
-        "outflow-type boundary condition, you must use that.");
-  }
   using domain::BoundaryConditions::is_periodic;
-  if (is_periodic(inner_boundary_condition_) or
-      is_periodic(outer_boundary_condition_)) {
+  if (not fill_interior_) {
+    const auto& inner_bc = std::get<Excision>(interior_).boundary_condition;
+    if (is_none(inner_bc)) {
+      PARSE_ERROR(context,
+                  "None boundary condition for the inner boundary is not "
+                  "supported when the center is excised. If you would like an "
+                  "outflow-type boundary condition, you must use that.");
+    }
+    if (is_periodic(inner_bc)) {
+      PARSE_ERROR(context,
+                  "Cannot have periodic boundary conditions with "
+                  "NonconformingSphericalShells");
+    }
+    if ((inner_bc == nullptr) != (outer_boundary_condition_ == nullptr)) {
+      PARSE_ERROR(
+          context,
+          "Must specify either both inner and outer boundary conditions "
+          "or neither.");
+    }
+  }
+  if (is_none(outer_boundary_condition_)) {
+    PARSE_ERROR(context,
+                "None boundary condition is not supported for the outer "
+                "boundary. If you would like an outflow-type boundary "
+                "condition, you must use that.");
+  }
+  if (is_periodic(outer_boundary_condition_)) {
     PARSE_ERROR(context,
                 "Cannot have periodic boundary conditions with "
                 "NonconformingSphericalShells");
   }
-  // Validate consistency of inner and outer boundary condition
-  if ((inner_boundary_condition_ == nullptr) !=
-      (outer_boundary_condition_ == nullptr)) {
+
+  // Validate inner radial partitions
+  set_shell_distribution(make_not_null(&num_cube_shells_),
+                         make_not_null(radial_distribution_.data()),
+                         radial_partitioning_[0], radial_distribution[0],
+                         inner_radius_, interface_radius_, "inner", "interface",
+                         context);
+  if (fill_interior_ and radial_distribution_[0].front() !=
+                             domain::CoordinateMaps::Distribution::Linear) {
     PARSE_ERROR(context,
-                "Must specify either both inner and outer boundary conditions "
-                "or neither.");
+                "The 'RadialDistribution' must be 'Linear' for the innermost "
+                "shell filled with a cube because it changes in sphericity. "
+                "Add entries to 'RadialPartitioning' to add outer shells for "
+                "which you can select different radial distributions.");
+  }
+  // Validate outer radial partitions
+  set_shell_distribution(
+      make_not_null(&num_sh_shells_), make_not_null(&radial_distribution_[1]),
+      radial_partitioning_[1], radial_distribution[1], interface_radius_,
+      outer_radius_, "interface", "outer", context);
+
+  num_blocks_ =
+      6 * num_cube_shells_ + num_sh_shells_ + (fill_interior_ ? 1 : 0);
+
+  // Build block names and groups
+  static const std::array<std::string, 6> wedge_directions{
+      "UpperZ", "LowerZ", "UpperY", "LowerY", "UpperX", "LowerX"};
+
+  std::vector<std::string> cube_block_names;
+  std::unordered_map<std::string, std::unordered_set<std::string>>
+      cube_block_groups;
+  if (fill_interior_) {
+    block_names_.emplace_back("InnerCube");
+    cube_block_names.emplace_back("InnerCube");
+    block_groups_["InnerRegion"].insert("InnerCube");
+    cube_block_groups["InnerRegion"].insert("InnerCube");
+  }
+  for (size_t shell = 0; shell < num_cube_shells_; ++shell) {
+    const std::string shell_prefix = "InnerShell" + std::to_string(shell);
+    for (const auto& dir : wedge_directions) {
+      const std::string name = shell_prefix + dir;
+      block_names_.emplace_back(name);
+      cube_block_names.emplace_back(name);
+      block_groups_[shell_prefix].insert(name);
+      block_groups_["Wedges"].insert(name);
+      block_groups_["InnerRegion"].insert(name);
+      cube_block_groups[shell_prefix].insert(name);
+      cube_block_groups["Wedges"].insert(name);
+      cube_block_groups["InnerRegion"].insert(name);
+    }
   }
 
-  // correct for outer spherical shell
-  initial_number_of_grid_points_[6] = {{initial_number_of_radial_grid_points_,
-                                        initial_spherical_harmonic_l_ + 1,
-                                        2 * initial_spherical_harmonic_l_ + 1}};
-  initial_refinement_levels_[6] = {{initial_radial_refinement_, 0_st, 0_st}};
+  std::vector<std::string> sh_block_names;
+  std::unordered_map<std::string, std::unordered_set<std::string>>
+      sh_block_groups;
+  for (size_t sh = 0; sh < num_sh_shells_; ++sh) {
+    const std::string name = "OuterShell" + std::to_string(sh);
+    block_names_.emplace_back(name);
+    sh_block_names.emplace_back(name);
+    block_groups_["OuterShells"].insert(name);
+    sh_block_groups["OuterShells"].insert(name);
+  }
+
+  ASSERT(block_names_.size() == num_blocks_,
+         "Invalid number of block names. Should be "
+             << num_blocks_ << " but is " << block_names_.size() << ".");
+
+  // Expand initial refinement and grid points over cube blocks
+  const ExpandOverBlocks<std::array<size_t, 2>> expand_cube{cube_block_names,
+                                                            cube_block_groups};
+  try {
+    initial_cube_refinement_ = std::visit(expand_cube, initial_cube_refinement);
+  } catch (const std::exception& error) {
+    PARSE_ERROR(context, "Invalid 'InitialCubeRefinement': " << error.what());
+  }
+  try {
+    initial_cube_grid_points_ =
+        std::visit(expand_cube, initial_cube_grid_points);
+  } catch (const std::exception& error) {
+    PARSE_ERROR(context, "Invalid 'InitialCubeGridPoints': " << error.what());
+  }
+
+  if (fill_interior_) {
+    if (initial_cube_refinement_.front()[0] !=
+        initial_cube_refinement_.front()[1]) {
+      PARSE_ERROR(
+          context,
+          "The inner cube has different refinement for angular and radial "
+          "input. This block should only ever have the same values (it is not "
+          "worth getting the creator to only take one, hence an error). Got ["
+              << initial_cube_refinement_.front()[0] << ", "
+              << initial_cube_refinement_.front()[1] << "].");
+    }
+    if (initial_cube_grid_points_.front()[0] !=
+        initial_cube_grid_points_.front()[1]) {
+      PARSE_ERROR(
+          context,
+          "The inner cube has a different number of grid points for angular "
+          "and radial input. This block should only ever have the same values "
+          "(it is not worth getting the creator to only take one, hence an "
+          "error). Got ["
+              << initial_cube_grid_points_.front()[0] << ", "
+              << initial_cube_grid_points_.front()[1] << "].");
+    }
+  }
+
+  // Expand initial refinement and grid points over SH blocks
+  const ExpandOverBlocks<size_t> expand_sh_ref{sh_block_names, sh_block_groups};
+  try {
+    initial_sh_refinement_ = std::visit(expand_sh_ref, initial_sh_refinement);
+  } catch (const std::exception& error) {
+    PARSE_ERROR(context, "Invalid 'InitialSHRefinement': " << error.what());
+  }
+
+  const ExpandOverBlocks<std::array<size_t, 2>> expand_sh_gp{sh_block_names,
+                                                             sh_block_groups};
+  try {
+    initial_sh_grid_points_ = std::visit(expand_sh_gp, initial_sh_grid_points);
+  } catch (const std::exception& error) {
+    PARSE_ERROR(context, "Invalid 'InitialSHGridPoints': " << error.what());
+  }
+
+  if (time_dependent_options_.has_value()) {
+    use_hard_coded_maps_ =
+        std::holds_alternative<sphere::TimeDependentMapOptions>(
+            time_dependent_options_.value());
+    if (use_hard_coded_maps_) {
+      // Build combined radial partitioning for TimeDependentMapOptions:
+      // inner partitions + interface_radius + outer partitions
+      std::vector<double> combined_partitioning = radial_partitioning_[0];
+      combined_partitioning.push_back(interface_radius_);
+      for (const double r : radial_partitioning_[1]) {
+        combined_partitioning.push_back(r);
+      }
+      std::get<sphere::TimeDependentMapOptions>(time_dependent_options_.value())
+          .build_maps(std::array{0.0, 0.0, 0.0}, fill_interior_, inner_radius_,
+                      combined_partitioning, outer_radius_);
+    }
+  }
 }
 
 Domain<3> NonconformingSphericalShells::create_domain() const {
-  std::vector<Block<3>> blocks;
-  blocks.reserve(7);
-  const std::vector<std::array<size_t, 8>> corners_of_wedges =
-      corners_for_radially_layered_domains(1, false);
-  std::vector<DirectionMap<3, BlockNeighbors<3>>> neighbors_of_wedges{};
-  set_internal_boundaries<3>(make_not_null(&neighbors_of_wedges),
-                             corners_of_wedges);
+  const size_t num_cube_blocks =
+      6 * num_cube_shells_ + (fill_interior_ ? 1 : 0);
+
+  // Build inner block coordinate maps (wedges)
+  auto cube_coord_maps =
+      make_vector_coordinate_map_base<Frame::BlockLogical, Frame::Inertial, 3>(
+          sph_wedge_coordinate_maps(
+              inner_radius_, interface_radius_,
+              fill_interior_ ? std::get<InnerCube>(interior_).sphericity : 1.0,
+              1.0, use_equiangular_map_, std::nullopt, false,
+              radial_partitioning_[0], radial_distribution_[0]));
+
+  // Build inner cube coordinate map and insert it before the wedges
+  if (fill_interior_) {
+    const double sphericity = std::get<InnerCube>(interior_).sphericity;
+    std::unique_ptr<
+        domain::CoordinateMapBase<Frame::BlockLogical, Frame::Inertial, 3>>
+        cube_map;
+    if (sphericity == 0.0) {
+      if (use_equiangular_map_) {
+        cube_map =
+            make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
+                Equiangular3D{
+                    Equiangular(-1.0, 1.0, -1.0 * inner_radius_ / sqrt(3.0),
+                                inner_radius_ / sqrt(3.0)),
+                    Equiangular(-1.0, 1.0, -1.0 * inner_radius_ / sqrt(3.0),
+                                inner_radius_ / sqrt(3.0)),
+                    Equiangular(-1.0, 1.0, -1.0 * inner_radius_ / sqrt(3.0),
+                                inner_radius_ / sqrt(3.0))});
+      } else {
+        cube_map =
+            make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
+                Affine3D{Affine(-1.0, 1.0, -1.0 * inner_radius_ / sqrt(3.0),
+                                inner_radius_ / sqrt(3.0)),
+                         Affine(-1.0, 1.0, -1.0 * inner_radius_ / sqrt(3.0),
+                                inner_radius_ / sqrt(3.0)),
+                         Affine(-1.0, 1.0, -1.0 * inner_radius_ / sqrt(3.0),
+                                inner_radius_ / sqrt(3.0))});
+      }
+    } else {
+      cube_map = make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
+          BulgedCube{inner_radius_, sphericity, use_equiangular_map_});
+    }
+    cube_coord_maps.insert(cube_coord_maps.begin(), std::move(cube_map));
+  }
+
+  // Build neighbor maps for inner blocks using corner numbering.
+  // When the interior is filled, the cube block is placed first (index 0),
+  // so rotate the corners vector so the central block entry comes first.
+  auto corners =
+      corners_for_radially_layered_domains(num_cube_shells_, fill_interior_);
+  if (fill_interior_) {
+    std::rotate(corners.begin(), corners.end() - 1, corners.end());
+  }
+  std::vector<DirectionMap<3, BlockNeighbors<3>>> inner_neighbors{};
+  set_internal_boundaries<3>(make_not_null(&inner_neighbors), corners);
+
+  // Non-conforming interface: xi of the first SH shell maps to zeta of the
+  // wedges (no discrete rotation in the angular directions).
   const OrientationMap<3> shell_to_wedge{
       {{Direction<3>::upper_zeta(), Direction<3>::self(),
         Direction<3>::self()}}};
-  DirectionMap<3, BlockNeighbors<3>> neighbors_of_shell{};
-  neighbors_of_shell.emplace(std::pair{Direction<3>::lower_xi(),
-                                       BlockNeighbors<3>{{0, 1, 2, 3, 4, 5},
-                                                         {{0, shell_to_wedge},
-                                                          {1, shell_to_wedge},
-                                                          {2, shell_to_wedge},
-                                                          {3, shell_to_wedge},
-                                                          {4, shell_to_wedge},
-                                                          {5, shell_to_wedge}},
-                                                         false}});
-  for (size_t i = 0; i < 6; ++i) {
-    neighbors_of_wedges[i].emplace(std::pair{
+  // Wedge block indices are offset by 1 when the cube occupies block 0.
+  const size_t cube_block_offset = fill_interior_ ? 1 : 0;
+  for (size_t i = cube_block_offset + 6 * (num_cube_shells_ - 1);
+       i < cube_block_offset + 6 * num_cube_shells_; ++i) {
+    inner_neighbors[i].emplace(
         Direction<3>::upper_zeta(),
-        BlockNeighbors<3>{{6}, {{6, shell_to_wedge.inverse_map()}}, false}});
+        BlockNeighbors<3>{{num_cube_blocks},
+                          {{num_cube_blocks, shell_to_wedge.inverse_map()}},
+                          false});
   }
 
-  auto wedge_coord_maps =
-      make_vector_coordinate_map_base<Frame::BlockLogical, Frame::Inertial, 3>(
-          sph_wedge_coordinate_maps(inner_radius_, interface_radius_, 1.0, 1.0,
-                                    true));
-  auto sphere_map =
-      make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
-          CoordinateMaps::ProductOf2Maps<CoordinateMaps::Affine,
-                                         CoordinateMaps::Identity<2>>{
-              CoordinateMaps::Affine{-1.0, 1.0, interface_radius_,
-                                     outer_radius_},
-              CoordinateMaps::Identity<2>{}},
-          CoordinateMaps::SphericalToCartesianPfaffian{});
-  for (size_t i = 0; i < 6; ++i) {
-    blocks.emplace_back(
-        std::move(wedge_coord_maps[i]), i, std::move(neighbors_of_wedges[i]),
-        "Wedge" + std::to_string(i), domain::topologies::hypercube<3>);
+  // Excision sphere for non-filled interior
+  std::unordered_map<std::string, ExcisionSphere<3>> excision_spheres{};
+  if (not fill_interior_) {
+    excision_spheres.emplace(
+        "ExcisionSphere",
+        ExcisionSphere<3>{inner_radius_,
+                          tnsr::I<double, 3, Frame::Grid>{0.0},
+                          {{0, Direction<3>::lower_zeta()},
+                           {1, Direction<3>::lower_zeta()},
+                           {2, Direction<3>::lower_zeta()},
+                           {3, Direction<3>::lower_zeta()},
+                           {4, Direction<3>::lower_zeta()},
+                           {5, Direction<3>::lower_zeta()}}});
   }
-  blocks.emplace_back(std::move(sphere_map), 6_st,
-                      std::move(neighbors_of_shell), "Shell",
-                      domain::topologies::spherical_shell);
-  return Domain(std::move(blocks));
+
+  std::vector<Block<3>> blocks;
+  blocks.reserve(num_blocks_);
+
+  // Inner cube blocks (wedges + optional cube)
+  for (size_t i = 0; i < num_cube_blocks; ++i) {
+    blocks.emplace_back(std::move(cube_coord_maps[i]), i,
+                        std::move(inner_neighbors[i]), block_names_[i],
+                        domain::topologies::hypercube<3>);
+  }
+
+  // SH shell blocks
+  const auto aligned = OrientationMap<3>::create_aligned();
+  for (size_t sh_i = 0; sh_i < num_sh_shells_; ++sh_i) {
+    const size_t block_id = num_cube_blocks + sh_i;
+    const double sh_inner =
+        (sh_i == 0) ? interface_radius_ : radial_partitioning_[1][sh_i - 1];
+    const double sh_outer = (sh_i == num_sh_shells_ - 1)
+                                ? outer_radius_
+                                : radial_partitioning_[1][sh_i];
+    auto sh_map =
+        make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
+            CoordinateMaps::ProductOf2Maps<CoordinateMaps::Interval,
+                                           CoordinateMaps::Identity<2>>{
+                CoordinateMaps::Interval{-1.0, 1.0, sh_inner, sh_outer,
+                                         radial_distribution_[1][sh_i], 0.0},
+                CoordinateMaps::Identity<2>{}},
+            CoordinateMaps::SphericalToCartesianPfaffian{});
+
+    DirectionMap<3, BlockNeighbors<3>> sh_neighbors;
+    if (sh_i == 0) {
+      // Non-conforming connection: lower_xi of the first SH shell abuts the
+      // upper_zeta faces of the 6 outermost inner wedge blocks.
+      const size_t w = cube_block_offset + 6 * (num_cube_shells_ - 1);
+      sh_neighbors.emplace(
+          Direction<3>::lower_xi(),
+          BlockNeighbors<3>{{w + 0, w + 1, w + 2, w + 3, w + 4, w + 5},
+                            {{w + 0, shell_to_wedge},
+                             {w + 1, shell_to_wedge},
+                             {w + 2, shell_to_wedge},
+                             {w + 3, shell_to_wedge},
+                             {w + 4, shell_to_wedge},
+                             {w + 5, shell_to_wedge}},
+                            false});
+    } else {
+      sh_neighbors.emplace(Direction<3>::lower_xi(),
+                           BlockNeighbors<3>{block_id - 1, aligned});
+    }
+    if (sh_i < num_sh_shells_ - 1) {
+      sh_neighbors.emplace(Direction<3>::upper_xi(),
+                           BlockNeighbors<3>{block_id + 1, aligned});
+    }
+    blocks.emplace_back(std::move(sh_map), block_id, std::move(sh_neighbors),
+                        block_names_[block_id],
+                        domain::topologies::spherical_shell);
+  }
+
+  ASSERT(blocks.size() == num_blocks_, "Unexpected number of blocks. Expected "
+                                           << num_blocks_ << " but created "
+                                           << blocks.size() << ".");
+
+  Domain<3> domain(std::move(blocks), std::move(excision_spheres),
+                   block_groups_);
+
+  if (time_dependent_options_.has_value()) {
+    std::vector<std::unique_ptr<
+        domain::CoordinateMapBase<Frame::Grid, Frame::Inertial, 3>>>
+        block_maps_grid_to_inertial{num_blocks_};
+    std::vector<std::unique_ptr<
+        domain::CoordinateMapBase<Frame::Grid, Frame::Distorted, 3>>>
+        block_maps_grid_to_distorted{num_blocks_};
+    std::vector<std::unique_ptr<
+        domain::CoordinateMapBase<Frame::Distorted, Frame::Inertial, 3>>>
+        block_maps_distorted_to_inertial{num_blocks_};
+
+    if (use_hard_coded_maps_) {
+      const auto& hard_coded_options =
+          std::get<sphere::TimeDependentMapOptions>(
+              time_dependent_options_.value());
+
+      // Inner cube block (if present): block 0, shell = num_cube_shells_
+      if (fill_interior_) {
+        block_maps_grid_to_distorted[0] =
+            hard_coded_options.grid_to_distorted_map(num_cube_shells_, 0, true);
+        block_maps_distorted_to_inertial[0] =
+            hard_coded_options.distorted_to_inertial_map(num_cube_shells_,
+                                                         true);
+        block_maps_grid_to_inertial[0] =
+            hard_coded_options.grid_to_inertial_map(num_cube_shells_, 0, false,
+                                                    true);
+      }
+
+      // Wedge blocks: block_id = cube_block_offset + shell*6 + shape_map_index
+      for (size_t block_id = cube_block_offset;
+           block_id < cube_block_offset + 6 * num_cube_shells_; ++block_id) {
+        const size_t shell = (block_id - cube_block_offset) / 6;
+        const size_t shape_map_index = (block_id - cube_block_offset) % 6;
+        block_maps_grid_to_distorted[block_id] =
+            hard_coded_options.grid_to_distorted_map(shell, shape_map_index,
+                                                     false);
+        block_maps_distorted_to_inertial[block_id] =
+            hard_coded_options.distorted_to_inertial_map(shell, false);
+        block_maps_grid_to_inertial[block_id] =
+            hard_coded_options.grid_to_inertial_map(shell, shape_map_index,
+                                                    false, false);
+      }
+
+      // SH shell blocks: shell = num_cube_shells_ + sh_i
+      for (size_t sh_i = 0; sh_i < num_sh_shells_; ++sh_i) {
+        const size_t block_id = num_cube_blocks + sh_i;
+        const size_t shell = num_cube_shells_ + sh_i;
+        const bool is_outer_shell = (sh_i == num_sh_shells_ - 1);
+        block_maps_grid_to_distorted[block_id] =
+            hard_coded_options.grid_to_distorted_map(shell, 0, false);
+        block_maps_distorted_to_inertial[block_id] =
+            hard_coded_options.distorted_to_inertial_map(shell, false);
+        block_maps_grid_to_inertial[block_id] =
+            hard_coded_options.grid_to_inertial_map(shell, 0, is_outer_shell,
+                                                    false);
+      }
+
+      if (not fill_interior_) {
+        domain.inject_time_dependent_map_for_excision_sphere(
+            "ExcisionSphere",
+            hard_coded_options.grid_to_inertial_map(0, 0, false, true));
+      }
+    } else {
+      const auto& time_dependence = std::get<std::unique_ptr<
+          domain::creators::time_dependence::TimeDependence<3>>>(
+          time_dependent_options_.value());
+
+      block_maps_grid_to_inertial =
+          time_dependence->block_maps_grid_to_inertial(num_blocks_);
+      block_maps_grid_to_distorted =
+          time_dependence->block_maps_grid_to_distorted(num_blocks_);
+      block_maps_distorted_to_inertial =
+          time_dependence->block_maps_distorted_to_inertial(num_blocks_);
+    }
+
+    for (size_t block_id = 0; block_id < num_blocks_; ++block_id) {
+      domain.inject_time_dependent_map_for_block(
+          block_id, std::move(block_maps_grid_to_inertial[block_id]),
+          std::move(block_maps_grid_to_distorted[block_id]),
+          std::move(block_maps_distorted_to_inertial[block_id]));
+    }
+  }
+
+  return domain;
 }
 
 std::unordered_map<std::string, tnsr::I<double, 3, Frame::Grid>>
@@ -187,33 +521,80 @@ NonconformingSphericalShells::external_boundary_conditions() const {
   }
   std::vector<DirectionMap<
       3, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
-      boundary_conditions{7};
-  for (size_t i = 0; i < 6; ++i) {
-    boundary_conditions[i][Direction<3>::lower_zeta()] =
-        inner_boundary_condition_->get_clone();
-  }
-  boundary_conditions[6][Direction<3>::upper_xi()] =
-      outer_boundary_condition_->get_clone();
-  return boundary_conditions;
-}
+      boundary_conditions{num_blocks_};
 
-std::vector<std::string> NonconformingSphericalShells::block_names() const {
-  std::vector<std::string> names{};
-  names.reserve(7);
-  for (size_t i = 0; i < 6; ++i) {
-    names.emplace_back("Wedge" + std::to_string(i));
+  // Outer boundary: upper_xi of the last SH shell block
+  boundary_conditions[num_blocks_ - 1][Direction<3>::upper_xi()] =
+      outer_boundary_condition_->get_clone();
+
+  // Inner boundary: lower_zeta of the innermost wedge blocks (excision case)
+  if (not fill_interior_) {
+    const auto& inner_bc = std::get<Excision>(interior_).boundary_condition;
+    for (size_t i = 0; i < 6; ++i) {
+      boundary_conditions[i][Direction<3>::lower_zeta()] =
+          inner_bc->get_clone();
+    }
   }
-  names.emplace_back("Shell");
-  return names;
+
+  return boundary_conditions;
 }
 
 std::vector<std::array<size_t, 3>>
 NonconformingSphericalShells::initial_extents() const {
-  return initial_number_of_grid_points_;
+  std::vector<std::array<size_t, 3>> extents;
+  extents.reserve(num_blocks_);
+
+  // Cube blocks: use stored cube grid points directly
+  for (const auto& gp : initial_cube_grid_points_) {
+    extents.emplace_back(std::array{gp[0], gp[0], gp[1]});
+  }
+
+  // SH blocks: stored as [l_max, r], convert to {r, l_max+1, 2*l_max+1}
+  for (const auto& sh_gp : initial_sh_grid_points_) {
+    const size_t l_max = sh_gp[0];
+    const size_t n_r = sh_gp[1];
+    extents.push_back({n_r, l_max + 1, 2 * l_max + 1});
+  }
+
+  return extents;
 }
 
 std::vector<std::array<size_t, 3>>
 NonconformingSphericalShells::initial_refinement_levels() const {
-  return initial_refinement_levels_;
+  std::vector<std::array<size_t, 3>> refinement;
+  refinement.reserve(num_blocks_);
+
+  // Cube blocks: use stored cube refinement directly
+  for (const auto& ref : initial_cube_refinement_) {
+    refinement.emplace_back(std::array{ref[0], ref[0], ref[1]});
+  }
+
+  // SH blocks: radial refinement only (angular directions are not AMR-refined)
+  for (const size_t sh_ref : initial_sh_refinement_) {
+    refinement.push_back({sh_ref, 0_st, 0_st});
+  }
+
+  return refinement;
+}
+
+std::unordered_map<std::string,
+                   std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>
+NonconformingSphericalShells::functions_of_time(
+    const std::unordered_map<std::string, double>& initial_expiration_times)
+    const {
+  if (time_dependent_options_.has_value()) {
+    if (use_hard_coded_maps_) {
+      return std::get<sphere::TimeDependentMapOptions>(
+                 time_dependent_options_.value())
+          .create_functions_of_time(initial_expiration_times);
+    } else {
+      return std::get<std::unique_ptr<
+          domain::creators::time_dependence::TimeDependence<3>>>(
+                 time_dependent_options_.value())
+          ->functions_of_time(initial_expiration_times);
+    }
+  } else {
+    return {};
+  }
 }
 }  // namespace domain::creators

--- a/src/Domain/Creators/NonconformingSphericalShells.hpp
+++ b/src/Domain/Creators/NonconformingSphericalShells.hpp
@@ -6,13 +6,23 @@
 #include <array>
 #include <cstddef>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
+#include <variant>
 #include <vector>
 
 #include "Domain/BoundaryConditions/BoundaryCondition.hpp"
 #include "Domain/BoundaryConditions/GetBoundaryConditionsBase.hpp"
+#include "Domain/CoordinateMaps/BulgedCube.hpp"
+#include "Domain/CoordinateMaps/Equiangular.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.hpp"
 #include "Domain/Creators/DomainCreator.hpp"
+#include "Domain/Creators/Sphere.hpp"
+#include "Domain/Creators/TimeDependence/TimeDependence.hpp"
+#include "Domain/Creators/TimeDependentOptions/Sphere.hpp"
+#include "Options/Auto.hpp"
 #include "Options/Context.hpp"
 #include "Options/String.hpp"
 #include "Utilities/TMPL.hpp"
@@ -45,23 +55,39 @@ namespace domain::creators {
  * \brief A set of non-conforming concentric spherical shells
  *
  * \details The inner spherical shells are decomposed into six wedges
- * surrounding an excised interior region.  The outer spherical shells will use
- * a spherical harmonic basis which cannot be used with subcell.
+ * surrounding an optionally excised interior region.  The outer spherical
+ * shells will use a spherical harmonic basis which cannot be used with subcell.
  *
  * This domain creator offers one grid anchor "Center" at the origin.
  *
  */
 class NonconformingSphericalShells : public DomainCreator<3> {
+ private:
+  using Affine = CoordinateMaps::Affine;
+  using Affine3D = CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>;
+  using Equiangular = CoordinateMaps::Equiangular;
+  using Equiangular3D =
+      CoordinateMaps::ProductOf3Maps<Equiangular, Equiangular, Equiangular>;
+  using BulgedCube = CoordinateMaps::BulgedCube;
+
  public:
-  using maps_list =
-      tmpl::list<domain::CoordinateMap<
-                     Frame::BlockLogical, Frame::Inertial,
-                     domain::CoordinateMaps::ProductOf2Maps<
-                         domain::CoordinateMaps::Affine,
-                         domain::CoordinateMaps::Identity<2>>,
-                     domain::CoordinateMaps::SphericalToCartesianPfaffian>,
-                 domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial,
-                                       CoordinateMaps::Wedge<3>>>;
+  using maps_list = tmpl::list<
+      // Inner cube
+      domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial, BulgedCube>,
+      domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial, Affine3D>,
+      domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial,
+                            Equiangular3D>,
+      // Wedges
+      domain::CoordinateMap<Frame::BlockLogical, Frame::Inertial,
+                            CoordinateMaps::Wedge<3>>,
+      // Spherical shells
+      domain::CoordinateMap<
+          Frame::BlockLogical, Frame::Inertial,
+          domain::CoordinateMaps::ProductOf2Maps<
+              domain::CoordinateMaps::Interval,
+              domain::CoordinateMaps::Identity<2>>,
+          domain::CoordinateMaps::SphericalToCartesianPfaffian>,
+      typename sphere::TimeDependentMapOptions::maps_list>;
 
   struct InnerRadius {
     using type = double;
@@ -82,44 +108,96 @@ class NonconformingSphericalShells : public DomainCreator<3> {
         "Outer radius of the outer spherical shell."};
   };
 
-  struct InitialRadialRefinement {
-    using type = size_t;
+  using Excision = detail::Excision;
+  using InnerCube = detail::InnerCube;
+
+  struct Interior {
+    using type = std::variant<Excision, InnerCube>;
     static constexpr Options::String help = {
-        "Initial radial refinement level for both the inner wedges and the "
-        "outer spherical shells."};
+        "Specify 'ExciseWithBoundaryCondition' and a boundary condition to "
+        "excise the interior of the sphere, leaving a spherical shell "
+        "(or just 'Excise' if boundary conditions are disabled). "
+        "Or specify 'FillWithSphericity' to fill the interior."};
   };
 
-  struct InitialAngularRefinementOfWedges {
-    using type = size_t;
+  struct InitialCubeRefinement {
+    using type =
+        std::variant<std::array<size_t, 2>, std::vector<std::array<size_t, 2>>,
+                     std::unordered_map<std::string, std::array<size_t, 2>>>;
     static constexpr Options::String help = {
-        "Initial angular refinement levels of inner wedges."};
+        "Initial cube refinement level. Specify one of: a "
+        "list representing [angular, r], or such a list for every block "
+        "in the domain. The central cube always uses the angular value for all "
+        "directions."};
   };
 
-  struct InitialNumberOfRadialGridPoints {
-    using type = size_t;
+  struct InitialSHRefinement {
+    using type = std::variant<size_t, std::vector<size_t>,
+                              std::unordered_map<std::string, size_t>>;
     static constexpr Options::String help = {
-        "Initial number of radial grid points for both the inner wedges and "
-        "the outer spherical shells."};
+        "Initial spherical harmonic shell radial refinement level. Specify one "
+        "of: a single number, or such a number for every block in the domain."};
   };
 
-  struct InitialSphericalHarmonicL {
-    using type = size_t;
+  struct InitialCubeGridPoints {
+    using type =
+        std::variant<std::array<size_t, 2>, std::vector<std::array<size_t, 2>>,
+                     std::unordered_map<std::string, std::array<size_t, 2>>>;
     static constexpr Options::String help = {
-        "Initial spherical harmonic resolution specified as the highest "
-        "spherical harmonic represented on the grid."};
+        "Initial number of grid points for the cube region. Specify one of: a "
+        "list representing [angular, r], or such a list for every block "
+        "in the domain. The central cube always uses the angular value for all "
+        "directions."};
   };
 
-  struct InitialNumberOfAngularGridPointsOfWedges {
-    using type = size_t;
+  struct InitialSHGridPoints {
+    using type =
+        std::variant<std::array<size_t, 2>, std::vector<std::array<size_t, 2>>,
+                     std::unordered_map<std::string, std::array<size_t, 2>>>;
     static constexpr Options::String help = {
-        "Initial angular refinement levels of inner wedges."};
+        "Initial number of grid points for the spherical harmonic shells. "
+        "Specify one of: a list representing [l_max, r], or such a list for "
+        "every block in the domain."};
   };
 
-  template <typename BoundaryConditionsBase>
-  struct InnerBoundaryCondition {
-    static constexpr Options::String help =
-        "Options for the boundary conditions at the inner radius.";
-    using type = std::unique_ptr<BoundaryConditionsBase>;
+  struct RadialPartitioning {
+    using type = std::array<std::vector<double>, 2>;
+    static constexpr Options::String help = {
+        "Radial coordinates of the boundaries splitting the spherical shell "
+        "between InnerRadius and InterfaceRadius and then the InterfaceRadius "
+        "and OuterRadius. They must be given in ascending order."};
+  };
+
+  struct RadialDistribution {
+    using type =
+        std::array<std::vector<domain::CoordinateMaps::Distribution>, 2>;
+    static constexpr Options::String help = {
+        "Select the radial distribution of grid points in each spherical "
+        "shell. There must be N+1 radial distributions specified for N radial "
+        "partitions for both the wedges and spherical shells. If the interior "
+        "of the sphere is filled with a cube, the innermost shell must have a "
+        "'Linear' distribution because it changes in sphericity."};
+  };
+
+  struct UseEquiangularMap {
+    using type = bool;
+    static constexpr Options::String help = {
+        "Use equiangular instead of equidistant coordinates. Equiangular "
+        "coordinates give better gridpoint spacings in the angular "
+        "directions, while equidistant coordinates give better gridpoint "
+        "spacings in the inner cube."};
+  };
+
+  using TimeDepOptionType = std::variant<
+      sphere::TimeDependentMapOptions,
+      std::unique_ptr<domain::creators::time_dependence::TimeDependence<3>>>;
+
+  struct TimeDependentMaps {
+    using type = Options::Auto<TimeDepOptionType, Options::AutoLabel::None>;
+    static constexpr Options::String help = {
+        "The options for time dependent maps. This can either be a "
+        "TimeDependence or hard coded time dependent options. Specify `None` "
+        "for no time dependent maps."};
   };
 
   template <typename BoundaryConditionsBase>
@@ -130,10 +208,10 @@ class NonconformingSphericalShells : public DomainCreator<3> {
   };
 
   using basic_options =
-      tmpl::list<InnerRadius, InterfaceRadius, OuterRadius,
-                 InitialRadialRefinement, InitialAngularRefinementOfWedges,
-                 InitialNumberOfRadialGridPoints, InitialSphericalHarmonicL,
-                 InitialNumberOfAngularGridPointsOfWedges>;
+      tmpl::list<InnerRadius, InterfaceRadius, OuterRadius, Interior,
+                 InitialCubeRefinement, InitialSHRefinement,
+                 InitialCubeGridPoints, InitialSHGridPoints, RadialPartitioning,
+                 RadialDistribution, UseEquiangularMap, TimeDependentMaps>;
 
   template <typename Metavariables>
   using options = tmpl::conditional_t<
@@ -141,9 +219,6 @@ class NonconformingSphericalShells : public DomainCreator<3> {
           typename Metavariables::system>,
       tmpl::push_back<
           basic_options,
-          InnerBoundaryCondition<
-              domain::BoundaryConditions::get_boundary_conditions_base<
-                  typename Metavariables::system>>,
           OuterBoundaryCondition<
               domain::BoundaryConditions::get_boundary_conditions_base<
                   typename Metavariables::system>>>,
@@ -154,13 +229,20 @@ class NonconformingSphericalShells : public DomainCreator<3> {
 
   NonconformingSphericalShells(
       double inner_radius, double interface_radius, double outer_radius,
-      size_t initial_radial_refinement,
-      size_t initial_angular_refinement,
-      size_t initial_number_of_radial_grid_points,
-      size_t initial_spherical_harmonic_l,
-      size_t initial_number_of_angular_grid_points_of_wedges,
-      std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
-          inner_boundary_condition = nullptr,
+      std::variant<Excision, InnerCube> interior,
+      const typename InitialCubeRefinement::type& initial_cube_refinement,
+      const typename InitialSHRefinement::type& initial_sh_refinement,
+      const typename InitialCubeGridPoints::type& initial_cube_grid_points,
+      const typename InitialSHGridPoints::type& initial_sh_grid_points,
+      std::array<std::vector<double>, 2> radial_partitioning = {},
+      std::array<std::vector<domain::CoordinateMaps::Distribution>, 2>
+          radial_distribution =
+              {std::vector<domain::CoordinateMaps::Distribution>{
+                   domain::CoordinateMaps::Distribution::Linear},
+               std::vector<domain::CoordinateMaps::Distribution>{
+                   domain::CoordinateMaps::Distribution::Linear}},
+      bool use_equiangular_map = true,
+      std::optional<TimeDepOptionType> time_dependent_options = std::nullopt,
       std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
           outer_boundary_condition = nullptr,
       const Options::Context& context = {});
@@ -183,26 +265,47 @@ class NonconformingSphericalShells : public DomainCreator<3> {
       3, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
   external_boundary_conditions() const override;
 
-  std::vector<std::string> block_names() const override;
+  std::vector<std::string> block_names() const override { return block_names_; }
+
+  std::unordered_map<std::string, std::unordered_set<std::string>>
+  block_groups() const override {
+    return block_groups_;
+  }
 
   std::vector<std::array<size_t, 3>> initial_extents() const override;
 
   std::vector<std::array<size_t, 3>> initial_refinement_levels() const override;
+
+  auto functions_of_time(const std::unordered_map<std::string, double>&
+                             initial_expiration_times = {}) const
+      -> std::unordered_map<
+          std::string,
+          std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>> override;
+
  private:
   double inner_radius_{};
   double interface_radius_{};
   double outer_radius_{};
-  size_t initial_radial_refinement_{};
-  size_t initial_angular_refinement_{};
-  size_t initial_number_of_radial_grid_points_{};
-  size_t initial_spherical_harmonic_l_{};
-  size_t initial_number_of_angular_grid_points_of_wedges_{};
-  std::vector<std::array<size_t, 3>> initial_refinement_levels_{};
-  std::vector<std::array<size_t, 3>> initial_number_of_grid_points_{};
-  std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
-      inner_boundary_condition_{};
+  std::variant<Excision, InnerCube> interior_{};
+  bool fill_interior_ = false;
+  std::vector<std::array<size_t, 2>> initial_cube_refinement_{};
+  std::vector<size_t> initial_sh_refinement_{};
+  std::vector<std::array<size_t, 2>> initial_cube_grid_points_{};
+  std::vector<std::array<size_t, 2>> initial_sh_grid_points_{};
+  std::array<std::vector<double>, 2> radial_partitioning_;
+  std::array<std::vector<domain::CoordinateMaps::Distribution>, 2>
+      radial_distribution_;
+  bool use_equiangular_map_ = false;
+  std::optional<TimeDepOptionType> time_dependent_options_{};
+  bool use_hard_coded_maps_{false};
   std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
       outer_boundary_condition_{};
+  std::vector<std::string> block_names_;
+  std::unordered_map<std::string, std::unordered_set<std::string>>
+      block_groups_;
+  size_t num_blocks_{};
+  size_t num_cube_shells_{};
+  size_t num_sh_shells_{};
   std::unordered_map<std::string, tnsr::I<double, 3, Frame::Grid>>
       grid_anchors_{};
 };

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStarSphericalShells.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStarSphericalShells.yaml
@@ -63,14 +63,20 @@ DomainCreator:
     InnerRadius: 5.0
     InterfaceRadius: 12.0
     OuterRadius: 18.0
-    InitialRadialRefinement: 1
-    InitialAngularRefinementOfWedges: 1
-    InitialNumberOfRadialGridPoints: 6
-    InitialSphericalHarmonicL: 10
-    InitialNumberOfAngularGridPointsOfWedges: 6
-    InnerBoundaryCondition:
-      DirichletAnalytic:
-        AnalyticPrescription: *InitialData
+    Interior:
+      FillWithSphericity: 0.
+    InitialCubeRefinement: [1, 1]
+    InitialSHRefinement: 0
+    InitialCubeGridPoints: [6, 6]
+    InitialSHGridPoints: [10, 5]
+    RadialPartitioning:
+      - []
+      - []
+    RadialDistribution:
+      - [Linear]
+      - [Linear]
+    UseEquiangularMap: False
+    TimeDependentMaps: None
     OuterBoundaryCondition:
       DirichletAnalytic:
         AnalyticPrescription: *InitialData

--- a/tests/InputFiles/ScalarWave/NonconformingSphericalWave.yaml
+++ b/tests/InputFiles/ScalarWave/NonconformingSphericalWave.yaml
@@ -55,14 +55,20 @@ DomainCreator:
     InnerRadius: 1.9
     InterfaceRadius: 2.4
     OuterRadius: 2.9
-    InitialRadialRefinement: 0
-    InitialAngularRefinementOfWedges: 1
-    InitialNumberOfRadialGridPoints: 5
-    InitialSphericalHarmonicL: 4
-    InitialNumberOfAngularGridPointsOfWedges: 5
-    InnerBoundaryCondition:
-      DirichletAnalytic:
-        AnalyticPrescription: *InitialData
+    Interior:
+      FillWithSphericity: 0.
+    InitialCubeRefinement: [0, 0]
+    InitialSHRefinement: 0
+    InitialCubeGridPoints: [4, 4]
+    InitialSHGridPoints: [6, 5]
+    RadialPartitioning:
+      - []
+      - []
+    RadialDistribution:
+      - [Linear]
+      - [Linear]
+    UseEquiangularMap: False
+    TimeDependentMaps: None
     OuterBoundaryCondition:
       DirichletAnalytic:
         AnalyticPrescription: *InitialData
@@ -72,10 +78,24 @@ SpatialDiscretization:
     UpwindPenalty:
   DiscontinuousGalerkin:
     Filtering:
-      # Scalar Wave doesn't yet have Ylm filtering implemented.
-      # That will be needed for stable evolutions.
-      - None:
+      - Hypercube:
+          HalfPower: 128
+          Enable: True
           BlocksToFilter: All
+          VolumeFilterOnSubstep: true
+          BoundaryCorrectionFilterOnSubstep: false
+          VolumeFilterEveryNSteps: None
+          BoundaryCorrectionFilterEveryNSteps: None
+      - SphericalShell:
+          NumModesToKill: 1
+          AngularHalfPower: 128
+          RadialHalfPower: 128
+          BlocksToFilter: All
+          Enable: true
+          VolumeFilterOnSubstep: true
+          BoundaryCorrectionFilterOnSubstep: false
+          VolumeFilterEveryNSteps: None
+          BoundaryCorrectionFilterEveryNSteps: None
     Formulation: StrongInertial
     Quadrature: GaussLobatto
 

--- a/tests/Unit/Domain/Creators/Test_NonconformingSphericalShells.cpp
+++ b/tests/Unit/Domain/Creators/Test_NonconformingSphericalShells.cpp
@@ -7,13 +7,13 @@
 #include <cstddef>
 #include <memory>
 #include <string>
+#include <variant>
 #include <vector>
 
-#include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "Domain/BlockLogicalCoordinates.hpp"
 #include "Domain/BoundaryConditions/BoundaryCondition.hpp"
+#include "Domain/CoordinateMaps/Distribution.hpp"
 #include "Domain/Creators/NonconformingSphericalShells.hpp"
 #include "Domain/Domain.hpp"
 #include "Domain/ElementMap.hpp"
@@ -26,25 +26,40 @@
 #include "Utilities/Gsl.hpp"
 
 namespace {
+
+using Excision = domain::creators::NonconformingSphericalShells::Excision;
+using InnerCube = domain::creators::NonconformingSphericalShells::InnerCube;
+using Distribution = domain::CoordinateMaps::Distribution;
+
 std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
-create_boundary_condition(const bool outer) {
+create_inner_boundary_condition() {
   return std::make_unique<
       TestHelpers::domain::BoundaryConditions::TestBoundaryCondition<3>>(
-      outer ? Direction<3>::upper_xi() : Direction<3>::lower_zeta(), 50);
+      Direction<3>::lower_zeta(), 50);
 }
 
-std::string option_string(
-    const double inner_radius, const double interface_radius,
-    const double outer_radius, const size_t radial_refinement,
-    const size_t angular_refinement, const size_t radial_extents,
-    const size_t spherical_harmonic_l, const size_t angular_extents,
-    const bool with_boundary_conditions) {
-  const std::string inner_bc_option = with_boundary_conditions
-                                          ? "  InnerBoundaryCondition:\n"
-                                            "    TestBoundaryCondition:\n"
-                                            "      Direction: lower-xi\n"
-                                            "      BlockId: 50\n"
-                                          : "";
+std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>
+create_outer_boundary_condition() {
+  return std::make_unique<
+      TestHelpers::domain::BoundaryConditions::TestBoundaryCondition<3>>(
+      Direction<3>::upper_xi(), 50);
+}
+
+std::string option_string(const double inner_radius,
+                          const double interface_radius,
+                          const double outer_radius,
+                          const std::array<size_t, 2>& cube_refinement,
+                          const size_t sh_refinement,
+                          const std::array<size_t, 2>& cube_grid_points,
+                          const std::array<size_t, 2>& sh_grid_points,
+                          const bool with_boundary_conditions) {
+  const std::string interior_option = with_boundary_conditions
+                                          ? "  Interior:\n"
+                                            "    ExciseWithBoundaryCondition:\n"
+                                            "      TestBoundaryCondition:\n"
+                                            "        Direction: lower-zeta\n"
+                                            "        BlockId: 50\n"
+                                          : "  Interior: Excise\n";
   const std::string outer_bc_option = with_boundary_conditions
                                           ? "  OuterBoundaryCondition:\n"
                                             "    TestBoundaryCondition:\n"
@@ -59,20 +74,25 @@ std::string option_string(
          std::to_string(interface_radius) +
          "\n"
          "  OuterRadius: " +
-         std::to_string(outer_radius) + "\n" +
-         "  InitialRadialRefinement: " + std::to_string(radial_refinement) +
+         std::to_string(outer_radius) + "\n" + interior_option +
+         "  InitialCubeRefinement: [" + std::to_string(cube_refinement[0]) +
+         ", " + std::to_string(cube_refinement[1]) +
+         "]\n"
+         "  InitialSHRefinement: " +
+         std::to_string(sh_refinement) +
          "\n"
-         "  InitialAngularRefinementOfWedges: " +
-         std::to_string(angular_refinement) +
-         "\n"
-         "  InitialNumberOfRadialGridPoints: " +
-         std::to_string(radial_extents) +
-         "\n"
-         "  InitialSphericalHarmonicL: " +
-         std::to_string(spherical_harmonic_l) +
-         "\n"
-         "  InitialNumberOfAngularGridPointsOfWedges: " +
-         std::to_string(angular_extents) + "\n" + inner_bc_option +
+         "  InitialCubeGridPoints: [" +
+         std::to_string(cube_grid_points[0]) + ", " +
+         std::to_string(cube_grid_points[1]) +
+         "]\n"
+         "  InitialSHGridPoints: [" +
+         std::to_string(sh_grid_points[0]) + ", " +
+         std::to_string(sh_grid_points[1]) +
+         "]\n"
+         "  RadialPartitioning: [[], []]\n"
+         "  RadialDistribution: [[Linear], [Linear]]\n"
+         "  UseEquiangularMap: false\n"
+         "  TimeDependentMaps: None\n" +
          outer_bc_option;
 }
 
@@ -81,88 +101,131 @@ void test_parse_errors() {
   const double inner_radius = 1.9;
   const double interface_radius = 2.4;
   const double outer_radius = 2.9;
-  const size_t radial_refinement = 0;
-  const size_t angular_refinement = 1;
-  const size_t radial_extents = 12;
-  const size_t l = 9;
-  const size_t angular_extents = 11;
+  const std::array<size_t, 2> cube_ref{1_st, 0_st};
+  const size_t sh_ref = 0;
+  const std::array<size_t, 2> cube_gp{3_st, 4_st};
+  const std::array<size_t, 2> sh_gp{2_st, 3_st};
+  const std::array<std::vector<double>, 2> radial_partitioning{};
+  const std::array<std::vector<Distribution>, 2> radial_distribution{
+      std::vector<Distribution>{Distribution::Linear},
+      std::vector<Distribution>{Distribution::Linear}};
 
   CHECK_THROWS_WITH(
       domain::creators::NonconformingSphericalShells(
-          inner_radius, 0.5 * inner_radius, outer_radius, radial_refinement,
-          angular_refinement, radial_extents, l, angular_extents, nullptr,
-          nullptr, Options::Context{false, {}, 1, 1}),
+          inner_radius, 0.5 * inner_radius, outer_radius,
+          Excision{create_inner_boundary_condition()}, cube_ref, sh_ref,
+          cube_gp, sh_gp, radial_partitioning, radial_distribution, false,
+          std::nullopt, create_outer_boundary_condition(),
+          Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "Inner radius must be smaller than interface radius"));
 
   CHECK_THROWS_WITH(
       domain::creators::NonconformingSphericalShells(
-          inner_radius, 1.5 * outer_radius, outer_radius, radial_refinement,
-          angular_refinement, radial_extents, l, angular_extents, nullptr,
-          nullptr, Options::Context{false, {}, 1, 1}),
+          inner_radius, 1.5 * outer_radius, outer_radius,
+          Excision{create_inner_boundary_condition()}, cube_ref, sh_ref,
+          cube_gp, sh_gp, radial_partitioning, radial_distribution, false,
+          std::nullopt, create_outer_boundary_condition(),
+          Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "Interface radius must be smaller than outer radius"));
 
+  // Inner BC only, no outer BC
   CHECK_THROWS_WITH(
       domain::creators::NonconformingSphericalShells(
-          inner_radius, interface_radius, outer_radius, radial_refinement,
-          angular_refinement, radial_extents, l, angular_extents,
-          create_boundary_condition(false), nullptr,
-          Options::Context{false, {}, 1, 1}),
+          inner_radius, interface_radius, outer_radius,
+          Excision{create_inner_boundary_condition()}, cube_ref, sh_ref,
+          cube_gp, sh_gp, radial_partitioning, radial_distribution, false,
+          std::nullopt, nullptr, Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "Must specify either both inner and outer boundary conditions "
           "or neither."));
+
+  // Periodic inner BC
   CHECK_THROWS_WITH(
       domain::creators::NonconformingSphericalShells(
-          inner_radius, interface_radius, outer_radius, radial_refinement,
-          angular_refinement, radial_extents, l, angular_extents,
-          create_boundary_condition(false),
+          inner_radius, interface_radius, outer_radius,
+          Excision{std::make_unique<TestHelpers::domain::BoundaryConditions::
+                                        TestPeriodicBoundaryCondition<3>>()},
+          cube_ref, sh_ref, cube_gp, sh_gp, radial_partitioning,
+          radial_distribution, false, std::nullopt,
+          create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
+      Catch::Matchers::ContainsSubstring(
+          "Cannot have periodic boundary conditions with "
+          "NonconformingSphericalShells"));
+
+  // Periodic outer BC
+  CHECK_THROWS_WITH(
+      domain::creators::NonconformingSphericalShells(
+          inner_radius, interface_radius, outer_radius,
+          Excision{create_inner_boundary_condition()}, cube_ref, sh_ref,
+          cube_gp, sh_gp, radial_partitioning, radial_distribution, false,
+          std::nullopt,
           std::make_unique<TestHelpers::domain::BoundaryConditions::
                                TestPeriodicBoundaryCondition<3>>(),
           Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
           "Cannot have periodic boundary conditions with "
           "NonconformingSphericalShells"));
+
+  // None outer BC
   CHECK_THROWS_WITH(
       domain::creators::NonconformingSphericalShells(
-          inner_radius, interface_radius, outer_radius, radial_refinement,
-          angular_refinement, radial_extents, l, angular_extents,
-          std::make_unique<TestHelpers::domain::BoundaryConditions::
-                               TestPeriodicBoundaryCondition<3>>(),
-          create_boundary_condition(true), Options::Context{false, {}, 1, 1}),
-      Catch::Matchers::ContainsSubstring(
-          "Cannot have periodic boundary conditions with "
-          "NonconformingSphericalShells"));
-  CHECK_THROWS_WITH(
-      domain::creators::NonconformingSphericalShells(
-          inner_radius, interface_radius, outer_radius, radial_refinement,
-          angular_refinement, radial_extents, l, angular_extents,
-          create_boundary_condition(false),
+          inner_radius, interface_radius, outer_radius,
+          Excision{create_inner_boundary_condition()}, cube_ref, sh_ref,
+          cube_gp, sh_gp, radial_partitioning, radial_distribution, false,
+          std::nullopt,
           std::make_unique<TestHelpers::domain::BoundaryConditions::
                                TestNoneBoundaryCondition<3>>(),
           Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
-          "None boundary condition is not supported. If you would like "
-          "an outflow-type boundary condition, you must use that."));
+          "None boundary condition is not supported for the outer boundary"));
+
+  // None inner BC (excision)
   CHECK_THROWS_WITH(
       domain::creators::NonconformingSphericalShells(
-          inner_radius, interface_radius, outer_radius, radial_refinement,
-          angular_refinement, radial_extents, l, angular_extents,
-          std::make_unique<TestHelpers::domain::BoundaryConditions::
-                               TestNoneBoundaryCondition<3>>(),
-          create_boundary_condition(true), Options::Context{false, {}, 1, 1}),
+          inner_radius, interface_radius, outer_radius,
+          Excision{std::make_unique<TestHelpers::domain::BoundaryConditions::
+                                        TestNoneBoundaryCondition<3>>()},
+          cube_ref, sh_ref, cube_gp, sh_gp, radial_partitioning,
+          radial_distribution, false, std::nullopt,
+          create_outer_boundary_condition(), Options::Context{false, {}, 1, 1}),
       Catch::Matchers::ContainsSubstring(
-          "None boundary condition is not supported. If you would like "
-          "an outflow-type boundary condition, you must use that."));
+          "None boundary condition for the inner boundary is not supported "
+          "when the center is excised"));
+
+  // InnerCube with mismatched angular/radial refinement
+  CHECK_THROWS_WITH(
+      domain::creators::NonconformingSphericalShells(
+          inner_radius, interface_radius, outer_radius, InnerCube{0.0},
+          std::array<size_t, 2>{1_st, 2_st}, sh_ref, cube_gp, sh_gp,
+          radial_partitioning, radial_distribution, false, std::nullopt,
+          nullptr, Options::Context{false, {}, 1, 1}),
+      Catch::Matchers::ContainsSubstring(
+          "The inner cube has different refinement for angular and radial "
+          "input."));
+
+  // InnerCube with mismatched angular/radial grid points
+  CHECK_THROWS_WITH(
+      domain::creators::NonconformingSphericalShells(
+          inner_radius, interface_radius, outer_radius, InnerCube{0.0},
+          std::array<size_t, 2>{1_st, 1_st}, sh_ref,
+          std::array<size_t, 2>{3_st, 4_st}, sh_gp, radial_partitioning,
+          radial_distribution, false, std::nullopt, nullptr,
+          Options::Context{false, {}, 1, 1}),
+      Catch::Matchers::ContainsSubstring(
+          "The inner cube has a different number of grid points for angular "
+          "and radial input."));
 }
 
+// Test the excision case: 6 wedge blocks + 1 SH shell block.
+// Verifies radii at block faces, external boundaries, and boundary conditions.
 template <typename Generator>
-void test_nonconforming_spherical_shells_construction(
+void test_excision_construction(
     const gsl::not_null<Generator*> gen,
     const domain::creators::NonconformingSphericalShells& creator,
     const double inner_radius, const double interface_radius,
-    const double outer_radius, const bool expect_boundary_conditions = true) {
-  // check consistency of domain
+    const double outer_radius, const bool expect_boundary_conditions) {
   const auto domain = TestHelpers::domain::creators::test_domain_creator(
       creator, expect_boundary_conditions);
   const auto& grid_anchors = creator.grid_anchors();
@@ -172,13 +235,34 @@ void test_nonconforming_spherical_shells_construction(
         tnsr::I<double, 3, Frame::Grid>{std::array{0.0, 0.0, 0.0}});
 
   const auto& blocks = domain.blocks();
-  const auto block_names = creator.block_names();
   const size_t num_blocks = blocks.size();
   CAPTURE(num_blocks);
-  const auto all_boundary_conditions = creator.external_boundary_conditions();
-  const auto functions_of_time = creator.functions_of_time();
+  // 6 wedge blocks + 1 SH shell
+  CHECK(num_blocks == 7);
 
-  // Check total number of external boundaries
+  // Check block groups: "Wedges" and "InnerRegion" both contain the 6 wedge
+  // blocks (no inner cube in excision case), "InnerShells" is gone.
+  {
+    const auto& groups = creator.block_groups();
+    const std::unordered_set<std::string> wedge_names{
+        "InnerShell0UpperZ", "InnerShell0LowerZ", "InnerShell0UpperY",
+        "InnerShell0LowerY", "InnerShell0UpperX", "InnerShell0LowerX"};
+    REQUIRE(groups.count("Wedges") == 1);
+    CHECK(groups.at("Wedges") == wedge_names);
+    REQUIRE(groups.count("InnerRegion") == 1);
+    CHECK(groups.at("InnerRegion") == wedge_names);
+    REQUIRE(groups.count("InnerShell0") == 1);
+    CHECK(groups.at("InnerShell0") == wedge_names);
+    REQUIRE(groups.count("OuterShells") == 1);
+    CHECK(groups.at("OuterShells") ==
+          std::unordered_set<std::string>{"OuterShell0"});
+    CHECK(not groups.contains("InnerShells"));
+    CHECK(not groups.contains("InnerCube"));
+  }
+
+  const auto all_boundary_conditions = creator.external_boundary_conditions();
+
+  // 6 inner (excision) + 1 outer
   const size_t num_external_boundaries =
       alg::accumulate(blocks, 0_st, [](const size_t count, const auto& block) {
         return count + block.external_boundaries().size();
@@ -187,35 +271,35 @@ void test_nonconforming_spherical_shells_construction(
 
   // NOLINTNEXTLINE(misc-const-correctness)
   std::uniform_real_distribution<> xi_distribution(-1.0, 1.0);
-  for (size_t block_id = 0; block_id < num_blocks - 1; ++block_id) {
+
+  // Check wedge blocks (0–5)
+  for (size_t block_id = 0; block_id < 6; ++block_id) {
     CAPTURE(block_id);
     const auto& block = blocks[block_id];
-    const ElementMap<3, Frame::Grid> grid_element_map{ElementId<3>{block_id},
-                                                      block};
     const ElementMap<3, Frame::Inertial> inertial_element_map{
         ElementId<3>{block_id}, block};
     {
-      INFO("Radius of random point on lower face of cubed shells");
+      INFO("Radius of random point on lower face of wedge block");
       const tnsr::I<double, 3, Frame::ElementLogical> x_logical{
           {{xi_distribution(*gen), xi_distribution(*gen), -1.0}}};
-      auto x_inertial = inertial_element_map(x_logical);
+      const auto x_inertial = inertial_element_map(x_logical);
       CHECK(get(magnitude(x_inertial)) == approx(inner_radius));
     }
     {
-      INFO("Radius of random point on upper face of cubed shells");
+      INFO("Radius of random point on upper face of wedge block");
       const tnsr::I<double, 3, Frame::ElementLogical> x_logical{
           {{xi_distribution(*gen), xi_distribution(*gen), 1.0}}};
-      auto x_inertial = inertial_element_map(x_logical);
+      const auto x_inertial = inertial_element_map(x_logical);
       CHECK(get(magnitude(x_inertial)) == approx(interface_radius));
     }
     {
-      INFO("External boundaries of cubed shells");
+      INFO("External boundaries of wedge block");
       const auto& external_boundaries = block.external_boundaries();
       CHECK(external_boundaries.size() == 1);
       CHECK(alg::found(external_boundaries, Direction<3>::lower_zeta()));
     }
     if (expect_boundary_conditions) {
-      INFO("Boundary conditions of cubed shells");
+      INFO("Boundary conditions of wedge block");
       const auto& boundary_conditions = all_boundary_conditions[block_id];
       for (const auto& direction : block.external_boundaries()) {
         CAPTURE(direction);
@@ -227,44 +311,120 @@ void test_nonconforming_spherical_shells_construction(
       }
     }
   }
+
+  // Check SH shell block (block 6)
   // NOLINTNEXTLINE(misc-const-correctness)
   std::uniform_real_distribution<> theta_distribution(0.0, M_PI);
   // NOLINTNEXTLINE(misc-const-correctness)
   std::uniform_real_distribution<> phi_distribution(0.0, 2.0 * M_PI);
-  const auto& block = blocks[6];
-  const ElementMap<3, Frame::Grid> grid_element_map{ElementId<3>{6}, block};
-  const ElementMap<3, Frame::Inertial> inertial_element_map{ElementId<3>{6},
-                                                            block};
   {
-    INFO("Radius of random point on lower face of spherical shell");
-    const tnsr::I<double, 3, Frame::ElementLogical> x_logical{
-        {{-1.0, theta_distribution(*gen), phi_distribution(*gen)}}};
-    auto x_inertial = inertial_element_map(x_logical);
-    CHECK(get(magnitude(x_inertial)) == approx(interface_radius));
+    const auto& block = blocks[6];
+    const ElementMap<3, Frame::Inertial> inertial_element_map{ElementId<3>{6},
+                                                              block};
+    {
+      INFO("Radius of random point on inner face of SH shell");
+      const tnsr::I<double, 3, Frame::ElementLogical> x_logical{
+          {{-1.0, theta_distribution(*gen), phi_distribution(*gen)}}};
+      const auto x_inertial = inertial_element_map(x_logical);
+      CHECK(get(magnitude(x_inertial)) == approx(interface_radius));
+    }
+    {
+      INFO("Radius of random point on outer face of SH shell");
+      const tnsr::I<double, 3, Frame::ElementLogical> x_logical{
+          {{1.0, theta_distribution(*gen), phi_distribution(*gen)}}};
+      const auto x_inertial = inertial_element_map(x_logical);
+      CHECK(get(magnitude(x_inertial)) == approx(outer_radius));
+    }
+    {
+      INFO("External boundaries of SH shell");
+      const auto& external_boundaries = block.external_boundaries();
+      CHECK(external_boundaries.size() == 1);
+      CHECK(alg::found(external_boundaries, Direction<3>::upper_xi()));
+    }
+    if (expect_boundary_conditions) {
+      INFO("Boundary conditions of SH shell");
+      const auto& boundary_conditions = all_boundary_conditions[6];
+      for (const auto& direction : block.external_boundaries()) {
+        CAPTURE(direction);
+        const auto& boundary_condition =
+            dynamic_cast<const TestHelpers::domain::BoundaryConditions::
+                             TestBoundaryCondition<3>&>(
+                *boundary_conditions.at(direction));
+        CHECK(boundary_condition.direction() == direction);
+      }
+    }
   }
+}
+
+// Test the filled-interior case: 6 wedge blocks + 1 inner cube + 1 SH shell.
+template <typename Generator>
+void test_fill_construction(
+    const gsl::not_null<Generator*> gen,
+    const domain::creators::NonconformingSphericalShells& creator,
+    const double interface_radius, const double outer_radius) {
+  const auto domain =
+      TestHelpers::domain::creators::test_domain_creator(creator, false);
+  const auto& blocks = domain.blocks();
+  const size_t num_blocks = blocks.size();
+  CAPTURE(num_blocks);
+  // 6 wedge blocks + 1 inner cube + 1 SH shell
+  CHECK(num_blocks == 8);
+
+  // No excision sphere → only 1 outer external boundary
+  const size_t num_external_boundaries =
+      alg::accumulate(blocks, 0_st, [](const size_t count, const auto& block) {
+        return count + block.external_boundaries().size();
+      });
+  CHECK(num_external_boundaries == 1);
+
+  // Check block groups: "InnerRegion" includes wedges + inner cube block;
+  // "Wedges" contains only the wedge blocks; "InnerShells" is gone.
   {
-    INFO("Radius of random point on upper face of spherical shell");
-    const tnsr::I<double, 3, Frame::ElementLogical> x_logical{
-        {{1.0, theta_distribution(*gen), phi_distribution(*gen)}}};
-    auto x_inertial = inertial_element_map(x_logical);
-    CHECK(get(magnitude(x_inertial)) == approx(outer_radius));
+    const auto& groups = creator.block_groups();
+    const std::unordered_set<std::string> wedge_names{
+        "InnerShell0UpperZ", "InnerShell0LowerZ", "InnerShell0UpperY",
+        "InnerShell0LowerY", "InnerShell0UpperX", "InnerShell0LowerX"};
+    std::unordered_set<std::string> inner_region_names = wedge_names;
+    inner_region_names.insert("InnerCube");
+    REQUIRE(groups.count("Wedges") == 1);
+    CHECK(groups.at("Wedges") == wedge_names);
+    REQUIRE(groups.count("InnerRegion") == 1);
+    CHECK(groups.at("InnerRegion") == inner_region_names);
+    REQUIRE(groups.count("OuterShells") == 1);
+    CHECK(groups.at("OuterShells") ==
+          std::unordered_set<std::string>{"OuterShell0"});
+    CHECK(not groups.contains("InnerShells"));
+    CHECK(not groups.contains("InnerCube"));
   }
+
+  // Check SH shell block (block 7 in the fill case)
+  // NOLINTNEXTLINE(misc-const-correctness)
+  std::uniform_real_distribution<> theta_distribution(0.0, M_PI);
+  // NOLINTNEXTLINE(misc-const-correctness)
+  std::uniform_real_distribution<> phi_distribution(0.0, 2.0 * M_PI);
   {
-    INFO("External boundaries of spherical shell");
-    const auto& external_boundaries = block.external_boundaries();
-    CHECK(external_boundaries.size() == 1);
-    CHECK(alg::found(external_boundaries, Direction<3>::upper_xi()));
-  }
-  if (expect_boundary_conditions) {
-    INFO("Boundary conditions of spherical shell");
-    const auto& boundary_conditions = all_boundary_conditions[6];
-    for (const auto& direction : block.external_boundaries()) {
-      CAPTURE(direction);
-      const auto& boundary_condition =
-          dynamic_cast<const TestHelpers::domain::BoundaryConditions::
-                           TestBoundaryCondition<3>&>(
-              *boundary_conditions.at(direction));
-      CHECK(boundary_condition.direction() == direction);
+    const auto& block = blocks[7];
+    const ElementMap<3, Frame::Inertial> inertial_element_map{ElementId<3>{7},
+                                                              block};
+    {
+      INFO("Radius of random point on inner face of SH shell (fill case)");
+      const tnsr::I<double, 3, Frame::ElementLogical> x_logical{
+          {{-1.0, theta_distribution(*gen), phi_distribution(*gen)}}};
+      const auto x_inertial = inertial_element_map(x_logical);
+      CHECK(get(magnitude(x_inertial)) == approx(interface_radius));
+    }
+    {
+      INFO("Radius of random point on outer face of SH shell (fill case)");
+      const tnsr::I<double, 3, Frame::ElementLogical> x_logical{
+          {{1.0, theta_distribution(*gen), phi_distribution(*gen)}}};
+      const auto x_inertial = inertial_element_map(x_logical);
+      CHECK(get(magnitude(x_inertial)) == approx(outer_radius));
+    }
+    {
+      INFO("External boundaries of SH shell (fill case)");
+      const auto& external_boundaries = block.external_boundaries();
+      CHECK(external_boundaries.size() == 1);
+      CHECK(alg::found(external_boundaries, Direction<3>::upper_xi()));
     }
   }
 }
@@ -274,32 +434,63 @@ void test(const gsl::not_null<Generator*> gen) {
   const double inner_radius = 1.0;
   const double interface_radius = 1.5;
   const double outer_radius = 2.0;
-  const size_t radial_refinement = 3;
-  const size_t angular_refinement = 2;
-  const size_t radial_extents = 5;
-  const size_t l = 6;
-  const size_t angular_extents = 7;
+  const std::array<size_t, 2> cube_ref{2_st, 1_st};
+  const size_t sh_ref = 0;
+  const std::array<size_t, 2> cube_gp{3_st, 4_st};
+  const std::array<size_t, 2> sh_gp{4_st, 3_st};
+  const std::array<std::vector<double>, 2> radial_partitioning{};
+  const std::array<std::vector<Distribution>, 2> radial_distribution{
+      std::vector<Distribution>{Distribution::Linear},
+      std::vector<Distribution>{Distribution::Linear}};
+
+  // Test excision case with and without boundary conditions
   for (const bool with_boundary_conditions : {true, false}) {
     CAPTURE(with_boundary_conditions);
     const domain::creators::NonconformingSphericalShells creator{
         inner_radius,
         interface_radius,
         outer_radius,
-        radial_refinement,
-        angular_refinement,
-        radial_extents,
-        l,
-        angular_extents,
-        with_boundary_conditions ? create_boundary_condition(false) : nullptr,
-        with_boundary_conditions ? create_boundary_condition(true) : nullptr};
-    test_nonconforming_spherical_shells_construction(
-        gen, creator, inner_radius, interface_radius, outer_radius,
-        with_boundary_conditions);
+        Excision{with_boundary_conditions ? create_inner_boundary_condition()
+                                          : nullptr},
+        cube_ref,
+        sh_ref,
+        cube_gp,
+        sh_gp,
+        radial_partitioning,
+        radial_distribution,
+        false,
+        std::nullopt,
+        with_boundary_conditions ? create_outer_boundary_condition() : nullptr};
+    test_excision_construction(gen, creator, inner_radius, interface_radius,
+                               outer_radius, with_boundary_conditions);
     TestHelpers::domain::creators::test_creation(
-        option_string(inner_radius, interface_radius, outer_radius,
-                      radial_refinement, angular_refinement, radial_extents, l,
-                      angular_extents, with_boundary_conditions),
+        option_string(inner_radius, interface_radius, outer_radius, cube_ref,
+                      sh_ref, cube_gp, sh_gp, with_boundary_conditions),
         creator, with_boundary_conditions);
+  }
+
+  // Test filled-interior case (no boundary conditions).
+  // The inner cube requires equal angular/radial refinement and grid points.
+  {
+    const std::array<size_t, 2> fill_cube_ref{2_st, 2_st};
+    const std::array<size_t, 2> fill_cube_gp{3_st, 3_st};
+    const domain::creators::NonconformingSphericalShells creator{
+        inner_radius,
+        interface_radius,
+        outer_radius,
+        InnerCube{0.0},
+        fill_cube_ref,
+        sh_ref,
+        fill_cube_gp,
+        sh_gp,
+        radial_partitioning,
+        std::array<std::vector<Distribution>, 2>{
+            std::vector<Distribution>{Distribution::Linear},
+            std::vector<Distribution>{Distribution::Linear}},
+        false,
+        std::nullopt,
+        nullptr};
+    test_fill_construction(gen, creator, interface_radius, outer_radius);
   }
 }
 }  // namespace

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryCorrections.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Actions/Test_ApplyBoundaryCorrections.cpp
@@ -1608,8 +1608,16 @@ void test_deterministic_mortar_interpolation() {
 
   const size_t spherical_harmonic_l = 4;
   const size_t cube_angular_extents = 2;
+  using Excision = domain::creators::NonconformingSphericalShells::Excision;
   const domain::creators::NonconformingSphericalShells creator{
-      1.9, 2.4, 2.9, 0, 1, 2, spherical_harmonic_l, cube_angular_extents};
+      1.9,
+      2.4,
+      2.9,
+      Excision{},
+      std::array<size_t, 2>{size_t{1}, size_t{0}},
+      size_t{0},
+      std::array<size_t, 2>{cube_angular_extents, size_t{2}},
+      std::array<size_t, 2>{spherical_harmonic_l, size_t{2}}};
   const Domain<3> domain = creator.create_domain();
   const auto initial_extents = creator.initial_extents();
   const auto initial_refinement = creator.initial_refinement_levels();

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Initialization/Test_Mortars.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Initialization/Test_Mortars.cpp
@@ -431,8 +431,10 @@ struct Test<3> {
 
 void test_nonconforming_blocks(const bool local_time_stepping) {
   INFO("NonconformingSphericalShells");
+  using Excision = domain::creators::NonconformingSphericalShells::Excision;
   const auto creator = domain::creators::NonconformingSphericalShells(
-      2.0, 3.0, 4.0, 0, 0, 5, 7, 11, nullptr, nullptr);
+      2.0, 3.0, 4.0, Excision{}, std::array<size_t, 2>{0_st, 0_st}, 0_st,
+      std::array<size_t, 2>{11_st, 5_st}, std::array<size_t, 2>{7_st, 5_st});
   auto domain = creator.create_domain();
   const auto initial_refinement = creator.initial_refinement_levels();
   const auto initial_extents = creator.initial_extents();

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_MortarInfo.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_MortarInfo.cpp
@@ -59,8 +59,10 @@ void test(
 SPECTRE_TEST_CASE("Unit.Evolution.DG.MortarInfo", "[Unit][Evolution]") {
   test<1>({{}}, std::nullopt);
   test<2>({{Spectral::SegmentSize::Full}}, std::nullopt);
+  using Excision = domain::creators::NonconformingSphericalShells::Excision;
   const auto creator = domain::creators::NonconformingSphericalShells(
-      2.0, 3.0, 4.0, 0, 0, 5, 8, 11, nullptr, nullptr);
+      2.0, 3.0, 4.0, Excision{}, std::array<size_t, 2>{0_st, 0_st}, 0_st,
+      std::array<size_t, 2>{11_st, 5_st}, std::array<size_t, 2>{8_st, 5_st});
   const auto domain = creator.create_domain();
   test<3>(
       {{Spectral::SegmentSize::UpperHalf, Spectral::SegmentSize::LowerHalf}},

--- a/tests/Unit/Evolution/Initialization/Test_DgDomain.cpp
+++ b/tests/Unit/Evolution/Initialization/Test_DgDomain.cpp
@@ -602,9 +602,11 @@ void test(const Spectral::Quadrature quadrature) {
 void test_nonconforming_blocks() {
   using metavars = Metavariables<3>;
   using component = Component<metavars>;
+  using Excision = domain::creators::NonconformingSphericalShells::Excision;
 
   const auto creator = domain::creators::NonconformingSphericalShells(
-      2.0, 3.0, 4.0, 0, 0, 5, 7, 11, nullptr, nullptr);
+      2.0, 3.0, 4.0, Excision{}, std::array<size_t, 2>{0_st, 0_st}, 0_st,
+      std::array<size_t, 2>{11_st, 5_st}, std::array<size_t, 2>{7_st, 5_st});
   auto domain = creator.create_domain();
   const auto initial_refinement = creator.initial_refinement_levels();
   const auto initial_extents = creator.initial_extents();

--- a/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_MortarInterpolator.cpp
+++ b/tests/Unit/NumericalAlgorithms/DiscontinuousGalerkin/Test_MortarInterpolator.cpp
@@ -103,8 +103,10 @@ void insert_mortar_data(
 }
 
 void test_non_conforming_spheres() {
+  using Excision = domain::creators::NonconformingSphericalShells::Excision;
   const auto creator = domain::creators::NonconformingSphericalShells(
-      2.0, 3.0, 4.0, 0, 2, 5, 8, 11, nullptr, nullptr);
+      2.0, 3.0, 4.0, Excision{}, std::array<size_t, 2>{2_st, 0_st}, 0_st,
+      std::array<size_t, 2>{11_st, 5_st}, std::array<size_t, 2>{8_st, 5_st});
   const auto domain = creator.create_domain();
   const auto refinement_levels = creator.initial_refinement_levels();
   const ElementId<3> shell_id{6};


### PR DESCRIPTION
## Proposed changes

This is primarily for Nick to use in his supernova runs.

The added functionality is primarily to match that of the Sphere domain creator, with the goal to now mimic the sphere creator with added outer spherical shells (Larry will be reworking all sphere domain creators soon, so this is just a quick fix until he does that)

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent was used, have a co-author trailer of the form
      "Co-Authored-By: <agent name> <agent email>" as the last line of the
      commit, e.g. "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>".

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
