### PR TITLE
Add Lax-Friedrichs flux for the LDG system SecondOrderScalarWave

### DIFF
--- a/src/Evolution/Systems/SecondOrderScalarWave/BoundaryCorrections/CMakeLists.txt
+++ b/src/Evolution/Systems/SecondOrderScalarWave/BoundaryCorrections/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+spectre_target_sources(
+  ${LIBRARY}
+  PRIVATE
+  LaxFriedrichs.cpp
+  )
+
+spectre_target_headers(
+  ${LIBRARY}
+  INCLUDE_DIRECTORY ${CMAKE_SOURCE_DIR}/src
+  HEADERS
+  Factory.hpp
+  LaxFriedrichs.hpp
+  )

--- a/src/Evolution/Systems/SecondOrderScalarWave/BoundaryCorrections/Factory.hpp
+++ b/src/Evolution/Systems/SecondOrderScalarWave/BoundaryCorrections/Factory.hpp
@@ -1,0 +1,14 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+
+#include "Evolution/Systems/SecondOrderScalarWave/BoundaryCorrections/LaxFriedrichs.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace SecondOrderScalarWave::BoundaryCorrections {
+template <size_t Dim>
+using standard_boundary_corrections = tmpl::list<LaxFriedrichs<Dim>>;
+}  // namespace SecondOrderScalarWave::BoundaryCorrections

--- a/src/Evolution/Systems/SecondOrderScalarWave/BoundaryCorrections/LaxFriedrichs.cpp
+++ b/src/Evolution/Systems/SecondOrderScalarWave/BoundaryCorrections/LaxFriedrichs.cpp
@@ -1,0 +1,143 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Evolution/Systems/SecondOrderScalarWave/BoundaryCorrections/LaxFriedrichs.hpp"
+
+#include <limits>
+#include <memory>
+#include <optional>
+#include <pup.h>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/Variables.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
+#include "Utilities/GenerateInstantiations.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace SecondOrderScalarWave::BoundaryCorrections {
+
+template <size_t Dim>
+LaxFriedrichs<Dim>::LaxFriedrichs(CkMigrateMessage* msg)
+    : BoundaryCorrection(msg) {}
+
+template <size_t Dim>
+LaxFriedrichs<Dim>::LaxFriedrichs(const double tau) : tau_(tau) {}
+
+template <size_t Dim>
+std::unique_ptr<evolution::BoundaryCorrection> LaxFriedrichs<Dim>::get_clone()
+    const {
+  return std::make_unique<LaxFriedrichs>(*this);
+}
+
+template <size_t Dim>
+void LaxFriedrichs<Dim>::pup(PUP::er& p) {
+  BoundaryCorrection::pup(p);
+  p | tau_;
+}
+
+template <size_t Dim>
+double LaxFriedrichs<Dim>::dg_package_data(
+    const gsl::not_null<Scalar<DataVector>*> packaged_pi,
+    const gsl::not_null<Scalar<DataVector>*> packaged_normal_dot_phi,
+
+    const Scalar<DataVector>& /*psi*/, const Scalar<DataVector>& pi,
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& phi,
+
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_covector,
+    const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
+    /*mesh_velocity*/,
+    const std::optional<Scalar<DataVector>>& /*normal_dot_mesh_velocity*/)
+    const {
+  get(*packaged_pi) = get(pi);
+  get(*packaged_normal_dot_phi) = 0.0;
+  for (size_t d = 0; d < Dim; ++d) {
+    get(*packaged_normal_dot_phi) += normal_covector.get(d) * phi.get(d);
+  }
+
+  return 1.0;
+}
+
+template <size_t Dim>
+void LaxFriedrichs<Dim>::dg_boundary_terms(
+    const gsl::not_null<Scalar<DataVector>*> psi_boundary_correction,
+    const gsl::not_null<Scalar<DataVector>*> pi_boundary_correction,
+
+    const Scalar<DataVector>& pi_int,
+    const Scalar<DataVector>& normal_dot_phi_int,
+
+    const Scalar<DataVector>& pi_ext,
+    const Scalar<DataVector>& normal_dot_phi_ext,
+
+    dg::Formulation /*dg_formulation*/) const {
+  get(*psi_boundary_correction) = 0.0;
+  get(*pi_boundary_correction) =
+      -0.5 * (get(normal_dot_phi_int) + get(normal_dot_phi_ext)) -
+      tau_ * 0.5 * (get(pi_ext) - get(pi_int));
+}
+
+template <size_t Dim>
+double LaxFriedrichs<Dim>::dg_auxiliary_package_data(
+    const gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*>
+        psi_times_normal,
+
+    const Scalar<DataVector>& psi, const Scalar<DataVector>& /*pi*/,
+
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_covector,
+    const std::optional<
+        tnsr::I<DataVector, Dim, Frame::Inertial>>& /*mesh_velocity*/,
+    const std::optional<Scalar<DataVector>>& /*normal_dot_mesh_velocity*/)
+    const {
+  for (size_t d = 0; d < Dim; ++d) {
+    psi_times_normal->get(d) = get(psi) * normal_covector.get(d);
+  }
+
+  return std::numeric_limits<double>::signaling_NaN();
+}
+
+template <size_t Dim>
+void LaxFriedrichs<Dim>::dg_auxiliary_boundary_terms(
+    const gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*>
+        phi_boundary_correction,
+
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& psi_times_normal_int,
+
+    const tnsr::i<DataVector, Dim, Frame::Inertial>& psi_times_normal_ext,
+
+    dg::Formulation /*dg_formulation*/) const {
+  for (size_t d = 0; d < Dim; ++d) {
+    phi_boundary_correction->get(d) =
+        0.5 * (psi_times_normal_int.get(d) + psi_times_normal_ext.get(d));
+  }
+}
+
+template <size_t LocalDim>
+bool operator==(const LaxFriedrichs<LocalDim>& lhs,
+                const LaxFriedrichs<LocalDim>& rhs) {
+  return lhs.tau_ == rhs.tau_;
+}
+
+template <size_t Dim>
+bool operator!=(const LaxFriedrichs<Dim>& lhs, const LaxFriedrichs<Dim>& rhs) {
+  return not(lhs == rhs);
+}
+
+template <size_t Dim>
+// NOLINTNEXTLINE
+PUP::able::PUP_ID LaxFriedrichs<Dim>::my_PUP_ID = 0;
+
+#define DIM(data) BOOST_PP_TUPLE_ELEM(0, data)
+
+#define INSTANTIATION(_, data)                                   \
+  template class LaxFriedrichs<DIM(data)>;                       \
+  template bool operator==(const LaxFriedrichs<DIM(data)>& lhs,  \
+                           const LaxFriedrichs<DIM(data)>& rhs); \
+  template bool operator!=(const LaxFriedrichs<DIM(data)>& lhs,  \
+                           const LaxFriedrichs<DIM(data)>& rhs);
+
+GENERATE_INSTANTIATIONS(INSTANTIATION, (1, 2, 3))
+
+#undef INSTANTIATION
+#undef DIM
+
+}  // namespace SecondOrderScalarWave::BoundaryCorrections

