### PR TITLE
Make domain test helper reorient coords like OrientationMapHelpers

### DIFF
--- a/tests/Unit/Domain/Test_DomainTestHelpers.cpp
+++ b/tests/Unit/Domain/Test_DomainTestHelpers.cpp
@@ -3,16 +3,37 @@
 
 #include "Framework/TestingFramework.hpp"
 
-#include <algorithm>
+#include <array>
+#include <cmath>
 #include <cstddef>
 #include <limits>
+#include <memory>
 #include <random>
+#include <string>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/EagerMath/Magnitude.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
-#include "Domain/FunctionsOfTime/FunctionOfTime.hpp"
+#include "Domain/Block.hpp"
+#include "Domain/CoordinateMaps/Affine.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.hpp"
+#include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/DiscreteRotation.hpp"
+#include "Domain/CoordinateMaps/Identity.hpp"
+#include "Domain/CoordinateMaps/Interval.hpp"
+#include "Domain/CoordinateMaps/PolarToCartesian.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.hpp"
+#include "Domain/CoordinateMaps/ProductMaps.tpp"
+#include "Domain/CoordinateMaps/Rotation.hpp"
+#include "Domain/Domain.hpp"
+#include "Domain/Structure/BlockNeighbors.hpp"
 #include "Domain/Structure/Direction.hpp"
+#include "Domain/Structure/DirectionMap.hpp"
+#include "Domain/Structure/OrientationMap.hpp"
 #include "Framework/CheckWithRandomValues.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
