### PR TITLE
Define BBH directory structure

### DIFF
--- a/support/Pipelines/Bbh/Cce.py
+++ b/support/Pipelines/Bbh/Cce.py
@@ -9,7 +9,10 @@ from typing import Optional, Sequence, Union
 import click
 
 from spectre.IO.H5.CombineH5Dat import combine_h5_dat
-from spectre.support.DirectoryStructure import PipelineStep, list_pipeline_steps
+from spectre.Pipelines.EccentricityControl.DirectoryStructure import (
+    EccIteration,
+)
+from spectre.support.DirectoryStructure import Segment
 from spectre.support.Schedule import schedule, scheduler_options
 
 logger = logging.getLogger(__name__)
@@ -21,6 +24,7 @@ def run_cce(
     bondi_sachs_data: Union[Union[str, Path], Sequence[Union[str, Path]]],
     force: bool = False,
     cce_input_file_template: Union[str, Path] = CCE_INPUT_FILE_TEMPLATE,
+    lev: Optional[int] = None,
     pipeline_dir: Optional[Union[str, Path]] = None,
     run_dir: Optional[Union[str, Path]] = None,
     segments_dir: Optional[Union[str, Path]] = None,
@@ -37,11 +41,17 @@ def run_cce(
     details.
 
     Arguments:
-        bondi_sachs_data: Path to one or more files containing Bondi-Sachs data
-        pipeline_dir: Directory where steps in the pipeline are created.
-        run_dir: Directory where the CCE executable is run. Mutually exclusive
+      bondi_sachs_data: Path to one or more files containing Bondi-Sachs data
+      lev: Resolution of the simulation that the waveforms are extracted from.
+        Required when running in a 'pipeline_dir', because it determines the
+        directory that CCE runs in.
+      pipeline_dir: Directory of the simulation, in which the pipeline
+        creates its runs.
+      run_dir: Directory where the CCE executable is run. Mutually exclusive
         with 'pipeline_dir'.
-        cce_input_file_template: Input file template for CCE. This should be a
+      segments_dir: Directory in which the CCE run is created. Mutually
+        exclusive with 'pipeline_dir' and 'run_dir'.
+      cce_input_file_template: Input file template for CCE. This should be a
         yaml file that defines the steps in the CCE pipeline.
     """
     logger.warning(
@@ -49,26 +59,25 @@ def run_cce(
         " input files."
     )
 
-    if not any([pipeline_dir, run_dir]):
+    if not any([pipeline_dir, run_dir, segments_dir]):
         raise ValueError(
-            "Specify either '--run-dir' / '-o' or '--pipeline-dir' / '-d'."
+            "Specify a '--run-dir' / '-o', a '--segments-dir' / '-O', or a"
+            " '--pipeline-dir' / '-d'."
         )
-    # If there is a pipeline directory, set run directory as well
+    # Resolve the run directory. CCE writes no checkpoints, so it always runs in
+    # a single run directory rather than in a series of segments.
     if pipeline_dir:
         pipeline_dir = Path(pipeline_dir).resolve()
-    if segments_dir:
-        raise ValueError(
-            "CCE does not use segments at the moment. Specify"
-            " '--run-dir' / '-o' or '--pipeline-dir' / '-d' instead."
+        assert lev is not None, (
+            "Specify a '--lev' when running in a '--pipeline-dir' / '-d',"
+            " because it determines the directory that CCE runs in. Specify a"
+            " '--run-dir' / '-o' or '--segments-dir' / '-O' to choose the"
+            " directory yourself."
         )
-    if pipeline_dir and not run_dir:
-        pipeline_steps = list_pipeline_steps(pipeline_dir)
-        if pipeline_steps:  # Check if the list is not empty
-            run_dir = pipeline_steps[-1].next(label="Cce").path
-        else:
-            run_dir = PipelineStep.first(
-                directory=pipeline_dir, label="Cce"
-            ).path
+        # Run in the directory of the resolution we extract from
+        segments_dir = EccIteration.current(pipeline_dir).lev_dir(lev)
+    if segments_dir and not run_dir:
+        run_dir = Segment.next(segments_dir, label="Cce").path
 
     # Check number of arguments. If one, check file ends with extraction radius.
     # For multiple files, ensure all extraction radii are the same and combine
@@ -141,7 +150,6 @@ def run_cce(
         **scheduler_kwargs,
         pipeline_dir=pipeline_dir,
         run_dir=run_dir,
-        segments_dir=segments_dir,
     )
 
 
@@ -172,13 +180,22 @@ def run_cce(
     show_default=True,
 )
 @click.option(
+    "--lev",
+    type=int,
+    help=(
+        "Resolution of the simulation that the waveforms are extracted from."
+        " Required with '--pipeline-dir' / '-d', because it determines the"
+        " directory that CCE runs in."
+    ),
+)
+@click.option(
     "--pipeline-dir",
     "-d",
     type=click.Path(
         writable=True,
         path_type=Path,
     ),
-    help="Directory where steps in the pipeline are created.",
+    help="Directory of the simulation, in which the pipeline creates its runs.",
 )
 @scheduler_options
 def run_cce_command(**kwargs):

--- a/support/Pipelines/Bbh/ControlId.py
+++ b/support/Pipelines/Bbh/ControlId.py
@@ -12,6 +12,7 @@ import yaml
 import spectre.IO.H5 as spectre_h5
 from spectre.IO.H5 import to_dataframe
 from spectre.Pipelines.Bbh.InitialData import TargetParams, generate_id
+from spectre.support.DirectoryStructure import Segment
 
 logger = logging.getLogger(__name__)
 
@@ -171,8 +172,11 @@ def control_id(
         orbital_angular_velocity=orbital_angular_velocity,
     )
 
-    # Prepare file and legends to output diagnostic data
-    output_filename = f"{id_run_dir}/../ControlParams.h5"
+    # Prepare file and legends to output diagnostic data. Every run of the
+    # control loop is a segment in the initial-data directory, so the diagnostic
+    # data goes next to them.
+    id_dir = Path(id_run_dir).resolve().parent
+    output_filename = str(id_dir / "ControlParams.h5")
     residual_legend = []
     jacobian_legend = []
     for param in control_params:
@@ -206,8 +210,6 @@ def control_id(
                 f" Control of BBH Parameters ({iteration}) "
                 "=========================================="
             )
-            control_run_dir = f"{id_run_dir}/../ControlParams_{iteration:03}"
-
             # Start with initial free data choices and update the ones being
             # controlled in `control_params` with the numeric value from `u`
             free_data = initial_free_data.copy()
@@ -218,12 +220,13 @@ def control_id(
                 else:
                     free_data[key] = [next(u_iterator) for _ in range(3)]
 
-            # Run ID and find horizons
+            # Run ID and find horizons. The run continues the sequence of
+            # initial-data runs in the 'id_dir', like any other run.
             generate_id(
                 target_params,
                 **free_data,
                 separation=separation,
-                run_dir=control_run_dir,
+                segments_dir=id_dir,
                 control=False,
                 evolve=False,
                 scheduler=None,
@@ -231,6 +234,7 @@ def control_id(
                 polynomial_order=polynomial_order,
                 negative_expansion_bc=negative_expansion_bc,
             )
+            control_run_dir = str(Segment.last(id_dir).path)
 
         # Initialize dictionary to hold the measured physical parameters
         measured_params: Dict[TargetParams, Union[float, Sequence[float]]] = {}

--- a/support/Pipelines/Bbh/EccentricityControl.py
+++ b/support/Pipelines/Bbh/EccentricityControl.py
@@ -18,7 +18,6 @@ from spectre.Pipelines.EccentricityControl.EccentricityControlParams import (
     eccentricity_control_params,
     eccentricity_control_params_options,
 )
-from spectre.support.DirectoryStructure import PipelineStep, list_pipeline_steps
 from spectre.support.Schedule import scheduler_options
 
 logger = logging.getLogger(__name__)
@@ -67,14 +66,17 @@ def eccentricity_control(
     Arguments:
       h5_files: files that contain the trajectory data
       id_input_file_path: path to the input file of the initial data run
-      pipeline_dir: directory where the pipeline outputs are stored.
+      pipeline_dir: Directory of the simulation, in which the pipeline
+        creates its runs.
       evolve: Evolve the initial data after generation to continue eccentricity
         control. You can disable this to generate only the new initial data if
         you want to manually start the next inspiral.
       branch_levs_when_complete: Optional list of levs to start when
-        eccentricity control is complete. Each lev will run in a separate
-        subdirectory. If no levs are specified, the simulation will just stop
-        after eccentricity control. See `Inspiral.INSPIRAL_LEVS` for the
+        eccentricity control is complete. Each lev continues in the 'Lev'
+        subdirectory of the current eccentricity-control iteration, so the lev
+        that was just run continues its sequence of segments and others branch
+        into a new directory. If no levs are specified, the simulation will just
+        stop after eccentricity control. See `Inspiral.INSPIRAL_LEVS` for the
         definition of the levs.
       inspiral_input_file_path: Path to the input file for the inspiral run.
         Required only if `branch_levs_when_complete` is specified, as the
@@ -118,15 +120,9 @@ def eccentricity_control(
     ):
         logger.info("Eccentricity control complete.")
         if branch_levs_when_complete:
-            # Continue inspiral in a subdirectory for each lev
+            # Continue the inspiral at each lev. The lev that we just ran
+            # continues in the same directory, others branch into a new one.
             for lev in branch_levs_when_complete:
-                lev_label = f"Lev{lev}"
-                pipeline_steps = list_pipeline_steps(pipeline_dir)
-                lev_dir = (
-                    pipeline_steps[-1].next(label=lev_label)
-                    if pipeline_steps
-                    else PipelineStep.first(pipeline_dir, label=lev_label)
-                )
                 start_inspiral(
                     # Start from inspiral data
                     id_input_file_path=inspiral_input_file_path,
@@ -135,7 +131,7 @@ def eccentricity_control(
                     lev=lev,
                     inspiral_input_file_template=inspiral_input_file_template,
                     continue_with_ringdown=True,
-                    pipeline_dir=lev_dir.path,
+                    pipeline_dir=pipeline_dir,
                     **scheduler_kwargs,
                 )
         return
@@ -185,7 +181,7 @@ def eccentricity_control(
         writable=True,
         path_type=Path,
     ),
-    help="Directory where steps in the pipeline are created.",
+    help="Directory of the simulation, in which the pipeline creates its runs.",
 )
 @click.option(
     "--evolve/--no-evolve",

--- a/support/Pipelines/Bbh/InitialData.py
+++ b/support/Pipelines/Bbh/InitialData.py
@@ -13,7 +13,9 @@ from rich.pretty import pretty_repr
 from SimulationSupport.EccentricityControl.InitialOrbitalParameters import (
     initial_orbital_parameters,
 )
-from spectre.support.DirectoryStructure import PipelineStep, list_pipeline_steps
+from spectre.Pipelines.EccentricityControl.DirectoryStructure import (
+    EccIteration,
+)
 from spectre.support.Schedule import schedule, scheduler_options
 
 logger = logging.getLogger(__name__)
@@ -247,9 +249,10 @@ def generate_id(
         be inside of the apparent horizons. This helps to find horizons and
         start an evolution from the initial data without extrapolation.
         (default: True)
-      pipeline_dir: Directory where steps in the pipeline are created. Required
-        when 'evolve' is set to True. The initial data will be created in a
-        subdirectory '001_InitialData'.
+      pipeline_dir: Directory of the simulation, in which the pipeline
+        creates its runs. Required when 'evolve' is set to True. The initial
+        data runs in the 'ID' directory of the next eccentricity-control
+        iteration, e.g. 'Ecc0/ID'.
       run_dir: Directory where the initial data is generated. Mutually exclusive
         with 'pipeline_dir'.
       segments_dir: Directory where the evolution data is generated. Mutually
@@ -280,15 +283,10 @@ def generate_id(
             " evolution, etc will be created in the 'pipeline_dir'"
             " automatically."
         )
-    # If there is a pipeline directory, set run directory as well
+    # If there is a pipeline directory, set run directory as well. The initial
+    # data starts a new eccentricity-control iteration.
     if pipeline_dir and not run_dir:
-        pipeline_steps = list_pipeline_steps(pipeline_dir)
-        if pipeline_steps:  # Check if the list is not empty
-            run_dir = pipeline_steps[-1].next(label="InitialData").path
-        else:
-            run_dir = PipelineStep.first(
-                directory=pipeline_dir, label="InitialData"
-            ).path
+        run_dir = EccIteration.next(pipeline_dir).id_dir
     # If we run a control loop, then run initial data in a subdirectory
     if control:
         run_dir = f"{run_dir}/ControlParams_000"
@@ -558,7 +556,7 @@ def generate_id(
         writable=True,
         path_type=Path,
     ),
-    help="Directory where steps in the pipeline are created.",
+    help="Directory of the simulation, in which the pipeline creates its runs.",
 )
 @scheduler_options
 def generate_id_command(

--- a/support/Pipelines/Bbh/InitialData.py
+++ b/support/Pipelines/Bbh/InitialData.py
@@ -252,11 +252,12 @@ def generate_id(
       pipeline_dir: Directory of the simulation, in which the pipeline
         creates its runs. Required when 'evolve' is set to True. The initial
         data runs in the 'ID' directory of the next eccentricity-control
-        iteration, e.g. 'Ecc0/ID'.
+        iteration, e.g. 'Ecc0/ID/0000_InitialData'.
       run_dir: Directory where the initial data is generated. Mutually exclusive
         with 'pipeline_dir'.
-      segments_dir: Directory where the evolution data is generated. Mutually
-        exclusive with 'pipeline_dir' and 'run_dir'.
+      segments_dir: Directory in which the initial-data run is created. Every
+        run of the control loop is a new segment in it. Mutually exclusive with
+        'pipeline_dir' and 'run_dir'.
       out_file_name: Optional. Name of the log file. (Default: "spectre.out")
     """
     logger.warning(
@@ -267,29 +268,29 @@ def generate_id(
     # Resolve directories
     if pipeline_dir:
         pipeline_dir = Path(pipeline_dir).resolve()
-    assert segments_dir is None, (
-        "Initial data generation doesn't use segments at the moment. Specify"
-        " '--run-dir' / '-o' or '--pipeline-dir' / '-d' instead."
-    )
     if evolve:
         assert pipeline_dir is not None, (
             "Specify a '--pipeline-dir' / '-d' to evolve the initial data."
             " Don't specify a '--run-dir' / '-o' because it will be created in"
             " the 'pipeline_dir' automatically."
         )
-        assert run_dir is None, (
+        assert run_dir is None and segments_dir is None, (
             "Specify the '--pipeline-dir' / '-d' rather than '--run-dir' / '-o'"
-            " when evolving the initial data. Directories for the initial data,"
-            " evolution, etc will be created in the 'pipeline_dir'"
-            " automatically."
+            " or '--segments-dir' / '-O' when evolving the initial data."
+            " Directories for the initial data, evolution, etc will be created"
+            " in the 'pipeline_dir' automatically."
         )
-    # If there is a pipeline directory, set run directory as well. The initial
-    # data starts a new eccentricity-control iteration.
-    if pipeline_dir and not run_dir:
-        run_dir = EccIteration.next(pipeline_dir).id_dir
-    # If we run a control loop, then run initial data in a subdirectory
+    # If there is a pipeline directory, set the segments directory as well. The
+    # initial data starts a new eccentricity-control iteration.
+    if pipeline_dir and not run_dir and not segments_dir:
+        segments_dir = EccIteration.next(pipeline_dir).id_dir
     if control:
-        run_dir = f"{run_dir}/ControlParams_000"
+        # Every run of the control loop is a segment, so the initial data runs
+        # in a segment rather than directly in the 'run_dir'
+        if run_dir and not segments_dir:
+            segments_dir = run_dir
+            run_dir = None
+        # Collect the logs of all runs in the control loop in a single file
         out_file_name = f"../{out_file_name}"
 
     # Determine orbital parameters

--- a/support/Pipelines/Bbh/Inspiral.py
+++ b/support/Pipelines/Bbh/Inspiral.py
@@ -13,8 +13,10 @@ from rich.pretty import pretty_repr
 
 import spectre.IO.H5 as spectre_h5
 from spectre.IO.H5 import available_subfiles, open_volfiles, select_observation
+from spectre.Pipelines.EccentricityControl.DirectoryStructure import (
+    EccIteration,
+)
 from spectre.support.CliExceptions import RequiredChoiceError
-from spectre.support.DirectoryStructure import PipelineStep, list_pipeline_steps
 from spectre.support.Schedule import schedule, scheduler_options
 
 logger = logging.getLogger(__name__)
@@ -553,13 +555,15 @@ def start_inspiral(
             " 'pipeline_dir' automatically."
         )
     if pipeline_dir and not run_dir and not segments_dir:
-        pipeline_steps = list_pipeline_steps(pipeline_dir)
-        if pipeline_steps:  # Check if the list is not empty
-            segments_dir = pipeline_steps[-1].next(label="Inspiral").path
-        else:
-            segments_dir = PipelineStep.first(
-                directory=pipeline_dir, label="Inspiral"
-            ).path
+        assert lev is not None, (
+            "Specify a '--lev' when running in a '--pipeline-dir' / '-d',"
+            " because it determines the directory that the evolution runs in."
+            " Specify a '--run-dir' / '-o' or '--segments-dir' / '-O' to choose"
+            " the directory yourself."
+        )
+        # Continue the current eccentricity-control iteration at this
+        # resolution
+        segments_dir = EccIteration.current(pipeline_dir).lev_dir(lev)
 
     # Determine resource allocation
     if (
@@ -695,7 +699,7 @@ def start_inspiral(
         writable=True,
         path_type=Path,
     ),
-    help="Directory where steps in the pipeline are created.",
+    help="Directory of the simulation, in which the pipeline creates its runs.",
 )
 @scheduler_options
 def start_inspiral_command(**kwargs):

--- a/support/Pipelines/Bbh/Inspiral.yaml
+++ b/support/Pipelines/Bbh/Inspiral.yaml
@@ -20,7 +20,7 @@ Next:
 Next:
   Run: spectre.Pipelines.Bbh.EccentricityControl:eccentricity_control
   With:
-    h5_files: "../Segment_*/BbhReductions.h5"
+    h5_files: "../*_Inspiral/BbhReductions.h5"
     id_input_file_path: {{ id_input_file_path }}
     plot_output_dir: ./
     ecc_params_output_file: "../EccentricityParams.yaml"

--- a/support/Pipelines/Bbh/PostprocessId.py
+++ b/support/Pipelines/Bbh/PostprocessId.py
@@ -88,7 +88,8 @@ def postprocess_id(
         for details.
       evolve: Evolve the initial data after postprocessing (default: False).
       negative_expansion_bc: Place the excisions inside of apparent horizons.
-      pipeline_dir: Directory where steps in the pipeline are created.
+      pipeline_dir: Directory of the simulation, in which the pipeline
+        creates its runs.
         Required if 'evolve' is set to True.
     """
     # Read input file
@@ -230,7 +231,7 @@ def postprocess_id(
     "--pipeline-dir",
     "-d",
     type=click.Path(writable=True, path_type=Path),
-    help="Directory where steps in the pipeline are created.",
+    help="Directory of the simulation, in which the pipeline creates its runs.",
 )
 @click.option(
     "--horizon-l-max",

--- a/support/Pipelines/Bbh/Ringdown.py
+++ b/support/Pipelines/Bbh/Ringdown.py
@@ -20,7 +20,9 @@ from spectre.Evolution.Ringdown.ComputeRingdownShapeAndTranslationFoT import (
 from spectre.IO.H5.FunctionsOfTimeFromVolume import (
     functions_of_time_from_volume,
 )
-from spectre.support.DirectoryStructure import PipelineStep, list_pipeline_steps
+from spectre.Pipelines.EccentricityControl.DirectoryStructure import (
+    EccIteration,
+)
 from spectre.support.Schedule import schedule, scheduler_options
 
 logger = logging.getLogger(__name__)
@@ -168,20 +170,19 @@ def start_ringdown(
     if pipeline_dir:
         pipeline_dir = Path(pipeline_dir).resolve()
     if pipeline_dir and not segments_dir and not run_dir:
-        pipeline_steps = list_pipeline_steps(pipeline_dir)
-        if pipeline_steps:
-            segments_dir = pipeline_steps[-1].next(label="Ringdown").path
-        else:
-            segments_dir = PipelineStep.first(
-                directory=pipeline_dir, label="Ringdown"
-            ).path
+        assert lev is not None, (
+            "Specify a '--lev' when running in a '--pipeline-dir' / '-d',"
+            " because it determines the directory that the ringdown runs in."
+            " Specify a '--run-dir' / '-o' or '--segments-dir' / '-O' to choose"
+            " the directory yourself."
+        )
+        # Continue in the same directory as the inspiral
+        segments_dir = EccIteration.current(pipeline_dir).lev_dir(lev)
 
     if path_to_output_h5 == None:
-        ringdown_dir = Path(segments_dir or run_dir)
-        ringdown_dir.mkdir(parents=True, exist_ok=True)
-        path_to_output_h5 = (
-            Path(ringdown_dir).resolve() / "RingdownShapeCoefs.h5"
-        )
+        output_dir = Path(segments_dir or run_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        path_to_output_h5 = Path(output_dir).resolve() / "RingdownShapeCoefs.h5"
     else:
         path_to_output_h5 = Path(path_to_output_h5).resolve()
 
@@ -569,7 +570,7 @@ def start_ringdown(
         writable=True,
         path_type=Path,
     ),
-    help="Directory where steps in the pipeline are created.",
+    help="Directory of the simulation, in which the pipeline creates its runs.",
 )
 @scheduler_options
 def start_ringdown_command(**kwargs):

--- a/support/Pipelines/EccentricityControl/CMakeLists.txt
+++ b/support/Pipelines/EccentricityControl/CMakeLists.txt
@@ -6,5 +6,6 @@ spectre_python_add_module(
   MODULE_PATH Pipelines
   PYTHON_FILES
   __init__.py
+  DirectoryStructure.py
   EccentricityControlParams.py
 )

--- a/support/Pipelines/EccentricityControl/DirectoryStructure.py
+++ b/support/Pipelines/EccentricityControl/DirectoryStructure.py
@@ -1,0 +1,115 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import logging
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional, Union
+
+logger = logging.getLogger(__name__)
+
+# Name of the directory that holds the initial data of an eccentricity-control
+# iteration
+ID_DIR_NAME = "ID"
+
+
+@dataclass(frozen=True, order=True)
+class EccIteration:
+    """One iteration of the eccentricity-control loop
+
+    Each iteration generates initial data, evolves it for a few orbits, and
+    measures the eccentricity. If the eccentricity is not yet within tolerance,
+    the next iteration starts with updated orbital parameters. Once it is, the
+    evolution of the last iteration continues to completion, branching into one
+    or more resolutions ("Levs").
+
+    We currently write eccentricity-control iterations in a directory structure
+    like this:
+
+    ```
+    PIPELINE_DIR/
+        Ecc0/
+            ID/
+                0000_InitialData/
+                0001_InitialData/
+                ...
+            Lev1/
+                0000_Inspiral/
+                0001_Inspiral/
+                ...
+        Ecc1/
+            ...
+    ```
+
+    The 'ID' directory and the 'Lev' directories are segments directories, so
+    the runs in them are 'Segment's (see
+    'spectre.support.DirectoryStructure.Segment').
+
+    WARNING: Don't assume that simulations always have the above directory
+    structure. You don't want your code to break when files are copied, moved
+    around, or renamed. Instead of relying on some directory structure, have
+    your code take the files it needs as input. This is quite easy using globs.
+    """
+
+    path: Path
+    id: int
+
+    NAME_PATTERN = re.compile(r"Ecc(\d+)")
+
+    @classmethod
+    def match(cls, path: Union[str, Path]) -> Optional["EccIteration"]:
+        """Checks if the 'path' is an eccentricity-control iteration"""
+        path = Path(path)
+        match = re.match(cls.NAME_PATTERN, path.resolve().name)
+        if not match:
+            return None
+        return cls(path=path, id=int(match.group(1)))
+
+    @classmethod
+    def last(cls, pipeline_dir: Union[str, Path]) -> Optional["EccIteration"]:
+        """The last iteration in the 'pipeline_dir', or 'None' if it has none"""
+        all_iterations = list_ecc_iterations(pipeline_dir)
+        return all_iterations[-1] if all_iterations else None
+
+    @classmethod
+    def next(cls, pipeline_dir: Union[str, Path]) -> "EccIteration":
+        """The next iteration to create in the 'pipeline_dir'
+
+        Continues the numbering of the iterations in the 'pipeline_dir', or
+        starts at zero if it has none.
+        """
+        last_iteration = cls.last(pipeline_dir)
+        next_id = last_iteration.id + 1 if last_iteration else 0
+        return cls(path=Path(pipeline_dir) / f"Ecc{next_id}", id=next_id)
+
+    @classmethod
+    def current(cls, pipeline_dir: Union[str, Path]) -> "EccIteration":
+        """The iteration in progress in the 'pipeline_dir'
+
+        The first iteration if the 'pipeline_dir' has none yet, or else the last
+        iteration.
+        """
+        return cls.last(pipeline_dir) or cls.next(pipeline_dir)
+
+    @property
+    def id_dir(self) -> Path:
+        """Directory that holds the initial data of this iteration"""
+        return self.path / ID_DIR_NAME
+
+    def lev_dir(self, lev: int) -> Path:
+        """Directory that holds the evolution of this iteration at 'lev'"""
+        return self.path / f"Lev{lev}"
+
+
+def list_ecc_iterations(pipeline_dir: Union[str, Path]) -> List[EccIteration]:
+    """All eccentricity-control iterations in the 'pipeline_dir'"""
+    pipeline_dir = Path(pipeline_dir)
+    if not pipeline_dir.exists():
+        return []
+    matches = map(EccIteration.match, pipeline_dir.iterdir())
+    # Sort by id, not by name, because the ids are not zero-padded
+    return sorted(
+        (match for match in matches if match),
+        key=lambda iteration: iteration.id,
+    )

--- a/support/Python/DirectoryStructure.py
+++ b/support/Python/DirectoryStructure.py
@@ -1,6 +1,23 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+"""Directories that simulations are organized in
+
+Three kinds of directory appear throughout the code, and the name of a
+variable says which kind it holds:
+
+- 'run_dir': one invocation of an executable runs here. It holds the input
+  file, the submit script, output files, and a 'Checkpoints' directory.
+- 'segments_dir': holds a numbered sequence of runs, such as '0000_Inspiral'
+  through '0013_Ringdown'. See 'Segment' below.
+- 'pipeline_dir': the directory of a simulation, in which a pipeline creates
+  all its runs. Each pipeline defines how it groups runs in there, e.g.
+  'spectre.Pipelines.EccentricityControl.DirectoryStructure'.
+
+A name that qualifies one of these, such as 'id_run_dir' or
+'inspiral_run_dir', refers to that directory of a specific step.
+"""
+
 import logging
 import re
 from dataclasses import dataclass
@@ -64,19 +81,29 @@ class Segment:
     We have to split simulations into segments because supercomputers don't
     typically support unlimited run times. Therefore, we terminate the job,
     write the simulation state to disk as a checkpoint, and submit a new job
-    that restarts from the last checkpoint.
+    that restarts from the last checkpoint. Segments are also how a pipeline
+    proceeds from one executable to the next, e.g. from an inspiral to a
+    ringdown. Therefore, each segment carries a 'label' that says what ran in
+    it, in addition to the 'id' that enumerates the segments.
 
     We currently write segments in a directory structure like this:
 
     ```
     SEGMENTS_DIR/
-        Segment_0000/
-            InputFile.yaml
+        0000_Inspiral/
+            Inspiral.yaml
             Submit.sh
             Output.h5
             Checkpoints/
-        Segment_0001/...
+        0001_Inspiral/
+            ...
+        0002_Ringdown/
+            ...
     ```
+
+    Note: "Inspiral" and "Ringdown" are examples, any label can be used. The id
+    goes _before_ the label so that a plain 'ls' of the segments directory lists
+    the segments in the order they ran, no matter which executable ran in them.
 
     WARNING: Don't assume that simulations always have the above directory
     structure. You don't want your code to break when files are copied, moved
@@ -86,20 +113,10 @@ class Segment:
 
     path: Path
     id: int
+    label: str
 
-    NAME_PATTERN = re.compile(r"Segment_(\d+)")
+    NAME_PATTERN = re.compile(r"(\d+)_(.+)")
     NUM_DIGITS = 4
-
-    @classmethod
-    def first(cls, directory: Union[str, Path]) -> "Segment":
-        name = "Segment_" + "0" * cls.NUM_DIGITS
-        return Segment(path=Path(directory) / name, id=0)
-
-    @property
-    def next(self) -> "Segment":
-        next_id = self.id + 1
-        next_name = "Segment_" + str(next_id).zfill(self.NUM_DIGITS)
-        return Segment(path=self.path.resolve().parent / next_name, id=next_id)
 
     @classmethod
     def match(cls, path: Union[str, Path]) -> Optional["Segment"]:
@@ -108,7 +125,30 @@ class Segment:
         match = re.match(cls.NAME_PATTERN, path.resolve().name)
         if not match:
             return None
-        return cls(path=path, id=int(match.group(1)))
+        return cls(path=path, id=int(match.group(1)), label=match.group(2))
+
+    @classmethod
+    def last(cls, segments_dir: Union[str, Path]) -> Optional["Segment"]:
+        """The last segment in the 'segments_dir', or 'None' if it has none"""
+        all_segments = list_segments(segments_dir)
+        return all_segments[-1] if all_segments else None
+
+    @classmethod
+    def next(cls, segments_dir: Union[str, Path], label: str) -> "Segment":
+        """The next segment to create in the 'segments_dir'
+
+        Continues the numbering of the segments in the 'segments_dir', or starts
+        at zero if it has none.
+        """
+        last_segment = cls.last(segments_dir)
+        next_id = last_segment.id + 1 if last_segment else 0
+        next_name = f"{str(next_id).zfill(cls.NUM_DIGITS)}_{label}"
+        return cls(path=Path(segments_dir) / next_name, id=next_id, label=label)
+
+    @property
+    def input_file(self) -> Path:
+        """The input file for the segment (has the same name as the label)"""
+        return self.path / f"{self.label}.yaml"
 
     @property
     def checkpoints_dir(self) -> Path:
@@ -125,77 +165,6 @@ def list_segments(segments_dir: Union[str, Path]) -> List[Segment]:
     if not segments_dir.exists():
         return []
     matches = map(Segment.match, segments_dir.iterdir())
-    return sorted(match for match in matches if match)
-
-
-@dataclass(frozen=True, order=True)
-class PipelineStep:
-    """A step in a pipeline
-
-    Each pipeline step is a numbered directory with a label, e.g.
-    "000_InitialData".
-    It can contain a simulation or a pre- or post-processing step
-    such as archiving.
-    Here is an example for the directory structure:
-
-    ```
-    BASE_DIR/
-        000_InitialData/
-            InputFile.yaml
-            Submit.sh
-            ...
-        001_Inspiral/
-            Segment_0000/
-                InputFile.yaml
-                Submit.sh
-                ...
-            Segment_0001/
-                ...
-        002_InitialData/
-            ...
-        ...
-    ```
-
-    Note: "InitialData" and "Inspiral" are examples, any name can be used.
-    """
-
-    path: Path
-    id: int
-    label: str
-
-    NAME_PATTERN = re.compile(r"(\d+)_(.+)")
-    NUM_DIGITS = 3
-
-    @classmethod
-    def first(cls, directory: Union[str, Path], label: str) -> "PipelineStep":
-        """Create the first directory in a sequence"""
-        name = "0" * cls.NUM_DIGITS + "_" + label
-        return PipelineStep(path=Path(directory) / name, id=0, label=label)
-
-    def next(self, label: str) -> "PipelineStep":
-        """Get the next directory in the sequence"""
-        next_id = self.id + 1
-        next_name = f"{str(next_id).zfill(self.NUM_DIGITS)}_{label}"
-        return PipelineStep(
-            path=self.path.resolve().parent / next_name,
-            id=next_id,
-            label=label,
-        )
-
-    @classmethod
-    def match(cls, path: Union[str, Path]) -> Optional["PipelineStep"]:
-        """Checks if the 'path' is a step in the pipeline"""
-        path = Path(path)
-        match = re.match(cls.NAME_PATTERN, path.resolve().name)
-        if not match:
-            return None
-        return cls(path=path, id=int(match.group(1)), label=match.group(2))
-
-
-def list_pipeline_steps(base_dir: Union[str, Path]) -> List[PipelineStep]:
-    """List all subdirectories in the base directory"""
-    base_dir = Path(base_dir)
-    if not base_dir.exists():
-        return []
-    matches = map(PipelineStep.match, base_dir.iterdir())
-    return sorted(match for match in matches if match)
+    return sorted(
+        (match for match in matches if match), key=lambda segment: segment.id
+    )

--- a/support/Python/Resubmit.py
+++ b/support/Python/Resubmit.py
@@ -37,8 +37,8 @@ def resubmit(
     # Resolve last segment
     all_segments = list_segments(segments_dir)
     assert all_segments, (
-        f"Directory '{segments_dir}' contains no segments "
-        f"that match the pattern '{Segment.NAME_PATTERN.pattern}'."
+        f"Directory '{segments_dir}' contains no segments that match the "
+        f"pattern '{Segment.NAME_PATTERN.pattern}', e.g. '0000_Inspiral'."
     )
     last_segment = all_segments[-1]
     if segment:

--- a/support/Python/Schedule.py
+++ b/support/Python/Schedule.py
@@ -490,14 +490,19 @@ def schedule(
             run_dir = all_segments[-1].next.path
         else:
             run_dir = Segment.first(segments_dir).path
-    if segments_dir and all_segments:
+        if all_segments and not from_checkpoint:
+            # A new segment that doesn't continue from a checkpoint starts a
+            # new run in the same directory. That's how a pipeline proceeds to
+            # the next executable, but it may also be a mistake, so warn.
+            logger.warning(
+                f"Found existing segments in directory '{segments_dir}', but"
+                " you're not continuing from a checkpoint in them. Starting a"
+                f" new run in '{run_dir}'. Use '--from-last-checkpoint' to"
+                " continue from the last checkpoint in this directory instead."
+            )
+    if segments_dir and all_segments and from_checkpoint:
         # Make sure we're continuing the last checkpoint of the last segment.
         # This requirement can be relaxed in the future if needed.
-        assert from_checkpoint, (
-            f"Found existing segments in directory '{segments_dir}'. Use"
-            " '--from-last-checkpoint' to continue from the last"
-            " checkpoint in this directory."
-        )
         last_segment = all_segments[-1]
         assert (
             from_checkpoint.parent == last_segment.checkpoints_dir.resolve()
@@ -875,8 +880,9 @@ def scheduler_options(f):
         # No `type=click.Path` because this can be a Jinja template
         help=(
             "The directory in which to create the next segment. "
-            "Requires '--from-checkpoint' or '--from-last-checkpoint' "
-            "unless starting the first segment."
+            "Continue the previous segment with '--from-checkpoint' or "
+            "'--from-last-checkpoint', or start a new run in the same "
+            "directory."
         ),
     )
     @click.option(

--- a/support/Python/Schedule.py
+++ b/support/Python/Schedule.py
@@ -165,8 +165,9 @@ def schedule(
     executable will run (but not both). If you specify a 'run_dir', the
     executable will run in it directly. If you specify a 'segments_dir', a new
     segment will be created and used as the 'run_dir'. Segments are named with
-    incrementing integers and continue the run from the previous segment. For
-    example, the following is a typical 'segments_dir':
+    incrementing integers, followed by a label that is the name of the input
+    file, and continue the run from the previous segment. For example, the
+    following is a typical 'segments_dir':
 
     \b
     ```sh
@@ -176,8 +177,8 @@ def schedule(
     SubmitTemplateBase.sh
     SubmitTemplate.sh
     # One segment per day
-    Segment_0000/
-        InputFile.yaml
+    0000_Inspiral/
+        Inspiral.yaml
         Submit.sh
         Output.h5
         # Occasional checkpoints, and a checkpoint before termination
@@ -185,7 +186,9 @@ def schedule(
             Checkpoint_0000/
             Checkpoint_0001/...
     # Next segment continues from last checkpoint of previous segment
-    Segment_0001/...
+    0001_Inspiral/...
+    # A pipeline can continue with another executable in the same sequence
+    0002_Ringdown/...
     ```
 
     You can omit the 'run_dir' if the current working directory already contains
@@ -486,10 +489,10 @@ def schedule(
             template_env.from_string(str(segments_dir)).render(context).strip()
         )
         all_segments = list_segments(segments_dir)
-        if all_segments:
-            run_dir = all_segments[-1].next.path
-        else:
-            run_dir = Segment.first(segments_dir).path
+        # Label the segment with the name of the input file, e.g. "Inspiral"
+        run_dir = Segment.next(
+            segments_dir, label=Path(input_file_name).stem
+        ).path
         if all_segments and not from_checkpoint:
             # A new segment that doesn't continue from a checkpoint starts a
             # new run in the same directory. That's how a pipeline proceeds to

--- a/tests/support/Pipelines/Bbh/Test_Cce.py
+++ b/tests/support/Pipelines/Bbh/Test_Cce.py
@@ -25,8 +25,8 @@ class TestCce(unittest.TestCase):
         # Set up directories to hold input and output files
         self.inspiral_dir = self.test_dir / "Inspiral"
         self.ringdown_dir = self.test_dir / "Ringdown"
-        self.inspiral_seg_dir = self.inspiral_dir / "Segment_0000"
-        self.ringdown_seg_dir = self.ringdown_dir / "Segment_0000"
+        self.inspiral_seg_dir = self.inspiral_dir / "0000_Inspiral"
+        self.ringdown_seg_dir = self.ringdown_dir / "0000_Ringdown"
         if os.path.exists(self.inspiral_dir):
             shutil.rmtree(self.inspiral_dir)
         if os.path.exists(self.ringdown_dir):
@@ -176,6 +176,37 @@ class TestCce(unittest.TestCase):
             standalone_mode=False,
         )
         self.assertTrue((self.test_dir / "02_Output/Cce.yaml").exists())
+        # Run in a pipeline directory, where CCE continues the sequence of runs
+        # of the resolution that the waveforms are extracted from
+        run_cce_command.main(
+            args=[
+                self.inspiral_input_file_path,
+                "--pipeline-dir",
+                str(self.test_dir / "Pipeline"),
+                "--lev",
+                "1",
+                "-E",
+                str(self.bin_dir / "CharacteristicExtract"),
+                "--no-submit",
+            ],
+            standalone_mode=False,
+        )
+        self.assertTrue(
+            (self.test_dir / "Pipeline/Ecc0/Lev1/0000_Cce/Cce.yaml").exists()
+        )
+        # Run in a segments directory
+        run_cce_command.main(
+            args=[
+                self.inspiral_input_file_path,
+                "--segments-dir",
+                str(self.test_dir / "Segments"),
+                "-E",
+                str(self.bin_dir / "CharacteristicExtract"),
+                "--no-submit",
+            ],
+            standalone_mode=False,
+        )
+        self.assertTrue((self.test_dir / "Segments/0000_Cce/Cce.yaml").exists())
 
 
 if __name__ == "__main__":

--- a/tests/support/Pipelines/Bbh/Test_InitialData.py
+++ b/tests/support/Pipelines/Bbh/Test_InitialData.py
@@ -131,7 +131,7 @@ class TestInitialData(unittest.TestCase):
         except SystemExit as e:
             self.assertEqual(e.code, 0)
         self.assertTrue(
-            (self.test_dir / "ControlParams_000/InitialData.yaml").exists()
+            (self.test_dir / "0000_InitialData/InitialData.yaml").exists()
         )
         # Test with pipeline directory
         try:
@@ -149,7 +149,7 @@ class TestInitialData(unittest.TestCase):
             self.assertEqual(e.code, 0)
         with open(
             self.test_dir
-            / "Pipeline/Ecc0/ID/ControlParams_000/InitialData.yaml",
+            / "Pipeline/Ecc0/ID/0000_InitialData/InitialData.yaml",
             "r",
         ) as open_input_file:
             metadata = next(yaml.safe_load_all(open_input_file))

--- a/tests/support/Pipelines/Bbh/Test_InitialData.py
+++ b/tests/support/Pipelines/Bbh/Test_InitialData.py
@@ -149,7 +149,7 @@ class TestInitialData(unittest.TestCase):
             self.assertEqual(e.code, 0)
         with open(
             self.test_dir
-            / "Pipeline/000_InitialData/ControlParams_000/InitialData.yaml",
+            / "Pipeline/Ecc0/ID/ControlParams_000/InitialData.yaml",
             "r",
         ) as open_input_file:
             metadata = next(yaml.safe_load_all(open_input_file))

--- a/tests/support/Pipelines/Bbh/Test_Inspiral.py
+++ b/tests/support/Pipelines/Bbh/Test_Inspiral.py
@@ -46,7 +46,7 @@ class TestInspiral(unittest.TestCase):
             submit=False,
             executable=str(self.bin_dir / "SolveXcts"),
         )
-        self.id_dir = self.test_dir / "ID"
+        self.id_run_dir = self.test_dir / "ID"
         # Purposefully not in the ID directory
         self.horizons_filename = self.test_dir / "Horizons.h5"
         with spectre_h5.H5File(
@@ -62,18 +62,18 @@ class TestInspiral(unittest.TestCase):
         shutil.rmtree(self.test_dir, ignore_errors=True)
 
     def test_inspiral_parameters(self):
-        with open(self.id_dir / "InitialData.yaml") as open_input_file:
+        with open(self.id_run_dir / "InitialData.yaml") as open_input_file:
             id_metadata, id_input_file = yaml.safe_load_all(open_input_file)
         params = inspiral_parameters(
             id_input_file=id_input_file,
             id_metadata=id_metadata,
-            id_run_dir=self.id_dir,
+            id_run_dir=self.id_run_dir,
             id_subfile_name="VolumeData",
             id_horizons_path=self.horizons_filename,
         )
         self.assertEqual(
             params["IdFileGlob"],
-            str((self.id_dir).resolve() / "BbhVolume*.h5"),
+            str((self.id_run_dir).resolve() / "BbhVolume*.h5"),
         )
         self.assertEqual(params["IdSubfile"], "VolumeData")
         self.assertAlmostEqual(params["ExcisionRadiusA"], 1.116 * 1.0385 * 0.82)
@@ -134,7 +134,7 @@ class TestInspiral(unittest.TestCase):
 
     def test_cli(self):
         common_args = [
-            str(self.id_dir / "InitialData.yaml"),
+            str(self.id_run_dir / "InitialData.yaml"),
             "--id-subfile-name",
             "VolumeData",
             "--id-horizons-path",
@@ -163,11 +163,11 @@ class TestInspiral(unittest.TestCase):
         except SystemExit as e:
             self.assertEqual(e.code, 0)
         self.assertTrue(
-            (self.test_dir / "Inspiral/Segment_0000/Inspiral.yaml").exists()
+            (self.test_dir / "Inspiral/0000_Inspiral/Inspiral.yaml").exists()
         )
 
         with open(
-            self.test_dir / "Inspiral/Segment_0000/Inspiral.yaml", "r"
+            self.test_dir / "Inspiral/0000_Inspiral/Inspiral.yaml", "r"
         ) as open_input_file:
             _, input_file = yaml.safe_load_all(open_input_file)
         ah_ab_max_tolerance = 0.000216536 * 4 ** (-2)
@@ -215,7 +215,7 @@ class TestInspiral(unittest.TestCase):
         except SystemExit as e:
             self.assertEqual(e.code, 0)
         with open(
-            self.test_dir / "Pipeline/000_Inspiral/Segment_0000/Inspiral.yaml",
+            self.test_dir / "Pipeline/Ecc0/Lev-2/0000_Inspiral/Inspiral.yaml",
             "r",
         ) as open_input_file:
             metadata = next(yaml.safe_load_all(open_input_file))
@@ -251,7 +251,7 @@ class TestInspiral(unittest.TestCase):
         except SystemExit as e:
             self.assertEqual(e.code, 0)
         with open(
-            self.test_dir / "Pipeline/001_Inspiral/Segment_0000/Inspiral.yaml",
+            self.test_dir / "Pipeline/Ecc0/Lev-2/0001_Inspiral/Inspiral.yaml",
             "r",
         ) as open_input_file:
             metadata = next(yaml.safe_load_all(open_input_file))
@@ -262,9 +262,9 @@ class TestInspiral(unittest.TestCase):
             {
                 "Run": modulename + ":eccentricity_control",
                 "With": {
-                    "h5_files": "../Segment_*/BbhReductions.h5",
+                    "h5_files": "../*_Inspiral/BbhReductions.h5",
                     "id_input_file_path": str(
-                        self.id_dir.resolve() / "InitialData.yaml"
+                        self.id_run_dir.resolve() / "InitialData.yaml"
                     ),
                     "plot_output_dir": "./",
                     "ecc_params_output_file": "../EccentricityParams.yaml",

--- a/tests/support/Pipelines/Bbh/Test_PostprocessId.py
+++ b/tests/support/Pipelines/Bbh/Test_PostprocessId.py
@@ -42,7 +42,7 @@ class TestPostprocessId(unittest.TestCase):
             submit=False,
             executable=str(self.bin_dir / "SolveXcts"),
         )
-        self.id_dir = self.test_dir / "ID"
+        self.id_run_dir = self.test_dir / "ID"
 
     def tearDown(self):
         shutil.rmtree(self.test_dir, ignore_errors=True)
@@ -55,7 +55,7 @@ class TestPostprocessId(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "Number of observations"):
             postprocess_id_command(
                 [
-                    str(self.id_dir / "InitialData.yaml"),
+                    str(self.id_run_dir / "InitialData.yaml"),
                 ]
             )
 

--- a/tests/support/Pipelines/Bbh/Test_Ringdown.py
+++ b/tests/support/Pipelines/Bbh/Test_Ringdown.py
@@ -65,8 +65,8 @@ class TestInitialData(unittest.TestCase):
             submit=False,
             executable=str(self.bin_dir / "SolveXcts"),
         )
-        self.id_dir = self.test_dir / "ID"
-        self.horizons_filename = self.id_dir / "Horizons.h5"
+        self.id_run_dir = self.test_dir / "ID"
+        self.horizons_filename = self.id_run_dir / "Horizons.h5"
         with spectre_h5.H5File(
             str(self.horizons_filename.resolve()), "a"
         ) as horizons_file:
@@ -85,7 +85,7 @@ class TestInitialData(unittest.TestCase):
             submit=False,
             executable=str(self.bin_dir / "EvolveGhBinaryBlackHole"),
         )
-        self.inspiral_dir = self.test_dir / "Inspiral" / "Segment_0000"
+        self.inspiral_dir = self.test_dir / "Inspiral" / "0000_Inspiral"
         # Making fake reduction data with simple derivative
         self.inspiral_reduction_data = self.inspiral_dir / "BbhReductions.h5"
         with spectre_h5.H5File(
@@ -279,7 +279,7 @@ class TestInitialData(unittest.TestCase):
         except SystemExit as e:
             self.assertEqual(e.code, 0)
         self.assertTrue(
-            (self.test_dir / "Ringdown/Segment_0000/Ringdown.yaml").exists()
+            (self.test_dir / "Ringdown/0000_Ringdown/Ringdown.yaml").exists()
         )
         self.assertTrue(
             (self.test_dir / "RingdownCoefs.h5").exists(),
@@ -303,13 +303,12 @@ class TestInitialData(unittest.TestCase):
             self.assertEqual(e.code, 0)
         self.assertTrue(
             (
-                self.test_dir
-                / "Pipeline/000_Ringdown/Segment_0000/Ringdown.yaml"
+                self.test_dir / "Pipeline/Ecc0/Lev1/0000_Ringdown/Ringdown.yaml"
             ).exists()
         )
         self.assertTrue(
             (
-                self.test_dir / "Pipeline/000_Ringdown/RingdownShapeCoefs.h5"
+                self.test_dir / "Pipeline/Ecc0/Lev1/RingdownShapeCoefs.h5"
             ).exists(),
         )
 

--- a/tests/support/Pipelines/EccentricityControl/CMakeLists.txt
+++ b/tests/support/Pipelines/EccentricityControl/CMakeLists.txt
@@ -1,6 +1,12 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
+spectre_add_python_bindings_test(
+  "support.Pipelines.EccentricityControl.DirectoryStructure"
+  Test_DirectoryStructure.py
+  "Python"
+  None)
+
 if (SpEC_FOUND)
   spectre_add_python_bindings_test(
     "support.Pipelines.EccentricityControl.EccentricityControlParams"

--- a/tests/support/Pipelines/EccentricityControl/Test_DirectoryStructure.py
+++ b/tests/support/Pipelines/EccentricityControl/Test_DirectoryStructure.py
@@ -1,0 +1,77 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import logging
+import shutil
+import unittest
+from pathlib import Path
+
+from spectre.Informer import unit_test_build_path
+from spectre.Pipelines.EccentricityControl.DirectoryStructure import (
+    EccIteration,
+    list_ecc_iterations,
+)
+from spectre.support.Logging import configure_logging
+
+
+class TestDirectoryStructure(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = Path(
+            unit_test_build_path(),
+            "Pipelines/EccentricityControl/DirectoryStructure",
+        )
+        shutil.rmtree(self.test_dir, ignore_errors=True)
+        self.test_dir.mkdir(parents=True, exist_ok=True)
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir, ignore_errors=True)
+
+    def test_ecc_iterations(self):
+        # The first iteration in an empty directory starts the numbering at zero
+        self.assertIsNone(EccIteration.last(self.test_dir))
+        self.assertEqual(list_ecc_iterations(self.test_dir), [])
+        first_iteration = EccIteration.next(self.test_dir)
+        # Without any iterations yet, the first one is also the current one
+        self.assertEqual(EccIteration.current(self.test_dir), first_iteration)
+        self.assertEqual(
+            first_iteration,
+            EccIteration(path=self.test_dir / "Ecc0", id=0),
+        )
+        self.assertEqual(
+            EccIteration.match(first_iteration.path), first_iteration
+        )
+        self.assertIsNone(EccIteration.match(self.test_dir / "NotAnIteration"))
+
+        first_iteration.path.mkdir()
+        self.assertEqual(list_ecc_iterations(self.test_dir), [first_iteration])
+        self.assertEqual(EccIteration.last(self.test_dir), first_iteration)
+
+        next_iteration = EccIteration.next(self.test_dir)
+        self.assertEqual(
+            next_iteration, EccIteration(path=self.test_dir / "Ecc1", id=1)
+        )
+
+        # The names are not zero-padded, so they must be sorted numerically
+        tenth_iteration = EccIteration(path=self.test_dir / "Ecc10", id=10)
+        tenth_iteration.path.mkdir()
+        next_iteration.path.mkdir()
+        self.assertEqual(
+            list_ecc_iterations(self.test_dir),
+            [first_iteration, next_iteration, tenth_iteration],
+        )
+        self.assertEqual(EccIteration.last(self.test_dir), tenth_iteration)
+        self.assertEqual(EccIteration.current(self.test_dir), tenth_iteration)
+        self.assertEqual(EccIteration.next(self.test_dir).id, 11)
+
+    def test_iteration_subdirs(self):
+        iteration = EccIteration.next(self.test_dir)
+        self.assertEqual(iteration.id_dir, self.test_dir / "Ecc0" / "ID")
+        self.assertEqual(iteration.lev_dir(1), self.test_dir / "Ecc0" / "Lev1")
+        self.assertEqual(
+            iteration.lev_dir(-1), self.test_dir / "Ecc0" / "Lev-1"
+        )
+
+
+if __name__ == "__main__":
+    configure_logging(log_level=logging.DEBUG)
+    unittest.main(verbosity=2)

--- a/tests/support/Pipelines/EccentricityControl/Test_DirectoryStructure.py
+++ b/tests/support/Pipelines/EccentricityControl/Test_DirectoryStructure.py
@@ -41,6 +41,9 @@ class TestDirectoryStructure(unittest.TestCase):
             EccIteration.match(first_iteration.path), first_iteration
         )
         self.assertIsNone(EccIteration.match(self.test_dir / "NotAnIteration"))
+        self.assertNotEqual(
+            EccIteration.match(self.test_dir / "Ecc1"), first_iteration
+        )
 
         first_iteration.path.mkdir()
         self.assertEqual(list_ecc_iterations(self.test_dir), [first_iteration])

--- a/tests/support/Python/Test_DirectoryStructure.py
+++ b/tests/support/Python/Test_DirectoryStructure.py
@@ -9,10 +9,8 @@ from pathlib import Path
 from spectre.Informer import unit_test_build_path
 from spectre.support.DirectoryStructure import (
     Checkpoint,
-    PipelineStep,
     Segment,
     list_checkpoints,
-    list_pipeline_steps,
     list_segments,
 )
 from spectre.support.Logging import configure_logging
@@ -40,56 +38,51 @@ class TestDirectoryStructure(unittest.TestCase):
         self.assertEqual(list_checkpoints(self.test_dir), [checkpoint])
 
     def test_segments(self):
-        first_segment = Segment.first(self.test_dir)
+        # The first segment in an empty directory starts the numbering at zero
+        self.assertIsNone(Segment.last(self.test_dir))
+        first_segment = Segment.next(self.test_dir, label="Inspiral")
         self.assertEqual(
-            first_segment, Segment(path=self.test_dir / "Segment_0000", id=0)
+            first_segment,
+            Segment(
+                path=self.test_dir / "0000_Inspiral", id=0, label="Inspiral"
+            ),
         )
         self.assertEqual(Segment.match(first_segment.path), first_segment)
-
-        segment = Segment.match(self.test_dir / "Segment_0003")
-        self.assertEqual(
-            segment, Segment(path=self.test_dir / "Segment_0003", id=3)
-        )
-
-        next_segment = segment.next
-        self.assertEqual(next_segment.id, 4)
-        self.assertEqual(next_segment.path.name, "Segment_0004")
-        self.assertEqual(
-            next_segment.path.resolve().parent, segment.path.resolve().parent
-        )
+        self.assertIsNone(Segment.match(self.test_dir / "NotASegment"))
 
         self.assertEqual(list_segments(self.test_dir), [])
         first_segment.path.mkdir()
-        segment.path.mkdir()
-        next_segment.path.mkdir()
-        self.assertEqual(
-            list_segments(self.test_dir), [first_segment, segment, next_segment]
-        )
+        self.assertEqual(list_segments(self.test_dir), [first_segment])
+        self.assertEqual(Segment.last(self.test_dir), first_segment)
 
-    def test_pipeline_steps(self):
-        first_step = PipelineStep.first(self.test_dir, "InitialData")
+        # The next segment continues the numbering, and can have a different
+        # label because a pipeline can continue with another executable
+        next_segment = Segment.next(self.test_dir, label="Ringdown")
         self.assertEqual(
-            first_step,
-            PipelineStep(
-                path=self.test_dir / "000_InitialData",
-                id=0,
-                label="InitialData",
+            next_segment,
+            Segment(
+                path=self.test_dir / "0001_Ringdown", id=1, label="Ringdown"
             ),
         )
-        self.assertEqual(PipelineStep.match(first_step.path), first_step)
-
-        next_step = first_step.next("Processing")
-        self.assertEqual(next_step.id, 1)
-        self.assertEqual(next_step.path.name, "001_Processing")
+        next_segment.path.mkdir()
         self.assertEqual(
-            next_step.path.resolve().parent, first_step.path.resolve().parent
+            list_segments(self.test_dir), [first_segment, next_segment]
         )
+        self.assertEqual(Segment.last(self.test_dir), next_segment)
 
-        self.assertEqual(list_pipeline_steps(self.test_dir), [])
-        first_step.path.mkdir()
-        next_step.path.mkdir()
+        # Checkpoints are stored in the segment
         self.assertEqual(
-            list_pipeline_steps(self.test_dir), [first_step, next_step]
+            next_segment.checkpoints_dir, next_segment.path / "Checkpoints"
+        )
+        self.assertEqual(next_segment.checkpoints, [])
+        (next_segment.checkpoints_dir / "Checkpoint_0000").mkdir(parents=True)
+        self.assertEqual(
+            next_segment.checkpoints,
+            [
+                Checkpoint(
+                    path=next_segment.checkpoints_dir / "Checkpoint_0000", id=0
+                )
+            ],
         )
 
 

--- a/tests/support/Python/Test_Schedule.py
+++ b/tests/support/Python/Test_Schedule.py
@@ -136,16 +136,6 @@ NUM_TASKS_PER_NODE={{ num_slurm_tasks | default (5) }}
         )
 
         # Create next segment
-        # - Can't continue without a previous checkpoint
-        with self.assertRaisesRegex(AssertionError, "continue from the last"):
-            schedule(
-                input_file_template=self.input_file_template,
-                scheduler=None,
-                executable=self.executable,
-                segments_dir=self.test_dir,
-                extra_option="TestOpt",
-                metadata_option="MetaOpt",
-            )
         # - Can't continue from an earlier checkpoint than the last
         earlier_checkpoint = Checkpoint.match(
             self.test_dir / "Segment_0000/Checkpoints/Checkpoint_0000"
@@ -174,6 +164,25 @@ NUM_TASKS_PER_NODE={{ num_slurm_tasks | default (5) }}
             from_checkpoint=last_checkpoint,
             extra_option="TestOpt",
             metadata_option="MetaOpt",
+        )
+        # - Starting a new run without continuing from a checkpoint is allowed,
+        #   but warns. This is how a pipeline proceeds to the next executable in
+        #   the same directory.
+        with self.assertLogs(level="WARNING") as captured_logs:
+            schedule(
+                input_file_template=self.input_file_template,
+                scheduler=None,
+                executable=self.executable,
+                segments_dir=self.test_dir,
+                extra_option="TestOpt",
+                metadata_option="MetaOpt",
+            )
+        self.assertIn(
+            "not continuing from a checkpoint", "\n".join(captured_logs.output)
+        )
+        self.assertEqual(
+            [segment.path.name for segment in list_segments(self.test_dir)],
+            ["Segment_0000", "Segment_0001", "Segment_0002"],
         )
 
     def test_schedule(self):

--- a/tests/support/Python/Test_Schedule.py
+++ b/tests/support/Python/Test_Schedule.py
@@ -127,22 +127,22 @@ NUM_TASKS_PER_NODE={{ num_slurm_tasks | default (5) }}
             metadata_option="MetaOpt",
         )
         self.assertEqual(
-            sorted(self.test_dir.glob("Segment*")),
-            [self.test_dir / "Segment_0000"],
+            sorted(self.test_dir.glob("[0-9]*_InputFile")),
+            [self.test_dir / "0000_InputFile"],
         )
         self.assertEqual(
-            sorted(self.test_dir.glob("Segment*/InputFile.yaml")),
-            [self.test_dir / "Segment_0000/InputFile.yaml"],
+            sorted(self.test_dir.glob("[0-9]*_InputFile/InputFile.yaml")),
+            [self.test_dir / "0000_InputFile/InputFile.yaml"],
         )
 
         # Create next segment
         # - Can't continue from an earlier checkpoint than the last
         earlier_checkpoint = Checkpoint.match(
-            self.test_dir / "Segment_0000/Checkpoints/Checkpoint_0000"
+            self.test_dir / "0000_InputFile/Checkpoints/Checkpoint_0000"
         )
         earlier_checkpoint.path.mkdir(parents=True)
         last_checkpoint = Checkpoint.match(
-            self.test_dir / "Segment_0000/Checkpoints/Checkpoint_0001"
+            self.test_dir / "0000_InputFile/Checkpoints/Checkpoint_0001"
         )
         last_checkpoint.path.mkdir(parents=True)
         with self.assertRaisesRegex(AssertionError, "continue from the last"):
@@ -182,7 +182,7 @@ NUM_TASKS_PER_NODE={{ num_slurm_tasks | default (5) }}
         )
         self.assertEqual(
             [segment.path.name for segment in list_segments(self.test_dir)],
-            ["Segment_0000", "Segment_0001", "Segment_0002"],
+            ["0000_InputFile", "0001_InputFile", "0002_InputFile"],
         )
 
     def test_schedule(self):
@@ -200,33 +200,33 @@ NUM_TASKS_PER_NODE={{ num_slurm_tasks | default (5) }}
         self.assertEqual(
             sorted(self.test_dir.glob("Segments/**/*")),
             [
-                self.test_dir / "Segments/Segment_0000",
-                self.test_dir / "Segments/Segment_0000/InputFile.yaml",
-                self.test_dir / "Segments/Segment_0000/SchedulerContext.yaml",
-                self.test_dir / "Segments/Segment_0000/Submit.sh",
-                self.test_dir / "Segments/Segment_0000/jobid.txt",
-                self.test_dir / "Segments/Segment_0000/out.txt",
+                self.test_dir / "Segments/0000_InputFile",
+                self.test_dir / "Segments/0000_InputFile/InputFile.yaml",
+                self.test_dir / "Segments/0000_InputFile/SchedulerContext.yaml",
+                self.test_dir / "Segments/0000_InputFile/Submit.sh",
+                self.test_dir / "Segments/0000_InputFile/jobid.txt",
+                self.test_dir / "Segments/0000_InputFile/out.txt",
                 self.test_dir / "Segments/SubmitTemplate.sh",
                 self.test_dir / "Segments/SubmitTemplateBase.sh",
                 self.test_dir / "Segments/TestExec",
             ],
         )
         self.assertEqual(
-            (self.test_dir / "Segments/Segment_0000/jobid.txt").read_text(),
+            (self.test_dir / "Segments/0000_InputFile/jobid.txt").read_text(),
             "000",
         )
         self.assertEqual(
-            (self.test_dir / "Segments/Segment_0000/out.txt")
+            (self.test_dir / "Segments/0000_InputFile/out.txt")
             .read_text()
             .split(),
             [
                 "--input-file",
-                str(self.test_dir / "Segments/Segment_0000/InputFile.yaml"),
+                str(self.test_dir / "Segments/0000_InputFile/InputFile.yaml"),
                 "--check-options",
             ],
         )
         with open(
-            self.test_dir / "Segments/Segment_0000/SchedulerContext.yaml", "r"
+            self.test_dir / "Segments/0000_InputFile/SchedulerContext.yaml", "r"
         ) as open_context_file:
             context = yaml.safe_load(open_context_file)
         self.assertDictEqual(
@@ -246,10 +246,10 @@ NUM_TASKS_PER_NODE={{ num_slurm_tasks | default (5) }}
                 input_file_template=str(self.test_dir / "InputFile.yaml"),
                 job_name="TestExec",
                 out_file=str(
-                    self.test_dir / "Segments/Segment_0000/spectre.out"
+                    self.test_dir / "Segments/0000_InputFile/spectre.out"
                 ),
                 out_file_name="spectre.out",
-                run_dir=str(self.test_dir / "Segments/Segment_0000"),
+                run_dir=str(self.test_dir / "Segments/0000_InputFile"),
                 scheduler=["echo", "Submitted batch job 000"],
                 segments_dir=str(self.test_dir / "Segments"),
                 spectre_cli=str(self.spectre_cli),
@@ -261,7 +261,7 @@ NUM_TASKS_PER_NODE={{ num_slurm_tasks | default (5) }}
             ),
         )
         self.assertEqual(
-            (self.test_dir / "Segments/Segment_0000/Submit.sh").read_text(),
+            (self.test_dir / "Segments/0000_InputFile/Submit.sh").read_text(),
             """\
 SPECTRE_EXECUTABLE={executable}
 SPECTRE_CLI={spectre_cli}
@@ -275,12 +275,13 @@ NUM_TASKS_PER_NODE=5
 
         # Resubmit from the first segment using `schedule`
         checkpoint = Checkpoint.match(
-            self.test_dir / "Segments/Segment_0000/Checkpoints/Checkpoint_0000"
+            self.test_dir
+            / "Segments/0000_InputFile/Checkpoints/Checkpoint_0000"
         )
         checkpoint.path.mkdir(parents=True)
         schedule(
             input_file_template=self.test_dir
-            / "Segments/Segment_0000/InputFile.yaml",
+            / "Segments/0000_InputFile/InputFile.yaml",
             scheduler=["echo", "Submitted batch job 001"],
             submit_script_template=self.test_dir / "Segments/SubmitTemplate.sh",
             executable=self.test_dir / "Segments/TestExec",
@@ -291,18 +292,19 @@ NUM_TASKS_PER_NODE=5
             submit=True,
         )
         self.assertEqual(
-            (self.test_dir / "Segments/Segment_0001/jobid.txt").read_text(),
+            (self.test_dir / "Segments/0001_InputFile/jobid.txt").read_text(),
             "001",
         )
 
         # Resubmit from the second segment using `resubmit`
         checkpoint = Checkpoint.match(
-            self.test_dir / "Segments/Segment_0001/Checkpoints/Checkpoint_0000"
+            self.test_dir
+            / "Segments/0001_InputFile/Checkpoints/Checkpoint_0000"
         )
         checkpoint.path.mkdir(parents=True)
         resubmit(self.test_dir / "Segments", submit=True)
         self.assertEqual(
-            (self.test_dir / "Segments/Segment_0002/jobid.txt").read_text(),
+            (self.test_dir / "Segments/0002_InputFile/jobid.txt").read_text(),
             "001",
         )
 
@@ -344,7 +346,8 @@ NUM_TASKS_PER_NODE=5
             catch_exceptions=False,
         )
         checkpoint = Checkpoint.match(
-            self.test_dir / "Segments/Segment_0000/Checkpoints/Checkpoint_0000"
+            self.test_dir
+            / "Segments/0000_InputFile/Checkpoints/Checkpoint_0000"
         )
         checkpoint.path.mkdir(parents=True)
         runner.invoke(

--- a/tools/Status/ExecutableStatus/ExecutableStatus.py
+++ b/tools/Status/ExecutableStatus/ExecutableStatus.py
@@ -13,7 +13,7 @@ import numpy as np
 import pandas as pd
 
 from spectre.IO.H5 import to_dataframe
-from spectre.support.DirectoryStructure import list_segments
+from spectre.support.DirectoryStructure import Segment, list_segments
 from spectre.Visualization.ReadInputFile import find_event
 
 logger = logging.getLogger(__name__)
@@ -21,10 +21,15 @@ logger = logging.getLogger(__name__)
 
 def list_reduction_files(job: dict, input_file: dict):
     reductions_file_name = input_file["Observers"]["ReductionFileName"] + ".h5"
-    if job["SegmentsDir"]:
+    segment = Segment.match(job["WorkDir"]) if job["SegmentsDir"] else None
+    if segment:
+        # Collect only the segments of this run. Segments of other executables
+        # can share the directory, e.g. the ringdown that continues an inspiral,
+        # and they write to a file of the same name.
         reduction_files = [
-            segment_dir.path / reductions_file_name
-            for segment_dir in list_segments(job["SegmentsDir"])
+            other_segment.path / reductions_file_name
+            for other_segment in list_segments(job["SegmentsDir"])
+            if other_segment.label == segment.label
         ]
     else:
         reduction_files = [Path(job["WorkDir"]) / reductions_file_name]


### PR DESCRIPTION
## Proposed changes

- Relax the concept of "segments" a bit: the next segment may now run a different executable than the previous one. To distinguish these, give segments a label: "0000_Inspiral", ..., "0013_Ringdown". The input file carries the same label.
- Let the pipeline define the directory structure of a simulation, rather than hard-coding it to a chain of numbered steps. The BBH pipeline's directory structure is owned by eccentricity-control (see below).

Three kinds of directories remain: a 'run_dir' that an executable runs in, a 'segments_dir' holding a numbered sequence of runs, and a 'pipeline_dir' that a whole simulation lives in. Part of #7413.

Note that the question of symlinking and other PBJ details is not touched here yet. Also, the question of bin directories is left to #7507 (follow-up).

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->
BBH simulations now follow a directory structure defined by eccentricity-control:
```sh
    Ecc0/
      ID/
      Lev1/
        0000_Inspiral/
        ...
        0013_Ringdown/
```
<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent was used, have a co-author trailer of the form
      "Co-Authored-By: <agent name> <agent email>" as the last line of the
      commit, e.g. "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>".

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
