### PR TITLE
Create equal rate region generator to handle both subcell and nonconforming interfaces

### DIFF
--- a/src/Evolution/DgSubcell/CMakeLists.txt
+++ b/src/Evolution/DgSubcell/CMakeLists.txt
@@ -42,6 +42,7 @@ spectre_target_headers(
   SliceData.hpp
   SliceTensor.hpp
   SliceVariable.hpp
+  SubcellAndNonconformingEqualRateRegions.hpp
   SubcellEqualRateRegion.hpp
   SubcellOptions.hpp
   TwoMeshRdmpTci.hpp
@@ -68,6 +69,7 @@ spectre_target_sources(
   Reconstruction.cpp
   ReconstructionMethod.cpp
   SliceData.cpp
+  SubcellAndNonconformingEqualRateRegions.cpp
   SubcellEqualRateRegion.cpp
   SubcellOptions.cpp
   )

--- a/src/Evolution/DgSubcell/SubcellAndNonconformingEqualRateRegions.cpp
+++ b/src/Evolution/DgSubcell/SubcellAndNonconformingEqualRateRegions.cpp
@@ -1,0 +1,310 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/DgSubcell/SubcellAndNonconformingEqualRateRegions.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <pup.h>
+#include <pup_stl.h>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "Domain/Creators/DomainCreator.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/Side.hpp"
+#include "Evolution/DgSubcell/Tags/SubcellOptions.hpp"
+#include "Evolution/DiscontinuousGalerkin/EqualRateLts/EqualRateRegions.tpp"
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/ConstantExpressions.hpp"
+#include "Utilities/ErrorHandling/Assert.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace evolution::dg::subcell {
+template <size_t Dim>
+SubcellAndNonconformingEqualRateRegions<Dim>::
+    SubcellAndNonconformingEqualRateRegions(
+        const SubcellOptions& subcell_options,
+        const std::unique_ptr<DomainCreator<Dim>>& domain_creator) {
+  // Reconstruct the  SubcellOptions to get the auto-detected
+  // only_dg_block_ids (non-hypercube topology blocks plus user-specified
+  // OnlyDgBlocksAndGroups).
+  const auto real_subcell_options =
+      Tags::SubcellOptions<Dim>::create_from_options(subcell_options,
+                                                     domain_creator);
+  only_dg_block_ids_ = real_subcell_options.only_dg_block_ids();
+
+  const Domain<Dim> domain = domain_creator->create_domain();
+  const auto initial_levels = domain_creator->initial_refinement_levels();
+
+  // Categorize each nonconforming interface (a block face with more than one
+  // neighbor) as either:
+  //   - subcell-adjacent: at least one block on either side is subcell-capable.
+  //     The DG-only blocks at this face are added to subcell_adjacent_dg_faces_
+  //     so their outermost elements join the Subcell region.
+  //   - purely DG: all blocks on both sides are DG-only.
+  //     Becomes a separate NonconformingN[+/-] region, identical to
+  //     NonconformingEqualRateRegions.
+  //
+  // Note: a DG-only block may appear at two nonconforming interfaces, one
+  // subcell-adjacent and one purely DG, placing it in both
+  // subcell_adjacent_dg_faces_ and a NonconformingN region.  Whether this
+  // creates an element-level conflict depends on the refinement and axis of
+  // the two faces.  A post-processing pass below resolves conflicts by merging
+  // the NonconformingN region into Subcell; when no conflict exists the region
+  // is kept as an independent LTS region.
+  //
+  // The loop structure mirrors NonconformingEqualRateRegions: it fires only for
+  // the "one" side (the block with multiple neighbors on a single face), since
+  // the "many" side blocks each see only one conforming neighbor.
+  for (const auto& block : domain.blocks()) {
+    // Collect all nonconforming boundaries of this block.
+    std::vector<std::vector<std::pair<size_t, Direction<Dim>>>> boundaries{};
+
+    for (const auto& [direction, neighbors] : block.neighbors()) {
+      if (neighbors.are_conforming() or neighbors.size() == 1) {
+        continue;
+      }
+
+      // Determine whether any block at this interface supports subcell.
+      // Skip the neighbor scan if the current block is already subcell-capable.
+      bool any_subcell_capable = not alg::found(only_dg_block_ids_, block.id());
+      if (not any_subcell_capable) {
+        for (const auto& [neighbor_id, orientation] :
+             neighbors.orientations()) {
+          if (not alg::found(only_dg_block_ids_, neighbor_id)) {
+            any_subcell_capable = true;
+            break;
+          }
+        }
+      }
+
+      if (any_subcell_capable) {
+        // Subcell-adjacent interface: record the DG-only faces to fold into
+        // the Subcell region.
+        if (alg::found(only_dg_block_ids_, block.id())) {
+          subcell_adjacent_dg_faces_.emplace_back(block.id(), direction);
+        }
+        for (const auto& [neighbor_id, orientation] :
+             neighbors.orientations()) {
+          if (alg::found(only_dg_block_ids_, neighbor_id)) {
+            subcell_adjacent_dg_faces_.emplace_back(
+                neighbor_id, orientation(direction).opposite());
+          }
+        }
+      } else {
+        // Purely DG nonconforming interface: collect for region creation.
+        std::vector<std::pair<size_t, Direction<Dim>>>
+            boundaries_for_direction{};
+        boundaries_for_direction.reserve(neighbors.size() + 1);
+        boundaries_for_direction.emplace_back(block.id(), direction);
+        for (const auto& [neighbor_id, orientation] :
+             neighbors.orientations()) {
+          boundaries_for_direction.emplace_back(
+              neighbor_id, orientation(direction).opposite());
+        }
+        boundaries.push_back(std::move(boundaries_for_direction));
+      }
+    }
+
+    // Create NonconformingN[+/-] regions from any purely-DG boundaries,
+    // using the same merging logic as NonconformingEqualRateRegions.
+    if (boundaries.empty()) {
+      continue;
+    }
+
+    if (boundaries.size() == 2 and
+        boundaries[0].front().second.dimension() ==
+            boundaries[1].front().second.dimension() and
+        gsl::at(gsl::at(initial_levels, block.id()),
+                boundaries[0].front().second.dimension()) > 0) {
+      // Two nonconforming sides along the same axis with interior elements
+      // between them: create two separate regions.
+      for (auto& boundary : boundaries) {
+        nonconforming_region_names_.push_back(
+            "Nonconforming" + std::to_string(block.id()) +
+            (boundary.front().second.side() == Side::Upper ? "+" : "-"));
+        nonconforming_regions_.push_back(std::move(boundary));
+      }
+    } else {
+      // One nonconforming side, or two sides whose outermost elements overlap:
+      // merge into a single region.
+      size_t full_size = 0;
+      for (const auto& boundary : boundaries) {
+        full_size += boundary.size();
+      }
+      auto boundary = std::move(boundaries.front());
+      boundary.reserve(full_size);
+      for (size_t i = 1; i < boundaries.size(); ++i) {
+        boundary.insert(boundary.end(), boundaries[i].begin(),
+                        boundaries[i].end());
+      }
+      nonconforming_region_names_.push_back("Nonconforming" +
+                                            std::to_string(block.id()));
+      nonconforming_regions_.push_back(std::move(boundary));
+    }
+  }
+
+  // Post-processing: resolve element-level conflicts between the Subcell region
+  // and any NonconformingN regions, merging only when necessary.
+  //
+  // A DG-only block B may appear in both subcell_adjacent_dg_faces_ (via
+  // subcell-adjacent face F1) and a NonconformingN region (via purely-DG face
+  // F2). A conflict exists only if some element of B is simultaneously
+  // extremal on F2 and in the Subcell region. The separability condition for
+  // block B (checked against every F1 of B in subcell_adjacent_dg_faces_):
+  //
+  //   F1.dimension() == F2.dimension()  AND
+  //   initial_refinement[B][F2.dimension()] > 0
+  //
+  // When this holds for all overlapping blocks, the F2-extremal elements are
+  // distinct from all F1-extremal elements: the NonconformingN region is kept
+  // as an independent equal-rate region, free to step at its own LTS rate.
+  //
+  // If ANY overlapping block fails the condition (faces on different axes, or
+  // refinement 0 meaning a single element is extremal on all its faces), the
+  // entire region is merged into Subcell. Merging may expose further overlaps
+  // in other regions, so the loop repeats until stable.
+  bool changed = true;
+  while (changed) {
+    changed = false;
+    for (size_t i = nonconforming_regions_.size(); i > 0; --i) {
+      const size_t idx = i - 1;
+
+      // Determine whether a merge is required for this region.
+      bool requires_merge = false;
+      for (const auto& region_face : nonconforming_regions_[idx]) {
+        const size_t bid = region_face.first;
+        for (const auto& adj_face : subcell_adjacent_dg_faces_) {
+          if (adj_face.first != bid) {
+            continue;
+          }
+          // An element extremal on region_face could also be in Subcell if the
+          // adj_face is on a different axis, or if refinement is 0 (single
+          // element is extremal on all its faces simultaneously).
+          if (adj_face.second.dimension() != region_face.second.dimension() or
+              gsl::at(gsl::at(initial_levels, bid),
+                      region_face.second.dimension()) == 0) {
+            requires_merge = true;
+            break;
+          }
+        }
+        if (requires_merge) {
+          break;
+        }
+      }
+
+      if (not requires_merge) {
+        continue;
+      }
+
+      // Merge all DG-only faces from this region into
+      // subcell_adjacent_dg_faces_.  No face can already be present: a face
+      // classified as subcell-adjacent in the main loop cannot appear in any
+      // NonconformingN region, and each (block, direction) pair is emitted at
+      // most once by the main loop so no face appears in two regions.
+      for (const auto& region_face : nonconforming_regions_[idx]) {
+        if (not alg::found(only_dg_block_ids_, region_face.first)) {
+          continue;  // subcell-capable block, already in Subcell
+        }
+        ASSERT(not alg::found(subcell_adjacent_dg_faces_, region_face),
+               "Face (" << region_face.first << ", " << region_face.second
+                        << ") is already in subcell_adjacent_dg_faces_ before "
+                           "merge; this indicates a bug in the classification "
+                           "logic.");
+        subcell_adjacent_dg_faces_.push_back(region_face);
+      }
+      nonconforming_region_names_.erase(nonconforming_region_names_.begin() +
+                                        static_cast<std::ptrdiff_t>(idx));
+      nonconforming_regions_.erase(nonconforming_regions_.begin() +
+                                   static_cast<std::ptrdiff_t>(idx));
+      changed = true;
+    }
+  }
+}
+
+template <size_t Dim>
+std::unordered_map<std::string, size_t>
+SubcellAndNonconformingEqualRateRegions<Dim>::regions() const {
+  std::unordered_map<std::string, size_t> result{};
+  result.emplace("Subcell", 0);
+  for (size_t i = 0; i < nonconforming_region_names_.size(); ++i) {
+    result.emplace(nonconforming_region_names_[i], i + 1);
+  }
+  return result;
+}
+
+template <size_t Dim>
+bool SubcellAndNonconformingEqualRateRegions<Dim>::is_in_region(
+    const size_t region, const ElementId<Dim>& element_id) const {
+  if (region == 0) {
+    // Subcell region: includes all subcell-capable elements, plus the outermost
+    // elements of DG-only blocks that touch a subcell-adjacent nonconforming
+    // face.
+    if (not alg::found(only_dg_block_ids_, element_id.block_id())) {
+      return true;
+    }
+    return alg::any_of(subcell_adjacent_dg_faces_, [&](const auto& face) {
+      const auto& [block_id, direction] = face;
+      if (element_id.block_id() != block_id) {
+        return false;
+      }
+      const auto& seg = element_id.segment_id(direction.dimension());
+      return seg.index() == (direction.side() == Side::Lower
+                                 ? 0
+                                 : two_to_the(seg.refinement_level()) - 1);
+    });
+  }
+  // Purely DG nonconforming region.
+  ASSERT(region - 1 < nonconforming_regions_.size(),
+         "Region " << region << " is out of range (have "
+                   << nonconforming_regions_.size()
+                   << " purely-DG nonconforming regions)");
+  return alg::any_of(nonconforming_regions_[region - 1], [&](const auto& face) {
+    const auto& [block_id, direction] = face;
+    if (element_id.block_id() != block_id) {
+      return false;
+    }
+    const auto& seg = element_id.segment_id(direction.dimension());
+    return seg.index() == (direction.side() == Side::Lower
+                               ? 0
+                               : two_to_the(seg.refinement_level()) - 1);
+  });
+}
+
+template <size_t Dim>
+void SubcellAndNonconformingEqualRateRegions<Dim>::pup(PUP::er& p) {
+  p | only_dg_block_ids_;
+  p | subcell_adjacent_dg_faces_;
+  p | nonconforming_region_names_;
+  p | nonconforming_regions_;
+}
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data) \
+  template class SubcellAndNonconformingEqualRateRegions<DIM(data)>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#undef INSTANTIATE
+#undef DIM
+}  // namespace evolution::dg::subcell
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATE(_, data)                      \
+  template class evolution::dg::EqualRateRegions< \
+      DIM(data),                                  \
+      tmpl::list<evolution::dg::subcell::         \
+                     SubcellAndNonconformingEqualRateRegions<DIM(data)>>>;
+
+GENERATE_INSTANTIATIONS(INSTANTIATE, (1, 2, 3))
+
+#undef INSTANTIATE
+#undef DIM

