### PR TITLE
Allow > 24 neighbors in Subcell

### DIFF
--- a/src/Evolution/DgSubcell/Actions/Initialize.hpp
+++ b/src/Evolution/DgSubcell/Actions/Initialize.hpp
@@ -13,6 +13,7 @@
 #include "DataStructures/TaggedTuple.hpp"
 #include "Domain/Structure/DirectionalId.hpp"
 #include "Domain/Structure/Element.hpp"
+#include "Domain/Structure/FaceType.hpp"
 #include "Domain/Tags.hpp"
 #include "Evolution/DgSubcell/ActiveGrid.hpp"
 #include "Evolution/DgSubcell/GhostData.hpp"
@@ -189,18 +190,33 @@ struct SetSubcellGrid {
     constexpr bool subcell_enabled_at_external_boundary =
         Metavariables::SubcellOptions::subcell_enabled_at_external_boundary;
 
-    db::mutate<Tags::NeighborTciDecisions<Dim>>(
-        [&element](const auto neighbor_decisions_ptr) {
-          neighbor_decisions_ptr->clear();
-          for (const auto& [direction, neighbors_in_direction] :
-               element.neighbors()) {
-            for (const auto& neighbor : neighbors_in_direction.ids()) {
-              neighbor_decisions_ptr->insert(
-                  std::pair{DirectionalId<Dim>{direction, neighbor}, 0});
+    // Non-hypercube elements (e.g. spherical shells) cannot use subcell and may
+    // have > 24 neighbors, which would overflow the fixed-size
+    // DirectionalIdMap, so their map is left empty. Hypercube elements that
+    // are forced to DG (e.g. because they border a DG-only block) still have
+    // a bounded neighbor count and continue to track TCI decisions normally.
+    //
+    // Within a hypercube element, also skip MultipleNonconforming directions.
+    // These arise on the "one" side of a many-to-one interface where
+    // bordering a non-hypercube element
+    if (fd::dg_mesh_supports_subcell(dg_mesh)) {
+      db::mutate<Tags::NeighborTciDecisions<Dim>>(
+          [&element](const auto neighbor_decisions_ptr) {
+            neighbor_decisions_ptr->clear();
+            for (const auto& [direction, neighbors_in_direction] :
+                 element.neighbors()) {
+              if (element.face_types().at(direction) ==
+                  domain::FaceType::MultipleNonconforming) {
+                continue;
+              }
+              for (const auto& neighbor : neighbors_in_direction.ids()) {
+                neighbor_decisions_ptr->insert(
+                    std::pair{DirectionalId<Dim>{direction, neighbor}, 0});
+              }
             }
-          }
-        },
-        make_not_null(&box));
+          },
+          make_not_null(&box));
+    }
 
     db::mutate_apply<
         tmpl::list<Tags::ActiveGrid, Tags::DidRollback,
@@ -541,15 +557,34 @@ struct SetInitialGridFromTciData {
 
       db::mutate<evolution::dg::subcell::Tags::NeighborTciDecisions<Dim>>(
           [&element, &received](const auto neighbor_tci_decisions_ptr) {
+            // Non-hypercube elements (e.g. spherical shells) have an empty
+            // NeighborTciDecisions map (see SetSubcellGrid) and will remain
+            // on DG regardless of neighbor TCI decisions.
+            if (neighbor_tci_decisions_ptr->empty()) {
+              return;
+            }
             for (const auto& [directional_element_id,
                               neighbor_initial_tci_data] : received->second) {
-              (void)element;
               ASSERT(neighbor_initial_tci_data.tci_status.has_value(),
                      "Neighbor in direction "
                          << directional_element_id.direction()
                          << " with element ID " << directional_element_id.id()
                          << " of " << element.id()
                          << " didn't send initial TCI decision correctly");
+              if (not neighbor_tci_decisions_ptr->contains(
+                      directional_element_id)) {
+                // TCI decisions for MultipleNonconforming neighbors are not
+                // tracked because those elements are forced to remain on DG.
+                ASSERT(element.face_types().at(
+                           directional_element_id.direction()) ==
+                           domain::FaceType::MultipleNonconforming,
+                       "NeighborTciDecisions does not contain the neighbor "
+                           << directional_element_id
+                           << " but the face is not MultipleNonconforming. "
+                              "This indicates a bug in the initialization of "
+                              "NeighborTciDecisions.");
+                continue;
+              }
               neighbor_tci_decisions_ptr->at(directional_element_id) =
                   neighbor_initial_tci_data.tci_status.value();
             }

--- a/src/Evolution/DgSubcell/Actions/ReconstructionCommunication.hpp
+++ b/src/Evolution/DgSubcell/Actions/ReconstructionCommunication.hpp
@@ -26,6 +26,7 @@
 #include "Domain/Structure/DirectionalIdMap.hpp"
 #include "Domain/Structure/Element.hpp"
 #include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/FaceType.hpp"
 #include "Domain/Structure/OrientationMapHelpers.hpp"
 #include "Domain/Structure/TrimMap.hpp"
 #include "Domain/Tags.hpp"
@@ -809,12 +810,22 @@ struct ReceiveDataForReconstruction {
                 subcell_mesh, ghost_zone_size, neighbor_dg_to_fd_interpolants,
                 typename Metavariables::SubcellOptions::GhostVariables::
                     ghost_variables_tag_list{});
-            ASSERT(neighbor_tci_decisions->contains(directional_element_id),
-                   "The NeighorTciDecisions should contain the neighbor ("
-                       << directional_element_id.direction() << ", "
-                       << directional_element_id.id() << ") but doesn't");
-            neighbor_tci_decisions->at(directional_element_id) =
-                boundary_data.tci_status;
+            if (neighbor_tci_decisions->contains(directional_element_id)) {
+              neighbor_tci_decisions->at(directional_element_id) =
+                  boundary_data.tci_status;
+            } else {
+              // TCI decisions for MultipleNonconforming neighbors are not
+              // tracked because those elements are forced to remain on DG.
+              ASSERT(
+                  element.face_types().at(directional_element_id.direction()) ==
+                      domain::FaceType::MultipleNonconforming,
+                  "NeighborTciDecisions does not contain the neighbor ("
+                      << directional_element_id.direction() << ", "
+                      << directional_element_id.id()
+                      << ") but the face is not MultipleNonconforming. "
+                         "This indicates a bug in the initialization of "
+                         "NeighborTciDecisions.");
+            }
           }
         },
         make_not_null(&box),

--- a/src/Evolution/DgSubcell/NeighborTciDecision.cpp
+++ b/src/Evolution/DgSubcell/NeighborTciDecision.cpp
@@ -12,7 +12,10 @@
 #include "DataStructures/DataVector.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/DirectionalId.hpp"
+#include "Domain/Structure/Element.hpp"
 #include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/FaceType.hpp"
+#include "Domain/Tags.hpp"
 #include "Evolution/DgSubcell/Tags/TciStatus.hpp"
 #include "Evolution/DiscontinuousGalerkin/BoundaryData.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
@@ -26,11 +29,24 @@ void neighbor_tci_decision(
     const gsl::not_null<db::Access*> box,
     const DirectionalId<Dim>& directional_element_id,
     const evolution::dg::BoundaryData<Dim>& neighbor_data) {
+  const auto& element = db::get<::domain::Tags::Element<Dim>>(*box);
   db::mutate<subcell::Tags::NeighborTciDecisions<Dim>>(
-      [&](const auto neighbor_tci_decisions_ptr) {
-        ASSERT(neighbor_tci_decisions_ptr->contains(directional_element_id),
-               "The NeighborTciDecisions tag does not contain the neighbor "
-                   << directional_element_id);
+      [&element, &directional_element_id,
+       &neighbor_data](const auto neighbor_tci_decisions_ptr) {
+        if (not neighbor_tci_decisions_ptr->contains(directional_element_id)) {
+          // Non-hypercube elements (e.g. spherical shells) have an empty
+          // NeighborTciDecisions map. Subcell-capable elements skip
+          // MultipleNonconforming directions. Either way, no update is needed
+          ASSERT(
+              neighbor_tci_decisions_ptr->empty() or
+                  element.face_types().at(directional_element_id.direction()) ==
+                      domain::FaceType::MultipleNonconforming,
+              "NeighborTciDecisions does not contain the neighbor "
+                  << directional_element_id
+                  << " but the map is not empty and the face direction is not "
+                     "MultipleNonconforming.");
+          return;
+        }
         neighbor_tci_decisions_ptr->at(directional_element_id) =
             neighbor_data.tci_status;
       },

--- a/src/Evolution/DgSubcell/ReceiveSubcellDataForDg.cpp
+++ b/src/Evolution/DgSubcell/ReceiveSubcellDataForDg.cpp
@@ -11,11 +11,14 @@
 #include "DataStructures/DataBox/Access.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "Domain/Structure/DirectionalId.hpp"
+#include "Domain/Tags.hpp"
 #include "Evolution/DgSubcell/GhostData.hpp"
+#include "Evolution/DgSubcell/Mesh.hpp"
 #include "Evolution/DgSubcell/Tags/DataForRdmpTci.hpp"
 #include "Evolution/DgSubcell/Tags/GhostDataForReconstruction.hpp"
 #include "Evolution/DgSubcell/Tags/MeshForGhostData.hpp"
 #include "Evolution/DiscontinuousGalerkin/BoundaryData.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "Utilities/ErrorHandling/Assert.hpp"
 #include "Utilities/GenerateInstantiations.hpp"
 #include "Utilities/Gsl.hpp"
@@ -26,6 +29,13 @@ void receive_subcell_data_for_dg(
     const gsl::not_null<db::Access*> box,
     const DirectionalId<VolumeDim>& mortar_id,
     const evolution::dg::BoundaryData<VolumeDim>& received_mortar_data) {
+  // Non-hypercube elements (e.g. spherical shells) cannot use subcell. They
+  // never need ghost data for reconstruction, so skip storing
+  if (not subcell::fd::dg_mesh_supports_subcell(
+          db::get<::domain::Tags::Mesh<VolumeDim>>(*box))) {
+    return;
+  }
+
   db::mutate<subcell::Tags::MeshForGhostData<VolumeDim>,
              subcell::Tags::GhostDataForReconstruction<VolumeDim>,
              subcell::Tags::DataForRdmpTci>(

--- a/src/Evolution/DgSubcell/Tags/InitialTciData.hpp
+++ b/src/Evolution/DgSubcell/Tags/InitialTciData.hpp
@@ -3,17 +3,16 @@
 
 #pragma once
 
+#include <boost/functional/hash.hpp>
 #include <cstddef>
 #include <iomanip>
 #include <map>
 #include <sstream>
 #include <string>
+#include <unordered_map>
 #include <utility>
 
-#include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/DirectionalId.hpp"
-#include "Domain/Structure/DirectionalIdMap.hpp"
-#include "Domain/Structure/ElementId.hpp"
 #include "Evolution/DgSubcell/InitialTciData.hpp"
 #include "Utilities/Gsl.hpp"
 
@@ -21,13 +20,22 @@ namespace evolution::dg::subcell::Tags {
 /*!
  * \brief Inbox tag for communicating the RDMP and TCI status/decision during
  * initialization.
+ *
+ * \note The inner map uses `std::unordered_map` rather than
+ * `DirectionalIdMap` because elements at non-conforming interfaces (e.g.
+ *  inner wedges bordering a spherical shell) can have more than
+ * `maximum_number_of_neighbors(Dim)` neighbors sending messages. This inbox
+ * is only populated during initialization and is erased after use, so the
+ * heap-allocation cost is negligible.
  */
 template <size_t Dim>
 struct InitialTciData {
   using temporal_id = int;
   using type =
       std::map<temporal_id,
-               DirectionalIdMap<Dim, evolution::dg::subcell::InitialTciData>>;
+               std::unordered_map<DirectionalId<Dim>,
+                                  evolution::dg::subcell::InitialTciData,
+                                  boost::hash<DirectionalId<Dim>>>>;
 
   template <typename ReceiveDataType>
   static bool insert_into_inbox(const gsl::not_null<type*> inbox,

--- a/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStarSphericalShells.yaml
+++ b/tests/InputFiles/GrMhd/GhValenciaDivClean/GhMhdTovStarSphericalShells.yaml
@@ -64,7 +64,7 @@ DomainCreator:
     InterfaceRadius: 12.0
     OuterRadius: 18.0
     InitialRadialRefinement: 1
-    InitialAngularRefinementOfWedges: 0
+    InitialAngularRefinementOfWedges: 1
     InitialNumberOfRadialGridPoints: 6
     InitialSphericalHarmonicL: 10
     InitialNumberOfAngularGridPointsOfWedges: 6

--- a/tests/Unit/Evolution/DgSubcell/Test_NeighborTciDecision.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_NeighborTciDecision.cpp
@@ -4,12 +4,17 @@
 #include "Framework/TestingFramework.hpp"
 
 #include <cstddef>
+#include <unordered_map>
 #include <utility>
 
 #include "DataStructures/DataBox/DataBox.hpp"
 #include "Domain/Structure/Direction.hpp"
 #include "Domain/Structure/DirectionalId.hpp"
+#include "Domain/Structure/Element.hpp"
 #include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/Neighbors.hpp"
+#include "Domain/Structure/OrientationMap.hpp"
+#include "Domain/Tags.hpp"
 #include "Evolution/DgSubcell/NeighborTciDecision.hpp"
 #include "Evolution/DgSubcell/Tags/TciStatus.hpp"
 #include "Evolution/DiscontinuousGalerkin/BoundaryData.hpp"
@@ -17,29 +22,81 @@
 
 namespace evolution::dg::subcell {
 namespace {
+// Builds an element with:
+// - lower_xi: one conforming neighbor (block 0) -> ConformingAligned
+// - upper_xi: two non-conforming neighbors (blocks 2, 3) ->
+//             MultipleNonconforming
+template <size_t Dim>
+Element<Dim> make_test_element() {
+  Neighbors<Dim> conforming_nbrs{{ElementId<Dim>{0}},
+                                 OrientationMap<Dim>::create_aligned()};
+  const std::unordered_map<size_t, OrientationMap<Dim>> nc_orientations{
+      {2, OrientationMap<Dim>::create_aligned()},
+      {3, OrientationMap<Dim>::create_aligned()}};
+  Neighbors<Dim> nc_nbrs{
+      {ElementId<Dim>{2}, ElementId<Dim>{3}}, nc_orientations, false};
+  return Element<Dim>{ElementId<Dim>{1},
+                      {{Direction<Dim>::lower_xi(), conforming_nbrs},
+                       {Direction<Dim>::upper_xi(), nc_nbrs}}};
+}
+
 template <size_t Dim>
 void test() {
   using tag = subcell::Tags::NeighborTciDecisions<Dim>;
   using Type = typename tag::type;
-  auto box = db::create<db::AddSimpleTags<tag>>(Type{});
-  using StorageType = evolution::dg::BoundaryData<Dim>;
-  StorageType neighbor_data{};
-  const DirectionalId<Dim> id_xi{Direction<Dim>::lower_xi(), ElementId<Dim>{0}};
+
+  const Element<Dim> element = make_test_element<Dim>();
+  const DirectionalId<Dim> conforming_did{Direction<Dim>::lower_xi(),
+                                          ElementId<Dim>{0}};
+  const DirectionalId<Dim> nc_did{Direction<Dim>::upper_xi(),
+                                  ElementId<Dim>{2}};
+
+  evolution::dg::BoundaryData<Dim> neighbor_data{};
   neighbor_data.tci_status = 10;
+
+  {
+    INFO("Empty map: function exits early without update or error");
+    auto box = db::create<db::AddSimpleTags<tag, domain::Tags::Element<Dim>>>(
+        Type{}, element);
+    neighbor_tci_decision(make_not_null(&box), conforming_did, neighbor_data);
+    CHECK(db::get<tag>(box).empty());
+  }
+
+  {
+    INFO("MultipleNonconforming direction: no-op even with a non-empty map");
+    Type decisions;
+    decisions.insert({conforming_did, 0});
+    auto box = db::create<db::AddSimpleTags<tag, domain::Tags::Element<Dim>>>(
+        std::move(decisions), element);
+    neighbor_tci_decision(make_not_null(&box), nc_did, neighbor_data);
+    CHECK(db::get<tag>(box).at(conforming_did) == 0);  // unchanged
+  }
+
+  {
+    INFO("Normal conforming case: status is updated");
+    Type decisions;
+    decisions.insert({conforming_did, 0});
+    auto box = db::create<db::AddSimpleTags<tag, domain::Tags::Element<Dim>>>(
+        std::move(decisions), element);
+    neighbor_tci_decision(make_not_null(&box), conforming_did, neighbor_data);
+    CHECK(db::get<tag>(box).at(conforming_did) == 10);
+  }
+
 #ifdef SPECTRE_DEBUG
-  // check ASSERT for neighbors works
-  CHECK_THROWS_WITH(
-      neighbor_tci_decision(make_not_null(&box), id_xi, neighbor_data),
-      Catch::Matchers::ContainsSubstring(
-          "The NeighborTciDecisions tag does not contain the neighbor"));
+  {
+    INFO("Non-empty map, conforming direction, neighbor not present -> ASSERT");
+    const DirectionalId<Dim> absent_did{Direction<Dim>::lower_xi(),
+                                        ElementId<Dim>{99}};
+    Type decisions;
+    decisions.insert({conforming_did, 0});
+    auto box = db::create<db::AddSimpleTags<tag, domain::Tags::Element<Dim>>>(
+        std::move(decisions), element);
+    CHECK_THROWS_WITH(
+        neighbor_tci_decision(make_not_null(&box), absent_did, neighbor_data),
+        Catch::Matchers::ContainsSubstring(
+            "NeighborTciDecisions does not contain the neighbor"));
+  }
 #endif
-  db::mutate<tag>(
-      [&id_xi](const auto neighbor_decisions_ptr) {
-        neighbor_decisions_ptr->insert(std::pair{id_xi, 0});
-      },
-      make_not_null(&box));
-  neighbor_tci_decision(make_not_null(&box), id_xi, neighbor_data);
-  CHECK(db::get<tag>(box).at(id_xi) == 10);
 }
 
 SPECTRE_TEST_CASE("Unit.Evolution.Subcell.NeighborTciDecision",

--- a/tests/Unit/Evolution/DgSubcell/Test_ReceiveSubcellDataForDg.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_ReceiveSubcellDataForDg.cpp
@@ -13,6 +13,7 @@
 #include "Domain/Structure/DirectionalId.hpp"
 #include "Domain/Structure/DirectionalIdMap.hpp"
 #include "Domain/Structure/ElementId.hpp"
+#include "Domain/Tags.hpp"
 #include "Evolution/DgSubcell/GhostData.hpp"
 #include "Evolution/DgSubcell/RdmpTciData.hpp"
 #include "Evolution/DgSubcell/ReceiveSubcellDataForDg.hpp"
@@ -48,11 +49,12 @@ void test() {
   const Mesh<Dim> dg_volume_mesh{2 + 2 * Dim, Spectral::Basis::Legendre,
                                  Spectral::Quadrature::GaussLobatto};
   auto box = db::create<
-      tmpl::list<evolution::dg::subcell::Tags::MeshForGhostData<Dim>,
+      tmpl::list<domain::Tags::Mesh<Dim>,
+                 evolution::dg::subcell::Tags::MeshForGhostData<Dim>,
                  evolution::dg::subcell::Tags::GhostDataForReconstruction<Dim>,
                  evolution::dg::subcell::Tags::DataForRdmpTci>>(
-      DirectionalIdMap<Dim, Mesh<Dim>>{}, std::move(neighbor_data_map),
-      std::move(rdmp_tci_data));
+      dg_volume_mesh, DirectionalIdMap<Dim, Mesh<Dim>>{},
+      std::move(neighbor_data_map), std::move(rdmp_tci_data));
 
   const Mesh<Dim> fd_volume_mesh{2 + 2 * Dim + 1,
                                  Spectral::Basis::FiniteDifference,
@@ -124,6 +126,43 @@ void test() {
   REQUIRE(ghost_meshes.contains(fd_id));
   CHECK(ghost_meshes.at(fd_id) == fd_volume_mesh);
 }
+
+// Elements whose mesh does not support subcell (e.g. spherical shells) must
+// be skipped entirely: they may have more neighbors than the DirectionalIdMap
+// capacity and they never need ghost data.
+template <size_t Dim>
+void test_nonhypercube_mesh() {
+  CAPTURE(Dim);
+
+  evolution::dg::subcell::RdmpTciData rdmp_tci_data{};
+  rdmp_tci_data.max_variables_values = DataVector{1.0, 2.0};
+  rdmp_tci_data.min_variables_values = DataVector{-2.0, 0.1};
+  const auto initial_rdmp = rdmp_tci_data;
+
+  const Mesh<Dim> sph_mesh{4, Spectral::Basis::SphericalHarmonic,
+                           Spectral::Quadrature::Gauss};
+
+  auto box = db::create<
+      tmpl::list<domain::Tags::Mesh<Dim>,
+                 evolution::dg::subcell::Tags::MeshForGhostData<Dim>,
+                 evolution::dg::subcell::Tags::GhostDataForReconstruction<Dim>,
+                 evolution::dg::subcell::Tags::DataForRdmpTci>>(
+      sph_mesh, DirectionalIdMap<Dim, Mesh<Dim>>{}, GhostDataMap<Dim>{},
+      std::move(rdmp_tci_data));
+
+  const DirectionalId<Dim> did{Direction<Dim>::upper_xi(), ElementId<Dim>{0}};
+  evolution::dg::subcell::receive_subcell_data_for_dg<Dim>(
+      make_not_null(&box), did, evolution::dg::BoundaryData<Dim>{});
+
+  // Nothing should have been stored; RDMP data is also unchanged.
+  CHECK(db::get<evolution::dg::subcell::Tags::MeshForGhostData<Dim>>(box)
+            .empty());
+  CHECK(db::get<evolution::dg::subcell::Tags::GhostDataForReconstruction<Dim>>(
+            box)
+            .empty());
+  CHECK(db::get<evolution::dg::subcell::Tags::DataForRdmpTci>(box) ==
+        initial_rdmp);
+}
 }  // namespace
 
 SPECTRE_TEST_CASE("Unit.Evolution.Subcell.ReceiveSubcellDataForDg",
@@ -131,4 +170,7 @@ SPECTRE_TEST_CASE("Unit.Evolution.Subcell.ReceiveSubcellDataForDg",
   test<1>();
   test<2>();
   test<3>();
+  test_nonhypercube_mesh<1>();
+  test_nonhypercube_mesh<2>();
+  test_nonhypercube_mesh<3>();
 }


### PR DESCRIPTION
## Proposed changes

Non-conforming interfaces can easily have > 100 neighbors when cubes get refined.

The TCI DirectionalId is the limiter in this case. For initialization, all data must be sent so we use a std::unordered_map which does not have the size restriction (and it does now require a heap allocation but it is only called in initialization and never again). For the rest of the code, we just avoid doing anything with TCI data when we know we don't need it (DG-only blocks do not need it, and it is only ever in such blocks we can have non-conforming interfaces that were the problem in the first place)

Depends on:
 - [x] #7481
 - got rid of dependency on  #7503

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent was used, have a co-author trailer of the form
      "Co-Authored-By: <agent name> <agent email>" as the last line of the
      commit, e.g. "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>".

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
