### PR TITLE
Fix Tabulated3D minimum enthalpy

### DIFF
--- a/src/PointwiseFunctions/Hydro/EquationsOfState/Tabulated3d.cpp
+++ b/src/PointwiseFunctions/Hydro/EquationsOfState/Tabulated3d.cpp
@@ -198,8 +198,9 @@ void Tabulated3D<IsRelativistic>::initialize(const h5::EosTable& spectre_eos) {
             std::log(specific_entropy[index_spectre]);
 
         // Determine specific enthalpy minimum
-        double h = 1. + table_point[Epsilon] +
-                   table_point[Pressure] / std::exp(log_density[iR]);
+        const double h = 1. + eps[index_spectre] +
+                         press_MeV_to_geom * pressure[index_spectre] /
+                             std::exp(log_density[iR]);
         enthalpy_minimum = std::min(enthalpy_minimum, h);
         // NOLINTEND(cppcoreguidelines-pro-bounds-pointer-arithmetic)
       }

--- a/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_Tabulated3D.cpp
+++ b/tests/Unit/PointwiseFunctions/Hydro/EquationsOfState/Test_Tabulated3D.cpp
@@ -299,6 +299,12 @@ SPECTRE_TEST_CASE("Unit.PointwiseFunctions.EquationsOfState.Tabulated3D",
 
   eos.initialize(compose_eos);
 
+  // The table stores pressure and shifted energy logarithmically, but the
+  // enthalpy lower bound must be computed from physical values without the log.
+  // h_min < 1 is physical when bound matter has less energy per baryon than
+  // the neutron mass used for normalization.
+  CHECK(eos.specific_enthalpy_lower_bound() == approx(0.9923212708074246));
+
   test_against_reference_values(eos);
 
   // Test serialization


### PR DESCRIPTION
## Proposed changes

Correct the Tabulated3D minimum specific enthalpy calculation to use the physical pressure and specific internal energy instead of their logarithmic interpolation values. Add a regression test using the DD2 table.

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent was used, have a co-author trailer of the form
      "Co-Authored-By: <agent name> <agent email>" as the last line of the
      commit, e.g. "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>".

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
