### PR TITLE
Fix SetupBlas check for disabling openblas multithreading

### DIFF
--- a/cmake/CheckOpenBlasThreads.cpp
+++ b/cmake/CheckOpenBlasThreads.cpp
@@ -1,0 +1,7 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details
+extern "C" {
+void openblas_set_num_threads(int);
+}
+
+int main() { openblas_set_num_threads(1); }

--- a/cmake/SetupBlas.cmake
+++ b/cmake/SetupBlas.cmake
@@ -8,6 +8,23 @@ file(APPEND
   "BLAS_LIBRARIES: ${BLAS_LIBRARIES}\n"
   )
 
+set(IS_OPENBLAS FALSE)
+
+if(BLAS_FOUND)
+  string(TOLOWER "${BLAS_LIBRARIES}" BLAS_LIBS_LOWER)
+  if(BLAS_LIBS_LOWER MATCHES "openblas")
+    set(IS_OPENBLAS TRUE)
+  else()
+    if(TARGET BLAS::BLAS)
+      get_target_property(BLAS_LINK_LIBS BLAS::BLAS INTERFACE_LINK_LIBRARIES)
+      string(TOLOWER "${BLAS_LINK_LIBS}" BLAS_TARGET_LIBS_LOWER)
+      if(BLAS_TARGET_LIBS_LOWER MATCHES "openblas")
+        set(IS_OPENBLAS TRUE)
+      endif()
+    endif()
+  endif()
+endif()
+
 set_property(
   GLOBAL APPEND PROPERTY SPECTRE_THIRD_PARTY_LIBS
   BLAS::BLAS
@@ -16,28 +33,24 @@ set_property(
 # Check if we have found OpenBLAS and can disable its multithreading, since it
 # conflicts with Charm++ parallelism. Details:
 # https://github.com/xianyi/OpenBLAS/wiki/Faq#multi-threaded
-# We use `execute_process` instead of `try_compile` to avoid potentially slow
-# disk IO.
-set(
-  CHECK_DISABLE_OPENBLAS_MULTITHREADING_SOURCE
-  "extern \"C\" { void openblas_set_num_threads(int); }\n\
-int main() { openblas_set_num_threads(1); }"
-  )
-string(REPLACE ";" " " BLAS_LIBRARIES_JOINED_WITH_SPACES "${BLAS_LIBRARIES}")
-execute_process(
-  COMMAND
-  bash -c
-  "${CMAKE_CXX_COMPILER} ${BLAS_LIBRARIES_JOINED_WITH_SPACES} -x c++ - <<< $'\
-${CHECK_DISABLE_OPENBLAS_MULTITHREADING_SOURCE}' -o /dev/null"
-  RESULT_VARIABLE CHECK_DISABLE_OPENBLAS_MULTITHREADING_RESULT
-  ERROR_VARIABLE CHECK_DISABLE_OPENBLAS_MULTITHREADING_ERROR
-  OUTPUT_QUIET
-  )
-if(${CHECK_DISABLE_OPENBLAS_MULTITHREADING_RESULT} EQUAL 0)
+try_compile(CHECK_DISABLE_OPENBLAS_MULTITHREADING_RESULT
+  ${CMAKE_BINARY_DIR}
+  ${CMAKE_SOURCE_DIR}/cmake/CheckOpenBlasThreads.cpp
+  LINK_LIBRARIES BLAS::BLAS
+  OUTPUT_VARIABLE DISABLE_CHECK_OUTPUT
+)
+
+if(CHECK_DISABLE_OPENBLAS_MULTITHREADING_RESULT)
   set(DISABLE_OPENBLAS_MULTITHREADING ON)
-  add_definitions(-DDISABLE_OPENBLAS_MULTITHREADING)
+  add_compile_definitions(DISABLE_OPENBLAS_MULTITHREADING)
   message(STATUS "Disabled OpenBLAS multithreading")
 else()
-  message(STATUS "BLAS vendor is probably not OpenBLAS. Make sure it doesn't "
-    "try to do multithreading that might conflict with Charm++ parallelism.")
+  if(IS_OPENBLAS)
+    message(STATUS ${DISABLE_CHECK_OUTPUT})
+    message(FATAL_ERROR
+            "BLAS vendor is OpenBLAS but disabling multithreading failed.")
+  else()
+    message(STATUS "BLAS vendor is not OpenBLAS. Make sure it doesn't "
+      "try to do multithreading that might conflict with Charm++ parallelism.")
+  endif()
 endif()


### PR DESCRIPTION

## Proposed changes

Fix SetupBlas check for disabling openblas multithreading as the current check fails for gcc
Added a FATAL_ERROR if openblas is the vendor, but disabling multithreading failed.


### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent was used, have a co-author trailer of the form
      "Co-Authored-By: <agent name> <agent email>" as the last line of the
      commit, e.g. "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>".

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