@@ -22,6 +43,250 @@
 #include "Utilities/StdHelpers.hpp"
 
 namespace {
+using Affine = domain::CoordinateMaps::Affine;
+using Identity1D = domain::CoordinateMaps::Identity<1>;
+using Interval = domain::CoordinateMaps::Interval;
+using PolarToCartesian = domain::CoordinateMaps::PolarToCartesian;
+
+::domain::CoordinateMap<
+    Frame::BlockLogical, Frame::Inertial,
+    domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>>
+make_affine_map_3d(const std::array<double, 3>& center,
+                   const std::array<double, 3>& dimensions) {
+  return domain::make_coordinate_map<Frame::BlockLogical, Frame::Inertial>(
+      domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Affine>{
+          Affine{-1.0, 1.0, center[0] - 0.5 * dimensions[0],
+                 center[0] + 0.5 * dimensions[0]},
+          Affine{-1.0, 1.0, center[1] - 0.5 * dimensions[1],
+                 center[1] + 0.5 * dimensions[1]},
+          Affine{-1.0, 1.0, center[2] - 0.5 * dimensions[2],
+                 center[2] + 0.5 * dimensions[2]}});
+}
+
+// Domain creator consisting of two cubed blocks that are conforming neighbors,
+// where one block has rotated local coordinates with respect to the other.
+struct ConformingCubes {
+  static constexpr size_t Dim = 3;
+
+  ConformingCubes() = default;
+  Domain<Dim> create_domain() const {
+    // pick a location not at the origin to make this test domain less trivial
+    const std::array<double, Dim> center_block_1{-0.8, 1.3, 4.1};
+    // length x width x depth
+    const std::array<double, Dim> dimensions_block_1{5.0, 6.0, 7.0};
+
+    auto coord_map_block_1 =
+        make_affine_map_3d(center_block_1, dimensions_block_1);
+
+    // block 2 has a shift in the x coord because it abuts block 1 on +x side
+    const std::array<double, Dim> center_block_2{
+        center_block_1[0] + dimensions_block_1[0], center_block_1[1],
+        center_block_1[2]};
+    const std::array<double, Dim> dimensions_block_2 = dimensions_block_1;
+
+    // [-1, 1]^3
+    auto unit_cube = make_affine_map_3d(std::array<double, Dim>{0.0, 0.0, 0.0},
+                                        std::array<double, Dim>{2.0, 2.0, 2.0});
+    const OrientationMap<3> rotation_block_2{std::array<Direction<Dim>, Dim>{
+        Direction<3>::lower_zeta(), Direction<Dim>::lower_xi(),
+        Direction<3>::upper_eta()}};
+    // rotate unit cube, then translate and scale it to abut block 1
+    auto coord_map_block_2 = domain::push_back(
+        domain::push_back(
+            unit_cube,
+            domain::CoordinateMaps::DiscreteRotation<Dim>(rotation_block_2)),
+        make_affine_map_3d(center_block_2, dimensions_block_2));
+
+    std::vector<std::unique_ptr<
+        domain::CoordinateMapBase<Frame::BlockLogical, Frame::Inertial, Dim>>>
+        coordinate_maps{};
+    coordinate_maps.emplace_back(
+        std::make_unique<std::decay_t<decltype(coord_map_block_1)>>(
+            std::move(coord_map_block_1)));
+    coordinate_maps.emplace_back(
+        std::make_unique<std::decay_t<decltype(coord_map_block_2)>>(
+            std::move(coord_map_block_2)));
+
+    std::vector<DirectionMap<Dim, BlockNeighbors<Dim>>> block_neighbors{
+        coordinate_maps.size()};
+    // add block 2 as a neighbor of block 1
+    block_neighbors[0].emplace(Direction<Dim>::upper_xi(),
+                               BlockNeighbors<Dim>{{1},
+                                                   {{1, rotation_block_2}},
+                                                   /*are_conforming=*/true});
+    // add block 1 as a neighbor of block 2
+    block_neighbors[1].emplace(
+        Direction<Dim>::upper_zeta(),
+        BlockNeighbors<Dim>{{0},
+                            {{0, rotation_block_2.inverse_map()}},
+                            /*are_conforming=*/true});
+
+    std::vector<Block<Dim>> blocks;
+    blocks.reserve(coordinate_maps.size());
+
+    blocks.emplace_back(std::move(coordinate_maps[0]), 0,
+                        std::move(block_neighbors[0]), block_names_.at(0),
+                        domain::topologies::hypercube<Dim>);
+    blocks.emplace_back(std::move(coordinate_maps[1]), 1,
+                        std::move(block_neighbors[1]), block_names_.at(1),
+                        domain::topologies::hypercube<Dim>);
+
+    Domain<3> domain{std::move(blocks), {}, block_groups};
+
+    return domain;
+  }
+
+  std::vector<std::string> block_names_{"Block1", "Block2"};
+  std::unordered_map<std::string, std::unordered_set<std::string>> block_groups{
+      {"Blocks", {"Block1", "Block2"}}};
+};
+
+// Helper for creating a filled or hollow cylindrical block coordinate map
+//
+// inner_radius = 0.0 for a cylinder, inner_radius > 0.0 for a hollow cylinder
+domain::CoordinateMap<
+    Frame::BlockLogical, Frame::Inertial,
+    domain::CoordinateMaps::ProductOf3Maps<
+        ::domain::CoordinateMaps::Affine, ::domain::CoordinateMaps::Identity<1>,
+        ::domain::CoordinateMaps::Interval>,
+    domain::CoordinateMaps::ProductOf2Maps<
+        ::domain::CoordinateMaps::PolarToCartesian,
+        ::domain::CoordinateMaps::Identity<1>>>
+make_cyl_coordinate_map(const double inner_radius, const double outer_radius,
+                        const double lower_z_bound,
+                        const double upper_z_bound) {
+  const auto linear = domain::CoordinateMaps::Distribution::Linear;
+
+  // Map: (xi, eta, zeta) in [-1,1] x [0, 2pi) x [-1, 1]
+  //   xi -> r in [inner_r, outer_r]  (Affine)
+  //   eta -> phi in [0, 2pi)         (Identity<1>, passes through)
+  //   zeta -> z in [z_lower, z_upper] (Interval)
+  // Then PolarToCartesian x Identity<1> maps (r, phi, z) -> (x, y, z)
+  return domain::make_coordinate_map<Frame::BlockLogical, Frame::Inertial>(
+      domain::CoordinateMaps::ProductOf3Maps<Affine, Identity1D, Interval>{
+          Affine{-1.0, 1.0, inner_radius, outer_radius}, Identity1D{},
+          Interval{-1.0, 1.0, lower_z_bound, upper_z_bound, linear}},
+      domain::CoordinateMaps::ProductOf2Maps<PolarToCartesian, Identity1D>{
+          PolarToCartesian{}, Identity1D{}});
+}
+
+// Domain creator consisting of a filled cylinder surrounded by a hollow
+// cylinder, which are conforming neighbors, and where the hollow cylinder
+// has its angular and axial (z) coordinates in the opposite direction of those
+// of the filled cylinder.
+//
+// This test case is meant to target the reversal of an angular coordinate when
+// we have S1 topology, because a reversal of the array of coordinates with S1
+// is not symmetric like it is for the reversal of coordinates with I1. When
+// using an OrientationMap to communicate that the angular coordinate of a
+// conforming neighbor block is in the opposite direction of the angular
+// coordinate of the host block, this lack of symmetry must be handled.
+//
+// More specifically, we can imagine having the filled and hollow cylinder with
+// the same extents in each direction, but the hollow cylinder is flipped
+// upside-down so that its angular coordinates go in the opposite direction.
+// The coordinates will not geometrically overlap at this point unless we have
+// an even number of coordinates, but in practice we use odd for numerical
+// stability. To get the odd coordinates to overlap geometrically and have each
+// block's 0th coordinate (local theta = 0) be at the same physical location,
+// we could rotate the filled cylinder about its z axis by 180 degrees. Now,
+// the blocks' 0th coordinates would be at the same location, but one block's
+// 1st coordinate would overlap with the other's N - 1 coordinate. In this way,
+// the set of coordinates would geometrically align but proceed in opposite
+// local directions. While the interface here would be geometrically conforming
+// and the points are seemingly aligned, data between the two blocks would not
+// be communicated properly. This is because when orient_variables_on_slice()
+// reverses the list of angular points, the 0th point of one cylinder will be
+// mapped to the N - 1 coordinate of the other, which are not in the same
+// physical location and are instead separated by 2pi/N, where N is the number
+// of angular points. (This is notably different than the behavior with I1
+// topology, where the 0th coordinate of one cube would be in the same physical
+// location as the N - 1 coordinate.) Instead, the way to make these two
+// cylinders have opposite angular directions and also for their points to be
+// related by a simple OrientationMap reversal, they must be staggered by the
+// additional 2pi/N. This domain creator does exactly that to make it so that
+// grid points map to themselves and not their angular neighbor at the interface
+// between the two blocks.
+struct ConformingNestedReversedCylinders {
+  static constexpr size_t Dim = 3;
+
+  ConformingNestedReversedCylinders() = default;
+  Domain<Dim> create_domain() const {
+    const double inner_cyl_outer_radius = 3.0;
+    const double outer_cyl_outer_radius = 5.0;
+    const double height = 8.0;
+    const double half_height = 0.5 * height;
+
+    auto inner_cyl_coord_map = make_cyl_coordinate_map(
+        0.0, inner_cyl_outer_radius, -half_height, half_height);
+
+    const OrientationMap<Dim> rotate_upside_down{
+        std::array<Direction<Dim>, Dim>{Direction<3>::lower_xi(),
+                                        Direction<3>::upper_eta(),
+                                        Direction<3>::lower_zeta()}};
+
+    // check_block_face_grid_points_align() uses N=9 angular grid points for the
+    // interface mesh, and pi - 2pi/N = 7pi/9, which will rotate the hollow
+    // cylinder so that the N-1 point of the hollow cylinder overlaps with the
+    // 0th point of the filled cylinder
+    const double rotation_about_z = 7.0 * M_PI / 9.0;
+    auto outer_cyl_coord_map = domain::push_back(
+        domain::push_back(
+            make_cyl_coordinate_map(inner_cyl_outer_radius,
+                                    outer_cyl_outer_radius, -half_height,
+                                    half_height),
+            domain::CoordinateMaps::DiscreteRotation<Dim>(rotate_upside_down)),
+        domain::CoordinateMaps::Rotation<3>(rotation_about_z, 0.0, 0.0));
+
+    std::vector<std::unique_ptr<
+        domain::CoordinateMapBase<Frame::BlockLogical, Frame::Inertial, Dim>>>
+        coordinate_maps{};
+    coordinate_maps.emplace_back(
+        std::make_unique<std::decay_t<decltype(inner_cyl_coord_map)>>(
+            std::move(inner_cyl_coord_map)));
+    coordinate_maps.emplace_back(
+        std::make_unique<std::decay_t<decltype(outer_cyl_coord_map)>>(
+            std::move(outer_cyl_coord_map)));
+
+    const OrientationMap<Dim> inner_to_outer_cyl_map{
+        std::array<Direction<Dim>, Dim>{Direction<3>::upper_xi(),
+                                        Direction<3>::lower_eta(),
+                                        Direction<3>::lower_zeta()}};
+
+    std::vector<DirectionMap<Dim, BlockNeighbors<Dim>>> block_neighbors{
+        coordinate_maps.size()};
+    // add hollow cylinder as neighbor of filled cylinder
+    block_neighbors[0].emplace(
+        Direction<Dim>::upper_xi(),
+        BlockNeighbors<Dim>{{1},
+                            {{1, inner_to_outer_cyl_map}},
+                            /*are_conforming=*/true});
+    // add filled cylinder as neighbor of hollow cylinder
+    block_neighbors[1].emplace(
+        Direction<Dim>::lower_xi(),
+        BlockNeighbors<Dim>{{0},
+                            {{0, inner_to_outer_cyl_map}},
+                            /*are_conforming=*/true});
+
+    std::vector<Block<Dim>> blocks;
+    blocks.reserve(coordinate_maps.size());
+
+    blocks.emplace_back(std::move(coordinate_maps[0]), 0,
+                        std::move(block_neighbors[0]), block_names_.at(0),
+                        domain::topologies::full_cylinder);
+    blocks.emplace_back(std::move(coordinate_maps[1]), 1,
+                        std::move(block_neighbors[1]), block_names_.at(1),
+                        domain::topologies::cylindrical_shell);
+
+    Domain<3> domain{std::move(blocks), {}, block_groups};
+
+    return domain;
+  }
+
+  std::vector<std::string> block_names_{"Block1", "Block2"};
+  std::unordered_map<std::string, std::unordered_set<std::string>> block_groups{
+      {"Blocks", {"Block1", "Block2"}}};
+};
 
 template <typename DataType, size_t SpatialDim>
 tnsr::II<DataType, SpatialDim> random_inv_spatial_metric(
@@ -69,10 +334,30 @@ void test_unit_basis_form(const DataType& used_for_size) {
   }
 }
 
+// Test the domain test helper, test_physical_separation()
+void test_test_physical_separation() {
+  // Test conforming interface with I1 topology and rotated local coordinates
+  const ConformingCubes conforming_cubes_creator{};
+  const Domain<3> conforming_cubes_domain =
+      conforming_cubes_creator.create_domain();
+  const auto& conforming_cubes_blocks = conforming_cubes_domain.blocks();
+  test_physical_separation(conforming_cubes_blocks, 0.0);
+
+  // Test conforming interface with S1 topology and reversed local coordinates
+  const ConformingNestedReversedCylinders
+      conforming_nested_reversed_cylinders_creator{};
+  const Domain<3> conforming_nested_reversed_cylinders_domain =
+      conforming_nested_reversed_cylinders_creator.create_domain();
+  const auto& conforming_nested_reversed_cylinders_blocks =
+      conforming_nested_reversed_cylinders_domain.blocks();
+  test_physical_separation(conforming_nested_reversed_cylinders_blocks, 0.0);
+}
 }  //  namespace
 
