### PR TITLE
Set locale variables for file tests

### DIFF
--- a/tools/FileTestDefs.sh
+++ b/tools/FileTestDefs.sh
@@ -20,6 +20,17 @@ die() {
     exit 1
 }
 
+# Set locale information, so grep behaves consistently across systems.
+# We set it globally here so scripts that source this one also get the
+# settings, but only set the particular variables we are about so as
+# to affect those scripts as little as possible.  If the user set
+# LC_ALL we assume they did so intentionally and don't want us to
+# ignore it, but it will break our checks so we error.
+test -n "${LC_ALL}" && die "Cannot run file tests with LC_ALL set"
+export LC_COLLATE=C
+export LC_CTYPE=$(locale -a | grep --max-count=1 '\.utf8$')
+test -n "${LC_CTYPE}" || die "Cannot find a UTF-8 locale"
+
 # Option to enable color in grep or the empty string if grep does not
 # support color
 color_option=''
@@ -326,6 +337,11 @@ long_lines_test() {
     test_check pass foo.cpp "// \\image ${eighty}"$'\n'
     test_check pass foo.cpp "// \\link ${eighty}"$'\n'
     test_check pass foo.cpp "// \\endlink ${eighty}"$'\n'
+    local multibyte
+    printf -v multibyte '\xf0\x9f\x98\x82' # U+1F602: 4 bytes in UTF-8
+    local tenmultibyte=${multibyte}${multibyte}${multibyte}${multibyte}\
+${multibyte}${multibyte}${multibyte}${multibyte}${multibyte}${multibyte}
+    test_check pass foo.cpp "${tenmultibyte}${tenmultibyte}${tenmultibyte}"$'\n'
 }
 standard_checks+=(long_lines)
 


### PR DESCRIPTION
This should ensure consistent behavior across machines.  The main check this is relevant for is the long-lines check, which should now consistently check for lines with over 80 Unicode code points instead of sometimes counting bytes instead.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent was used, have a co-author trailer of the form
      "Co-Authored-By: <agent name> <agent email>" as the last line of the
      commit, e.g. "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>".

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