--- a/src/Evolution/DgSubcell/SubcellAndNonconformingEqualRateRegions.hpp
+++ b/src/Evolution/DgSubcell/SubcellAndNonconformingEqualRateRegions.hpp
@@ -1,0 +1,89 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "Domain/Creators/OptionTags.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Evolution/DgSubcell/Tags/SubcellOptions.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+template <size_t VolumeDim>
+class DomainCreator;
+template <size_t VolumeDim>
+class ElementId;
+namespace PUP {
+class er;
+}  // namespace PUP
+namespace evolution::dg::subcell {
+class SubcellOptions;
+}  // namespace evolution::dg::subcell
+/// \endcond
+
+namespace evolution::dg::subcell {
+/// Combined equal-rate region generator for subcell evolution with
+/// nonconforming block boundaries.
+///
+/// When using local time stepping (LTS) with both subcell evolution and
+/// nonconforming block boundaries, the two separate region generators
+/// `NonconformingEqualRateRegions` and `SubcellEqualRateRegion`
+/// cannot be combined without conflicts in their regions.  This class merges
+/// the two generators into one, treating subcell-adjacent nonconforming
+/// interfaces as part of the "Subcell" region rather than as separate
+/// "NonconformingN" regions.
+///
+/// **Subcell region (region 0)**: Contains all subcell-capable elements (those
+/// not in `OnlyDgBlocksAndGroups`) **plus** the elements of DG-only
+/// blocks that lie directly on a nonconforming face bordering a subcell-capable
+/// block.
+///
+/// **NonconformingN[+/-] regions (regions 1…N)**: Created only for
+/// nonconforming interfaces where every block on both sides is DG-only (no
+/// subcell capability on either side).  These behave identically to the
+/// regions produced by `NonconformingEqualRateRegions`.
+///
+/// \note If your domain has no nonconforming block boundaries, use
+/// `SubcellEqualRateRegion` instead: it is simpler and has no overhead.
+template <size_t Dim>
+class SubcellAndNonconformingEqualRateRegions {
+ public:
+  SubcellAndNonconformingEqualRateRegions() = default;
+
+  using creation_tags = tmpl::list<OptionTags::SubcellOptions,
+                                   domain::OptionTags::DomainCreator<Dim>>;
+
+  SubcellAndNonconformingEqualRateRegions(
+      const SubcellOptions& subcell_options,
+      const std::unique_ptr<DomainCreator<Dim>>& domain_creator);
+
+  std::unordered_map<std::string, size_t> regions() const;
+
+  bool is_in_region(size_t region, const ElementId<Dim>& element_id) const;
+
+  void pup(PUP::er& p);
+
+ private:
+  // DG-only block IDs: non-hypercube topology blocks (detected automatically)
+  // plus user-specified OnlyDgBlocksAndGroups blocks. Subcell-capable blocks
+  // (those NOT in this list) are always in region 0 ("Subcell")
+  std::vector<size_t> only_dg_block_ids_{};
+  // (block_id, direction) pairs identifying the faces of DG-only blocks that
+  // touch a nonconforming boundary with at least one subcell-capable neighbor.
+  // The elements on these faces are included in region 0 ("Subcell").
+  std::vector<std::pair<size_t, Direction<Dim>>> subcell_adjacent_dg_faces_{};
+  // Names and face-membership data for purely DG nonconforming regions
+  // (region index i here corresponds to region i+1 overall, since region 0
+  // is "Subcell").
+  std::vector<std::string> nonconforming_region_names_{};
+  std::vector<std::vector<std::pair<size_t, Direction<Dim>>>>
+      nonconforming_regions_{};
+};
+}  // namespace evolution::dg::subcell