--- a/src/Evolution/Systems/SecondOrderScalarWave/BoundaryCorrections/LaxFriedrichs.hpp
+++ b/src/Evolution/Systems/SecondOrderScalarWave/BoundaryCorrections/LaxFriedrichs.hpp
@@ -1,0 +1,190 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <limits>
+#include <memory>
+#include <optional>
+
+#include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/Tensor/TypeAliases.hpp"
+#include "Domain/Tags.hpp"
+#include "Evolution/BoundaryCorrection.hpp"
+#include "Evolution/Systems/SecondOrderScalarWave/Tags.hpp"
+#include "NumericalAlgorithms/DiscontinuousGalerkin/Formulation.hpp"
+#include "Options/String.hpp"
+#include "Utilities/Serialization/CharmPupable.hpp"
+#include "Utilities/TMPL.hpp"
+
+/// \cond
+class DataVector;
+namespace gsl {
+template <typename T>
+class not_null;
+}  // namespace gsl
+namespace PUP {
+class er;
+}  // namespace PUP
+/// \endcond
+
+namespace SecondOrderScalarWave::BoundaryCorrections {
+/*!
+ * \brief A Lax-Friedrichs-type boundary correction for the second-order
+ * scalar wave system, providing the numerical fluxes for the local
+ * discontinuous Galerkin (LDG) scheme.
+ *
+ * Each evaluation of the system's time derivative proceeds in two passes: the
+ * auxiliary pass computes \f$\Phi_i = \partial_i \Psi\f$, then the physical
+ * pass evolves \f$\partial_t \Pi = -\partial_i \Phi^i\f$ and
+ * \f$\partial_t \Psi = -\Pi\f$. This class supplies the numerical flux for
+ * each pass: the `dg_auxiliary_*` interface couples neighboring elements in
+ * the auxiliary pass, the standard `dg_*` interface in the physical pass.
+ *
+ * Below, \f$n^i\f$ denotes the interior element's outward-directed unit face
+ * normal. \f$\{\{\Psi\}\}\f$ denotes the central average of \f$\Psi\f$ across
+ * the interface, and
+ * \f$[[\Psi]]^i=n^i\left(\Psi^\text{int}-\Psi^\text{ext}\right)\f$
+ * denotes the jump of \f$\Psi\f$ across the interface.
+ *
+ * ### Auxiliary pass
+ *
+ * Integrating \f$\Phi_i = \partial_i \Psi\f$ against a test
+ * function \f$l\f$ by parts twice over an element \f$K\f$ gives
+ *
+ * \f{align*}{
+ * \int_K \Phi_i l = \int_K (\partial_i \Psi)\, l
+ *   + \oint_{\partial K} l n_i \left(\Psi^* - \Psi\right),
+ * \f}
+ *
+ * where
+ *
+ * \f{align*}{
+ * \Psi^* = \{\{ \Psi \}\}
+ * \f}
+ *
+ * is the central flux.
+ *
+ * ### Physical pass
+ *
+ * Integrating \f$\partial_t \Pi = -\partial_i \Phi^i\f$ by parts twice gives
+ *
+ * \f{align*}{
+ * \int_K (\partial_t \Pi)\, l = -\int_K (\partial_i f_\Phi^i)\, l
+ *   - \oint_{\partial K}
+ *   \left[(f_\Phi^i)^* - f_\Phi^i\right] l n_i ,
+ * \f}
+ *
+ * where
+ *
+ * \f{align*}{
+ * f_\Phi^i = \Phi^i,
+ * \f}
+ *
+ * \f{align*}{
+ * (f_\Phi^i)^* = \{\{ f_\Phi^i \}\} + \frac{\tau}{2} [[ \Pi ]]^i
+ * \f}
+ *
+ * \f$\partial_t \Psi = -\Pi\f$ contains no spatial derivative so receives
+ * no boundary correction.
+ */
+template <size_t Dim>
+class LaxFriedrichs final : public evolution::BoundaryCorrection {
+ public:
+  struct Tau {
+    using type = double;
+    static constexpr Options::String help = {
+        "The penalty parameter tau for the physical numerical flux."};
+  };
+
+  using options = tmpl::list<Tau>;
+  static constexpr Options::String help = {
+      "Boundary correction to the LDG method using the LaxFriedrichs numerical "
+      "flux."};
+
+  LaxFriedrichs() = default;
+  explicit LaxFriedrichs(double tau);
+  LaxFriedrichs(const LaxFriedrichs&) = default;
+  LaxFriedrichs& operator=(const LaxFriedrichs&) = default;
+  LaxFriedrichs(LaxFriedrichs&&) = default;
+  LaxFriedrichs& operator=(LaxFriedrichs&&) = default;
+  ~LaxFriedrichs() override = default;
+
+  /// \cond
+  explicit LaxFriedrichs(CkMigrateMessage* msg);
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(LaxFriedrichs);  // NOLINT
+  /// \endcond
+  void pup(PUP::er& p) override;  // NOLINT
+
+  std::unique_ptr<BoundaryCorrection> get_clone() const override;
+
+  using dg_package_field_tags = tmpl::list<Tags::Pi, Tags::NormalDotPhi>;
+  using dg_package_data_temporary_tags = tmpl::list<>;
+  using dg_package_data_volume_tags = tmpl::list<>;
+  using dg_boundary_terms_volume_tags = tmpl::list<>;
+
+  double dg_package_data(
+      gsl::not_null<Scalar<DataVector>*> packaged_pi,
+      gsl::not_null<Scalar<DataVector>*> packaged_normal_dot_phi,
+
+      const Scalar<DataVector>& /*psi*/, const Scalar<DataVector>& pi,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& phi,
+
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_covector,
+      const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
+      /*mesh_velocity*/,
+      const std::optional<Scalar<DataVector>>& /*normal_dot_mesh_velocity*/)
+      const;
+
+  void dg_boundary_terms(
+      gsl::not_null<Scalar<DataVector>*> psi_boundary_correction,
+      gsl::not_null<Scalar<DataVector>*> pi_boundary_correction,
+
+      const Scalar<DataVector>& pi_int,
+      const Scalar<DataVector>& normal_dot_phi_int,
+
+      const Scalar<DataVector>& pi_ext,
+      const Scalar<DataVector>& normal_dot_phi_ext,
+
+      dg::Formulation /*dg_formulation*/) const;
+
+  using dg_auxiliary_package_field_tags = tmpl::list<Tags::PsiTimesNormal<Dim>>;
+  using dg_auxiliary_package_data_temporary_tags = tmpl::list<>;
+  using dg_auxiliary_package_data_volume_tags = tmpl::list<>;
+  using dg_auxiliary_boundary_terms_volume_tags = tmpl::list<>;
+
+  double dg_auxiliary_package_data(
+      gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*>
+          psi_times_normal,
+
+      const Scalar<DataVector>& psi, const Scalar<DataVector>& /*pi*/,
+
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_covector,
+      const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
+      /*mesh_velocity*/,
+      const std::optional<Scalar<DataVector>>& /*normal_dot_mesh_velocity*/)
+      const;
+
+  void dg_auxiliary_boundary_terms(
+      gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*>
+          phi_boundary_correction,
+
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& psi_times_normal_int,
+
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& psi_times_normal_ext,
+
+      dg::Formulation /*dg_formulation*/) const;
+
+ private:
+  template <size_t LocalDim>
+  // NOLINTNEXTLINE(readability-redundant-declaration)
+  friend bool operator==(const LaxFriedrichs<LocalDim>& lhs,
+                         const LaxFriedrichs<LocalDim>& rhs);
+
+  double tau_ = std::numeric_limits<double>::signaling_NaN();
+};
+
+template <size_t Dim>
+bool operator!=(const LaxFriedrichs<Dim>& lhs, const LaxFriedrichs<Dim>& rhs);
+}  // namespace SecondOrderScalarWave::BoundaryCorrections

--- a/src/Evolution/Systems/SecondOrderScalarWave/CMakeLists.txt
+++ b/src/Evolution/Systems/SecondOrderScalarWave/CMakeLists.txt
@@ -36,3 +36,4 @@ target_link_libraries(
   )
 
 add_subdirectory(BoundaryConditions)
+add_subdirectory(BoundaryCorrections)

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/BoundaryCorrectionsHelper.py
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/BoundaryCorrectionsHelper.py
@@ -69,7 +69,11 @@ def dg_boundary_terms(
     normal_dot_flux_var2_ext,
     abs_char_speed_ext,
     use_strong_form,
+    volume_double,
 ):
+    if not isinstance(volume_double, float):
+        volume_double = volume_double[0]
+    assert volume_double == 2.3
     if use_strong_form:
         return (
             np.asarray(
@@ -100,3 +104,77 @@ def dg_boundary_terms(
                 * (var2_ext - var2_int)
             ),
         )
+
+
+def dg_package_data_aux_system(
+    var1,
+    var2,
+    aux_var,
+    normal_covector,
+    mesh_velocity,
+    normal_dot_mesh_velocity,
+    volume_double,
+    extra_arg,
+):
+    if not isinstance(volume_double, float):
+        volume_double = volume_double[0]
+    assert volume_double == 2.3
+    assert extra_arg == 1.25
+    return (
+        var1,
+        np.asarray(np.einsum("i,i", normal_covector, aux_var)),
+        var1 * normal_covector,
+    )
+
+
+def dg_boundary_terms_aux_system(
+    var1_int,
+    normal_dot_aux_int,
+    var1_times_normal_int,
+    var1_ext,
+    normal_dot_aux_ext,
+    var1_times_normal_ext,
+    use_strong_form,
+    aux_boundary_double,
+    extra_arg,
+):
+    if not isinstance(aux_boundary_double, float):
+        aux_boundary_double = aux_boundary_double[0]
+    assert aux_boundary_double == 3.7
+    assert extra_arg == 1.25
+    return (
+        np.asarray(-0.5 * (normal_dot_aux_int + normal_dot_aux_ext)),
+        -0.5 * (var1_times_normal_int + var1_times_normal_ext),
+    )
+
+
+def dg_auxiliary_package_data_aux_system(
+    var1,
+    var2,
+    normal_covector,
+    mesh_velocity,
+    normal_dot_mesh_velocity,
+    volume_double,
+    extra_arg,
+):
+    if not isinstance(volume_double, float):
+        volume_double = volume_double[0]
+    assert volume_double == 2.3
+    assert extra_arg == 1.25
+    return (var1, var1 * normal_covector)
+
+
+def dg_auxiliary_boundary_terms_aux_system(
+    var1_int,
+    var1_times_normal_int,
+    var1_ext,
+    var1_times_normal_ext,
+    use_strong_form,
+    aux_boundary_double,
+    extra_arg,
+):
+    if not isinstance(aux_boundary_double, float):
+        aux_boundary_double = aux_boundary_double[0]
+    assert aux_boundary_double == 3.7
+    assert extra_arg == 1.25
+    return (0.5 * (var1_times_normal_int + var1_times_normal_ext),)

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_BoundaryCorrectionsHelper.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_BoundaryCorrectionsHelper.cpp
@@ -4,6 +4,9 @@
 #include "Framework/TestingFramework.hpp"
 
 #include <cstddef>
+#include <memory>
+#include <optional>
+#include <tuple>
 
 #include "DataStructures/DataBox/Tag.hpp"
 #include "DataStructures/DataVector.hpp"
@@ -65,6 +68,16 @@ template <size_t Dim>
 struct InverseSpatialMetric : db::SimpleTag {
   using type = tnsr::II<DataVector, Dim, Frame::Inertial>;
 };
+
+template <size_t Dim>
+struct AuxVar : db::SimpleTag {
+  using type = tnsr::i<DataVector, Dim, Frame::Inertial>;
+};
+
+template <typename Type>
+struct AuxBoundaryDouble : db::SimpleTag {
+  using type = Type;
+};
 }  // namespace Tags
 
 template <size_t Dim, bool IncludeTypeAlias>