-SPECTRE_TEST_CASE("Unit.Domain.TestHelpers.BasisVector", "[Unit][Domain]") {
+SPECTRE_TEST_CASE("Unit.Domain.TestHelpers", "[Unit][Domain]") {
   GENERATE_UNINITIALIZED_DOUBLE_AND_DATAVECTOR;
   CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_euclidean_basis_vector, (1, 2, 3));
   CHECK_FOR_DOUBLES_AND_DATAVECTORS(test_unit_basis_form, (1, 2, 3));
+
+  test_test_physical_separation();
 }

--- a/tests/Unit/Helpers/Domain/DomainTestHelpers.cpp
+++ b/tests/Unit/Helpers/Domain/DomainTestHelpers.cpp
@@ -32,6 +32,7 @@
 #include "Domain/Structure/InitialElementIds.hpp"
 #include "Domain/Structure/Neighbors.hpp"
 #include "Domain/Structure/OrientationMap.hpp"
+#include "Domain/Structure/OrientationMapHelpers.hpp"
 #include "Domain/Structure/Side.hpp"
 #include "Domain/Structure/Topology.hpp"
 #include "Framework/TestHelpers.hpp"
@@ -274,7 +275,8 @@ void check_block_face_grid_points_align(
     const std::unordered_map<
         std::string, std::unique_ptr<domain::FunctionsOfTime::FunctionOfTime>>&
         functions_of_time = {}) {
-  const auto direction = find_direction_to_neighbor(host_block, neighbor_block);
+  const auto host_direction =
+      find_direction_to_neighbor(host_block, neighbor_block);
   const auto orientation =
       find_neighbor_orientation(host_block, neighbor_block);
   // Set up a Mesh on the shared face. Corner points are already checked by
@@ -282,28 +284,28 @@ void check_block_face_grid_points_align(
   // GaussLobatto points are used so that endpoints are also checked since
   // physical_separation cannot be called for cylindrical blocks since they do
   // not have corners.
-  Mesh<VolumeDim - 1> face_mesh;
+  Mesh<VolumeDim - 1> host_face_mesh;
   if constexpr (VolumeDim == 3) {
     if (host_block.topologies()[VolumeDim - 1] ==
       domain::Topology::CartoonCylinder) {
-      face_mesh = Mesh<VolumeDim - 1>{
+      host_face_mesh = Mesh<VolumeDim - 1>{
           {3, 1},
           {Spectral::Basis::Legendre, Spectral::Basis::Cartoon},
           {Spectral::Quadrature::Gauss, Spectral::Quadrature::AxialSymmetry}};
     } else if (host_block.topologies() == domain::topologies::full_cylinder) {
       if (neighbor_block.topologies() == domain::topologies::full_cylinder and
-          (direction == Direction<VolumeDim>::upper_zeta() or
-           direction == Direction<VolumeDim>::lower_zeta())) {
-        face_mesh = Mesh<VolumeDim - 1>{
+          (host_direction == Direction<VolumeDim>::upper_zeta() or
+           host_direction == Direction<VolumeDim>::lower_zeta())) {
+        host_face_mesh = Mesh<VolumeDim - 1>{
             {3, 9},
             {Spectral::Basis::ZernikeB2, Spectral::Basis::ZernikeB2},
             {Spectral::Quadrature::GaussRadauUpper,
              Spectral::Quadrature::Equiangular}};
       } else if (neighbor_block.topologies() ==
                      domain::topologies::cylindrical_shell and
-                 (direction == Direction<VolumeDim>::upper_xi() or
-                  direction == Direction<VolumeDim>::lower_xi())) {
-        face_mesh = Mesh<VolumeDim - 1>{
+                 (host_direction == Direction<VolumeDim>::upper_xi() or
+                  host_direction == Direction<VolumeDim>::lower_xi())) {
+        host_face_mesh = Mesh<VolumeDim - 1>{
             {9, 5},
             {Spectral::Basis::ZernikeB2, Spectral::Basis::Legendre},
             {Spectral::Quadrature::Equiangular,
@@ -321,36 +323,36 @@ void check_block_face_grid_points_align(
       // NOLINTBEGIN
       if (neighbor_block.topologies() ==
               domain::topologies::cylindrical_shell and
-          (direction == Direction<VolumeDim>::upper_xi() or
-           direction == Direction<VolumeDim>::lower_xi())) {
-        face_mesh = Mesh<VolumeDim - 1>{
+          (host_direction == Direction<VolumeDim>::upper_xi() or
+           host_direction == Direction<VolumeDim>::lower_xi())) {
+        host_face_mesh = Mesh<VolumeDim - 1>{
             {3, 9},
             {Spectral::Basis::Fourier, Spectral::Basis::Legendre},
             {Spectral::Quadrature::Equiangular,
              Spectral::Quadrature::GaussLobatto}};
       } else if (neighbor_block.topologies() ==
                      domain::topologies::cylindrical_shell and
-                 (direction == Direction<VolumeDim>::upper_zeta() or
-                  direction == Direction<VolumeDim>::lower_zeta())) {
-        face_mesh = Mesh<VolumeDim - 1>{
+                 (host_direction == Direction<VolumeDim>::upper_zeta() or
+                  host_direction == Direction<VolumeDim>::lower_zeta())) {
+        host_face_mesh = Mesh<VolumeDim - 1>{
             {9, 5},
             {Spectral::Basis::Legendre, Spectral::Basis::Fourier},
             {Spectral::Quadrature::GaussLobatto,
              Spectral::Quadrature::Equiangular}};
       } else if (neighbor_block.topologies() ==
                      domain::topologies::full_cylinder and
-                 (direction == Direction<VolumeDim>::upper_zeta() or
-                  direction == Direction<VolumeDim>::lower_zeta())) {
-        face_mesh = Mesh<VolumeDim - 1>{
+                 (host_direction == Direction<VolumeDim>::upper_zeta() or
+                  host_direction == Direction<VolumeDim>::lower_zeta())) {
+        host_face_mesh = Mesh<VolumeDim - 1>{
             {9, 5},
             {Spectral::Basis::Legendre, Spectral::Basis::Fourier},
             {Spectral::Quadrature::GaussLobatto,
              Spectral::Quadrature::Equiangular}};
       } else if (neighbor_block.topologies() ==
                      domain::topologies::spherical_shell and
-                 (direction == Direction<VolumeDim>::upper_xi() or
-                  direction == Direction<VolumeDim>::lower_xi())) {
-        face_mesh = Mesh<VolumeDim - 1>{
+                 (host_direction == Direction<VolumeDim>::upper_xi() or
+                  host_direction == Direction<VolumeDim>::lower_xi())) {
+        host_face_mesh = Mesh<VolumeDim - 1>{
             {3, 9},
             {Spectral::Basis::Fourier, Spectral::Basis::Legendre},
             {Spectral::Quadrature::Equiangular,
@@ -368,44 +370,39 @@ void check_block_face_grid_points_align(
           "check_block_face_grid_points_align() is not implemented for "
           "spherical shell host blocks.");
     } else {
-      face_mesh = Mesh<VolumeDim - 1>{3_st, Spectral::Basis::Legendre,
-                                    Spectral::Quadrature::Gauss};
+      host_face_mesh = Mesh<VolumeDim - 1>{3_st, Spectral::Basis::Legendre,
+                                           Spectral::Quadrature::Gauss};
     }
   } else if (host_block.topologies()[VolumeDim - 1] ==
       domain::Topology::CartoonCylinder) {
     ERROR("Cartoon basis used with non 3D mesh, got dim = " << VolumeDim);
   } else {
-    face_mesh = Mesh<VolumeDim - 1>{3_st, Spectral::Basis::Legendre,
-                                    Spectral::Quadrature::Gauss};
+    host_face_mesh = Mesh<VolumeDim - 1>{3_st, Spectral::Basis::Legendre,
+                                         Spectral::Quadrature::Gauss};
   }
 
-  // We want block logical coordinates on face_mesh on the host side and the
-  // neighbor. The following returns element logical coordinates in the host
-  // frame, which we then copy into tensors holding block logical coordinates,
-  // taking into account the OrientationMap between the host and neighbor
-  // blocks.
-  tnsr::I<DataVector, VolumeDim, Frame::ElementLogical> xi =
-      interface_logical_coordinates(face_mesh, direction);
-  tnsr::I<DataVector, VolumeDim, Frame::BlockLogical> xi_host{};
-  tnsr::I<DataVector, VolumeDim, Frame::BlockLogical> xi_neighbor{};
+  // Neighbor's interface mesh and direction in its own frame
+  const Mesh<VolumeDim - 1> neighbor_face_mesh = orient_mesh_on_slice(
+      host_face_mesh, host_direction.dimension(), orientation);
+  const auto neighbor_direction = orientation(host_direction.opposite());
+
+  // We want block logical coordinates of the face mesh on the host side and the
+  // neighbor. The following returns the host's element logical coordinates in
+  // its own frame and the neighbor's element logical coordinates in its own
+  // frame. We then copy these values into tensors holding block logical
+  // coordinates.
+  const tnsr::I<DataVector, VolumeDim, Frame::ElementLogical> xi_host =
+      interface_logical_coordinates(host_face_mesh, host_direction);
+  const tnsr::I<DataVector, VolumeDim, Frame::ElementLogical> xi_neighbor =
+      interface_logical_coordinates(neighbor_face_mesh, neighbor_direction);
+  tnsr::I<DataVector, VolumeDim, Frame::BlockLogical> xi_host_block_logical{};
+  tnsr::I<DataVector, VolumeDim, Frame::BlockLogical>
+      xi_neighbor_block_logical{};
   for (size_t d = 0; d < VolumeDim; ++d) {
     // assume an Element covering the Block which maps element logical
     // coordinates to block logical coordinates with the identity map
-    xi_host[d] = xi[d];
-    const auto dth_upper_direction_in_neighbor_frame =
-        orientation(Direction<VolumeDim>(d, Side::Upper));
-    // This takes into account the permutation of dimensions induced by the
-    // OrientationMap
-    xi_neighbor[dth_upper_direction_in_neighbor_frame.dimension()] = xi[d];
-    // There is a sign flip if this is the dimension of the direction to the
-    // neighbor as the logical coord is -1/+1 on the lower/upper side of the
-    // block.
-    // There is also a sign flip if the mapped upper direction becomes a lower
-    // direction
-    if ((dth_upper_direction_in_neighbor_frame.side() == Side::Lower) xor
-        (d == direction.dimension())) {
-      xi_neighbor[dth_upper_direction_in_neighbor_frame.dimension()] *= -1.0;
-    }
+    xi_host_block_logical[d] = xi_host[d];
+    xi_neighbor_block_logical[d] = xi_neighbor[d];
   }
   if (host_block.is_time_dependent() != neighbor_block.is_time_dependent()) {
     ERROR(
@@ -414,8 +411,8 @@ void check_block_face_grid_points_align(
         << std::boolalpha << host_block.is_time_dependent()
         << " and neighbor_block has: " << neighbor_block.is_time_dependent());
   }
-  CAPTURE(xi_host);
-  CAPTURE(xi_neighbor);
+  CAPTURE(xi_host_block_logical);
+  CAPTURE(xi_neighbor_block_logical);
   // Check that each grid point on the face Mesh has the same grid and
   // inertial coordinates when mapped from the logical coordinates of each
   // Block.
@@ -431,20 +428,49 @@ void check_block_face_grid_points_align(
         neighbor_block.moving_mesh_logical_to_grid_map();
     const auto& neighbor_map_grid_to_inertial =
         neighbor_block.moving_mesh_grid_to_inertial_map();
-    const auto x_grid_self = host_map_logical_to_grid(xi_host);
-    const auto x_grid_neighbor = neighbor_map_logical_to_grid(xi_neighbor);
-    CHECK_ITERABLE_APPROX(x_grid_self, x_grid_neighbor);
+    const auto x_grid_self = host_map_logical_to_grid(xi_host_block_logical);
+    const auto x_grid_neighbor =
+        neighbor_map_logical_to_grid(xi_neighbor_block_logical);
     const auto x_inertial_self =
         host_map_grid_to_inertial(x_grid_self, time, functions_of_time);
     const auto x_inertial_neighbor =
         neighbor_map_grid_to_inertial(x_grid_neighbor, time, functions_of_time);
-    CHECK_ITERABLE_APPROX(x_inertial_self, x_inertial_neighbor);
+
+    tnsr::I<DataVector, VolumeDim, Frame::Grid> x_grid_self_in_neighbor_frame{};
+    tnsr::I<DataVector, VolumeDim, Frame::Inertial>
+        x_inertial_self_in_neighbor_frame{};
+    for (size_t d = 0; d < VolumeDim; d++) {
+      // We use orient_variables_on_slice() to map the grid points, as this is
+      // what is used to reorient and copy data to a shared grid point between
+      // neighbor blocks
+      x_grid_self_in_neighbor_frame[d] =
+          orient_variables_on_slice(x_grid_self[d], host_face_mesh.extents(),
+                                    host_direction.dimension(), orientation);
+      x_inertial_self_in_neighbor_frame[d] = orient_variables_on_slice(
+          x_inertial_self[d], host_face_mesh.extents(),
+          host_direction.dimension(), orientation);
+    }
+
+    CHECK_ITERABLE_APPROX(x_grid_self_in_neighbor_frame, x_grid_neighbor);
+    CHECK_ITERABLE_APPROX(x_inertial_self_in_neighbor_frame,
+                          x_inertial_neighbor);
   } else {
     const auto& host_map = host_block.stationary_map();
     const auto& neighbor_map = neighbor_block.stationary_map();
-    const auto x_self = host_map(xi_host);
-    const auto x_neighbor = neighbor_map(xi_neighbor);
-    CHECK_ITERABLE_APPROX(x_self, x_neighbor);
+    const auto x_self = host_map(xi_host_block_logical);
+    const auto x_neighbor = neighbor_map(xi_neighbor_block_logical);
+
+    tnsr::I<DataVector, VolumeDim, Frame::Inertial> x_self_in_neighbor_frame{};
+    for (size_t d = 0; d < VolumeDim; d++) {
+      // We use orient_variables_on_slice() to map the grid points, as this is
+      // what is used to reorient and copy data to a shared grid point between
+      // neighbor blocks
+      x_self_in_neighbor_frame[d] =
+          orient_variables_on_slice(x_self[d], host_face_mesh.extents(),
+                                    host_direction.dimension(), orientation);
+    }
+
+    CHECK_ITERABLE_APPROX(x_self_in_neighbor_frame, x_neighbor);
   }
 }
 


### PR DESCRIPTION
This updates the domain test helper `check_block_face_grid_points_align()`, which checks that grid points at conforming block interfaces (and with no h refinment and the same p refinement) align. This addresses the issue encountered in #7479 when trying to have the faces of two cylindrical endcap blocks have the opposite angular orientation handled via an orientation map to reverse the direction of one with respect to the other, which didn't work due to having topology S1 instead of I1.

The commit's description describes the issue and fix in detail, but the important things that this commit changes about the test helper are:
- The neighbor block's logical coordinates are generated in the neighbor's frame, as opposed to them being generated from permuting and negating the host block's logical coordinates, where negation in the latter is not equivalent to the reversal done by `OrientationMapHelpers`
- `orient_variables_on_slice()` is used to map one block's coordinates into the other's frame in order to always be testing against the actual mapping used

By doing both of these, we avoid incorrectly constructing and mapping to a neighbor block's frame.

## Proposed changes

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent was used, have a co-author trailer of the form
      "Co-Authored-By: <agent name> <agent email>" as the last line of the
      commit, e.g. "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>".

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