--- a/src/Evolution/DgSubcell/SubcellEqualRateRegion.hpp
+++ b/src/Evolution/DgSubcell/SubcellEqualRateRegion.hpp
@@ -30,6 +30,11 @@ namespace evolution::dg::subcell {
 /// Generator for `EqualRateRegions` labeling all elements that are
 /// allowed to do subcell and their neighbors.  The inverse of the
 /// `OnlyDgBlocksAndGroups` input file option.
+///
+/// \note When subcell is combined with nonconforming block boundaries (e.g.,
+/// `domain::creators::NonconformingSphericalShells`), use
+/// `SubcellAndNonconformingEqualRateRegions` instead of pairing this class
+/// with `NonconformingEqualRateRegions`.
 template <size_t Dim>
 class SubcellEqualRateRegion {
  public:

--- a/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
+++ b/src/Evolution/Executables/GrMhd/GhValenciaDivClean/GhValenciaDivCleanBase.hpp
@@ -47,7 +47,7 @@
 #include "Evolution/DgSubcell/PerssonTci.hpp"
 #include "Evolution/DgSubcell/PrepareNeighborData.hpp"
 #include "Evolution/DgSubcell/SetInterpolators.hpp"
-#include "Evolution/DgSubcell/SubcellEqualRateRegion.hpp"
+#include "Evolution/DgSubcell/SubcellAndNonconformingEqualRateRegions.hpp"
 #include "Evolution/DgSubcell/Tags/ObserverCoordinates.hpp"
 #include "Evolution/DgSubcell/Tags/ObserverMesh.hpp"
 #include "Evolution/DgSubcell/Tags/ObserverMeshVelocity.hpp"
@@ -753,12 +753,11 @@ struct GhValenciaDivCleanTemplateBase<
           grmhd::GhValenciaDivClean::subcell::FixConservativesAndComputePrims<
               ordered_list_of_primitive_recovery_schemes, system>>>;
 
-  using equal_rate_regions = tmpl::flatten<
-      tmpl::list<evolution::dg::NonconformingEqualRateRegions<volume_dim>,
-                 tmpl::conditional_t<
-                     use_dg_subcell,
-                     evolution::dg::subcell::SubcellEqualRateRegion<volume_dim>,
-                     tmpl::list<>>>>;
+  using equal_rate_regions = tmpl::conditional_t<
+      use_dg_subcell,
+      tmpl::list<evolution::dg::subcell::
+                     SubcellAndNonconformingEqualRateRegions<volume_dim>>,
+      tmpl::list<evolution::dg::NonconformingEqualRateRegions<volume_dim>>>;
 
   using dg_step_actions = tmpl::flatten<tmpl::list<
       dg::Actions::SpectralFilter<volume_dim,

--- a/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
+++ b/src/Evolution/Executables/GrMhd/ValenciaDivClean/EvolveValenciaDivClean.hpp
@@ -33,7 +33,7 @@
 #include "Evolution/DgSubcell/PerssonTci.hpp"
 #include "Evolution/DgSubcell/PrepareNeighborData.hpp"
 #include "Evolution/DgSubcell/SetInterpolators.hpp"
-#include "Evolution/DgSubcell/SubcellEqualRateRegion.hpp"
+#include "Evolution/DgSubcell/SubcellAndNonconformingEqualRateRegions.hpp"
 #include "Evolution/DgSubcell/Tags/MethodOrder.hpp"
 #include "Evolution/DgSubcell/Tags/ObserverCoordinates.hpp"
 #include "Evolution/DgSubcell/Tags/ObserverMesh.hpp"
@@ -508,12 +508,11 @@ struct EvolutionMetavars<tmpl::list<InterpolationTargetTags...>,
   using dg_registration_list =
       tmpl::list<observers::Actions::RegisterEventsWithObservers>;
 
-  using equal_rate_regions = tmpl::flatten<
-      tmpl::list<evolution::dg::NonconformingEqualRateRegions<volume_dim>,
-                 tmpl::conditional_t<
-                     use_dg_subcell,
-                     evolution::dg::subcell::SubcellEqualRateRegion<volume_dim>,
-                     tmpl::list<>>>>;
+  using equal_rate_regions = tmpl::conditional_t<
+      use_dg_subcell,
+      tmpl::list<evolution::dg::subcell::
+                     SubcellAndNonconformingEqualRateRegions<volume_dim>>,
+      tmpl::list<evolution::dg::NonconformingEqualRateRegions<volume_dim>>>;
 
   using initialization_actions = tmpl::flatten<tmpl::list<
       Initialization::Actions::InitializeItems<

--- a/tests/Unit/Evolution/DgSubcell/CMakeLists.txt
+++ b/tests/Unit/Evolution/DgSubcell/CMakeLists.txt
@@ -43,6 +43,7 @@ set(LIBRARY_SOURCES
   Test_SliceData.cpp
   Test_SliceTensor.cpp
   Test_SliceVariable.cpp
+  Test_SubcellAndNonconformingEqualRateRegions.cpp
   Test_SubcellEqualRateRegion.cpp
   Test_SubcellOptions.cpp
   Test_Tags.cpp

--- a/tests/Unit/Evolution/DgSubcell/Test_SubcellAndNonconformingEqualRateRegions.cpp
+++ b/tests/Unit/Evolution/DgSubcell/Test_SubcellAndNonconformingEqualRateRegions.cpp
@@ -1,0 +1,528 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Domain/Block.hpp"
+#include "Domain/BoundaryConditions/BoundaryCondition.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/Identity.hpp"
+#include "Domain/Creators/DomainCreator.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/Structure/BlockNeighbors.hpp"
+#include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Domain/Structure/ElementId.hpp"
+#include "Domain/Structure/InitialElementIds.hpp"
+#include "Domain/Structure/OrientationMap.hpp"
+#include "Domain/Structure/Topology.hpp"
+#include "Evolution/DgSubcell/ReconstructionMethod.hpp"
+#include "Evolution/DgSubcell/SubcellAndNonconformingEqualRateRegions.hpp"
+#include "Evolution/DgSubcell/SubcellOptions.hpp"
+#include "Evolution/DiscontinuousGalerkin/EqualRateLts/EqualRateRegionGenerator.hpp"
+#include "NumericalAlgorithms/FiniteDifference/DerivativeOrder.hpp"
+#include "Utilities/Algorithm.hpp"
+#include "Utilities/Serialization/Serialize.hpp"
+
+namespace {
+static_assert(
+    evolution::dg::equal_rate_region_generator<
+        evolution::dg::subcell::SubcellAndNonconformingEqualRateRegions<1>, 1>);
+static_assert(
+    evolution::dg::equal_rate_region_generator<
+        evolution::dg::subcell::SubcellAndNonconformingEqualRateRegions<2>, 2>);
+static_assert(
+    evolution::dg::equal_rate_region_generator<
+        evolution::dg::subcell::SubcellAndNonconformingEqualRateRegions<3>, 3>);
+
+// A layer of two squares, the second rotated
+void add_squares(gsl::not_null<std::vector<Block<2>>*> blocks, const size_t id1,
+                 const std::optional<size_t>& inner_neighbor,
+                 const std::optional<size_t>& outer_neighbor) {
+  const auto map =
+      domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
+          domain::CoordinateMaps::Identity<2>{});
+  const auto aligned = OrientationMap<2>::create_aligned();
+  const OrientationMap<2> rotated{
+      {{Direction<2>::upper_eta(), Direction<2>::lower_xi()}}};
+  // First block
+  {
+    DirectionMap<2, BlockNeighbors<2>> neighbors{};
+    neighbors.emplace(Direction<2>::upper_eta(),
+                      BlockNeighbors<2>(id1 + 1, rotated));
+    neighbors.emplace(Direction<2>::lower_eta(),
+                      BlockNeighbors<2>(id1 + 1, rotated));
+    if (inner_neighbor.has_value()) {
+      neighbors.emplace(Direction<2>::lower_xi(),
+                        BlockNeighbors<2>({*inner_neighbor},
+                                          {{*inner_neighbor, aligned}}, false));
+    }
+    if (outer_neighbor.has_value()) {
+      neighbors.emplace(Direction<2>::upper_xi(),
+                        BlockNeighbors<2>({*outer_neighbor},
+                                          {{*outer_neighbor, aligned}}, false));
+    }
+    blocks->emplace_back(map->get_clone(), id1, std::move(neighbors),
+                         std::to_string(id1), domain::topologies::hypercube<2>);
+  }
+  // Second block
+  {
+    DirectionMap<2, BlockNeighbors<2>> neighbors{};
+    neighbors.emplace(rotated(Direction<2>::upper_eta()),
+                      BlockNeighbors<2>(id1, rotated.inverse_map()));
+    neighbors.emplace(rotated(Direction<2>::lower_eta()),
+                      BlockNeighbors<2>(id1 + 1, rotated.inverse_map()));
+    if (inner_neighbor.has_value()) {
+      neighbors.emplace(
+          rotated(Direction<2>::lower_xi()),
+          BlockNeighbors<2>({*inner_neighbor},
+                            {{*inner_neighbor, rotated.inverse_map()}}, false));
+    }
+    if (outer_neighbor.has_value()) {
+      neighbors.emplace(
+          rotated(Direction<2>::upper_xi()),
+          BlockNeighbors<2>({*outer_neighbor},
+                            {{*outer_neighbor, rotated.inverse_map()}}, false));
+    }
+    blocks->emplace_back(map->get_clone(), id1 + 1, std::move(neighbors),
+                         std::to_string(id1 + 1),
+                         domain::topologies::hypercube<2>);
+  }
+}
+
+void add_annulus(gsl::not_null<std::vector<Block<2>>*> blocks, const size_t id,
+                 const std::vector<size_t>& inner_neighbors,
+                 const std::vector<size_t>& outer_neighbors) {
+  const auto map =
+      domain::make_coordinate_map_base<Frame::BlockLogical, Frame::Inertial>(
+          domain::CoordinateMaps::Identity<2>{});
+  const auto aligned = OrientationMap<2>::create_aligned();
+  const OrientationMap<2> rotated{
+      {{Direction<2>::upper_eta(), Direction<2>::lower_xi()}}};
+  DirectionMap<2, BlockNeighbors<2>> neighbors{};
+  if (not inner_neighbors.empty()) {
+    std::unordered_set<size_t> neighbor_ids{};
+    std::unordered_map<size_t, OrientationMap<2>> orientations{};
+    neighbor_ids.emplace(inner_neighbors[0]);
+    orientations.emplace(inner_neighbors[0], aligned);
+    if (inner_neighbors.size() > 1) {
+      neighbor_ids.emplace(inner_neighbors[1]);
+      orientations.emplace(inner_neighbors[1], rotated);
+    }
+    neighbors.emplace(
+        Direction<2>::lower_xi(),
+        BlockNeighbors<2>(std::move(neighbor_ids), std::move(orientations),
+                          inner_neighbors.size() == 1));
+  }
+  if (not outer_neighbors.empty()) {
+    std::unordered_set<size_t> neighbor_ids{};
+    std::unordered_map<size_t, OrientationMap<2>> orientations{};
+    neighbor_ids.emplace(outer_neighbors[0]);
+    orientations.emplace(outer_neighbors[0], aligned);
+    if (outer_neighbors.size() > 1) {
+      neighbor_ids.emplace(outer_neighbors[1]);
+      orientations.emplace(outer_neighbors[1], rotated);
+    }
+    neighbors.emplace(
+        Direction<2>::upper_xi(),
+        BlockNeighbors<2>(std::move(neighbor_ids), std::move(orientations),
+                          outer_neighbors.size() == 1));
+  }
+  blocks->emplace_back(map->get_clone(), id, std::move(neighbors),
+                       std::to_string(id), domain::topologies::annulus);
+}
+
+// Domain matching the one in Test_NonconformingEqualRateRegions:
+//   Blocks 0,1  - square pair (hypercube, subcell-capable)
+//   Block  2    - annulus (DG-only)
+//   Blocks 3,4  - square pair (hypercube, subcell-capable)
+//   Block  5    - annulus (DG-only, two nonconforming sides)
+//   Blocks 6,7  - square pair (hypercube, subcell-capable)
+//   Block  8    - annulus (DG-only)
+//   Block  9    - annulus (DG-only, only inner neighbor)
+//
+// Nonconforming interfaces (annulus side is the "one" side):
+//   Block 2  <-> blocks 0,1 (lower_xi) and blocks 3,4 (upper_xi)
+//   Block 5  <-> blocks 3,4 (lower_xi) and blocks 6,7 (upper_xi)
+//   Block 8  <-> blocks 6,7 (lower_xi) and block  9  (upper_xi)
+//
+// All interfaces involve at least one subcell-capable block, so no
+// purely-DG nonconforming regions are created.
+class NonconformingCreator : public DomainCreator<2> {
+ public:
+  Domain<2> create_domain() const override {
+    std::vector<Block<2>> blocks{};
+    add_squares(make_not_null(&blocks), 0, std::nullopt, 2);
+    add_annulus(make_not_null(&blocks), 2, {0, 1}, {3, 4});
+    add_squares(make_not_null(&blocks), 3, 2, 5);
+    add_annulus(make_not_null(&blocks), 5, {3, 4}, {6, 7});
+    add_squares(make_not_null(&blocks), 6, 5, 8);
+    add_annulus(make_not_null(&blocks), 8, {6, 7}, {9});
+    add_annulus(make_not_null(&blocks), 9, {8}, {});
+    return Domain{std::move(blocks)};
+  }
+
+  std::unordered_map<std::string, tnsr::I<double, 2, Frame::Grid>>
+  grid_anchors() const override {
+    ERROR("");
+  }
+
+  std::vector<DirectionMap<
+      2, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
+  external_boundary_conditions() const override {
+    ERROR("");
+  }
+
+  std::vector<std::string> block_names() const override {
+    return {"0", "1", "2", "3", "4", "5", "6", "7", "8", "9"};
+  }
+
+  std::vector<std::array<size_t, 2>> initial_extents() const override {
+    ERROR("");
+  }
+
+  std::vector<std::array<size_t, 2>> initial_refinement_levels()
+      const override {
+    return {
+        {{2, 0}}, {{0, 2}},  // squares 0, 1
+        {{0, 0}},            // annulus 2
+        {{2, 0}}, {{0, 2}},  // squares 3, 4
+        {{2, 0}},            // annulus 5
+        {{2, 0}}, {{0, 2}},  // squares 6, 7
+        {{0, 0}},            // annulus 8
+        {{0, 0}},            // annulus 9
+    };
+  }
+};
+
+// Build SubcellOptions.  Annulus blocks are excluded from subcell
+// automatically by topology; square blocks can be forced DG-only by passing
+// their names in `only_dg`.
+evolution::dg::subcell::SubcellOptions make_subcell_options(
+    std::optional<std::vector<std::string>> only_dg = std::nullopt) {
+  return {4.0,
+          1,
+          2.0e-3,
+          2.0e-4,
+          false,
+          false,
+          evolution::dg::subcell::fd::ReconstructionMethod::DimByDim,
+          false,
+          std::move(only_dg),
+          fd::DerivativeOrder::Two,
+          1,
+          1,
+          1,
+          1};
+}
+
+void check_regions(
+    const evolution::dg::subcell::SubcellAndNonconformingEqualRateRegions<2>&
+        combined) {
+  // All nonconforming interfaces in this domain are subcell-adjacent, so only
+  // the "Subcell" region (index 0) should exist: no NonconformingN regions.
+  const auto regions = combined.regions();
+  CHECK(regions.size() == 1);
+  REQUIRE(regions.contains("Subcell"));
+  CHECK(regions.at("Subcell") == 0);
+
+  const std::vector<size_t> dg_only_blocks{2, 5, 8, 9};
+
+  // The DG-only elements folded into the Subcell region are those sitting
+  // at the outermost position in the direction perpendicular to a
+  // subcell-adjacent nonconforming face.
+  const std::unordered_set<ElementId<2>> expected_subcell_dg_only_elements{
+      {2, {{{0, 0}, {0, 0}}}},
+      {5, {{{2, 0}, {0, 0}}}},
+      {5, {{{2, 3}, {0, 0}}}},
+      {8, {{{0, 0}, {0, 0}}}}};
+
+  const auto all_elements =
+      initial_element_ids(NonconformingCreator{}.initial_refinement_levels());
+
+  for (const auto& id : all_elements) {
+    CAPTURE(id);
+    const bool in_dg_block = alg::found(dg_only_blocks, id.block_id());
+    if (not in_dg_block) {
+      // All subcell-capable elements are always in the Subcell region.
+      CHECK(combined.is_in_region(0, id));
+    } else {
+      // DG-only elements: in Subcell only at subcell-adjacent nonconforming
+      // faces.
+      CHECK(combined.is_in_region(0, id) ==
+            expected_subcell_dg_only_elements.contains(id));
+    }
+  }
+}
+
+// Domain for testing transitive propagation of subcell-adjacency:
+//   Same structure as NonconformingCreator except block 8 has TWO outer
+//   nonconforming neighbors - a square pair (blocks 9, 10) that are forced
+//   DG-only via subcell options.
+//
+// Block 8 is subcell-adjacent on its inner face (toward subcell-capable
+// blocks 6,7) and sees a purely-DG nonconforming face on its outer side
+// (toward DG-only blocks 9,10).  The main loop creates "Nonconforming8".
+// The post-processing pass detects that "Nonconforming8" overlaps
+// subcell_adjacent_dg_faces_ (via block 8) and merges blocks 9 and 10
+// into the Subcell region transitively, leaving no NonconformingN regions.
+class TransitiveNonconformingCreator : public DomainCreator<2> {
+ public:
+  Domain<2> create_domain() const override {
+    std::vector<Block<2>> blocks{};
+    add_squares(make_not_null(&blocks), 0, std::nullopt, 2);
+    add_annulus(make_not_null(&blocks), 2, {0, 1}, {3, 4});
+    add_squares(make_not_null(&blocks), 3, 2, 5);
+    add_annulus(make_not_null(&blocks), 5, {3, 4}, {6, 7});
+    add_squares(make_not_null(&blocks), 6, 5, 8);
+    // Block 8: inner face subcell-adjacent (neighbors 6,7), outer face
+    // nonconforming with two DG-only square neighbors (9,10).
+    add_annulus(make_not_null(&blocks), 8, {6, 7}, {9, 10});
+    add_squares(make_not_null(&blocks), 9, 8, std::nullopt);  // forced DG-only
+    return Domain{std::move(blocks)};
+  }
+
+  std::unordered_map<std::string, tnsr::I<double, 2, Frame::Grid>>
+  grid_anchors() const override {
+    ERROR("");
+  }
+
+  std::vector<DirectionMap<
+      2, std::unique_ptr<domain::BoundaryConditions::BoundaryCondition>>>
+  external_boundary_conditions() const override {
+    ERROR("");
+  }
+
+  std::vector<std::string> block_names() const override {
+    return {"0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"};
+  }
+
+  std::vector<std::array<size_t, 2>> initial_extents() const override {
+    ERROR("");
+  }
+
+  std::vector<std::array<size_t, 2>> initial_refinement_levels()
+      const override {
+    return {
+        {{2, 0}}, {{0, 2}},  // squares 0, 1
+        {{0, 0}},            // annulus 2
+        {{2, 0}}, {{0, 2}},  // squares 3, 4
+        {{2, 0}},            // annulus 5
+        {{2, 0}}, {{0, 2}},  // squares 6, 7
+        {{0, 0}},            // annulus 8
+        {{0, 0}},            // annulus 9
+        {{0, 0}},            // annulus 10 (new)
+    };
+  }
+};
+
+// Same domain as TransitiveNonconformingCreator but block 8 has refinement 1
+// in xi, giving it two distinct elements (inner index 0, outer index 1).
+class SeparableNonconformingCreator : public TransitiveNonconformingCreator {
+ public:
+  std::vector<std::array<size_t, 2>> initial_refinement_levels()
+      const override {
+    return {
+        {{2, 0}}, {{0, 2}},  // squares 0, 1
+        {{0, 0}},            // annulus 2
+        {{2, 0}}, {{0, 2}},  // squares 3, 4
+        {{2, 0}},            // annulus 5
+        {{2, 0}}, {{0, 2}},  // squares 6, 7
+        {{1, 0}},            // annulus 8 - 2 elements in xi, separable faces
+        {{0, 0}},            // annulus 9
+        {{0, 0}},            // annulus 10
+    };
+  }
+};
+
+// Block 8 is subcell-adjacent (inner face toward blocks 6,7) so it lands in
+// subcell_adjacent_dg_faces_.  Its outer face toward blocks 9,10 is initially
+// classified as a purely-DG nonconforming interface ("Nonconforming8").  The
+// post-processing pass detects the overlap (block 8 in both sets) and merges
+// "Nonconforming8" into Subcell, pulling blocks 9 and 10 along.
+void check_transitive_regions() {
+  const std::unique_ptr<DomainCreator<2>> domain_creator =
+      std::make_unique<TransitiveNonconformingCreator>();
+  // Blocks 9 and 10 are squares (hypercubes) so must be forced DG-only.
+  const auto subcell_opts = make_subcell_options({{"9", "10"}});
+
+  const evolution::dg::subcell::SubcellAndNonconformingEqualRateRegions<2>
+      combined(subcell_opts, domain_creator);
+
+  // Post-processing must have absorbed "Nonconforming8", leaving only Subcell.
+  const auto regions = combined.regions();
+  CHECK(regions.size() == 1);
+  REQUIRE(regions.contains("Subcell"));
+  CHECK(regions.at("Subcell") == 0);
+
+  const std::vector<size_t> dg_only_blocks{2, 5, 8, 9, 10};
+
+  // Same outermost DG-only elements as NonconformingCreator, plus blocks 9 and
+  // 10 (each a single element at index 0, refinement_level 0) which reach
+  // Subcell only via the transitive merge of block 8's outer face.
+  const std::unordered_set<ElementId<2>>
+      expected_subcell_dg_only_elements{
+          {2, {{{0, 0}, {0, 0}}}}, {5, {{{2, 0}, {0, 0}}}},
+          {5, {{{2, 3}, {0, 0}}}}, {8, {{{0, 0}, {0, 0}}}},
+          {9, {{{0, 0}, {0, 0}}}},    // reached via transitivity
+          {10, {{{0, 0}, {0, 0}}}}};  // reached via transitivity
+
+  const auto all_elements = initial_element_ids(
+      TransitiveNonconformingCreator{}.initial_refinement_levels());
+
+  for (const auto& id : all_elements) {
+    CAPTURE(id);
+    const bool in_dg_block = alg::found(dg_only_blocks, id.block_id());
+    if (not in_dg_block) {
+      CHECK(combined.is_in_region(0, id));
+    } else {
+      CHECK(combined.is_in_region(0, id) ==
+            expected_subcell_dg_only_elements.contains(id));
+    }
+  }
+}
+
+// With refinement 1 in xi on block 8, the inner element (index 0) is in
+// Subcell and the outer element (index 1) is in "Nonconforming8" together with
+// blocks 9 and 10.  The two groups can step at independent LTS rates.
+void check_separable_regions() {
+  const std::unique_ptr<DomainCreator<2>> domain_creator =
+      std::make_unique<SeparableNonconformingCreator>();
+  // Blocks 9 and 10 are squares (hypercubes) so must be forced DG-only.
+  const auto subcell_opts = make_subcell_options({{"9", "10"}});
+
+  const evolution::dg::subcell::SubcellAndNonconformingEqualRateRegions<2>
+      combined(subcell_opts, domain_creator);
+
+  // Post-processing must have left "Nonconforming8" intact
+  const auto regions = combined.regions();
+  CHECK(regions.size() == 2);
+  REQUIRE(regions.contains("Subcell"));
+  REQUIRE(regions.contains("Nonconforming8"));
+  const size_t subcell_idx = regions.at("Subcell");
+  const size_t nonconf_idx = regions.at("Nonconforming8");
+
+  const std::vector<size_t> dg_only_blocks{2, 5, 8, 9, 10};
+
+  // Subcell: block 8's inner element only (xi-index 0 at refinement_level 1).
+  // Nonconforming8: block 8's outer element (xi-index 1) + blocks 9 and 10.
+  const std::unordered_set<ElementId<2>> expected_subcell_dg_only{
+      {2, {{{0, 0}, {0, 0}}}},
+      {5, {{{2, 0}, {0, 0}}}},
+      {5, {{{2, 3}, {0, 0}}}},
+      {8, {{{1, 0}, {0, 0}}}}};  // inner element, index 0 at refinement 1
+  const std::unordered_set<ElementId<2>> expected_nonconf{
+      {8, {{{1, 1}, {0, 0}}}},  // outer element, index 1 = 2^1-1
+      {9, {{{0, 0}, {0, 0}}}},
+      {10, {{{0, 0}, {0, 0}}}}};
+
+  const auto all_elements = initial_element_ids(
+      SeparableNonconformingCreator{}.initial_refinement_levels());
+
+  for (const auto& id : all_elements) {
+    CAPTURE(id);
+    const bool in_dg_block = alg::found(dg_only_blocks, id.block_id());
+    if (not in_dg_block) {
+      CHECK(combined.is_in_region(subcell_idx, id));
+      CHECK(not combined.is_in_region(nonconf_idx, id));
+    } else {
+      CHECK(combined.is_in_region(subcell_idx, id) ==
+            expected_subcell_dg_only.contains(id));
+      CHECK(combined.is_in_region(nonconf_idx, id) ==
+            expected_nonconf.contains(id));
+    }
+  }
+}
+
+// With all blocks forced DG-only (annuli via topology, squares via subcell
+// options), no nonconforming interface is subcell-adjacent.  The combined
+// generator must produce the same regions as NonconformingEqualRateRegions
+// alone, plus an empty Subcell region - verifying the "no overlap -> same
+// output" guarantee.
+void check_no_overlap() {
+  const std::unique_ptr<DomainCreator<2>> domain_creator =
+      std::make_unique<NonconformingCreator>();
+  const auto subcell_opts =
+      make_subcell_options({{"0", "1", "3", "4", "6", "7"}});
+
+  const evolution::dg::subcell::SubcellAndNonconformingEqualRateRegions<2>
+      combined(subcell_opts, domain_creator);
+
+  const auto regions = combined.regions();
+  CHECK(regions.size() == 5);
+  REQUIRE(regions.contains("Subcell"));
+  REQUIRE(regions.contains("Nonconforming2"));
+  REQUIRE(regions.contains("Nonconforming5-"));
+  REQUIRE(regions.contains("Nonconforming5+"));
+  REQUIRE(regions.contains("Nonconforming8"));
+
+  const size_t subcell_idx = regions.at("Subcell");
+  const size_t region2 = regions.at("Nonconforming2");
+  const size_t region5m = regions.at("Nonconforming5-");
+  const size_t region5p = regions.at("Nonconforming5+");
+  const size_t region8 = regions.at("Nonconforming8");
+
+  // Expected element sets match Test_NonconformingEqualRateRegions exactly.
+  const std::unordered_set<ElementId<2>> expected_region2{
+      {0, {{{2, 3}, {0, 0}}}},
+      {1, {{{0, 0}, {2, 3}}}},
+      {2, {{{0, 0}, {0, 0}}}},
+      {3, {{{2, 0}, {0, 0}}}},
+      {4, {{{0, 0}, {2, 0}}}}};
+  const std::unordered_set<ElementId<2>> expected_region5m{
+      {3, {{{2, 3}, {0, 0}}}},
+      {4, {{{0, 0}, {2, 3}}}},
+      {5, {{{2, 0}, {0, 0}}}}};
+  const std::unordered_set<ElementId<2>> expected_region5p{
+      {5, {{{2, 3}, {0, 0}}}},
+      {6, {{{2, 0}, {0, 0}}}},
+      {7, {{{0, 0}, {2, 0}}}}};
+  const std::unordered_set<ElementId<2>> expected_region8{
+      {6, {{{2, 3}, {0, 0}}}},
+      {7, {{{0, 0}, {2, 3}}}},
+      {8, {{{0, 0}, {0, 0}}}}};
+
+  const auto all_elements =
+      initial_element_ids(NonconformingCreator{}.initial_refinement_levels());
+
+  for (const auto& id : all_elements) {
+    CAPTURE(id);
+    CHECK(not combined.is_in_region(subcell_idx, id));
+    CHECK(combined.is_in_region(region2, id) == expected_region2.contains(id));
+    CHECK(combined.is_in_region(region5m, id) ==
+          expected_region5m.contains(id));
+    CHECK(combined.is_in_region(region5p, id) ==
+          expected_region5p.contains(id));
+    CHECK(combined.is_in_region(region8, id) == expected_region8.contains(id));
+  }
+}
+
+SPECTRE_TEST_CASE(
+    "Unit.Evolution.Subcell.SubcellAndNonconformingEqualRateRegions",
+    "[Evolution][Unit]") {
+  const std::unique_ptr<DomainCreator<2>> domain_creator =
+      std::make_unique<NonconformingCreator>();
+  const auto subcell_opts = make_subcell_options();
+
+  const evolution::dg::subcell::SubcellAndNonconformingEqualRateRegions<2>
+      combined(subcell_opts, domain_creator);
+  check_regions(combined);
+  check_regions(serialize_and_deserialize(combined));
+
+  check_transitive_regions();
+  check_separable_regions();
+  check_no_overlap();
+}
+}  // namespace


### PR DESCRIPTION
## Proposed changes

The two existing equal-rate generators can claim the same element for their own
regions, causing a conflict. This fix combines the subcell and non-conforming
equal rate generators, which folds any problematic non-conforming equal-rate
regions into the subcell region

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent was used, have a co-author trailer of the form
      "Co-Authored-By: <agent name> <agent email>" as the last line of the
      commit, e.g. "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>".

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
