### PR TITLE
Add infra for computing time derivatives of boundary evolved fields

### DIFF
--- a/src/Evolution/DiscontinuousGalerkin/BoundaryEvolvedVariables.hpp
+++ b/src/Evolution/DiscontinuousGalerkin/BoundaryEvolvedVariables.hpp
@@ -1,0 +1,136 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#pragma once
+
+#include <cstddef>
+#include <type_traits>
+
+#include "DataStructures/DataBox/Tag.hpp"
+#include "Utilities/NoSuchType.hpp"
+#include "Utilities/TMPL.hpp"
+#include "Utilities/TypeTraits/CreateGetStaticMemberVariableOrDefault.hpp"
+#include "Utilities/TypeTraits/CreateGetTypeAliasOrDefault.hpp"
+#include "Utilities/TypeTraits/IsA.hpp"
+
+/// \cond
+namespace Tags {
+template <size_t Dim, typename TagsList>
+struct BoundaryVariables;
+}  // namespace Tags
+/// \endcond
+
+namespace evolution::dg {
+namespace Tags {
+/// \ingroup DiscontinuousGalerkinGroup
+/// \brief The boundary-evolved twin of an interior source field.
+///
+/// A boundary-evolved field is stored and time-integrated only on external
+/// boundary faces (a pointwise per-face-node ODE); it has no volume extent.
+/// This is a prefix tag wrapping the interior source, so its type matches the
+/// source.
+///
+/// \note Boundary evolved fields cannot currently be used with AMR or LTS.
+template <typename Source>
+struct BoundaryValue : db::PrefixTag, db::SimpleTag {
+  using type = typename Source::type;
+  /// The interior source field this boundary field is the twin of.
+  using tag = Source;
+};
+}  // namespace Tags
+
+namespace detail {
+template <typename Tag>
+struct is_boundary_variables_tag : std::false_type {};
+template <size_t Dim, typename TagsList>
+struct is_boundary_variables_tag<::Tags::BoundaryVariables<Dim, TagsList>>
+    : std::true_type {};
+
+template <typename VariablesTag>
+struct boundary_variables_tag_impl : std::false_type {
+  using type = NoSuchType;
+};
+template <typename VariablesTag>
+requires tt::is_a_v<tmpl::list, VariablesTag>
+struct boundary_variables_tag_impl<VariablesTag> {
+ private:
+  using back = tmpl::back<VariablesTag>;
+
+ public:
+  static constexpr bool value = is_boundary_variables_tag<back>::value;
+  static_assert(
+      tmpl::count_if<VariablesTag,
+                     tmpl::bind<is_boundary_variables_tag, tmpl::_1>>::value ==
+          (value ? 1 : 0),
+      "A list-valued variables_tag must contain at most one "
+      "::Tags::BoundaryVariables entry, and it must be the last entry.");
+  using type = tmpl::conditional_t<value, back, NoSuchType>;
+};
+}  // namespace detail
+
+/// \ingroup DiscontinuousGalerkinGroup
+/// \brief Whether the system declares boundary-evolved variables, i.e.
+/// whether `System::variables_tag` is a `tmpl::list` whose last entry is a
+/// `::Tags::BoundaryVariables`.
+template <typename System>
+constexpr bool system_has_boundary_variables_v =
+    detail::boundary_variables_tag_impl<typename System::variables_tag>::value;
+
+/// \ingroup DiscontinuousGalerkinGroup
+/// \brief The `::Tags::BoundaryVariables` entry of the system's list-valued
+/// `variables_tag`, or `NoSuchType` if the system does not declare
+/// boundary-evolved variables.
+template <typename System>
+using boundary_variables_tag = typename detail::boundary_variables_tag_impl<
+    typename System::variables_tag>::type;
+
+/// @{
+/// \ingroup DiscontinuousGalerkinGroup
+/// \brief The projected interior inputs to a boundary condition's
+/// `boundary_field_time_derivatives` method, in the order evolved,
+/// primitive, temporary.
+///
+/// They are declared separately from the `dg_ghost` interior inputs
+/// (`dg_interior_evolved_variables_tags` etc.) so that a boundary condition
+/// can request a different projected interior state for its boundary-field
+/// time derivative.  The boundary-condition pass projects the requested
+/// fields onto the face exactly as it does for the `dg_ghost` inputs.
+CREATE_GET_TYPE_ALIAS_OR_DEFAULT(
+    boundary_field_time_derivatives_evolved_variables_tags)
+CREATE_GET_TYPE_ALIAS_OR_DEFAULT(boundary_field_time_derivatives_primitive_tags)
+CREATE_GET_TYPE_ALIAS_OR_DEFAULT(boundary_field_time_derivatives_temporary_tags)
+
+template <typename BoundaryCondition>
+using boundary_field_time_derivatives_interior_tags = tmpl::append<
+    get_boundary_field_time_derivatives_evolved_variables_tags_or_default_t<
+        BoundaryCondition, tmpl::list<>>,
+    get_boundary_field_time_derivatives_primitive_tags_or_default_t<
+        BoundaryCondition, tmpl::list<>>,
+    get_boundary_field_time_derivatives_temporary_tags_or_default_t<
+        BoundaryCondition, tmpl::list<>>>;
+/// @}
+
+namespace detail {
+CREATE_GET_STATIC_MEMBER_VARIABLE_OR_DEFAULT(evolves_boundary_variables)
+
+// Detect if the boundary condition declares a `boundary_field_time_derivatives`
+// method.
+template <typename BoundaryCondition>
+constexpr bool has_boundary_field_time_derivatives_v = requires {
+  &BoundaryCondition::boundary_field_time_derivatives;
+};
+}  // namespace detail
+
+/// @{
+/// \ingroup DiscontinuousGalerkinGroup
+/// \brief Whether a boundary condition evolves the system's boundary-evolved
+/// variables: the opt-in is the marker
+/// `static constexpr bool evolves_boundary_variables = true;` on the
+/// boundary condition. An opt-in boundary condition must declare
+/// the method `boundary_field_time_derivatives`.
+template <typename BoundaryCondition>
+constexpr bool evolves_boundary_variables_v =
+    detail::get_evolves_boundary_variables_or_default_v<BoundaryCondition,
+                                                        false>;
+/// @}
+}  // namespace evolution::dg