@@ -86,6 +99,26 @@ struct System : public InverseSpatialMetric<Dim, CurvedBackground> {
   using flux_variables = tmpl::list<Tags::Var1, Tags::Var2<Dim>>;
   using gradient_variables = tmpl::list<>;
   using sourced_variables = tmpl::list<>;
+
+  struct TimeDerivativeTerms {
+    using temporary_tags = tmpl::list<>;
+  };
+
+  using compute_volume_time_derivative_terms = TimeDerivativeTerms;
+};
+
+template <size_t Dim>
+struct AuxSystem {
+  static constexpr bool is_in_flux_conservative_form = false;
+  static constexpr bool has_primitive_and_conservative_vars = false;
+  static constexpr size_t volume_dim = Dim;
+
+  using variables_tag =
+      ::Tags::Variables<tmpl::list<Tags::Var1, Tags::Var2<Dim>>>;
+  using flux_variables = tmpl::list<>;
+  using gradient_variables = tmpl::list<>;
+  using sourced_variables = tmpl::list<>;
+  using auxiliary_variables = tmpl::list<Tags::AuxVar<Dim>>;
 
   struct TimeDerivativeTerms {
     using temporary_tags = tmpl::list<>;
@@ -276,6 +309,145 @@ struct Correction final : public CorrectionBase {
 template <size_t Dim, typename VolumeDoubleType>
 PUP::able::PUP_ID Correction<Dim, VolumeDoubleType>::my_PUP_ID = 0;
 
+template <size_t Dim, typename VolumeDoubleType>
+struct AuxCorrection final : public CorrectionBase {
+ private:
+  struct NormalDotAux : db::SimpleTag {
+    using type = Scalar<DataVector>;
+  };
+  struct Var1TimesNormal : db::SimpleTag {
+    using type = tnsr::i<DataVector, Dim, Frame::Inertial>;
+  };
+
+  static double as_double(const VolumeDoubleType value) {
+    if constexpr (std::is_same_v<double, VolumeDoubleType>) {
+      return value;
+    } else {
+      return value.value;
+    }
+  }
+
+ public:
+  // Physical pass interface.
+  using dg_package_field_tags =
+      tmpl::list<Tags::Var1, NormalDotAux, Var1TimesNormal>;
+  using dg_package_data_temporary_tags = tmpl::list<>;
+  using dg_package_data_volume_tags =
+      tmpl::list<Tags::VolumeDouble<VolumeDoubleType>>;
+  using dg_boundary_terms_volume_tags =
+      tmpl::list<Tags::AuxBoundaryDouble<VolumeDoubleType>>;
+
+  // Auxiliary pass interface.
+  using dg_auxiliary_package_field_tags =
+      tmpl::list<Tags::Var1, Var1TimesNormal>;
+  using dg_auxiliary_package_data_temporary_tags = tmpl::list<>;
+  using dg_auxiliary_package_data_volume_tags =
+      tmpl::list<Tags::VolumeDouble<VolumeDoubleType>>;
+  using dg_auxiliary_boundary_terms_volume_tags =
+      tmpl::list<Tags::AuxBoundaryDouble<VolumeDoubleType>>;
+
+  AuxCorrection() = default;
+  AuxCorrection(const AuxCorrection&) = default;
+  AuxCorrection& operator=(const AuxCorrection&) = default;
+  AuxCorrection(AuxCorrection&&) = default;
+  AuxCorrection& operator=(AuxCorrection&&) = default;
+  ~AuxCorrection() override = default;
+
+  std::unique_ptr<CorrectionBase> get_clone() const override {
+    return std::make_unique<AuxCorrection>(*this);
+  }
+
+  explicit AuxCorrection(CkMigrateMessage* msg) : CorrectionBase(msg) {}
+  using PUP::able::register_constructor;
+  WRAPPED_PUPable_decl_template(AuxCorrection);  // NOLINT
+  void pup(PUP::er& p) override { CorrectionBase::pup(p); }
+
+  double dg_package_data(
+      const gsl::not_null<Scalar<DataVector>*> packaged_var1,
+      const gsl::not_null<Scalar<DataVector>*> packaged_normal_dot_aux,
+      const gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*>
+          var1_times_normal,
+      const Scalar<DataVector>& var1,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& /*var2*/,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& aux_var,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_covector,
+      const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
+      /*mesh_velocity*/,
+      const std::optional<Scalar<DataVector>>& /*normal_dot_mesh_velocity*/,
+      const VolumeDoubleType volume_double) const {
+    get(*packaged_var1) = get(var1);
+    get(*packaged_normal_dot_aux) = get<0>(aux_var) * get<0>(normal_covector);
+    for (size_t i = 1; i < Dim; ++i) {
+      get(*packaged_normal_dot_aux) += aux_var.get(i) * normal_covector.get(i);
+    }
+    for (size_t i = 0; i < Dim; ++i) {
+      var1_times_normal->get(i) = get(var1) * normal_covector.get(i);
+    }
+    CHECK(as_double(volume_double) == 2.3);
+    return 1.0;
+  }
+
+  void dg_boundary_terms(
+      const gsl::not_null<Scalar<DataVector>*> boundary_correction_var1,
+      const gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*>
+          boundary_correction_var2,
+      const Scalar<DataVector>& /*packaged_var1_int*/,
+      const Scalar<DataVector>& normal_dot_aux_int,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& var1_times_normal_int,
+      const Scalar<DataVector>& /*packaged_var1_ext*/,
+      const Scalar<DataVector>& normal_dot_aux_ext,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& var1_times_normal_ext,
+      const dg::Formulation /*dg_formulation*/,
+      const VolumeDoubleType aux_boundary_double) const {
+    get(*boundary_correction_var1) =
+        -0.5 * (get(normal_dot_aux_int) + get(normal_dot_aux_ext));
+    for (size_t i = 0; i < Dim; ++i) {
+      boundary_correction_var2->get(i) =
+          -0.5 * (var1_times_normal_int.get(i) + var1_times_normal_ext.get(i));
+    }
+    CHECK(as_double(aux_boundary_double) == 3.7);
+  }
+
+  double dg_auxiliary_package_data(
+      const gsl::not_null<Scalar<DataVector>*> packaged_var1,
+      const gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*>
+          var1_times_normal,
+      const Scalar<DataVector>& var1,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& /*var2*/,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& normal_covector,
+      const std::optional<tnsr::I<DataVector, Dim, Frame::Inertial>>&
+      /*mesh_velocity*/,
+      const std::optional<Scalar<DataVector>>& /*normal_dot_mesh_velocity*/,
+      const VolumeDoubleType volume_double) const {
+    get(*packaged_var1) = get(var1);
+    for (size_t i = 0; i < Dim; ++i) {
+      var1_times_normal->get(i) = get(var1) * normal_covector.get(i);
+    }
+    CHECK(as_double(volume_double) == 2.3);
+    return 0.0;
+  }
+
+  void dg_auxiliary_boundary_terms(
+      const gsl::not_null<tnsr::i<DataVector, Dim, Frame::Inertial>*>
+          aux_var_correction,
+      const Scalar<DataVector>& /*packaged_var1_int*/,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& var1_times_normal_int,
+      const Scalar<DataVector>& /*packaged_var1_ext*/,
+      const tnsr::i<DataVector, Dim, Frame::Inertial>& var1_times_normal_ext,
+      const dg::Formulation /*dg_formulation*/,
+      const VolumeDoubleType aux_boundary_double) const {
+    for (size_t i = 0; i < Dim; ++i) {
+      aux_var_correction->get(i) =
+          0.5 * (var1_times_normal_int.get(i) + var1_times_normal_ext.get(i));
+    }
+    CHECK(as_double(aux_boundary_double) == 3.7);
+  }
+};
+
+template <size_t Dim, typename VolumeDoubleType>
+// NOLINTNEXTLINE
+PUP::able::PUP_ID AuxCorrection<Dim, VolumeDoubleType>::my_PUP_ID = 0;
+
 template <size_t Dim, bool CurvedBackground, typename VolumeDoubleType>
 void test_impl(const gsl::not_null<std::mt19937*> gen) {
   PUPable_reg(SINGLE_ARG(Correction<Dim, VolumeDoubleType>));
@@ -301,6 +473,38 @@ void test_impl(const gsl::not_null<std::mt19937*> gen) {
       tuples::TaggedTuple<>{});
 }
 
+template <size_t Dim, typename VolumeDoubleType>
+void test_aux_impl(const gsl::not_null<std::mt19937*> gen) {
+  PUPable_reg(SINGLE_ARG(AuxCorrection<Dim, VolumeDoubleType>));
+  const AuxCorrection<Dim, VolumeDoubleType> correction{};
+  const Mesh<Dim - 1> face_mesh{Dim * Dim, Spectral::Basis::Legendre,
+                                Spectral::Quadrature::Gauss};
+
+  const tuples::TaggedTuple<Tags::VolumeDouble<VolumeDoubleType>,
+                            Tags::AuxBoundaryDouble<VolumeDoubleType>>
+      volume_data{VolumeDoubleType{2.3}, VolumeDoubleType{3.7}};
+
+  TestHelpers::evolution::dg::test_boundary_correction_conservation<
+      AuxSystem<Dim>>(gen, correction, face_mesh, volume_data,
+                      tuples::TaggedTuple<>{});
+
+  TestHelpers::evolution::dg::test_auxiliary_boundary_correction_conservation<
+      AuxSystem<Dim>>(gen, correction, face_mesh, volume_data,
+                      tuples::TaggedTuple<>{});
+
+  TestHelpers::evolution::dg::test_boundary_correction_with_python<
+      AuxSystem<Dim>, tmpl::list<VolumeDoubleConversion>>(
+      gen, "BoundaryCorrectionsHelper", "dg_package_data_aux_system",
+      "dg_boundary_terms_aux_system", correction, face_mesh, volume_data,
+      tuples::TaggedTuple<>{}, 1.0e-12, std::make_tuple(1.25));
+
+  TestHelpers::evolution::dg::test_auxiliary_boundary_correction_with_python<
+      AuxSystem<Dim>, tmpl::list<VolumeDoubleConversion>>(
+      gen, "BoundaryCorrectionsHelper", "dg_auxiliary_package_data_aux_system",
+      "dg_auxiliary_boundary_terms_aux_system", correction, face_mesh,
+      volume_data, tuples::TaggedTuple<>{}, 1.0e-12, std::make_tuple(1.25));
+}
+
 template <size_t Dim>
 void test(const gsl::not_null<std::mt19937*> gen) {
   test_impl<Dim, false, double>(gen);
@@ -308,6 +512,9 @@ void test(const gsl::not_null<std::mt19937*> gen) {
 
   test_impl<Dim, true, double>(gen);
   test_impl<Dim, true, VolumeDouble>(gen);
+
+  test_aux_impl<Dim, double>(gen);
+  test_aux_impl<Dim, VolumeDouble>(gen);
 }
 }  // namespace
 

--- a/tests/Unit/Evolution/Systems/SecondOrderScalarWave/BoundaryCorrections/LaxFriedrichs.py
+++ b/tests/Unit/Evolution/Systems/SecondOrderScalarWave/BoundaryCorrections/LaxFriedrichs.py
@@ -1,0 +1,56 @@
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+import numpy as np
+
+
+def dg_package_data(
+    psi,
+    pi,
+    phi,
+    normal_covector,
+    mesh_velocity,
+    normal_dot_mesh_velocity,
+    tau,
+):
+    return (
+        pi,
+        np.asarray(np.einsum("i,i", normal_covector, phi)),
+    )
+
+
+def dg_boundary_terms(
+    pi_int,
+    normal_dot_phi_int,
+    pi_ext,
+    normal_dot_phi_ext,
+    use_strong_form,
+    tau,
+):
+    return (
+        np.asarray(0.0 * pi_int),
+        np.asarray(
+            -0.5 * (normal_dot_phi_int + normal_dot_phi_ext)
+            - tau * 0.5 * (pi_ext - pi_int)
+        ),
+    )
+
+
+def dg_auxiliary_package_data(
+    psi,
+    pi,
+    normal_covector,
+    mesh_velocity,
+    normal_dot_mesh_velocity,
+    tau,
+):
+    return (np.asarray(psi * normal_covector),)
+
+
+def dg_auxiliary_boundary_terms(
+    psi_times_normal_int,
+    psi_times_normal_ext,
+    use_strong_form,
+    tau,
+):
+    return (np.asarray(0.5 * (psi_times_normal_int + psi_times_normal_ext)),)

--- a/tests/Unit/Evolution/Systems/SecondOrderScalarWave/BoundaryCorrections/Test_LaxFriedrichs.cpp
+++ b/tests/Unit/Evolution/Systems/SecondOrderScalarWave/BoundaryCorrections/Test_LaxFriedrichs.cpp
@@ -1,0 +1,122 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cmath>
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <random>
+#include <tuple>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "Evolution/BoundaryCorrection.hpp"
+#include "Evolution/Systems/SecondOrderScalarWave/BoundaryCorrections/LaxFriedrichs.hpp"
+#include "Evolution/Systems/SecondOrderScalarWave/System.hpp"
+#include "Framework/SetupLocalPythonEnvironment.hpp"
+#include "Framework/TestCreation.hpp"
+#include "Helpers/Evolution/DiscontinuousGalerkin/BoundaryCorrections.hpp"
+#include "NumericalAlgorithms/Spectral/Basis.hpp"
+#include "NumericalAlgorithms/Spectral/Mesh.hpp"
+#include "NumericalAlgorithms/Spectral/Quadrature.hpp"
+#include "Utilities/ErrorHandling/FloatingPointExceptions.hpp"
+#include "Utilities/Gsl.hpp"
+
+namespace {
+template <size_t Dim>
+Mesh<Dim - 1> face_mesh() {
+  if constexpr (Dim == 1) {
+    return Mesh<0>{};
+  } else {
+    return Mesh<Dim - 1>{5, Spectral::Basis::Legendre,
+                         Spectral::Quadrature::GaussLobatto};
+  }
+}
+
+template <size_t Dim>
+void test(const gsl::not_null<std::mt19937*> gen) {
+  CAPTURE(Dim);
+  PUPable_reg(SecondOrderScalarWave::BoundaryCorrections::LaxFriedrichs<Dim>);
+
+  std::uniform_real_distribution<> dist(0.0, 2.0);
+  const double tau = dist(*gen);
+  const SecondOrderScalarWave::BoundaryCorrections::LaxFriedrichs<Dim>
+      correction{tau};
+
+  const auto mesh = face_mesh<Dim>();
+
+  // The correction is a handful of O(1) multiply-adds, so C++ and python
+  // agree to a few ULP; 1.0e-14 is tight while leaving ~10x flake margin.
+  constexpr double eps = 1.0e-14;
+
+  TestHelpers::evolution::dg::test_boundary_correction_conservation<
+      SecondOrderScalarWave::System<Dim>>(
+      gen, correction, mesh, {}, {},
+      TestHelpers::evolution::dg::ZeroOnSmoothSolution::Yes, eps);
+  TestHelpers::evolution::dg::test_auxiliary_boundary_correction_conservation<
+      SecondOrderScalarWave::System<Dim>>(
+      gen, correction, mesh, {}, {},
+      TestHelpers::evolution::dg::ZeroOnSmoothSolution::Yes, eps);
+
+  TestHelpers::evolution::dg::test_boundary_correction_with_python<
+      SecondOrderScalarWave::System<Dim>>(
+      gen, "LaxFriedrichs", "dg_package_data", "dg_boundary_terms", correction,
+      mesh, {}, {}, eps, std::make_tuple(tau));
+  TestHelpers::evolution::dg::test_auxiliary_boundary_correction_with_python<
+      SecondOrderScalarWave::System<Dim>>(
+      gen, "LaxFriedrichs", "dg_auxiliary_package_data",
+      "dg_auxiliary_boundary_terms", correction, mesh, {}, {}, eps,
+      std::make_tuple(tau));
+
+  // Factory creation round-trips the options into an equal object.
+  const auto created = TestHelpers::test_factory_creation<
+      evolution::BoundaryCorrection,
+      SecondOrderScalarWave::BoundaryCorrections::LaxFriedrichs<Dim>>(
+      "LaxFriedrichs:\n"
+      "  Tau: 1.5\n");
+  const auto& downcast = dynamic_cast<
+      const SecondOrderScalarWave::BoundaryCorrections::LaxFriedrichs<Dim>&>(
+      *created);
+  CHECK(downcast ==
+        SecondOrderScalarWave::BoundaryCorrections::LaxFriedrichs<Dim>{1.5});
+
+  // Pin the return values of the two package-data functions: the physical pass
+  // returns the unit wave speed, the auxiliary pass returns a signaling NaN.
+  const size_t num_pts = 1;
+  const Scalar<DataVector> psi{num_pts, 0.5};
+  const Scalar<DataVector> pi{num_pts, 0.5};
+  const tnsr::i<DataVector, Dim, Frame::Inertial> phi{num_pts, 0.5};
+  tnsr::i<DataVector, Dim, Frame::Inertial> normal_covector{num_pts, 0.0};
+  get<0>(normal_covector) = 1.0;
+
+  Scalar<DataVector> packaged_pi{num_pts};
+  Scalar<DataVector> packaged_normal_dot_phi{num_pts};
+  const double max_char_speed = correction.dg_package_data(
+      make_not_null(&packaged_pi), make_not_null(&packaged_normal_dot_phi), psi,
+      pi, phi, normal_covector, std::nullopt, std::nullopt);
+  CHECK(max_char_speed == 1.0);
+
+  tnsr::i<DataVector, Dim, Frame::Inertial> psi_times_normal{num_pts};
+  const double auxiliary_speed = correction.dg_auxiliary_package_data(
+      make_not_null(&psi_times_normal), psi, pi, normal_covector, std::nullopt,
+      std::nullopt);
+  {
+    const ScopedFpeState disable_fpes(false);
+    CHECK(std::isnan(auxiliary_speed));
+  }
+}
+}  // namespace
+
+SPECTRE_TEST_CASE(
+    "Unit.SecondOrderScalarWave.BoundaryCorrections.LaxFriedrichs",
+    "[Unit][Evolution]") {
+  const pypp::SetupLocalPythonEnvironment local_python_env{
+      "Evolution/Systems/SecondOrderScalarWave/BoundaryCorrections"};
+  MAKE_GENERATOR(gen);
+
+  test<1>(make_not_null(&gen));
+  test<2>(make_not_null(&gen));
+  test<3>(make_not_null(&gen));
+}

--- a/tests/Unit/Evolution/Systems/SecondOrderScalarWave/CMakeLists.txt
+++ b/tests/Unit/Evolution/Systems/SecondOrderScalarWave/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LIBRARY Test_SecondOrderScalarWave)
 
 set(LIBRARY_SOURCES
   BoundaryConditions/Test_Periodic.cpp
+  BoundaryCorrections/Test_LaxFriedrichs.cpp
   Test_Characteristics.cpp
   Test_System.cpp
   Test_Tags.cpp

--- a/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/BoundaryCorrections.hpp
+++ b/tests/Unit/Helpers/Evolution/DiscontinuousGalerkin/BoundaryCorrections.hpp
@@ -9,6 +9,7 @@
 #include <optional>
 #include <random>
 #include <string>
+#include <tuple>
 #include <type_traits>
 
 #include "DataStructures/DataBox/PrefixHelpers.hpp"
@@ -20,6 +21,7 @@
 #include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
+#include "Evolution/DiscontinuousGalerkin/Actions/ComputeTimeDerivativeHelpers.hpp"
 #include "Framework/Pypp.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
@@ -73,8 +75,8 @@ template <bool HasPrimitiveVars, typename System>
 using get_system_primitive_vars = typename get_system_primitive_vars_impl<
     HasPrimitiveVars>::template f<System>;
 
-template <typename BoundaryCorrection, typename... PackageTags,
-          typename... FaceTags, typename... VolumeTags,
+template <bool IsAuxiliary = false, typename BoundaryCorrection,
+          typename... PackageTags, typename... FaceTags, typename... VolumeTags,
           typename... FaceTagsToForward, typename... VolumeTagsToForward,
           size_t Dim>
 double call_dg_package_data(
@@ -92,12 +94,19 @@ double call_dg_package_data(
     normal_dot_mesh_velocity =
         dot_product(*mesh_velocity, unit_normal_covector);
   }
-  const double max_speed = correction.dg_package_data(
-      make_not_null(&get<PackageTags>(*package_data))...,
-      get<FaceTagsToForward>(face_variables)..., unit_normal_covector,
-      mesh_velocity, normal_dot_mesh_velocity,
-      StdHelpers::retrieve(get<VolumeTagsToForward>(volume_data))...);
-  return max_speed;
+  if constexpr (IsAuxiliary) {
+    return correction.dg_auxiliary_package_data(
+        make_not_null(&get<PackageTags>(*package_data))...,
+        get<FaceTagsToForward>(face_variables)..., unit_normal_covector,
+        mesh_velocity, normal_dot_mesh_velocity,
+        StdHelpers::retrieve(get<VolumeTagsToForward>(volume_data))...);
+  } else {
+    return correction.dg_package_data(
+        make_not_null(&get<PackageTags>(*package_data))...,
+        get<FaceTagsToForward>(face_variables)..., unit_normal_covector,
+        mesh_velocity, normal_dot_mesh_velocity,
+        StdHelpers::retrieve(get<VolumeTagsToForward>(volume_data))...);
+  }
 }
 
 template <typename BoundaryCorrection, typename... PackageTags,
@@ -128,9 +137,9 @@ double call_dg_package_data(
   return max_speed;
 }
 
-template <typename BoundaryCorrection, typename... BoundaryCorrectionTags,
-          typename... PackageTags, typename... VolumeTags,
-          typename... VolumeTagsToForward>
+template <bool IsAuxiliary = false, typename BoundaryCorrection,
+          typename... BoundaryCorrectionTags, typename... PackageTags,
+          typename... VolumeTags, typename... VolumeTagsToForward>
 void call_dg_boundary_terms(
     const gsl::not_null<Variables<tmpl::list<BoundaryCorrectionTags...>>*>
         boundary_corrections,
@@ -140,15 +149,24 @@ void call_dg_boundary_terms(
     const Variables<tmpl::list<PackageTags...>>& exterior_package_data,
     const ::dg::Formulation dg_formulation,
     tmpl::list<VolumeTagsToForward...> /*meta*/) {
-  correction.dg_boundary_terms(
-      make_not_null(&get<BoundaryCorrectionTags>(*boundary_corrections))...,
-      get<PackageTags>(interior_package_data)...,
-      get<PackageTags>(exterior_package_data)..., dg_formulation,
-      StdHelpers::retrieve(get<VolumeTagsToForward>(volume_data))...);
+  if constexpr (IsAuxiliary) {
+    correction.dg_auxiliary_boundary_terms(
+        make_not_null(&get<BoundaryCorrectionTags>(*boundary_corrections))...,
+        get<PackageTags>(interior_package_data)...,
+        get<PackageTags>(exterior_package_data)..., dg_formulation,
+        StdHelpers::retrieve(get<VolumeTagsToForward>(volume_data))...);
+  } else {
+    correction.dg_boundary_terms(
+        make_not_null(&get<BoundaryCorrectionTags>(*boundary_corrections))...,
+        get<PackageTags>(interior_package_data)...,
+        get<PackageTags>(exterior_package_data)..., dg_formulation,
+        StdHelpers::retrieve(get<VolumeTagsToForward>(volume_data))...);
+  }
 }
 
-template <typename System, typename BoundaryCorrection, size_t FaceDim,
-          typename... VolumeTags, typename... RangeTags>
+template <typename System, bool IsAuxiliary = false,
+          typename BoundaryCorrection, size_t FaceDim, typename... VolumeTags,
+          typename... RangeTags>
 void test_boundary_correction_conservation_impl(
     const gsl::not_null<std::mt19937*> generator,
     const BoundaryCorrection& correction_in, const Mesh<FaceDim>& face_mesh,
@@ -162,29 +180,59 @@ void test_boundary_correction_conservation_impl(
   constexpr bool curved_background =
       detail::has_inverse_spatial_metric_tag_v<System>;
   CAPTURE(curved_background);
+  static_assert(not(IsAuxiliary and curved_background),
+                "The LDG auxiliary pass cannot be used with specified inverse "
+                "spatial metric.");
   Approx custom_approx = Approx::custom().epsilon(eps).scale(1.0);
 
   using variables_tags = typename System::variables_tag::tags_list;
+  using auxiliary_variables =
+      ::evolution::dg::Actions::detail::get_auxiliary_variables_or_default_t<
+          System, tmpl::list<>>;
   using primitive_variables_tags = detail::get_system_primitive_vars<
       System::has_primitive_and_conservative_vars, System>;
-  using flux_variables = typename System::flux_variables;
+  using flux_variables = tmpl::conditional_t<IsAuxiliary, tmpl::list<>,
+                                             typename System::flux_variables>;
   using flux_tags =
       db::wrap_tags_in<::Tags::Flux, flux_variables, tmpl::size_t<FaceDim + 1>,
                        Frame::Inertial>;
   using temporary_tags =
       typename System::compute_volume_time_derivative_terms::temporary_tags;
-  using dt_variables_tags = db::wrap_tags_in<::Tags::dt, variables_tags>;
+  // What `dg_boundary_terms` writes: time-derivative corrections for the
+  // physical pass, corrections to the auxiliary variables for the auxiliary
+  // pass.
+  using boundary_correction_tags =
+      tmpl::conditional_t<IsAuxiliary, auxiliary_variables,
+                          db::wrap_tags_in<::Tags::dt, variables_tags>>;
 
   using dg_package_field_tags =
-      typename BoundaryCorrection::dg_package_field_tags;
-  using dg_package_volume_tags =
-      typename BoundaryCorrection::dg_package_data_volume_tags;
-  using dg_boundary_terms_volume_tags =
-      typename BoundaryCorrection::dg_boundary_terms_volume_tags;
-  using package_temporary_tags =
-      typename BoundaryCorrection::dg_package_data_temporary_tags;
-  using package_primitive_tags = detail::get_correction_primitive_vars<
-      System::has_primitive_and_conservative_vars, BoundaryCorrection>;
+      tmpl::conditional_t<IsAuxiliary,
+                          ::evolution::dg::Actions::detail::
+                              get_dg_auxiliary_package_field_tags_or_default_t<
+                                  BoundaryCorrection, tmpl::list<>>,
+                          typename BoundaryCorrection::dg_package_field_tags>;
+  using dg_package_volume_tags = tmpl::conditional_t<
+      IsAuxiliary,
+      ::evolution::dg::Actions::detail::
+          get_dg_auxiliary_package_data_volume_tags_or_default_t<
+              BoundaryCorrection, tmpl::list<>>,
+      typename BoundaryCorrection::dg_package_data_volume_tags>;
+  using dg_boundary_terms_volume_tags = tmpl::conditional_t<
+      IsAuxiliary,
+      ::evolution::dg::Actions::detail::
+          get_dg_auxiliary_boundary_terms_volume_tags_or_default_t<
+              BoundaryCorrection, tmpl::list<>>,
+      typename BoundaryCorrection::dg_boundary_terms_volume_tags>;
+  using package_temporary_tags = tmpl::conditional_t<
+      IsAuxiliary,
+      ::evolution::dg::Actions::detail::
+          get_dg_auxiliary_package_data_temporary_tags_or_default_t<
+              BoundaryCorrection, tmpl::list<>>,
+      typename BoundaryCorrection::dg_package_data_temporary_tags>;
+  using package_primitive_tags = tmpl::conditional_t<
+      IsAuxiliary, tmpl::list<>,
+      detail::get_correction_primitive_vars<
+          System::has_primitive_and_conservative_vars, BoundaryCorrection>>;
 
   const auto correction_base_ptr =
       serialize_and_deserialize(correction_in.get_clone());
@@ -211,9 +259,13 @@ void test_boundary_correction_conservation_impl(
       "There are primitive tags needed by the boundary correction that are not "
       "listed in the system as being primitive variables");
 
-  using face_tags =
-      tmpl::append<variables_tags, flux_tags, package_temporary_tags,
-                   package_primitive_tags>;
+  // The physical pass projects the evolved variables followed by the LDG
+  // auxiliary variables; the auxiliary pass projects only the evolved
+  // variables.
+  using face_tags = tmpl::conditional_t<
+      IsAuxiliary, tmpl::append<variables_tags, package_temporary_tags>,
+      tmpl::append<variables_tags, auxiliary_variables, flux_tags,
+                   package_temporary_tags, package_primitive_tags>>;
   using face_tags_with_curved_background = tmpl::conditional_t<
       curved_background,
       tmpl::remove_duplicates<tmpl::push_back<
@@ -357,22 +409,22 @@ void test_boundary_correction_conservation_impl(
                          exterior_unit_normal_vector, mesh_velocity,
                          face_tags{}, dg_package_volume_tags{});
   } else {
-    call_dg_package_data(make_not_null(&interior_package_data), correction,
-                         interior_fields_on_face, volume_data,
-                         interior_unit_normal_covector, mesh_velocity,
-                         face_tags{}, dg_package_volume_tags{});
-    call_dg_package_data(make_not_null(&exterior_package_data), correction,
-                         exterior_fields_on_face, volume_data,
-                         exterior_unit_normal_covector, mesh_velocity,
-                         face_tags{}, dg_package_volume_tags{});
+    call_dg_package_data<IsAuxiliary>(
+        make_not_null(&interior_package_data), correction,
+        interior_fields_on_face, volume_data, interior_unit_normal_covector,
+        mesh_velocity, face_tags{}, dg_package_volume_tags{});
+    call_dg_package_data<IsAuxiliary>(
+        make_not_null(&exterior_package_data), correction,
+        exterior_fields_on_face, volume_data, exterior_unit_normal_covector,
+        mesh_velocity, face_tags{}, dg_package_volume_tags{});
   }
 
-  Variables<dt_variables_tags> boundary_corrections{
+  Variables<boundary_correction_tags> boundary_corrections{
       face_mesh.number_of_grid_points()};
-  call_dg_boundary_terms(make_not_null(&boundary_corrections), correction,
-                         volume_data, interior_package_data,
-                         exterior_package_data, dg_formulation,
-                         dg_boundary_terms_volume_tags{});
+  call_dg_boundary_terms<IsAuxiliary>(
+      make_not_null(&boundary_corrections), correction, volume_data,
+      interior_package_data, exterior_package_data, dg_formulation,
+      dg_boundary_terms_volume_tags{});
 
   if (dg_formulation == ::dg::Formulation::StrongInertial) {
     // The strong form should be (WeakForm - (n_i F^i)_{interior}).
@@ -391,19 +443,19 @@ void test_boundary_correction_conservation_impl(
                            exterior_unit_normal_vector, mesh_velocity,
                            face_tags{}, dg_package_volume_tags{});
     } else {
-      call_dg_package_data(make_not_null(&interior_package_data), correction,
-                           interior_fields_on_face, volume_data,
-                           interior_unit_normal_covector, mesh_velocity,
-                           face_tags{}, dg_package_volume_tags{});
-      call_dg_package_data(make_not_null(&exterior_package_data), correction,
-                           exterior_fields_on_face, volume_data,
-                           exterior_unit_normal_covector, mesh_velocity,
-                           face_tags{}, dg_package_volume_tags{});
+      call_dg_package_data<IsAuxiliary>(
+          make_not_null(&interior_package_data), correction,
+          interior_fields_on_face, volume_data, interior_unit_normal_covector,
+          mesh_velocity, face_tags{}, dg_package_volume_tags{});
+      call_dg_package_data<IsAuxiliary>(
+          make_not_null(&exterior_package_data), correction,
+          exterior_fields_on_face, volume_data, exterior_unit_normal_covector,
+          mesh_velocity, face_tags{}, dg_package_volume_tags{});
     }
 
-    Variables<dt_variables_tags> expected_boundary_corrections{
+    Variables<boundary_correction_tags> expected_boundary_corrections{
         face_mesh.number_of_grid_points()};
-    call_dg_boundary_terms(
+    call_dg_boundary_terms<IsAuxiliary>(
         make_not_null(&expected_boundary_corrections), correction, volume_data,
         interior_package_data, exterior_package_data,
         ::dg::Formulation::WeakInertial, dg_boundary_terms_volume_tags{});
@@ -451,42 +503,42 @@ void test_boundary_correction_conservation_impl(
             exterior_unit_normal_vector, mesh_velocity, face_tags{},
             dg_package_volume_tags{});
       } else {
-        call_dg_package_data(
+        call_dg_package_data<IsAuxiliary>(
             make_not_null(&interior_package_data_opposite_signs), correction,
             interior_fields_on_face, volume_data, exterior_unit_normal_covector,
             mesh_velocity, face_tags{}, dg_package_volume_tags{});
       }
-      Variables<dt_variables_tags> zero_boundary_correction{
+      Variables<boundary_correction_tags> zero_boundary_correction{
           face_mesh.number_of_grid_points()};
-      call_dg_boundary_terms(
+      call_dg_boundary_terms<IsAuxiliary>(
           make_not_null(&zero_boundary_correction), correction, volume_data,
           interior_package_data, interior_package_data_opposite_signs,
           ::dg::Formulation::StrongInertial, dg_boundary_terms_volume_tags{});
-      Variables<dt_variables_tags> expected_zero_boundary_correction{
+      Variables<boundary_correction_tags> expected_zero_boundary_correction{
           face_mesh.number_of_grid_points(), 0.0};
-      tmpl::for_each<dt_variables_tags>([&custom_approx,
-                                         &expected_zero_boundary_correction,
-                                         &zero_boundary_correction](
-                                            auto dt_variables_tag_v) {
-        using dt_variables_tag = tmpl::type_from<decltype(dt_variables_tag_v)>;
-        const std::string tag_name = db::tag_name<dt_variables_tag>();
-        CAPTURE(tag_name);
-        CHECK_ITERABLE_CUSTOM_APPROX(
-            get<dt_variables_tag>(zero_boundary_correction),
-            get<dt_variables_tag>(expected_zero_boundary_correction),
-            custom_approx);
-      });
+      tmpl::for_each<boundary_correction_tags>(
+          [&custom_approx, &expected_zero_boundary_correction,
+           &zero_boundary_correction](auto dt_variables_tag_v) {
+            using dt_variables_tag =
+                tmpl::type_from<decltype(dt_variables_tag_v)>;
+            const std::string tag_name = db::tag_name<dt_variables_tag>();
+            CAPTURE(tag_name);
+            CHECK_ITERABLE_CUSTOM_APPROX(
+                get<dt_variables_tag>(zero_boundary_correction),
+                get<dt_variables_tag>(expected_zero_boundary_correction),
+                custom_approx);
+          });
     }
   } else if (dg_formulation == ::dg::Formulation::WeakInertial) {
     INFO(
         "Checking that swapping the two sides results in an overall minus "
         "sign.");
-    Variables<dt_variables_tags> reverse_side_boundary_corrections{
+    Variables<boundary_correction_tags> reverse_side_boundary_corrections{
         face_mesh.number_of_grid_points()};
-    call_dg_boundary_terms(make_not_null(&reverse_side_boundary_corrections),
-                           correction, volume_data, exterior_package_data,
-                           interior_package_data, dg_formulation,
-                           dg_boundary_terms_volume_tags{});
+    call_dg_boundary_terms<IsAuxiliary>(
+        make_not_null(&reverse_side_boundary_corrections), correction,
+        volume_data, exterior_package_data, interior_package_data,
+        dg_formulation, dg_boundary_terms_volume_tags{});
     // Check that the flux leaving one element equals the flux entering its
     // neighbor, i.e., F*(interior, exterior) == -F*(exterior, interior)
     reverse_side_boundary_corrections *= -1.0;
@@ -543,9 +595,9 @@ void test_boundary_correction_conservation(
 
 namespace detail {
 template <typename System, typename ConversionClassList, typename VariablesTags,
-          typename BoundaryCorrection, size_t FaceDim, typename... FaceTags,
-          typename... VolumeTags, typename... RangeTags,
-          typename... DgPackageDataTags>
+          bool IsAuxiliary, typename BoundaryCorrection, size_t FaceDim,
+          typename... FaceTags, typename... VolumeTags, typename... RangeTags,
+          typename... DgPackageDataTags, typename... ExtraPythonArgs>
 void test_with_python(
     const gsl::not_null<std::mt19937*> generator,
     const std::string& python_module,
@@ -554,6 +606,7 @@ void test_with_python(
     const BoundaryCorrection& correction, const Mesh<FaceDim>& face_mesh,
     const tuples::TaggedTuple<VolumeTags...>& volume_data,
     const tuples::TaggedTuple<Tags::Range<RangeTags>...>& ranges,
+    const std::tuple<ExtraPythonArgs...>& extra_python_args,
     const bool use_moving_mesh, const ::dg::Formulation dg_formulation,
     const double epsilon, tmpl::list<FaceTags...> /*meta*/,
     tmpl::list<DgPackageDataTags...> /*meta*/) {
@@ -563,12 +616,27 @@ void test_with_python(
   REQUIRE(face_mesh.number_of_grid_points() >= 1);
   constexpr bool curved_background =
       detail::has_inverse_spatial_metric_tag_v<System>;
+  static_assert(not(IsAuxiliary and curved_background),
+                "The LDG auxiliary pass cannot be used with specified inverse "
+                "spatial metric.");
   using dg_package_field_tags =
-      typename BoundaryCorrection::dg_package_field_tags;
-  using dg_package_volume_tags =
-      typename BoundaryCorrection::dg_package_data_volume_tags;
-  using dg_boundary_terms_volume_tags =
-      typename BoundaryCorrection::dg_boundary_terms_volume_tags;
+      tmpl::conditional_t<IsAuxiliary,
+                          ::evolution::dg::Actions::detail::
+                              get_dg_auxiliary_package_field_tags_or_default_t<
+                                  BoundaryCorrection, tmpl::list<>>,
+                          typename BoundaryCorrection::dg_package_field_tags>;
+  using dg_package_volume_tags = tmpl::conditional_t<
+      IsAuxiliary,
+      ::evolution::dg::Actions::detail::
+          get_dg_auxiliary_package_data_volume_tags_or_default_t<
+              BoundaryCorrection, tmpl::list<>>,
+      typename BoundaryCorrection::dg_package_data_volume_tags>;
+  using dg_boundary_terms_volume_tags = tmpl::conditional_t<
+      IsAuxiliary,
+      ::evolution::dg::Actions::detail::
+          get_dg_auxiliary_boundary_terms_volume_tags_or_default_t<
+              BoundaryCorrection, tmpl::list<>>,
+      typename BoundaryCorrection::dg_boundary_terms_volume_tags>;
 
   using face_tags = tmpl::list<FaceTags...>;
   using face_tags_with_curved_background = tmpl::conditional_t<
@@ -653,10 +721,10 @@ void test_with_python(
                          unit_normal_vector, mesh_velocity,
                          tmpl::list<FaceTags...>{}, dg_package_volume_tags{});
   } else {
-    call_dg_package_data(make_not_null(&package_data), correction,
-                         fields_on_face, volume_data, unit_normal_covector,
-                         mesh_velocity, tmpl::list<FaceTags...>{},
-                         dg_package_volume_tags{});
+    call_dg_package_data<IsAuxiliary>(
+        make_not_null(&package_data), correction, fields_on_face, volume_data,
+        unit_normal_covector, mesh_velocity, tmpl::list<FaceTags...>{},
+        dg_package_volume_tags{});
   }
 
   // Call python implementation of dg_package_data
@@ -665,19 +733,37 @@ void test_with_python(
         tmpl::as_tuple<tmpl::transform<dg_package_field_tags,
                                        tmpl::bind<tmpl::type_from, tmpl::_1>>>;
     ResultType python_result{};
+    // Forward only the volume data the C++ `dg_package_data` receives
+    // (`dg_package_data_volume_tags`)
     if constexpr (curved_background) {
-      python_result = pypp::call<ResultType, ConversionClassList>(
-          python_module, python_dg_package_data_function,
-          get<FaceTags>(fields_on_face)..., unit_normal_covector,
-          unit_normal_vector, mesh_velocity, normal_dot_mesh_velocity,
-          StdHelpers::retrieve(get<VolumeTags>(volume_data))...);
+      python_result = [&]<typename... PackageVolumeTags>(
+                          tmpl::list<PackageVolumeTags...> /*meta*/) {
+        return std::apply(
+            [&](const auto&... expanded_extra_python_args) {
+              return pypp::call<ResultType, ConversionClassList>(
+                  python_module, python_dg_package_data_function,
+                  get<FaceTags>(fields_on_face)..., unit_normal_covector,
+                  unit_normal_vector, mesh_velocity, normal_dot_mesh_velocity,
+                  StdHelpers::retrieve(get<PackageVolumeTags>(volume_data))...,
+                  expanded_extra_python_args...);
+            },
+            extra_python_args);
+      }(dg_package_volume_tags{});
     } else {
       (void)unit_normal_vector;
-      python_result = pypp::call<ResultType, ConversionClassList>(
-          python_module, python_dg_package_data_function,
-          get<FaceTags>(fields_on_face)..., unit_normal_covector, mesh_velocity,
-          normal_dot_mesh_velocity,
-          StdHelpers::retrieve(get<VolumeTags>(volume_data))...);
+      python_result = [&]<typename... PackageVolumeTags>(
+                          tmpl::list<PackageVolumeTags...> /*meta*/) {
+        return std::apply(
+            [&](const auto&... expanded_extra_python_args) {
+              return pypp::call<ResultType, ConversionClassList>(
+                  python_module, python_dg_package_data_function,
+                  get<FaceTags>(fields_on_face)..., unit_normal_covector,
+                  mesh_velocity, normal_dot_mesh_velocity,
+                  StdHelpers::retrieve(get<PackageVolumeTags>(volume_data))...,
+                  expanded_extra_python_args...);
+            },
+            extra_python_args);
+      }(dg_package_volume_tags{});
     }
     tmpl::for_each<dg_package_field_tags>([&epsilon, &package_data,
                                            &python_result](
@@ -781,10 +867,10 @@ void test_with_python(
                          exterior_unit_normal_vector, mesh_velocity,
                          face_tags{}, dg_package_volume_tags{});
   } else {
-    call_dg_package_data(make_not_null(&exterior_package_data), correction,
-                         exterior_fields_on_face, volume_data,
-                         exterior_unit_normal_covector, mesh_velocity,
-                         face_tags{}, dg_package_volume_tags{});
+    call_dg_package_data<IsAuxiliary>(
+        make_not_null(&exterior_package_data), correction,
+        exterior_fields_on_face, volume_data, exterior_unit_normal_covector,
+        mesh_velocity, face_tags{}, dg_package_volume_tags{});
   }
 
   // We don't need to prefix the VariablesTags with anything because we are not
@@ -794,10 +880,10 @@ void test_with_python(
       face_mesh.number_of_grid_points()};
 
   // Call C++ implementation of dg_boundary_terms
-  call_dg_boundary_terms(make_not_null(&boundary_corrections), correction,
-                         volume_data, interior_package_data,
-                         exterior_package_data, dg_formulation,
-                         dg_boundary_terms_volume_tags{});
+  call_dg_boundary_terms<IsAuxiliary>(
+      make_not_null(&boundary_corrections), correction, volume_data,
+      interior_package_data, exterior_package_data, dg_formulation,
+      dg_boundary_terms_volume_tags{});
 
   // Call python implementation of dg_boundary_terms
   try {
@@ -807,11 +893,23 @@ void test_with_python(
     CAPTURE(python_module);
     const std::string& python_function = python_dg_boundary_terms_function;
     CAPTURE(python_function);
-    const ResultType python_result = pypp::call<ResultType>(
-        python_module, python_function,
-        get<DgPackageDataTags>(interior_package_data)...,
-        get<DgPackageDataTags>(exterior_package_data)...,
-        dg_formulation == ::dg::Formulation::StrongInertial);
+    // Foward `dg_boundary_terms_volume_tags` entries of `volume_data`
+    const ResultType python_result =
+        [&]<typename... BoundaryTermsVolumeTags>(
+            tmpl::list<BoundaryTermsVolumeTags...> /*meta*/) {
+          return std::apply(
+              [&](const auto&... expanded_extra_python_args) {
+                return pypp::call<ResultType, ConversionClassList>(
+                    python_module, python_function,
+                    get<DgPackageDataTags>(interior_package_data)...,
+                    get<DgPackageDataTags>(exterior_package_data)...,
+                    dg_formulation == ::dg::Formulation::StrongInertial,
+                    StdHelpers::retrieve(
+                        get<BoundaryTermsVolumeTags>(volume_data))...,
+                    expanded_extra_python_args...);
+              },
+              extra_python_args);
+        }(dg_boundary_terms_volume_tags{});
     tmpl::for_each<VariablesTags>([&python_result, epsilon,
                                    &boundary_corrections](
                                       auto boundary_correction_tag_v) {
@@ -853,10 +951,10 @@ void test_with_python(
  * - You can convert custom types using the `ConversionClassList` template
  *   parameter, which is then passed to `pypp::call()`. This allows you to,
  *   e.g., convert an equation of state into an array locally in a test file.
- * - There must be one python function to compute the packaged data for each tag
- *   in `dg_package_field_tags`
- * - There must be one python function to compute the boundary correction for
- *   each tag in `System::variables_tag`
+ * - The python function computing the packaged data returns a tuple with one
+ *   entry for each tag in `dg_package_field_tags`
+ * - The python function computing the boundary corrections returns a tuple
+ *   with one entry for each tag in `System::variables_tag`
  * - The arguments to the python functions for computing the packaged data are
  *   the same as the arguments for the C++ `dg_package_data` function, excluding
  *   the `gsl::not_null` arguments.
@@ -873,7 +971,7 @@ void test_with_python(
  */
 template <typename System, typename ConversionClassList = tmpl::list<>,
           typename BoundaryCorrection, size_t FaceDim, typename... VolumeTags,
-          typename... RangeTags>
+          typename... RangeTags, typename... ExtraPythonArgs>
 void test_boundary_correction_with_python(
     const gsl::not_null<std::mt19937*> generator,
     const std::string& python_module,
@@ -882,7 +980,8 @@ void test_boundary_correction_with_python(
     const BoundaryCorrection& correction, const Mesh<FaceDim>& face_mesh,
     const tuples::TaggedTuple<VolumeTags...>& volume_data,
     const tuples::TaggedTuple<Tags::Range<RangeTags>...>& ranges,
-    const double epsilon = 1.0e-12) {
+    const double epsilon = 1.0e-12,
+    const std::tuple<ExtraPythonArgs...>& extra_python_args = {}) {
   static_assert(std::is_final_v<std::decay_t<BoundaryCorrection>>,
                 "All boundary correction classes must be marked `final`.");
   using package_temporary_tags =
@@ -890,6 +989,9 @@ void test_boundary_correction_with_python(
   using package_primitive_tags = detail::get_correction_primitive_vars<
       System::has_primitive_and_conservative_vars, BoundaryCorrection>;
   using variables_tags = typename System::variables_tag::tags_list;
+  using auxiliary_variables =
+      ::evolution::dg::Actions::detail::get_auxiliary_variables_or_default_t<
+          System, tmpl::list<>>;
   using flux_variables = typename System::flux_variables;
   using flux_tags =
       db::wrap_tags_in<::Tags::Flux, flux_variables, tmpl::size_t<FaceDim + 1>,
@@ -898,13 +1000,109 @@ void test_boundary_correction_with_python(
   for (const auto use_moving_mesh : {false, true}) {
     for (const auto dg_formulation :
          {::dg::Formulation::StrongInertial, ::dg::Formulation::WeakInertial}) {
-      detail::test_with_python<System, ConversionClassList, variables_tags>(
+      detail::test_with_python<System, ConversionClassList, variables_tags,
+                               false>(
           generator, python_module, python_dg_package_data_function,
           python_dg_boundary_terms_function, correction, face_mesh, volume_data,
-          ranges, use_moving_mesh, dg_formulation, epsilon,
-          tmpl::append<variables_tags, flux_tags, package_temporary_tags,
-                       package_primitive_tags>{},
+          ranges, extra_python_args, use_moving_mesh, dg_formulation, epsilon,
+          tmpl::append<variables_tags, auxiliary_variables, flux_tags,
+                       package_temporary_tags, package_primitive_tags>{},
           typename BoundaryCorrection::dg_package_field_tags{});
+    }
+  }
+}
+
+/*!
+ * \ingroup TestingFrameworkGroup
+ * \brief The analog of `test_boundary_correction_conservation` for the
+ * LDG auxiliary pass, exercising `dg_auxiliary_package_data` and
+ * `dg_auxiliary_boundary_terms`.
+ *
+ * The auxiliary pass projects only the evolved variables to the face, and the
+ * boundary terms are corrections to `System::auxiliary_variables` rather than
+ * to time derivatives.
+ */
+template <typename System, typename BoundaryCorrection, size_t FaceDim,
+          typename... VolumeTags, typename... RangeTags>
+void test_auxiliary_boundary_correction_conservation(
+    const gsl::not_null<std::mt19937*> generator,
+    const BoundaryCorrection& correction, const Mesh<FaceDim>& face_mesh,
+    const tuples::TaggedTuple<VolumeTags...>& volume_data,
+    const tuples::TaggedTuple<Tags::Range<RangeTags>...>& ranges,
+    const ZeroOnSmoothSolution zero_on_smooth_solution =
+        ZeroOnSmoothSolution::Yes,
+    const double eps = 1.0e-12) {
+  static_assert(
+      not std::is_same_v<
+          ::evolution::dg::Actions::detail::
+              get_auxiliary_variables_or_default_t<System, tmpl::list<>>,
+          tmpl::list<>>,
+      "The system does not declare `auxiliary_variables`, so there is no "
+      "auxiliary pass to test.");
+  for (const auto use_moving_mesh : {true, false}) {
+    for (const auto& dg_formulation :
+         {::dg::Formulation::StrongInertial, ::dg::Formulation::WeakInertial}) {
+      detail::test_boundary_correction_conservation_impl<System, true>(
+          generator, correction, face_mesh, volume_data, ranges,
+          use_moving_mesh, dg_formulation, zero_on_smooth_solution, eps);
+    }
+  }
+}
+
+/*!
+ * \ingroup TestingFrameworkGroup
+ * \brief The analog of `test_boundary_correction_with_python` for the
+ * LDG auxiliary pass, exercising `dg_auxiliary_package_data` and
+ * `dg_auxiliary_boundary_terms`.
+ *
+ * The auxiliary pass projects only the evolved variables to the face, so the
+ * python function computing the packaged data receives the evolved variables
+ * (and any `dg_auxiliary_package_data_temporary_tags`) followed by the normal
+ * covector, the mesh velocity, and the normal dot mesh velocity. The python
+ * function computing the boundary corrections returns a tuple with one entry
+ * for each tag in `System::auxiliary_variables`. The `extra_python_args`
+ * tuple is appended to the arguments of both python functions, e.g. to
+ * forward constructor penalty parameters of the boundary correction.
+ */
+template <typename System, typename ConversionClassList = tmpl::list<>,
+          typename BoundaryCorrection, size_t FaceDim, typename... VolumeTags,
+          typename... RangeTags, typename... ExtraPythonArgs>
+void test_auxiliary_boundary_correction_with_python(
+    const gsl::not_null<std::mt19937*> generator,
+    const std::string& python_module,
+    const std::string& python_dg_package_data_function,
+    const std::string& python_dg_boundary_terms_function,
+    const BoundaryCorrection& correction, const Mesh<FaceDim>& face_mesh,
+    const tuples::TaggedTuple<VolumeTags...>& volume_data,
+    const tuples::TaggedTuple<Tags::Range<RangeTags>...>& ranges,
+    const double epsilon = 1.0e-12,
+    const std::tuple<ExtraPythonArgs...>& extra_python_args = {}) {
+  static_assert(std::is_final_v<std::decay_t<BoundaryCorrection>>,
+                "All boundary correction classes must be marked `final`.");
+  using variables_tags = typename System::variables_tag::tags_list;
+  using auxiliary_variables =
+      ::evolution::dg::Actions::detail::get_auxiliary_variables_or_default_t<
+          System, tmpl::list<>>;
+  static_assert(not std::is_same_v<auxiliary_variables, tmpl::list<>>,
+                "The system does not declare `auxiliary_variables`, so there "
+                "is no auxiliary pass to test.");
+  using package_temporary_tags = ::evolution::dg::Actions::detail::
+      get_dg_auxiliary_package_data_temporary_tags_or_default_t<
+          BoundaryCorrection, tmpl::list<>>;
+  using dg_auxiliary_package_field_tags = ::evolution::dg::Actions::detail::
+      get_dg_auxiliary_package_field_tags_or_default_t<BoundaryCorrection,
+                                                       tmpl::list<>>;
+
+  for (const auto use_moving_mesh : {false, true}) {
+    for (const auto dg_formulation :
+         {::dg::Formulation::StrongInertial, ::dg::Formulation::WeakInertial}) {
+      detail::test_with_python<System, ConversionClassList, auxiliary_variables,
+                               true>(
+          generator, python_module, python_dg_package_data_function,
+          python_dg_boundary_terms_function, correction, face_mesh, volume_data,
+          ranges, extra_python_args, use_moving_mesh, dg_formulation, epsilon,
+          tmpl::append<variables_tags, package_temporary_tags>{},
+          dg_auxiliary_package_field_tags{});
     }
   }
 }


### PR DESCRIPTION
## Proposed changes
Generalize the boundary correction test helper to handle LDG boundary corrections. Add `LaxFriedrichs` boundary correction for the LDG system `SecondOrderScalarWave`.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent was used, have a co-author trailer of the form
      "Co-Authored-By: <agent name> <agent email>" as the last line of the
      commit, e.g. "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>".

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
