### PR TITLE
Add UpdateAuxiliaryVariables for SecondOrderScalarWave

### DIFF
--- a/src/Evolution/Systems/SecondOrderScalarWave/CMakeLists.txt
+++ b/src/Evolution/Systems/SecondOrderScalarWave/CMakeLists.txt
@@ -21,6 +21,7 @@ spectre_target_headers(
   Tags.hpp
   TagsDeclarations.hpp
   TimeDerivative.hpp
+  UpdateAuxiliaryVariables.hpp
   )
 
 target_link_libraries(
@@ -29,5 +30,6 @@ target_link_libraries(
   DataStructures
   DiscontinuousGalerkin
   Domain
+  LinearOperators
   Utilities
   )

--- a/src/Evolution/Systems/SecondOrderScalarWave/UpdateAuxiliaryVariables.hpp
+++ b/src/Evolution/Systems/SecondOrderScalarWave/UpdateAuxiliaryVariables.hpp
@@ -1,0 +1,43 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/Systems/SecondOrderScalarWave/Tags.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace SecondOrderScalarWave {
+/*!
+ * \brief Computes the auxiliary variable \f$\Phi_i = \partial_i \Psi\f$
+ *
+ * \details In the LDG scheme, the auxiliary variable \f$\Phi_i\f$ is not
+ * evolved in time but is recomputed from \f$\Psi\f$ at each substep.
+ * After this mutator runs, the boundary correction from
+ * `ApplyAuxiliaryBoundaryCorrectionsToVariables` will correct \f$\Phi_i\f$
+ * at element interfaces.
+ */
+template <size_t Dim>
+struct UpdateAuxiliaryVariables {
+  using return_tags = tmpl::list<Tags::Phi<Dim>>;
+  using argument_tags =
+      tmpl::list<Tags::Psi, domain::Tags::Mesh<Dim>,
+                 domain::Tags::InverseJacobian<Dim, Frame::ElementLogical,
+                                               Frame::Inertial>>;
+
+  static void apply(
+      const gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*> phi,
+      const Scalar<DataVector>& psi, const Mesh<Dim>& mesh,
+      const InverseJacobian<DataVector, Dim, Frame::ElementLogical,
+                            Frame::Inertial>& inverse_jacobian) {
+    partial_derivative(phi, psi, mesh, inverse_jacobian);
+  }
+};
+}  // namespace SecondOrderScalarWave

--- a/tests/Unit/Evolution/Systems/SecondOrderScalarWave/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/SecondOrderScalarWave/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LIBRARY_SOURCES
   Test_System.cpp
   Test_Tags.cpp
   Test_TimeDerivative.cpp
+  Test_UpdateAuxiliaryVariables.cpp
   )
 
 add_test_library(${LIBRARY} "${LIBRARY_SOURCES}")
@@ -17,6 +18,7 @@ target_link_libraries(
   PRIVATE
   DataStructures
   Domain
+  LinearOperators
   MathFunctions
   SecondOrderScalarWave
   Spectral

--- a/tests/Unit/Evolution/Systems/SecondOrderScalarWave/Test_UpdateAuxiliaryVariables.cpp
+++ b/tests/Unit/Evolution/Systems/SecondOrderScalarWave/Test_UpdateAuxiliaryVariables.cpp
@@ -1,0 +1,67 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <random>
+
+#include "DataStructures/DataBox/DataBox.hpp"
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/Systems/SecondOrderScalarWave/Tags.hpp"
+#include "Evolution/Systems/SecondOrderScalarWave/UpdateAuxiliaryVariables.hpp"
+#include "Framework/TestHelpers.hpp"
+#include "Helpers/DataStructures/MakeWithRandomValues.hpp"
+#include "NumericalAlgorithms/LinearOperators/PartialDerivatives.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace {
+template <size_t Dim>
+void check_update_aux(const gsl::not_null<std::mt19937*> generator) {
+  CAPTURE(Dim);
+  std::uniform_real_distribution<> distribution(-1.0, 1.0);
+  const Mesh<Dim> mesh{4, Spectral::Basis::Legendre,
+                       Spectral::Quadrature::GaussLobatto};
+  const size_t num_pts = mesh.number_of_grid_points();
+
+  const auto psi = make_with_random_values<Scalar<DataVector>>(
+      generator, make_not_null(&distribution), DataVector(num_pts));
+
+  const std::array<double, 3> scales{{0.5, 1.5, 2.5}};
+  InverseJacobian<DataVector, Dim, Frame::ElementLogical, Frame::Inertial>
+      inv_jac{num_pts, 0.0};
+  for (size_t i = 0; i < Dim; ++i) {
+    inv_jac.get(i, i) = 1.0 / gsl::at(scales, i);
+  }
+
+  const auto expected_phi = partial_derivative(psi, mesh, inv_jac);
+
+  auto box = db::create<db::AddSimpleTags<
+      SecondOrderScalarWave::Tags::Psi, SecondOrderScalarWave::Tags::Phi<Dim>,
+      domain::Tags::Mesh<Dim>,
+      domain::Tags::InverseJacobian<Dim, Frame::ElementLogical,
+                                    Frame::Inertial>>>(
+      psi, tnsr::i<DataVector, Dim, Frame::Inertial>{num_pts, 0.0}, mesh,
+      inv_jac);
+  db::mutate_apply<SecondOrderScalarWave::UpdateAuxiliaryVariables<Dim>>(
+      make_not_null(&box));
+
+  CHECK_ITERABLE_APPROX((db::get<SecondOrderScalarWave::Tags::Phi<Dim>>(box)),
+                        expected_phi);
+}
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.Evolution.Systems.SecondOrderScalarWave.UpdateAuxiliaryVariables",
+    "[Unit][Evolution]") {
+  MAKE_GENERATOR(generator);
+  check_update_aux<1>(make_not_null(&generator));
+  check_update_aux<2>(make_not_null(&generator));
+  check_update_aux<3>(make_not_null(&generator));
+}


### PR DESCRIPTION
## Proposed changes

Add an action to compute the auxiliary (as opposed to evolved) variables for the LDG system `SecondOrderScalarWave`.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent was used, have a co-author trailer of the form
      "Co-Authored-By: <agent name> <agent email>" as the last line of the
      commit, e.g. "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>".

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