--- a/src/Evolution/DiscontinuousGalerkin/CMakeLists.txt
+++ b/src/Evolution/DiscontinuousGalerkin/CMakeLists.txt
@@ -8,6 +8,7 @@ spectre_target_headers(
   AtomicInboxBoundaryData.hpp
   BackgroundGrVars.hpp
   BoundaryData.hpp
+  BoundaryEvolvedVariables.hpp
   CleanMortarHistory.hpp
   DgElementArray.hpp
   InboxBoundaryData.hpp

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/CMakeLists.txt
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/CMakeLists.txt
@@ -18,6 +18,7 @@ set(LIBRARY_SOURCES
   Test_BackgroundGrVars.cpp
   Test_BoundaryCorrectionsHelper.cpp
   Test_BoundaryData.cpp
+  Test_BoundaryEvolvedVariables.cpp
   Test_CleanMortarHistory.cpp
   Test_InboxTags.cpp
   Test_InterfaceDataPolicy.cpp

--- a/tests/Unit/Evolution/DiscontinuousGalerkin/Test_BoundaryEvolvedVariables.cpp
+++ b/tests/Unit/Evolution/DiscontinuousGalerkin/Test_BoundaryEvolvedVariables.cpp
@@ -1,0 +1,111 @@
+// Distributed under the MIT License.
+// See LICENSE.txt for details.
+
+#include "Framework/TestingFramework.hpp"
+
+#include <cstddef>
+#include <optional>
+#include <string>
+
+#include "DataStructures/DataVector.hpp"
+#include "DataStructures/Tensor/Tensor.hpp"
+#include "DataStructures/VariablesTag.hpp"
+#include "Domain/BoundaryVariablesTag.hpp"
+#include "Evolution/DiscontinuousGalerkin/BoundaryEvolvedVariables.hpp"
+#include "Helpers/DataStructures/DataBox/TestHelpers.hpp"
+#include "Helpers/DataStructures/TestTags.hpp"
+#include "Utilities/Gsl.hpp"
+#include "Utilities/NoSuchType.hpp"
+#include "Utilities/TMPL.hpp"
+
+namespace {
+using ScalarTag = TestHelpers::Tags::Scalar<DataVector>;
+using Scalar2Tag = TestHelpers::Tags::Scalar2<DataVector>;
+using BoundaryScalar = evolution::dg::Tags::BoundaryValue<ScalarTag>;
+
+static_assert(std::is_same_v<BoundaryScalar::type, ScalarTag::type>);
+static_assert(std::is_same_v<BoundaryScalar::tag, ScalarTag>);
+
+// Systems for the boundary-variables detection: split with a
+// BoundaryVariables entry, split without one, and single-tag.
+struct SplitSystem {
+  using variables_tag =
+      tmpl::list<::Tags::Variables<tmpl::list<ScalarTag>>,
+                 ::Tags::BoundaryVariables<2, tmpl::list<BoundaryScalar>>>;
+};
+struct SplitWithoutBoundarySystem {
+  using variables_tag = tmpl::list<::Tags::Variables<tmpl::list<ScalarTag>>,
+                                   ::Tags::Variables<tmpl::list<Scalar2Tag>>>;
+};
+struct SingleTagSystem {
+  using variables_tag = ::Tags::Variables<tmpl::list<ScalarTag>>;
+};
+
+static_assert(evolution::dg::system_has_boundary_variables_v<SplitSystem>);
+static_assert(not evolution::dg::system_has_boundary_variables_v<
+              SplitWithoutBoundarySystem>);
+static_assert(
+    not evolution::dg::system_has_boundary_variables_v<SingleTagSystem>);
+static_assert(
+    std::is_same_v<evolution::dg::boundary_variables_tag<SplitSystem>,
+                   ::Tags::BoundaryVariables<2, tmpl::list<BoundaryScalar>>>);
+static_assert(
+    std::is_same_v<evolution::dg::boundary_variables_tag<SingleTagSystem>,
+                   NoSuchType>);
+
+struct OptingCondition {
+  static constexpr bool evolves_boundary_variables = true;
+  using boundary_field_time_derivatives_evolved_variables_tags =
+      tmpl::list<ScalarTag>;
+  using boundary_field_time_derivatives_temporary_tags = tmpl::list<Scalar2Tag>;
+  static std::optional<std::string> boundary_field_time_derivatives(
+      gsl::not_null<Scalar<DataVector>*> /*dt_boundary_scalar*/) {
+    return std::nullopt;
+  }
+};
+struct NonOptingCondition {
+  static std::optional<std::string> dg_ghost() { return std::nullopt; }
+};
+struct MethodWithoutMarkerCondition {
+  static std::optional<std::string> boundary_field_time_derivatives(
+      gsl::not_null<Scalar<DataVector>*> /*dt_boundary_scalar*/) {
+    return std::nullopt;
+  }
+};
+struct MarkerWithoutMethodCondition {
+  static constexpr bool evolves_boundary_variables = true;
+};
+
+static_assert(evolution::dg::evolves_boundary_variables_v<OptingCondition>);
+static_assert(
+    not evolution::dg::evolves_boundary_variables_v<NonOptingCondition>);
+static_assert(not evolution::dg::evolves_boundary_variables_v<
+              MethodWithoutMarkerCondition>);
+static_assert(
+    evolution::dg::evolves_boundary_variables_v<MarkerWithoutMethodCondition>);
+
+static_assert(evolution::dg::detail::has_boundary_field_time_derivatives_v<
+              OptingCondition>);
+static_assert(evolution::dg::detail::has_boundary_field_time_derivatives_v<
+              MethodWithoutMarkerCondition>);
+static_assert(not evolution::dg::detail::has_boundary_field_time_derivatives_v<
+              NonOptingCondition>);
+static_assert(not evolution::dg::detail::has_boundary_field_time_derivatives_v<
+              MarkerWithoutMethodCondition>);
+
+// The assembled interior inputs are ordered evolved, primitive, temporary,
+// with each undeclared list defaulting to empty.
+static_assert(
+    std::is_same_v<evolution::dg::boundary_field_time_derivatives_interior_tags<
+                       OptingCondition>,
+                   tmpl::list<ScalarTag, Scalar2Tag>>);
+static_assert(
+    std::is_same_v<evolution::dg::boundary_field_time_derivatives_interior_tags<
+                       NonOptingCondition>,
+                   tmpl::list<>>);
+
+SPECTRE_TEST_CASE("Unit.Evolution.Dg.BoundaryEvolvedVariables",
+                  "[Unit][Evolution]") {
+  TestHelpers::db::test_prefix_tag<BoundaryScalar>("BoundaryValue(Scalar)");
+}
+}  // namespace


### PR DESCRIPTION
## Proposed changes
Add infrastructure for computing the time derivatives of boundary evolved fields. The time derivatives are intended to be computed within each concrete boundary condition class.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent was used, have a co-author trailer of the form
      "Co-Authored-By: <agent name> <agent email>" as the last line of the
      commit, e.g. "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>".

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
