### PR TITLE
Add frame parameter to `sw_vars_list`

### DIFF
--- a/src/Evolution/Systems/ScalarWave/ApplyTensorYlmFilter.cpp
+++ b/src/Evolution/Systems/ScalarWave/ApplyTensorYlmFilter.cpp
@@ -23,8 +23,8 @@ namespace ylm::TensorYlm {
 namespace filter_detail {
 template <typename SrcFrame, typename DestFrame>
 void transform_spatial_tensors_to_different_frame_without_hessians(
-    const gsl::not_null<Variables<sw_vars_list>*> dest,
-    const Variables<sw_vars_list>& src,
+    const gsl::not_null<Variables<sw_vars_list<DestFrame>>*> dest,
+    const Variables<sw_vars_list<SrcFrame>>& src,
     const InverseJacobian<DataVector, 3, SrcFrame, DestFrame>& jac) {
   const auto& [src_psi, src_pi, src_phi] = src;
   auto& [dest_psi, dest_pi, dest_phi] = *dest;
@@ -43,7 +43,7 @@ void transform_spatial_tensors_to_different_frame_without_hessians(
 }  // namespace filter_detail
 
 template <>
-void fill_tensor_ylm_filters<filter_detail::sw_vars_list>(
+void fill_tensor_ylm_filters<filter_detail::sw_vars_list<Frame::Inertial>>(
     const gsl::not_null<FilterMatrixHolder*> matrix, const size_t ell_max,
     const size_t number_of_ell_modes_to_kill,
     const std::optional<size_t> half_power,
@@ -72,8 +72,12 @@ void fill_tensor_ylm_filters<filter_detail::sw_vars_list>(
 
 template <>
 void apply_tensor_ylm_filter(
-    const gsl::not_null<Variables<filter_detail::sw_vars_list>*> sw_vars,
-    const gsl::not_null<Variables<filter_detail::sw_vars_list>*> temp_storage,
+    const gsl::not_null<
+        Variables<filter_detail::sw_vars_list<Frame::Inertial>>*>
+        sw_vars,
+    const gsl::not_null<
+        Variables<filter_detail::sw_vars_list<Frame::Inertial>>*>
+        temp_storage,
     const InverseJacobian<DataVector, 3, Frame::Inertial, Frame::Grid>&
         jac_inertial_to_grid,
     const InverseJacobian<DataVector, 3, Frame::Grid, Frame::Inertial>&
@@ -106,16 +110,16 @@ void apply_tensor_ylm_filter(
   // (and we should not use any them simultaneously) and one
   // Variables that points into sw_vars (which we should not use
   // simultaneously with sw_vars).
-  Variables<filter_detail::sw_vars_list> sw_spectral_vars(temp_storage->data(),
-                                                          temp_storage->size());
-  Variables<filter_detail::sw_vars_list> temp_grid_vars(sw_vars->data(),
-                                                        sw_vars->size());
+  Variables<filter_detail::sw_vars_list<Frame::Grid>> sw_spectral_vars(
+      temp_storage->data(), temp_storage->size());
+  Variables<filter_detail::sw_vars_list<Frame::Grid>> temp_grid_vars(
+      sw_vars->data(), sw_vars->size());
   // The following Variables uses sw_vars->size() which is smaller
   // than temp_storage->size().
   ASSERT(sw_vars->size() <= temp_storage->size(),
          "Should have " << sw_vars->size() << " <= " << temp_storage->size());
-  Variables<filter_detail::sw_vars_list> temp_sw_vars(temp_storage->data(),
-                                                      sw_vars->size());
+  Variables<filter_detail::sw_vars_list<Frame::Grid>> temp_sw_vars(
+      temp_storage->data(), sw_vars->size());
 
   // 1. Multiply by inverse Jacobians to get into (mostly) grid frame.
   //    It's not really the grid frame because there are no Hessian
@@ -142,7 +146,7 @@ void apply_tensor_ylm_filter(
   // src: sw_spectral_vars
   // dest: sw_spectral_vars
   // but using temp_grid_vars as temp storage for each tensor
-  tmpl::for_each<filter_detail::sw_vars_list>(
+  tmpl::for_each<filter_detail::sw_vars_list<Frame::Grid>>(
       [&sw_spectral_vars, &temp_grid_vars, radial_extents,
        &filter_matrices]<class Tag>(const tmpl::type_<Tag> /*meta*/) {
         // Different compilers disagree on whether radial_extents
@@ -235,26 +239,36 @@ void apply_tensor_ylm_filter(
 
 namespace filter_detail {
 
-template void nodal_to_modal_ylm<sw_vars_list>(
-    gsl::not_null<Variables<sw_vars_list>*> modal,
-    const Variables<sw_vars_list>& nodal, const ::ylm::Spherepack& ylm,
-    size_t radial_extents);
+template void nodal_to_modal_ylm<sw_vars_list<Frame::Grid>>(
+    gsl::not_null<Variables<sw_vars_list<Frame::Grid>>*> modal,
+    const Variables<sw_vars_list<Frame::Grid>>& nodal,
+    const ::ylm::Spherepack& ylm, size_t radial_extents);
 
-template void modal_to_nodal_ylm<sw_vars_list>(
-    gsl::not_null<Variables<sw_vars_list>*> modal,
-    const Variables<sw_vars_list>& nodal, const ::ylm::Spherepack& ylm,
-    size_t radial_extents);
+template void nodal_to_modal_ylm<sw_vars_list<Frame::Inertial>>(
+    gsl::not_null<Variables<sw_vars_list<Frame::Inertial>>*> modal,
+    const Variables<sw_vars_list<Frame::Inertial>>& nodal,
+    const ::ylm::Spherepack& ylm, size_t radial_extents);
+
+template void modal_to_nodal_ylm<sw_vars_list<Frame::Grid>>(
+    gsl::not_null<Variables<sw_vars_list<Frame::Grid>>*> modal,
+    const Variables<sw_vars_list<Frame::Grid>>& nodal,
+    const ::ylm::Spherepack& ylm, size_t radial_extents);
+
+template void modal_to_nodal_ylm<sw_vars_list<Frame::Inertial>>(
+    gsl::not_null<Variables<sw_vars_list<Frame::Inertial>>*> modal,
+    const Variables<sw_vars_list<Frame::Inertial>>& nodal,
+    const ::ylm::Spherepack& ylm, size_t radial_extents);
 
 template void transform_spatial_tensors_to_different_frame_without_hessians<
     Frame::Grid, Frame::Inertial>(
-    gsl::not_null<Variables<sw_vars_list>*> dest,
-    const Variables<sw_vars_list>& src,
+    gsl::not_null<Variables<sw_vars_list<Frame::Inertial>>*> dest,
+    const Variables<sw_vars_list<Frame::Grid>>& src,
     const InverseJacobian<DataVector, 3, Frame::Grid, Frame::Inertial>& jac);
 
 template void transform_spatial_tensors_to_different_frame_without_hessians<
     Frame::Inertial, Frame::Grid>(
-    gsl::not_null<Variables<sw_vars_list>*> dest,
-    const Variables<sw_vars_list>& src,
+    gsl::not_null<Variables<sw_vars_list<Frame::Grid>>*> dest,
+    const Variables<sw_vars_list<Frame::Inertial>>& src,
     const InverseJacobian<DataVector, 3, Frame::Inertial, Frame::Grid>& jac);
 }  // namespace filter_detail
 }  // namespace ylm::TensorYlm

--- a/src/Evolution/Systems/ScalarWave/ApplyTensorYlmFilter.hpp
+++ b/src/Evolution/Systems/ScalarWave/ApplyTensorYlmFilter.hpp
@@ -24,8 +24,10 @@ namespace ylm::TensorYlm {
 /// tested independently in the unit tests.
 namespace filter_detail {
 
+/// Variables list for the ScalarWave evolved fields, parameterized by \p Frame.
+template <typename Frame>
 using sw_vars_list = tmpl::list<::ScalarWave::Tags::Psi, ::ScalarWave::Tags::Pi,
-                                ::ScalarWave::Tags::Phi<3>>;
+                                ::ScalarWave::Tags::Phi<3, Frame>>;
 
 /*!
  * \brief Transforms spatial tensors into a different frame, ignoring hessians.
@@ -48,8 +50,8 @@ using sw_vars_list = tmpl::list<::ScalarWave::Tags::Psi, ::ScalarWave::Tags::Pi,
  */
 template <typename SrcFrame, typename DestFrame>
 void transform_spatial_tensors_to_different_frame_without_hessians(
-    gsl::not_null<Variables<sw_vars_list>*> dest,
-    const Variables<sw_vars_list>& src,
+    gsl::not_null<Variables<sw_vars_list<DestFrame>>*> dest,
+    const Variables<sw_vars_list<SrcFrame>>& src,
     const InverseJacobian<DataVector, 3, SrcFrame, DestFrame>& jac);
 
 }  // namespace filter_detail
@@ -79,7 +81,11 @@ void transform_spatial_tensors_to_different_frame_without_hessians(
  * number of spectral coefficients, and both are different than the
  * size of the Spherepack storage array.
  *
- * \param sw_vars Scalar wave variables at collocation points.
+ * \param sw_vars ScalarWave variables in the inertial frame
+ *   (`sw_vars_list<Frame::Inertial>`). Internally, \f$\Phi_i\f$ is
+ *   frame-transformed to the grid frame before filtering and transformed back
+ *   afterward; `sw_vars` is updated in-place and remains in the inertial frame
+ *   on exit.
  * \param temp_storage Temporary storage for scalar wave variables,
  *   allocated outside apply_tensor_ylm_filter. See above for size requirements.
  * \param jac_inertial_to_grid Jacobian taking V_x from inertial to grid.
@@ -91,8 +97,10 @@ void transform_spatial_tensors_to_different_frame_without_hessians(
  */
 template <>
 void apply_tensor_ylm_filter(
-    gsl::not_null<Variables<filter_detail::sw_vars_list>*> sw_vars,
-    gsl::not_null<Variables<filter_detail::sw_vars_list>*> temp_storage,
+    gsl::not_null<Variables<filter_detail::sw_vars_list<Frame::Inertial>>*>
+        sw_vars,
+    gsl::not_null<Variables<filter_detail::sw_vars_list<Frame::Inertial>>*>
+        temp_storage,
     const InverseJacobian<DataVector, 3, Frame::Inertial, Frame::Grid>&
         jac_inertial_to_grid,
     const InverseJacobian<DataVector, 3, Frame::Grid, Frame::Inertial>&

--- a/src/Evolution/Systems/ScalarWave/Tags.hpp
+++ b/src/Evolution/Systems/ScalarWave/Tags.hpp
@@ -40,9 +40,9 @@ struct Pi : db::SimpleTag {
  * \details If \f$\Psi\f$ is the scalar field then we define
  * \f$\Phi_{i} = \partial_i \Psi\f$
  */
-template <size_t Dim>
+template <size_t Dim, typename Frame>
 struct Phi : db::SimpleTag {
-  using type = tnsr::i<DataVector, Dim, Frame::Inertial>;
+  using type = tnsr::i<DataVector, Dim, Frame>;
 };
 
 struct ConstraintGamma2 : db::SimpleTag {

--- a/src/Evolution/Systems/ScalarWave/TagsDeclarations.hpp
+++ b/src/Evolution/Systems/ScalarWave/TagsDeclarations.hpp
@@ -5,11 +5,17 @@
 
 #include <cstddef>
 
+/// \cond
+namespace Frame {
+struct Inertial;
+}  // namespace Frame
+/// \endcond
+
 /// \brief Tags for the ScalarWave evolution system
 namespace ScalarWave::Tags {
 struct Psi;
 struct Pi;
-template <size_t Dim>
+template <size_t Dim, typename Frame = Frame::Inertial>
 struct Phi;
 
 struct ConstraintGamma2;

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/PlaneWave.hpp
@@ -25,7 +25,7 @@ class DataVector;
 namespace ScalarWave::Tags {
 struct Psi;
 struct Pi;
-template <size_t Dim>
+template <size_t Dim, typename Frame>
 struct Phi;
 }  // namespace ScalarWave::Tags
 namespace Tags {
@@ -78,9 +78,9 @@ class PlaneWave : public evolution::initial_data::InitialData,
 
   static constexpr Options::String help = {
       "A plane wave solution of the Euclidean wave equation"};
-  using tags =
-      tmpl::list<Tags::Psi, Tags::Pi, Tags::Phi<Dim>, ::Tags::dt<Tags::Psi>,
-                 ::Tags::dt<Tags::Pi>, ::Tags::dt<Tags::Phi<Dim>>>;
+  using tags = tmpl::list<Tags::Psi, Tags::Pi, Tags::Phi<Dim, Frame::Inertial>,
+                          ::Tags::dt<Tags::Psi>, ::Tags::dt<Tags::Pi>,
+                          ::Tags::dt<Tags::Phi<Dim, Frame::Inertial>>>;
 
   PlaneWave() = default;
   PlaneWave(std::array<double, Dim> wave_vector, std::array<double, Dim> center,
@@ -125,9 +125,10 @@ class PlaneWave : public evolution::initial_data::InitialData,
   tnsr::ii<T, Dim> d2psi_dxdx(const tnsr::I<T, Dim>& x, double t) const;
 
   /// Retrieve the evolution variables at time `t` and spatial coordinates `x`
-  tuples::TaggedTuple<Tags::Psi, Tags::Pi, Tags::Phi<Dim>> variables(
-      const tnsr::I<DataVector, Dim>& x, double t,
-      tmpl::list<Tags::Psi, Tags::Pi, Tags::Phi<Dim>> /*meta*/) const;
+  tuples::TaggedTuple<Tags::Psi, Tags::Pi, Tags::Phi<Dim, Frame::Inertial>>
+  variables(const tnsr::I<DataVector, Dim>& x, double t,
+            tmpl::list<Tags::Psi, Tags::Pi,
+                       Tags::Phi<Dim, Frame::Inertial>> /*meta*/) const;
 
   /// Retrieve the time derivative of the evolution variables at time `t` and
   /// spatial coordinates `x`
@@ -135,10 +136,11 @@ class PlaneWave : public evolution::initial_data::InitialData,
   /// \note This function's expected use case is setting the past time
   /// derivative values for Adams-Bashforth-like steppers.
   tuples::TaggedTuple<::Tags::dt<Tags::Psi>, ::Tags::dt<Tags::Pi>,
-                      ::Tags::dt<Tags::Phi<Dim>>>
-  variables(const tnsr::I<DataVector, Dim>& x, double t,
-            tmpl::list<::Tags::dt<Tags::Psi>, ::Tags::dt<Tags::Pi>,
-                       ::Tags::dt<Tags::Phi<Dim>>> /*meta*/) const;
+                      ::Tags::dt<Tags::Phi<Dim, Frame::Inertial>>>
+  variables(
+      const tnsr::I<DataVector, Dim>& x, double t,
+      tmpl::list<::Tags::dt<Tags::Psi>, ::Tags::dt<Tags::Pi>,
+                 ::Tags::dt<Tags::Phi<Dim, Frame::Inertial>>> /*meta*/) const;
 
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& p) override;

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/RegularSphericalWave.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/RegularSphericalWave.hpp
@@ -23,7 +23,7 @@ class DataVector;
 namespace ScalarWave::Tags {
 struct Pi;
 struct Psi;
-template <size_t Dim>
+template <size_t Dim, typename Frame>
 struct Phi;
 }  // namespace ScalarWave::Tags
 namespace Tags {
@@ -79,9 +79,9 @@ class RegularSphericalWave : public evolution::initial_data::InitialData,
       "A spherical wave solution of the Euclidean wave equation that is "
       "regular at the origin"};
 
-  using tags =
-      tmpl::list<Tags::Psi, Tags::Pi, Tags::Phi<3>, ::Tags::dt<Tags::Psi>,
-                 ::Tags::dt<Tags::Pi>, ::Tags::dt<Tags::Phi<3>>>;
+  using tags = tmpl::list<Tags::Psi, Tags::Pi, Tags::Phi<3, Frame::Inertial>,
+                          ::Tags::dt<Tags::Psi>, ::Tags::dt<Tags::Pi>,
+                          ::Tags::dt<Tags::Phi<3, Frame::Inertial>>>;
 
   RegularSphericalWave() = default;
   explicit RegularSphericalWave(
@@ -101,15 +101,17 @@ class RegularSphericalWave : public evolution::initial_data::InitialData,
   WRAPPED_PUPable_decl_template(RegularSphericalWave);
   /// \endcond
 
-  tuples::TaggedTuple<Tags::Psi, Tags::Pi, Tags::Phi<3>> variables(
-      const tnsr::I<DataVector, 3>& x, double t,
-      tmpl::list<Tags::Psi, Tags::Pi, Tags::Phi<3>> /*meta*/) const;
+  tuples::TaggedTuple<Tags::Psi, Tags::Pi, Tags::Phi<3, Frame::Inertial>>
+  variables(const tnsr::I<DataVector, 3>& x, double t,
+            tmpl::list<Tags::Psi, Tags::Pi,
+                       Tags::Phi<3, Frame::Inertial>> /*meta*/) const;
 
   tuples::TaggedTuple<::Tags::dt<Tags::Psi>, ::Tags::dt<Tags::Pi>,
-                      ::Tags::dt<Tags::Phi<3>>>
-  variables(const tnsr::I<DataVector, 3>& x, double t,
-            tmpl::list<::Tags::dt<Tags::Psi>, ::Tags::dt<Tags::Pi>,
-                       ::Tags::dt<Tags::Phi<3>>> /*meta*/) const;
+                      ::Tags::dt<Tags::Phi<3, Frame::Inertial>>>
+  variables(
+      const tnsr::I<DataVector, 3>& x, double t,
+      tmpl::list<::Tags::dt<Tags::Psi>, ::Tags::dt<Tags::Pi>,
+                 ::Tags::dt<Tags::Phi<3, Frame::Inertial>>> /*meta*/) const;
 
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& p) override;

--- a/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/StandingWave.hpp
+++ b/src/PointwiseFunctions/AnalyticSolutions/WaveEquation/StandingWave.hpp
@@ -23,7 +23,7 @@ class DataVector;
 namespace ScalarWave::Tags {
 struct Psi;
 struct Pi;
-template <size_t Dim>
+template <size_t Dim, typename Frame>
 struct Phi;
 }  // namespace ScalarWave::Tags
 namespace Tags {
@@ -84,9 +84,9 @@ class StandingWave : public evolution::initial_data::InitialData,
       "Psi = A sin(k.(x-x0)) cos(omega t), with omega = |k|. "
       "At t=0, Pi=0 so the wave has equal left- and right-moving components."};
 
-  using tags =
-      tmpl::list<Tags::Psi, Tags::Pi, Tags::Phi<Dim>, ::Tags::dt<Tags::Psi>,
-                 ::Tags::dt<Tags::Pi>, ::Tags::dt<Tags::Phi<Dim>>>;
+  using tags = tmpl::list<Tags::Psi, Tags::Pi, Tags::Phi<Dim, Frame::Inertial>,
+                          ::Tags::dt<Tags::Psi>, ::Tags::dt<Tags::Pi>,
+                          ::Tags::dt<Tags::Phi<Dim, Frame::Inertial>>>;
 
   StandingWave() = default;
   StandingWave(std::array<double, Dim> wave_vector,
@@ -107,16 +107,18 @@ class StandingWave : public evolution::initial_data::InitialData,
   /// \endcond
 
   /// Retrieve the evolution variables at time `t` and spatial coordinates `x`
-  tuples::TaggedTuple<Tags::Psi, Tags::Pi, Tags::Phi<Dim>> variables(
-      const tnsr::I<DataVector, Dim>& x, double t,
-      tmpl::list<Tags::Psi, Tags::Pi, Tags::Phi<Dim>> /*meta*/) const;
+  tuples::TaggedTuple<Tags::Psi, Tags::Pi, Tags::Phi<Dim, Frame::Inertial>>
+  variables(const tnsr::I<DataVector, Dim>& x, double t,
+            tmpl::list<Tags::Psi, Tags::Pi,
+                       Tags::Phi<Dim, Frame::Inertial>> /*meta*/) const;
 
   /// Retrieve the time derivatives of the evolution variables
   tuples::TaggedTuple<::Tags::dt<Tags::Psi>, ::Tags::dt<Tags::Pi>,
-                      ::Tags::dt<Tags::Phi<Dim>>>
-  variables(const tnsr::I<DataVector, Dim>& x, double t,
-            tmpl::list<::Tags::dt<Tags::Psi>, ::Tags::dt<Tags::Pi>,
-                       ::Tags::dt<Tags::Phi<Dim>>> /*meta*/) const;
+                      ::Tags::dt<Tags::Phi<Dim, Frame::Inertial>>>
+  variables(
+      const tnsr::I<DataVector, Dim>& x, double t,
+      tmpl::list<::Tags::dt<Tags::Psi>, ::Tags::dt<Tags::Pi>,
+                 ::Tags::dt<Tags::Phi<Dim, Frame::Inertial>>> /*meta*/) const;
 
   // NOLINTNEXTLINE(google-runtime-references)
   void pup(PUP::er& p) override;

--- a/tests/Unit/Evolution/Systems/ScalarWave/Test_ApplyTensorYlmFilter.cpp
+++ b/tests/Unit/Evolution/Systems/ScalarWave/Test_ApplyTensorYlmFilter.cpp
@@ -11,7 +11,7 @@ namespace ylm::TensorYlm {
 
 SPECTRE_TEST_CASE("Unit.Evolution.Systems.ScalarWave.ApplyTensorYlmFilter",
                   "[NumericalAlgorithms][Unit]") {
-  test_apply_filter<filter_detail::sw_vars_list>(0);
-  test_apply_filter<filter_detail::sw_vars_list>(5);
+  test_apply_filter<filter_detail::sw_vars_list<Frame::Inertial>>(0);
+  test_apply_filter<filter_detail::sw_vars_list<Frame::Inertial>>(5);
 }
 }  // namespace ylm::TensorYlm


### PR DESCRIPTION
## Proposed changes

When we do frame transformations for SH filtering (and a coming PR for SH power monitors) it is more correct to have the frame be a template parameter.

The forward declarations in the solution files don't allow the default to be specified, so we have to do a few manual fills (rather than add an extra include)

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent was used, have a co-author trailer of the form
      "Co-Authored-By: <agent name> <agent email>" as the last line of the
      commit, e.g. "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>".

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
