### PR TITLE
Set up frozen bin directories

### DIFF
--- a/cmake/SpectrePythonExecutable.sh
+++ b/cmake/SpectrePythonExecutable.sh
@@ -3,5 +3,8 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-PYTHONPATH="@PYTHONPATH@" @PYTHON_EXEC_ENV_VARS@ @Python_EXECUTABLE@ \
-  @PYTHON_EXE_COMMAND@ "$@"
+# Find the Python package next to this script, so that a copy of the script in
+# a simulation's bin directory uses the package next to the copy
+SPECTRE_BIN_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+PYTHONPATH="${SPECTRE_BIN_DIR}/python:@PYTHONPATH@" @PYTHON_EXEC_ENV_VARS@ \
+  @Python_EXECUTABLE@ @PYTHON_EXE_COMMAND@ "$@"

--- a/cmake/SpectreSetupPythonPackage.cmake
+++ b/cmake/SpectreSetupPythonPackage.cmake
@@ -63,17 +63,11 @@ if (ENABLE_PYTHON)
   # file. Therefore we disable file locking here to avoid crashing simulations.
   # Better solutions are described in H5File.hpp.
   string(APPEND PYTHON_EXEC_ENV_VARS " HDF5_USE_FILE_LOCKING=FALSE")
+  # '@ONLY' because the wrapper uses shell '${...}' expansions that CMake must
+  # leave alone
   configure_file(
     "${CMAKE_SOURCE_DIR}/cmake/SpectrePythonExecutable.sh"
-    "${CMAKE_BINARY_DIR}/tmp/spectre")
-  file(COPY "${CMAKE_BINARY_DIR}/tmp/spectre"
-    DESTINATION "${CMAKE_BINARY_DIR}/bin"
-    FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ
-      GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
-
-  configure_file(
-    "${CMAKE_SOURCE_DIR}/cmake/SpectrePythonExecutable.sh"
-    "${CMAKE_BINARY_DIR}/tmp/spectre")
+    "${CMAKE_BINARY_DIR}/tmp/spectre" @ONLY)
   file(COPY "${CMAKE_BINARY_DIR}/tmp/spectre"
     DESTINATION "${CMAKE_BINARY_DIR}/bin"
     FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ
@@ -84,7 +78,7 @@ if (ENABLE_PYTHON)
   set(PYTHON_EXE_COMMAND "")
   configure_file(
     "${CMAKE_SOURCE_DIR}/cmake/SpectrePythonExecutable.sh"
-    "${CMAKE_BINARY_DIR}/tmp/python-spectre")
+    "${CMAKE_BINARY_DIR}/tmp/python-spectre" @ONLY)
   file(COPY "${CMAKE_BINARY_DIR}/tmp/python-spectre"
     DESTINATION "${CMAKE_BINARY_DIR}/bin"
     FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ

--- a/support/CMakeLists.txt
+++ b/support/CMakeLists.txt
@@ -1,5 +1,27 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+# Place support files in bin/ so they are available in copied or linked
+# simulation bin directories
+option(MACHINE "Select a machine that we know how to run on, such as a \
+particular supercomputer" OFF)
+if(MACHINE)
+  message(STATUS "Selected machine: ${MACHINE}")
+  configure_file(
+    ${CMAKE_SOURCE_DIR}/support/Machines/${MACHINE}.yaml
+    ${CMAKE_BINARY_DIR}/bin/Machine.yaml
+    )
+  configure_file(
+    ${CMAKE_SOURCE_DIR}/support/SubmitScripts/SubmitTemplateBase.sh
+    ${CMAKE_BINARY_DIR}/bin/SubmitTemplateBase.sh
+    @ONLY
+    )
+  configure_file(
+    ${CMAKE_SOURCE_DIR}/support/SubmitScripts/${MACHINE}.sh
+    ${CMAKE_BINARY_DIR}/bin/SubmitTemplate.sh
+    @ONLY
+    )
+endif()
+
 add_subdirectory(Pipelines)
 add_subdirectory(Python)

--- a/support/Python/BinDirectory.py
+++ b/support/Python/BinDirectory.py
@@ -1,0 +1,20 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+BIN_DIR_NAME = "bin"
+
+
+@dataclass(frozen=True)
+class BinDirectory:
+    path: Path
+
+    @classmethod
+    def this(cls) -> "BinDirectory":
+        """The bin directory that this script runs from"""
+        # This file sits in bin/python/spectre/support/ (three levels deep).
+        # Don't resolve symlinks, so this works also with PY_DEV_MODE.
+        return cls(path=Path(__file__).parents[3])

--- a/support/Python/BinDirectory.py
+++ b/support/Python/BinDirectory.py
@@ -1,15 +1,110 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+"""The bin directory that a segment runs from
+
+We freeze a copy of the bin directory into the segment so that the segment can
+run even if the build directory is deleted or changed. It contains everything
+the job needs to run and to submit the next segment:
+
+```
+0000_Inspiral/
+    bin/
+        EvolveGhBinaryBlackHole
+        python/
+        spectre
+        SubmitTemplate.sh
+        ...
+    Inspiral.yaml
+    Submit.sh
+0001_Inspiral/
+    bin -> ../0000_Inspiral/bin
+```
+
+The `<build>/bin` directory has this same layout, so it is valid to symlink a
+build directory instead of copying it for a segment.
+"""
+
+import logging
+import os
+import re
+import shutil
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Optional, Union
 
+logger = logging.getLogger(__name__)
 
 BIN_DIR_NAME = "bin"
+
+# Freeze these files, plus the requested executables
+FROZEN_FILES = (
+    "spectre",
+    "python-spectre",
+    "python",
+    "Machine.yaml",
+    "SubmitTemplate.sh",
+    "SubmitTemplateBase.sh",
+)
+
+
+def _staging(path: Path) -> Path:
+    """Where a copy is assembled before it is moved to the 'path'"""
+    return path.with_name(path.name + ".part")
+
+
+def _remove(path: Path) -> None:
+    """Delete the 'path', be it a symlink, a directory, or absent"""
+    if path.is_symlink() or path.is_file():
+        path.unlink()
+    elif path.is_dir():
+        shutil.rmtree(path)
+
+
+def _cmake_cache(bin_dir: Path) -> Optional[Path]:
+    """The CMake cache of the build directory the bin_dir is in, or None"""
+    cache_file = bin_dir.parent / "CMakeCache.txt"
+    return cache_file if cache_file.is_file() else None
+
+
+def _check_build_is_relocatable(bin_dir: Path) -> None:
+    """Raise if the 'bin_dir' holds shared SpECTRE libraries
+
+    Copying such executables would give a false sense of safety: they load the
+    libraries out of the build directory whatever happens to the copy.
+    """
+    cache_file = _cmake_cache(bin_dir)
+    if cache_file is None:
+        return
+    cache_entry = re.search(
+        r"^BUILD_SHARED_LIBS:[^=]*=(.*)$",
+        cache_file.read_text(),
+        re.MULTILINE,
+    )
+    if not cache_entry:
+        return
+    if cache_entry.group(1).strip().upper() in ("ON", "TRUE", "YES", "1"):
+        raise RuntimeError(
+            f"The build directory '{cache_file.parent}' is configured with"
+            " 'BUILD_SHARED_LIBS=ON'. Its executables load the SpECTRE"
+            " libraries out of it, so a copy of them stops working as soon as"
+            " the build directory changes, which defeats the purpose of the"
+            " bin directory. Either reconfigure with 'BUILD_SHARED_LIBS=OFF'"
+            " and rebuild, or schedule with '--no-freeze-bin', which"
+            " links to the build directory instead of copying it. That works"
+            " with shared libraries but ties the run to the build directory."
+        )
 
 
 @dataclass(frozen=True)
 class BinDirectory:
+    """A handle on a segment's bin directory
+
+    The 'path' need not exist yet. The bin directory is created either by
+    'freeze', which copies one, or by 'link', which symlinks to one. Executables
+    enter through 'add'.
+    """
+
     path: Path
 
     @classmethod
@@ -18,3 +113,97 @@ class BinDirectory:
         # This file sits in bin/python/spectre/support/ (three levels deep).
         # Don't resolve symlinks, so this works also with PY_DEV_MODE.
         return cls(path=Path(__file__).parents[3])
+
+    def freeze(self, source: Optional["BinDirectory"] = None) -> "BinDirectory":
+        """Copy the 'FROZEN_FILES' of the 'source' here, replacing what is here
+
+        Executables enter through 'add'. Symlinks are dereferenced. Either
+        completes or leaves nothing behind.
+
+        Arguments:
+          source: Optional. The bin directory to copy. (Default: 'this()')
+
+        Returns: This bin directory.
+        """
+        if not source:
+            source = BinDirectory.this()
+        source_dir = source.path.resolve()
+        logger.info(f"Freeze bin directory '{self.path}' from '{source_dir}'")
+
+        # Check before copying anything, which is expensive
+        _check_build_is_relocatable(source_dir)
+
+        # Assemble the copy in a staging directory, then move it into place
+        staging = _staging(self.path)
+        shutil.rmtree(staging, ignore_errors=True)
+        try:
+            staging.mkdir()
+            for name in FROZEN_FILES:
+                entry = source_dir / name
+                if entry.is_dir():
+                    shutil.copytree(
+                        entry,
+                        staging / name,
+                        ignore=shutil.ignore_patterns("__pycache__"),
+                    )
+                elif entry.is_file():
+                    shutil.copy2(entry, staging / name)
+            _remove(self.path)
+            os.replace(staging, self.path)
+        finally:
+            shutil.rmtree(staging, ignore_errors=True)
+        return self
+
+    def link(self, target: "BinDirectory") -> "BinDirectory":
+        """Symlink to the 'target', replacing what is here
+
+        The link is relative and never points at another symlink.
+
+        Returns: This bin directory.
+        """
+        target_dir = target.path.resolve()
+        logger.info(f"Link bin directory '{self.path}' -> '{target_dir}'")
+        _remove(self.path)
+        # Remove any staging directory, which is a leftover from a failed freeze
+        shutil.rmtree(_staging(self.path), ignore_errors=True)
+        self.path.symlink_to(
+            os.path.relpath(target_dir, self.path.parent.resolve()),
+            target_is_directory=True,
+        )
+        return self
+
+    def add(self, executable: Union[str, Path]) -> Path:
+        """Copy the 'executable' unless it is already here
+
+        Append-only, so a queued job keeps running the binary it was scheduled
+        with. Raises if this resolves into a build directory, which holds what
+        it built and nothing else.
+
+        Returns: The path of the executable in this directory.
+        """
+        executable = Path(executable)
+        target_dir = self.path.resolve()
+        destination = target_dir / executable.name
+        if destination.is_file():
+            logger.debug(f"Executable is already frozen: '{destination}'")
+            return destination
+        if _cmake_cache(target_dir) is not None:
+            raise RuntimeError(
+                f"The executable '{executable.name}' is not in the build"
+                f" directory '{target_dir.parent}' that this simulation links"
+                " to. Build it there, or freeze the simulation's own bin"
+                " directory with '--freeze-bin', which can hold executables"
+                " from anywhere."
+            )
+        logger.info(f"Add executable to bin directory: '{destination}'")
+        staging = _staging(destination)
+        try:
+            shutil.copy2(executable, staging)
+            os.replace(staging, destination)
+        finally:
+            staging.unlink(missing_ok=True)
+        return destination
+
+    def executable(self, name: Union[str, Path]) -> Path:
+        """The path of the executable 'name' in this directory"""
+        return self.path / Path(name).name

--- a/support/Python/CMakeLists.txt
+++ b/support/Python/CMakeLists.txt
@@ -5,11 +5,10 @@ if (NOT ENABLE_PYTHON)
   return()
 endif()
 
-option(MACHINE "Select a machine that we know how to run on, such as a \
-particular supercomputer" OFF)
 spectre_python_add_module(
   support
   PYTHON_FILES
+  BinDirectory.py
   CheckSpecImport.py
   CliExceptions.py
   DirectoryStructure.py
@@ -20,24 +19,6 @@ spectre_python_add_module(
   Schedule.py
   Yaml.py
 )
-
-if(MACHINE)
-  message(STATUS "Selected machine: ${MACHINE}")
-  configure_file(
-    ${CMAKE_SOURCE_DIR}/support/Machines/${MACHINE}.yaml
-    ${SPECTRE_PYTHON_PREFIX}/support/Machine.yaml
-    )
-  configure_file(
-    ${CMAKE_SOURCE_DIR}/support/SubmitScripts/SubmitTemplateBase.sh
-    ${SPECTRE_PYTHON_PREFIX}/support/SubmitTemplateBase.sh
-    @ONLY
-    )
-  configure_file(
-    ${CMAKE_SOURCE_DIR}/support/SubmitScripts/${MACHINE}.sh
-    ${SPECTRE_PYTHON_PREFIX}/support/SubmitTemplate.sh
-    @ONLY
-    )
-endif()
 
 # Generate shell completion scripts. These don't usually change, so they are
 # committed to the source code and configured to the build dir. See the

--- a/support/Python/DirectoryStructure.py
+++ b/support/Python/DirectoryStructure.py
@@ -24,6 +24,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Optional, Union
 
+from spectre.support.BinDirectory import BIN_DIR_NAME, BinDirectory
+
 logger = logging.getLogger(__name__)
 
 
@@ -91,6 +93,7 @@ class Segment:
     ```
     SEGMENTS_DIR/
         0000_Inspiral/
+            bin/
             Inspiral.yaml
             Submit.sh
             Output.h5
@@ -149,6 +152,14 @@ class Segment:
     def input_file(self) -> Path:
         """The input file for the segment (has the same name as the label)"""
         return self.path / f"{self.label}.yaml"
+
+    @property
+    def bin_dir(self) -> BinDirectory:
+        """Directory that holds the executables this segment runs
+
+        Can be a copy or a symlink. See 'spectre.support.BinDirectory'.
+        """
+        return BinDirectory(self.path / BIN_DIR_NAME)
 
     @property
     def checkpoints_dir(self) -> Path:

--- a/support/Python/Machines.py
+++ b/support/Python/Machines.py
@@ -26,6 +26,11 @@ except ImportError:
 
 import yaml
 
+from spectre.support.BinDirectory import BinDirectory
+
+# CMake configures the selected machine's description to this path
+default_machinefile_path = BinDirectory.this().path / "Machine.yaml"
+
 
 @dataclass(frozen=True)
 class Machine(yaml.YAMLObject):
@@ -102,7 +107,7 @@ class UnknownMachineError(Exception):
 
 @cache
 def this_machine(
-    machinefile_path=os.path.join(os.path.dirname(__file__), "Machine.yaml"),
+    machinefile_path=default_machinefile_path,
     raise_exception=True,
 ) -> Machine:
     """Determine the machine we are running on.

--- a/support/Python/Schedule.py
+++ b/support/Python/Schedule.py
@@ -17,6 +17,7 @@ import numpy as np
 import yaml
 from rich.pretty import pretty_repr
 
+from spectre.support.BinDirectory import BinDirectory
 from spectre.support.DirectoryStructure import (
     Checkpoint,
     Segment,
@@ -33,7 +34,7 @@ logger = logging.getLogger(__name__)
 
 # CMake configures the submit script templates for the current machine to this
 # path
-default_submit_script_template = Path(__file__).parent / "SubmitTemplate.sh"
+default_submit_script_template = BinDirectory.this().path / "SubmitTemplate.sh"
 
 
 def _resolve_executable(executable: Union[str, Path]) -> Path:
@@ -46,8 +47,7 @@ def _resolve_executable(executable: Union[str, Path]) -> Path:
     # when running the CLI. It is the bin dir of the build directory that
     # contains this script. When running Python code outside the CLI this should
     # also be the default bin dir.
-    default_bin_dir = Path(__file__).parent.parent.parent.parent.resolve()
-    path = os.environ["PATH"] + ":" + str(default_bin_dir)
+    path = os.environ["PATH"] + ":" + str(BinDirectory.this().path.resolve())
     which_exec = shutil.which(executable, path=path)
     if not which_exec:
         raise ValueError(

--- a/tests/support/Pipelines/Bbh/Test_Ringdown.py
+++ b/tests/support/Pipelines/Bbh/Test_Ringdown.py
@@ -39,7 +39,7 @@ from spectre.Pipelines.Bbh.Ringdown import (
 from spectre.support.Logging import configure_logging
 
 
-class TestInitialData(unittest.TestCase):
+class TestRingdown(unittest.TestCase):
     def setUp(self):
         self.test_dir = Path(
             unit_test_build_path(), "support/Pipelines/Bbh/Ringdown"

--- a/tests/support/Python/CMakeLists.txt
+++ b/tests/support/Python/CMakeLists.txt
@@ -23,6 +23,12 @@ if (BUILD_PYTHON_BINDINGS AND NOT PY_DEV_MODE)
 endif()
 
 spectre_add_python_bindings_test(
+  "support.BinDirectory"
+  Test_BinDirectory.py
+  "Python"
+  None)
+
+spectre_add_python_bindings_test(
   "support.DirectoryStructure"
   Test_DirectoryStructure.py
   "Python"

--- a/tests/support/Python/Test_BinDirectory.py
+++ b/tests/support/Python/Test_BinDirectory.py
@@ -2,6 +2,9 @@
 # See LICENSE.txt for details.
 
 import logging
+import os
+import shutil
+import stat
 import unittest
 from pathlib import Path
 
@@ -10,12 +13,98 @@ from spectre.support.BinDirectory import BIN_DIR_NAME, BinDirectory
 from spectre.support.Logging import configure_logging
 
 
+def _write_executable(path: Path, contents: str = "#!/bin/bash\n"):
+    path.write_text(contents)
+    path.chmod(path.stat().st_mode | stat.S_IEXEC)
+
+
 class TestBinDirectory(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = Path(unit_test_build_path(), "BinDirectory").resolve()
+        shutil.rmtree(self.test_dir, ignore_errors=True)
+        self.test_dir.mkdir(parents=True)
+
+        # A stand-in for a build directory, laid out the way CMake composes one
+        self.build_dir = self.test_dir / "Build"
+        self.source = BinDirectory(self.build_dir / BIN_DIR_NAME)
+        (self.source.path / "python/spectre/__pycache__").mkdir(parents=True)
+        (self.source.path / "python/spectre/Schedule.py").write_text("# code\n")
+        (self.source.path / "Machine.yaml").write_text("Machine:\n")
+        (self.source.path / "SubmitTemplate.sh").write_text("template\n")
+        for name in ["spectre", "python-spectre", "Inspiral", "Ringdown"]:
+            _write_executable(self.source.path / name)
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir, ignore_errors=True)
+
+    def segment(self, name: str) -> BinDirectory:
+        """A bin directory handle in a fresh segment of 'Sim'"""
+        segment_dir = self.test_dir / "Sim" / name
+        segment_dir.mkdir(parents=True, exist_ok=True)
+        return BinDirectory(segment_dir / BIN_DIR_NAME)
+
     def test_this(self):
         self.assertEqual(
             BinDirectory.this().path,
             Path(unit_test_build_path(), "../..", BIN_DIR_NAME).resolve(),
         )
+
+    def test_freeze(self):
+        bin_dir = self.segment("0000_Inspiral").freeze(self.source)
+        self.assertEqual(
+            sorted(entry.name for entry in bin_dir.path.iterdir()),
+            [
+                "Machine.yaml",
+                "SubmitTemplate.sh",
+                "python",
+                "python-spectre",
+                "spectre",
+            ],
+        )
+        self.assertTrue((bin_dir.path / "python/spectre/Schedule.py").is_file())
+        self.assertFalse((bin_dir.path / "python/spectre/__pycache__").exists())
+        for parent, dirs, files in os.walk(bin_dir.path):
+            for name in dirs + files:
+                self.assertFalse(Path(parent, name).is_symlink())
+
+        bin_dir.add(self.source.path / "Inspiral")
+        (self.source.path / "Machine.yaml").write_text("Machine: new\n")
+        bin_dir.freeze(self.source)
+        self.assertEqual(
+            (bin_dir.path / "Machine.yaml").read_text(), "Machine: new\n"
+        )
+        self.assertFalse((bin_dir.path / "Inspiral").exists())
+
+        (self.build_dir / "CMakeCache.txt").write_text(
+            "BUILD_SHARED_LIBS:BOOL=ON\n"
+        )
+        with self.assertRaisesRegex(RuntimeError, "BUILD_SHARED_LIBS"):
+            bin_dir.freeze(self.source)
+
+    def test_link_and_add(self):
+        root = self.segment("0000_Inspiral").freeze(self.source)
+        first = self.segment("0001_Inspiral").link(root)
+        self.assertEqual(os.readlink(first.path), "../0000_Inspiral/bin")
+        self.assertEqual(first.path.resolve(), root.path)
+
+        second = self.segment("0002_Ringdown").link(first)
+        self.assertEqual(os.readlink(second.path), "../0000_Inspiral/bin")
+
+        added = second.add(self.source.path / "Inspiral")
+        self.assertEqual(added, root.path / "Inspiral")
+        (self.source.path / "Inspiral").write_text("#!/bin/bash\n# rebuilt\n")
+        self.assertEqual(second.add(self.source.path / "Inspiral"), added)
+        self.assertNotIn("rebuilt", added.read_text())
+
+        (self.build_dir / "CMakeCache.txt").write_text(
+            "BUILD_SHARED_LIBS:BOOL=OFF\n"
+        )
+        linked_to_build = self.segment("0003_Inspiral").link(self.source)
+        outside = self.test_dir / "Outside"
+        _write_executable(outside)
+        with self.assertRaisesRegex(RuntimeError, "not in the build directory"):
+            linked_to_build.add(outside)
+        self.assertFalse((self.source.path / "Outside").exists())
 
 
 if __name__ == "__main__":

--- a/tests/support/Python/Test_BinDirectory.py
+++ b/tests/support/Python/Test_BinDirectory.py
@@ -1,0 +1,23 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import logging
+import unittest
+from pathlib import Path
+
+from spectre.Informer import unit_test_build_path
+from spectre.support.BinDirectory import BIN_DIR_NAME, BinDirectory
+from spectre.support.Logging import configure_logging
+
+
+class TestBinDirectory(unittest.TestCase):
+    def test_this(self):
+        self.assertEqual(
+            BinDirectory.this().path,
+            Path(unit_test_build_path(), "../..", BIN_DIR_NAME).resolve(),
+        )
+
+
+if __name__ == "__main__":
+    configure_logging(log_level=logging.DEBUG)
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Proposed changes

We need to freeze executables and support files when starting a job, so recompiling, branch changes, etc. don't interfere with the running job. This PR prepares the functionality, the next actually adds it to the BBH pipeline.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
Relocation of support files in build directory: Machine.yaml and SubmitTemplate.sh are now in `<build>/bin/`.
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent was used, have a co-author trailer of the form
      "Co-Authored-By: <agent name> <agent email>" as the last line of the
      commit, e.g. "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>".

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
