### PR TITLE
HalfFourier Partial Derivatives

### DIFF
--- a/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.cpp
+++ b/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.cpp
@@ -21,6 +21,7 @@
 #include "NumericalAlgorithms/Spectral/ModalToNodalMatrix.hpp"
 #include "NumericalAlgorithms/Spectral/NodalToModalMatrix.hpp"
 #include "NumericalAlgorithms/Spectral/Parity.hpp"
+#include "NumericalAlgorithms/Spectral/ParityFromSymmetry.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/Spherepack.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/SpherepackCache.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/SpherepackIterator.hpp"
@@ -503,6 +504,56 @@ void logical_partial_derivative(
       ERROR(
           "Support for complex numbers with cylinder is not yet implemented "
           "for logical_partial_derivative.");
+    }
+  } else if (Dim == 2 and mesh.basis(1) == Spectral::Basis::HalfFourier) {
+    if constexpr (std::is_same_v<typename DataType::value_type, double>) {
+      ASSERT(
+          mesh.basis(0) == Spectral::Basis::Legendre or
+              mesh.basis(0) == Spectral::Basis::Chebyshev,
+          "Only I1 bases (and Cartoon) should be paired with HalfFourier, got "
+              << mesh.basis(0));
+      const size_t n_r = mesh.extents(0);
+      const size_t n_phi = mesh.extents(1);
+      ASSERT(n_phi % 2 == 1,
+             "HalfFourier must have an odd number of gridpoints for the "
+             "even/odd modal spaces to have the same max degree, got "
+                 << n_phi);
+      const Matrix& D_r =
+          Spectral::differentiation_matrix(mesh.slice_through(0));
+      const Matrix& D_even =
+          Spectral::differentiation_matrix<Spectral::Basis::HalfFourier,
+                                           Spectral::Quadrature::Equiangular>(
+              n_phi, Spectral::Parity::Even);
+      const Matrix& D_odd =
+          Spectral::differentiation_matrix<Spectral::Basis::HalfFourier,
+                                           Spectral::Quadrature::Equiangular>(
+              n_phi, Spectral::Parity::Odd);
+      constexpr auto component_parities = Spectral::make_component_parity_array<
+          Tensor<DataType, SymmList, IndexList>>();
+      for (size_t storage_index = 0; storage_index < u.size();
+           ++storage_index) {
+        const auto u_tensor_index = u.get_tensor_index(storage_index);
+        // r-derivative: standard I1 differentiation
+        partial_derivatives_detail::apply_matrix_in_first_dim(
+            // NOLINTNEXTLINE(readability-redundant-smartptr-get)
+            logical_derivative_of_u->get(prepend(u_tensor_index, 0_st)).data(),
+            u[storage_index].data(), D_r, num_grid_points);
+        // phi-derivative: even-parity components use D_even, odd use D_odd
+        const Matrix& D_phi =
+            gsl::at(component_parities, storage_index) == Spectral::Parity::Even
+                ? D_even
+                : D_odd;
+        dgemm_<true>(
+            'N', 'T', n_r, n_phi, n_phi, 1.0, u[storage_index].data(), n_r,
+            D_phi.data(), D_phi.spacing(), 0.0,
+            // NOLINTNEXTLINE(readability-redundant-smartptr-get)
+            logical_derivative_of_u->get(prepend(u_tensor_index, 1_st)).data(),
+            n_r);
+      }
+    } else {
+      ERROR(
+          "Support for complex numbers with a HalfFourier basis is not yet "
+          "implemented for logical_partial_derivative.");
     }
   } else {
     const Matrix empty_matrix{};

--- a/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp
+++ b/src/NumericalAlgorithms/LinearOperators/PartialDerivatives.tpp
@@ -1031,6 +1031,15 @@ struct LogicalImpl<2, VariableTags, DerivativeTags> {
             "Support for complex numbers with a disk is not yet "
             "implemented for logical_partial_derivative.");
       }
+    } else if (UNLIKELY(mesh.basis(1) == Spectral::Basis::HalfFourier)) {
+      if constexpr (std::is_same_v<ValueType, double>) {
+        half_fourier_apply(logical_du, partial_u_wrt_eta, u_eta_fastest, u,
+                           mesh);
+      } else {
+        ERROR(
+            "Support for complex numbers with a HalfFourier basis is not yet "
+            "implemented for logical_partial_derivative.");
+      }
     } else {
       auto& logical_partial_derivatives_of_u = *logical_du;
       const size_t deriv_size =
@@ -1263,6 +1272,129 @@ struct LogicalImpl<2, VariableTags, DerivativeTags> {
 
     raw_transpose(make_not_null((*logical_du)[0]), local_buffer2.data(),
                   num_components_times_xi_slices, mesh.extents(0));
+  }
+
+  // Only used for 3D cartoon evolutions with axial symmetry
+  template <typename T>
+  static void half_fourier_apply(
+      const gsl::not_null<std::array<double*, Dim>*> logical_du,
+      Variables<T>* const local_buffer1,
+      Variables<DerivativeTags>* const local_buffer2,
+      const Variables<VariableTags>& u, const Mesh<2>& mesh) {
+    const size_t n_r = mesh.extents(0);
+    const size_t n_phi = mesh.extents(1);
+    ASSERT(n_phi % 2 == 1,
+           "HalfFourier must have an odd number of gridpoints for the even/odd "
+           "modal spaces to have the same max degree, got "
+               << n_phi);
+    constexpr size_t n_comp =
+        Variables<DerivativeTags>::number_of_independent_components;
+    const size_t block_size = n_r * n_phi;
+    const size_t deriv_size = n_comp * block_size;
+
+    // Dim 0: r-derivative
+    const Matrix& D_r = Spectral::differentiation_matrix(mesh.slice_through(0));
+    apply_matrix_in_first_dim((*logical_du)[0], u.data(), D_r, deriv_size);
+
+    // Dim 1: phi-derivative using a parity-split BLAS strategy.
+    const Matrix& D_even =
+        Spectral::differentiation_matrix<Spectral::Basis::HalfFourier,
+                                         Spectral::Quadrature::Equiangular>(
+            n_phi, Spectral::Parity::Even);
+    const Matrix& D_odd =
+        Spectral::differentiation_matrix<Spectral::Basis::HalfFourier,
+                                         Spectral::Quadrature::Equiangular>(
+            n_phi, Spectral::Parity::Odd);
+
+    // HalfFourier uses rotation-by-pi-about-y parity (both x and z flip).
+    constexpr auto parity_info =
+        Spectral::compute_parity_list<DerivativeTags, true>();
+    constexpr auto parity_list = std::get<0>(parity_info);
+    constexpr size_t n_even_comp = std::get<1>(parity_info);
+    constexpr size_t n_odd_comp = std::get<2>(parity_info);
+
+    // Partition local_buffer1 into [even_buf | odd_buf] and local_buffer2 into
+    // [even_result | odd_result]
+    double* const even_buf = local_buffer1->data();
+    double* const odd_buf = local_buffer1->data() + n_even_comp * block_size;
+    double* const even_result = local_buffer2->data();
+    double* const odd_result = local_buffer2->data() + n_even_comp * block_size;
+
+    // Transpose each component from r-first to phi-first and gather by parity.
+    {
+      size_t variable_index = 0;
+      size_t even_idx = 0;
+      size_t odd_idx = 0;
+      bool is_even = true;
+      for (const auto seg_size : parity_list) {
+        if (seg_size == 0) {
+          if (is_even) {
+            is_even = false;
+            continue;
+          } else {
+            break;
+          }
+        }
+        if (is_even) {
+          for (size_t k = 0; k < seg_size; ++k, ++variable_index, ++even_idx) {
+            // NOLINTNEXTLINE
+            raw_transpose(make_not_null(even_buf + even_idx * block_size),
+                          u.data() + block_size * variable_index, n_r, n_phi);
+          }
+        } else {
+          for (size_t k = 0; k < seg_size; ++k, ++variable_index, ++odd_idx) {
+            // NOLINTNEXTLINE
+            raw_transpose(make_not_null(odd_buf + odd_idx * block_size),
+                          u.data() + block_size * variable_index, n_r, n_phi);
+          }
+        }
+        is_even = not is_even;
+      }
+    }
+
+    if constexpr (n_even_comp > 0) {
+      apply_matrix_in_first_dim(even_result, even_buf, D_even,
+                                n_even_comp * block_size, false);
+    }
+    if constexpr (n_odd_comp > 0) {
+      apply_matrix_in_first_dim(odd_result, odd_buf, D_odd,
+                                n_odd_comp * block_size, false);
+    }
+
+    // Transpose back from phi-first to r-first and scatter by parity to output.
+    double* const p_dphi = (*logical_du)[1];
+    {
+      size_t variable_index = 0;
+      size_t even_idx = 0;
+      size_t odd_idx = 0;
+      bool is_even = true;
+      for (const auto seg_size : parity_list) {
+        if (seg_size == 0) {
+          if (is_even) {
+            is_even = false;
+            continue;
+          } else {
+            break;
+          }
+        }
+        if (is_even) {
+          for (size_t k = 0; k < seg_size; ++k, ++variable_index, ++even_idx) {
+            // NOLINTNEXTLINE
+            raw_transpose(make_not_null(p_dphi + block_size * variable_index),
+                          even_result + even_idx * block_size,  // NOLINT
+                          n_phi, n_r);
+          }
+        } else {
+          for (size_t k = 0; k < seg_size; ++k, ++variable_index, ++odd_idx) {
+            // NOLINTNEXTLINE
+            raw_transpose(make_not_null(p_dphi + block_size * variable_index),
+                          odd_result + odd_idx * block_size,  // NOLINT
+                          n_phi, n_r);
+          }
+        }
+        is_even = not is_even;
+      }
+    }
   }
 };
 

--- a/src/NumericalAlgorithms/Spectral/LogicalCoordinates.cpp
+++ b/src/NumericalAlgorithms/Spectral/LogicalCoordinates.cpp
@@ -135,6 +135,23 @@ void logical_coordinates(
         }
         break;
       }
+      case Spectral::Basis::HalfFourier: {
+        switch (mesh.quadrature(d)) {
+          case Spectral::Quadrature::Equiangular: {
+            const size_t n_phi = mesh.extents(d);
+            const double pi_over_n_phi = std::numbers::pi / n_phi;
+            for (IndexIterator<VolumeDim> index(mesh.extents()); index;
+                 ++index) {
+              logical_coords->get(d)[index.collapsed_index()] =
+                  pi_over_n_phi * (index()[d] + 0.5);
+            }
+            break;
+          }
+          default:
+            ERROR("Quadrature must be Equiangular for Basis HalfFourier");
+        }
+        break;
+      }
       // NOLINTNEXTLINE(bugprone-branch-clone)
       case Spectral::Basis::Chebyshev:
         [[fallthrough]];

--- a/src/NumericalAlgorithms/Spectral/MaximumNumberOfPoints.hpp
+++ b/src/NumericalAlgorithms/Spectral/MaximumNumberOfPoints.hpp
@@ -23,6 +23,7 @@ namespace Spectral {
 template <Basis basis>
 constexpr size_t maximum_number_of_points =
     basis == Basis::Fourier            ? 81
+    : basis == Basis::HalfFourier      ? 41
     : basis == Basis::FiniteDifference ? 40
                                        : 20;
 }  // namespace Spectral

--- a/src/NumericalAlgorithms/Spectral/ParityFromSymmetry.hpp
+++ b/src/NumericalAlgorithms/Spectral/ParityFromSymmetry.hpp
@@ -22,9 +22,9 @@
 
 namespace Spectral {
 /*!
- * \brief A compile-time function to determine parity, with respect to the
- * \f$x\f$ coordinate in an axisymmetric spacetime, of tensors in a Variables
- *
+ * \brief A compile-time function to determine parity of tensors in a
+ * Variables in an axisymmetric spacetime.
+
  * \details In a \f$d\f$-dimensional space where fields are regular everywhere
  * (particularly at the axis), we utilize the fact that smoothness corresponds
  * to a well-defined Taylor expansion in all \f$d\f$ coordinates. Viewing the
@@ -46,10 +46,20 @@ namespace Spectral {
  * only have even powers of \f$x\f$, and for an odd number of \f$x\f$-indices,
  * the expansion must have purely odd powers of \f$x\f$.
  *
- * The primary use-case for this is axisymmetric Cartoon simulations, where
- * elements touching the symmetry axis require ZernikeB1 bases for numerical
- * stability. These bases require knowledge of component parity for certain
- * operations (differentiation, interpolation, etc.).
+ * The above argument holds for operations related to the `ZernikeB1` basis,
+ * which is used only in the \f$x\f$-direction of cartoon
+ * simulations.
+ *
+ * The primary use-case is axisymmetric Cartoon simulations, where
+ * elements touching the symmetry axis require ZernikeB1 in the \f$x\f$
+ * direction bases for numerical stability. These bases require knowledge of
+ * component parity for certain operations (differentiation, interpolation,
+ * etc.). However, the true axial symmetry maps \f$(x, y, z) \to (-x, y,
+ * -z)\f$. Both the \f$x\f$-direction and the \f$z\f$-direction flip sign,
+ * contributing \f$(-1)^{n_x + n_z}\f$ per component. This is relevant for
+ * operations with the `HalfFourier` basis when used in an axisymmetric
+ * spacetime. Use `IncludeZ = true` for HalfFourier-based differentiation in
+ * the azimuthal direction.
  *
  * The returned array, alternating values for even/odd, stores the number of
  * next components with the same parity. When there are any neighboring parities
@@ -59,7 +69,7 @@ namespace Spectral {
  * The first returned `size_t` is the number of even components, while the
  * second is the number of odd components.
  */
-template <typename VariablesTags>
+template <typename VariablesTags, bool IncludeZ = false>
 constexpr std::tuple<
     std::array<size_t,
                Variables<VariablesTags>::number_of_independent_components + 1>,
@@ -69,17 +79,25 @@ compute_parity_list() {
       Variables<VariablesTags>::number_of_independent_components + 1;
   std::array<size_t, N> parity_run_lengths{};
 
-  const auto is_x_coordinate_index = [](const IndexType index_type,
-                                        const size_t index_value) {
-    return (index_type == IndexType::Spacetime and index_value == 1) or
-           (index_type == IndexType::Spatial and index_value == 0);
+  // x (spatial index 0 / spacetime index 1) always flips sign.
+  // z (spatial index 2 / spacetime index 3) flips sign only when IncludeZ.
+  const auto is_flipping_index = [](const IndexType index_type,
+                                    const size_t index_value) {
+    const bool is_x =
+        (index_type == IndexType::Spacetime and index_value == 1) or
+        (index_type == IndexType::Spatial and index_value == 0);
+    const bool is_z =
+        IncludeZ and
+        ((index_type == IndexType::Spacetime and index_value == 3) or
+         (index_type == IndexType::Spatial and index_value == 2));
+    return is_x or is_z;
   };
 
   size_t run_index = 0;
   bool current_parity_is_even = true;
   tmpl::for_each<VariablesTags>([&parity_run_lengths, &run_index,
                                  &current_parity_is_even,
-                                 &is_x_coordinate_index]<typename TensorTag>(
+                                 &is_flipping_index]<typename TensorTag>(
                                     tmpl::type_<TensorTag> /*meta*/) {
     using tensor_type = typename TensorTag::type;
     constexpr auto index_types = tensor_type::index_types();
@@ -88,16 +106,16 @@ compute_parity_list() {
     for (size_t component_index = 0; component_index < tensor_size;
          ++component_index) {
       const auto tensor_index = tensor_type::get_tensor_index(component_index);
-      size_t x_coordinate_count = 0;
+      size_t flipping_index_count = 0;
       for (size_t index_position = 0; index_position < index_types.size();
            ++index_position) {
-        if (is_x_coordinate_index(gsl::at(index_types, index_position),
-                                  gsl::at(tensor_index, index_position))) {
-          ++x_coordinate_count;
+        if (is_flipping_index(gsl::at(index_types, index_position),
+                              gsl::at(tensor_index, index_position))) {
+          ++flipping_index_count;
         }
       }
       // If current parity doesn't match last
-      const bool component_is_even = (x_coordinate_count % 2 == 0);
+      const bool component_is_even = (flipping_index_count % 2 == 0);
       if (component_is_even != current_parity_is_even) {
         ++run_index;
         current_parity_is_even = !current_parity_is_even;
@@ -117,35 +135,30 @@ compute_parity_list() {
 }
 
 /*!
- * \brief A compile-time function to determine parity, with respect to the
- * \f$x\f$ coordinate in an axisymmetric spacetime, of a tensor.
+ * \brief A compile-time function to determine parity of a tensor for an
+ * axisymmetric spacetime.
  *
- * \see `compute_parity_list(Variables)`
+ * \see `compute_parity_list`
  */
-template <typename TensorType>
+template <typename TensorType, bool IncludeZ = false>
   requires(tt::is_a_v<Tensor, TensorType>)
 constexpr std::tuple<std::array<size_t, TensorType::size() + 1>, size_t, size_t>
 compute_parity_list() {
   using tensor_type = Tensor<DataVector, typename TensorType::symmetry,
                              typename TensorType::index_list>;
   using vars_list = ::Tags::convert_to_temp_tensors<tmpl::list<tensor_type>, 0>;
-  return compute_parity_list<vars_list>();
+  return compute_parity_list<vars_list, IncludeZ>();
 }
 /*!
  * \brief Returns a compile-time array mapping each component index of
- * `TensorType` to its `Parity` (Even or Odd) based on the number of
- * \f$x\f$-coordinate indices, for use in an axisymmetric spacetime with the
- * Cartoon method.
- *
- * A component is `Parity::Even` if it has an even number of
- * \f$x\f$-coordinate indices, or `Parity::Odd` otherwise.
+ * `TensorType` to its `Parity` (Even or Odd) for an axisymmetric spacetime.
  *
  * \see `compute_parity_list`
  */
-template <typename TensorType>
+template <typename TensorType, bool IncludeZ = false>
   requires(tt::is_a_v<Tensor, TensorType>)
 constexpr std::array<Parity, TensorType::size()> make_component_parity_array() {
-  constexpr auto parity_info = compute_parity_list<TensorType>();
+  constexpr auto parity_info = compute_parity_list<TensorType, IncludeZ>();
   constexpr auto parity_list = std::get<0>(parity_info);
   constexpr size_t N = TensorType::size();
   std::array<Parity, N> result{};

--- a/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
+++ b/tests/Unit/NumericalAlgorithms/LinearOperators/Test_PartialDerivatives.cpp
@@ -22,6 +22,7 @@
 #include "DataStructures/Index.hpp"
 #include "DataStructures/IndexIterator.hpp"
 #include "DataStructures/Tags/TempTensor.hpp"
+#include "DataStructures/Tensor/IndexType.hpp"
 #include "DataStructures/Tensor/Metafunctions.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "DataStructures/Variables.hpp"
@@ -29,6 +30,7 @@
 #include "Domain/CoordinateMaps/Affine.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.hpp"
 #include "Domain/CoordinateMaps/CoordinateMap.tpp"
+#include "Domain/CoordinateMaps/DiscreteRotation.hpp"
 #include "Domain/CoordinateMaps/Identity.hpp"
 #include "Domain/CoordinateMaps/PolarToCartesian.hpp"
 #include "Domain/CoordinateMaps/ProductMaps.hpp"
@@ -54,6 +56,7 @@
 #include "NumericalAlgorithms/Spectral/MaximumNumberOfPoints.hpp"
 #include "NumericalAlgorithms/Spectral/Mesh.hpp"
 #include "NumericalAlgorithms/Spectral/MinimumNumberOfPoints.hpp"
+#include "NumericalAlgorithms/Spectral/ParityFromSymmetry.hpp"
 #include "NumericalAlgorithms/Spectral/Quadrature.hpp"
 #include "NumericalAlgorithms/SphericalHarmonics/RealSphericalHarmonics.hpp"
 #include "Time/Tags/Time.hpp"
@@ -647,6 +650,93 @@ void test_logical_partial_derivatives_disk(const size_t n_r,
         ERROR("Cannot get here");
     }
   }
+  const auto du = logical_partial_derivatives<GradientTags>(u, mesh);
+  const Approx local_approx = Approx::custom().epsilon(1.0e-13).scale(1.0);
+  CHECK_VARIABLES_CUSTOM_APPROX(du[0], du_expected[0], local_approx);
+  CHECK_VARIABLES_CUSTOM_APPROX(du[1], du_expected[1], local_approx);
+  // We've checked that du is correct, now test that taking derivatives of
+  // individual tensors gets the matching result.
+  test_logical_partial_derivative_per_tensor(du, u, mesh);
+}
+
+template <typename VariableTags, typename GradientTags = VariableTags>
+void test_logical_partial_derivatives_half_annulus(const size_t n_r,
+                                                   const size_t n_phi) {
+  CAPTURE(n_r);
+  CAPTURE(n_phi);
+  const Mesh<2> mesh{
+      {n_r, n_phi},
+      {Spectral::Basis::Legendre, Spectral::Basis::HalfFourier},
+      {Spectral::Quadrature::GaussLobatto, Spectral::Quadrature::Equiangular}};
+  const auto x = logical_coordinates(mesh);
+  const DataVector& r = x[0];
+  const DataVector& phi = x[1];
+  const size_t num_grid_points = mesh.number_of_grid_points();
+
+  const auto max_radial_pow = static_cast<double>(n_r - 1);
+  const DataVector xi_a = pow(r, max_radial_pow);
+  const DataVector d_xi_a = max_radial_pow == 0
+                                ? DataVector(num_grid_points, 0.0)
+                                : max_radial_pow * pow(r, max_radial_pow - 1.0);
+
+  // Determine per-component phi-parity at compile time from tensor symmetries.
+  // HalfFourier uses IncludeZ=true (rotation by pi about y: both x and z flip).
+  constexpr size_t n_comp =
+      Variables<VariableTags>::number_of_independent_components;
+  constexpr auto parity_info =
+      Spectral::compute_parity_list<VariableTags, true>();
+  constexpr auto parity_run_lengths = std::get<0>(parity_info);
+  std::array<Spectral::Parity, n_comp> component_parity{};
+  {
+    size_t ic = 0;
+    bool is_even = true;
+    for (const auto seg_size : parity_run_lengths) {
+      if (seg_size == 0) {
+        if (is_even) {
+          is_even = false;
+          continue;
+        } else {
+          break;
+        }
+      }
+      for (size_t k = 0; k < seg_size; ++k, ++ic) {
+        gsl::at(component_parity, ic) =
+            is_even ? Spectral::Parity::Even : Spectral::Parity::Odd;
+      }
+      is_even = not is_even;
+    }
+  }
+
+  Variables<VariableTags> u{num_grid_points};
+  for (size_t ic = 0; ic < n_comp; ++ic) {
+    DataVector comp(u.data() + ic * num_grid_points, num_grid_points);
+    if (gsl::at(component_parity, ic) == Spectral::Parity::Odd) {
+      comp = xi_a * sin(phi);
+    } else {
+      comp = xi_a * cos(phi);
+    }
+  }
+
+  std::array<Variables<GradientTags>, 2> du_expected{};
+  du_expected[0].initialize(num_grid_points);
+  du_expected[1].initialize(num_grid_points);
+
+  constexpr size_t n_grad_comp =
+      Variables<GradientTags>::number_of_independent_components;
+  for (size_t ic = 0; ic < n_grad_comp; ++ic) {
+    DataVector du_dr(du_expected[0].data() + ic * num_grid_points,
+                     num_grid_points);
+    DataVector du_dphi(du_expected[1].data() + ic * num_grid_points,
+                       num_grid_points);
+    if (gsl::at(component_parity, ic) == Spectral::Parity::Odd) {
+      du_dr = d_xi_a * sin(phi);
+      du_dphi = xi_a * cos(phi);
+    } else {
+      du_dr = d_xi_a * cos(phi);
+      du_dphi = -xi_a * sin(phi);
+    }
+  }
+
   const auto du = logical_partial_derivatives<GradientTags>(u, mesh);
   const Approx local_approx = Approx::custom().epsilon(1.0e-13).scale(1.0);
   CHECK_VARIABLES_CUSTOM_APPROX(du[0], du_expected[0], local_approx);
@@ -1269,7 +1359,8 @@ DataVector cartoon_dfunc(size_t deriv_index,
 }
 
 template <bool Spherical>
-void test_cartoon_partial_derivatives(const double x_start) {
+void test_cartoon_partial_derivatives(const double x_start,
+                                      const bool test_half_fourier = false) {
   Mesh<3> mesh;
   tnsr::I<DataVector, 3, Frame::Grid> coords;
   InverseJacobian<DataVector, 3, Frame::ElementLogical, Frame::Grid>
@@ -1301,29 +1392,67 @@ void test_cartoon_partial_derivatives(const double x_start) {
     coords = map(logical_coordinates(mesh));
   } else {
     // axial symmetry
-    const size_t num_x_grid_pts = 6;
+    const size_t num_x_grid_pts = 7;
     const double x_end = 3.25;
-    const size_t num_y_grid_pts = 7;
+    const size_t num_y_grid_pts = 6;
+    const size_t num_phi_grid_pts = 11;
     const double y_start = -2.5;
     const double y_end = 4.0;
 
-    mesh = Mesh<3>{{{num_x_grid_pts, num_y_grid_pts, 1}},
-                   {{Spectral::Basis::Legendre, Spectral::Basis::Legendre,
-                     Spectral::Basis::Cartoon}},
-                   {{Spectral::Quadrature::GaussLobatto,
-                     Spectral::Quadrature::GaussLobatto,
-                     Spectral::Quadrature::AxialSymmetry}}};
+    mesh =
+        test_half_fourier
+            ? Mesh<3>{{{num_x_grid_pts, num_phi_grid_pts, 1}},
+                      {{Spectral::Basis::Legendre, Spectral::Basis::HalfFourier,
+                        Spectral::Basis::Cartoon}},
+                      {{Spectral::Quadrature::GaussLobatto,
+                        Spectral::Quadrature::Equiangular,
+                        Spectral::Quadrature::AxialSymmetry}}}
+            : Mesh<3>{{{num_x_grid_pts, num_y_grid_pts, 1}},
+                      {{Spectral::Basis::Legendre, Spectral::Basis::Legendre,
+                        Spectral::Basis::Cartoon}},
+                      {{Spectral::Quadrature::GaussLobatto,
+                        Spectral::Quadrature::GaussLobatto,
+                        Spectral::Quadrature::AxialSymmetry}}};
 
     const Affine affine_x_map(-1.0, 1.0, x_start, x_end);
     const Affine affine_y_map(-1.0, 1.0, y_start, y_end);
 
-    using Cartoon_map_combination =
-        domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Identity1D>;
-    const domain::CoordinateMap<Frame::ElementLogical, Frame::Grid,
-                                Cartoon_map_combination>
-        map{{affine_x_map, affine_y_map, identity_cartoon_map}};
-    inv_jacobian = map.inv_jacobian(logical_coordinates(mesh));
-    coords = map(logical_coordinates(mesh));
+    if (test_half_fourier) {
+      using Cartoon_map_combination =
+          domain::CoordinateMaps::ProductOf3Maps<Affine, Identity1D,
+                                                 Identity1D>;
+      // HalfFourier parity (phi -> -phi) must match the cartoon x -> -x
+      // parity, so x  must be odd under phi -> -phi. We need to rotate the
+      // coordinates so the cartoon symmetry axis x=0 lies at the HalfFourier
+      // boundaries phi = 0, pi
+      const auto map =
+          domain::make_coordinate_map<Frame::ElementLogical, Frame::Grid>(
+              Cartoon_map_combination{affine_x_map, identity_cartoon_map,
+                                      identity_cartoon_map},
+              domain::CoordinateMaps::ProductOf2Maps<
+                  domain::CoordinateMaps::PolarToCartesian,
+                  domain::CoordinateMaps::Identity<1>>{
+                  domain::CoordinateMaps::PolarToCartesian{},
+                  domain::CoordinateMaps::Identity<1>{}},
+              domain::CoordinateMaps::ProductOf2Maps<
+                  domain::CoordinateMaps::DiscreteRotation<2>,
+                  domain::CoordinateMaps::Identity<1>>{
+                  domain::CoordinateMaps::DiscreteRotation<2>{OrientationMap<2>{
+                      std::array<Direction<2>, 2>{Direction<2>::upper_eta(),
+                                                  Direction<2>::lower_xi()}}},
+                  domain::CoordinateMaps::Identity<1>{}});
+
+      inv_jacobian = map.inv_jacobian(logical_coordinates(mesh));
+      coords = map(logical_coordinates(mesh));
+    } else {
+      using Cartoon_map_combination =
+          domain::CoordinateMaps::ProductOf3Maps<Affine, Affine, Identity1D>;
+      const domain::CoordinateMap<Frame::ElementLogical, Frame::Grid,
+                                  Cartoon_map_combination>
+          map{{affine_x_map, affine_y_map, identity_cartoon_map}};
+      inv_jacobian = map.inv_jacobian(logical_coordinates(mesh));
+      coords = map(logical_coordinates(mesh));
+    }
   }
 
   using Tempabc =
@@ -1349,7 +1478,7 @@ void test_cartoon_partial_derivatives(const double x_start) {
   // The point of these prefactors is to ensure the tensors respect the
   // symmetry of the spacetime: it is not sufficient that each component
   // follows the symmetry, rather the entire tensor must satisfy
-  // \mathcal{L}_\xi (tensor) = 0. Each rank has it's own form of prefactor
+  // \mathcal{L}_\xi (tensor) = 0. Each rank has its own form of prefactor
   Variables<VarTags> prefactor_vars{mesh.number_of_grid_points()};
 
   using TempiA =
@@ -1410,7 +1539,7 @@ void test_cartoon_partial_derivatives(const double x_start) {
     get<2>(vector) = get<2>(one_form) = DataVector(dv_size, 0.0);
     get<3>(vector) = get<3>(one_form) = get<0>(coords);
 
-    // \partial_i of x_a is (0, \delta_i2, 0, \delta_i0)
+    // \partial_i of x_a is (0, -1 * \delta_i2, 0, \delta_i0)
     for (size_t i = 0; i < index_dim<0>(d_vector); ++i) {
       for (size_t a = 0; a < index_dim<1>(d_vector); ++a) {
         if (i == 2 and a == 1) {
@@ -1484,7 +1613,7 @@ void test_cartoon_partial_derivatives(const double x_start) {
   // metric, which though not a tensor mathematically still must obey
   // \mathcal{L}_\xi \Phi_{iab} = 0
   // Using the form
-  // x_a x_b x_c + \delta_ab x_c \delta_ac x_b \delta_bc x_a
+  // x_a x_b x_c + \delta_ab x_c + \delta_ac x_b + \delta_bc x_a
   for (size_t a = 0; a < index_dim<0>(rank3); ++a) {
     for (size_t b = 0; b < index_dim<1>(rank3); ++b) {
       for (size_t c = 0; c < index_dim<2>(rank3); ++c) {
@@ -1507,8 +1636,8 @@ void test_cartoon_partial_derivatives(const double x_start) {
       }
     }
   }
-  // \partial_i of (x_a x_b x_c + \delta_ab x_c \delta_ac x_b \delta_bc x_a) is
-  // \delta_ia x_b x_c + \delta_ib x_a x_c + \delta_ic x_a x_b +
+  // \partial_i of (x_a x_b x_c + \delta_ab x_c + \delta_ac x_b + \delta_bc x_a)
+  // is \delta_ia x_b x_c + \delta_ib x_a x_c + \delta_ic x_a x_b +
   //   \delta_ab \delta_ic + \delta_ac \delta_ib + \delta_bc \delta_ia
   for (size_t i = 0; i < index_dim<0>(d_rank3); ++i) {
     for (size_t a = 0; a < index_dim<1>(d_rank3); ++a) {
@@ -2198,6 +2327,12 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.LogicalDerivs",
       }
     }
   }
+  for (size_t n_r = 2; n_r <= 5; ++n_r) {
+    for (size_t n_phi = 3; n_phi <= 7; n_phi += 2) {
+      test_logical_partial_derivatives_half_annulus<two_vars<DataVector, 2>>(
+          n_r, n_phi);
+    }
+  }
 #ifdef SPECTRE_DEBUG
   CHECK_THROWS_WITH(
       (test_logical_partial_derivatives_disk<two_vars<DataVector, 2>>(2, 7)),
@@ -2222,6 +2357,11 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.LogicalDerivs",
                                                                             4)),
       Catch::Matchers::ContainsSubstring(
           "ZernikeB3 radial resolution is insufficient"));
+  CHECK_THROWS_WITH(
+      (test_logical_partial_derivatives_half_annulus<two_vars<DataVector, 2>>(
+          2, 4)),
+      Catch::Matchers::ContainsSubstring(
+          "HalfFourier must have an odd number of gridpoints "));
 #endif  // SPECTRE_DEBUG
 
   for (size_t n_r = 3; n_r <= 8; ++n_r) {
@@ -2284,6 +2424,8 @@ SPECTRE_TEST_CASE("Unit.Numerical.LinearOperators.PartialDerivs",
   // testing without L'Hopital
   test_cartoon_partial_derivatives<true>(1.0);
   test_cartoon_partial_derivatives<false>(1.0);
+  // testing with HalfFourier basis
+  test_cartoon_partial_derivatives<false>(1.0, true);
 
   test_cartoon_partial_derivative_and_choosers();
 

--- a/tests/Unit/NumericalAlgorithms/Spectral/Test_ParityFromSymmetry.cpp
+++ b/tests/Unit/NumericalAlgorithms/Spectral/Test_ParityFromSymmetry.cpp
@@ -176,20 +176,71 @@ void test_make_component_parity_array() {
   }
 }
 
+// Tests for IncludeZ=true (rotation by pi about y-axis: both x and z flip),
+// used by HalfFourier differentiation.
+void test_include_z_parity() {
+  // Spacetime covector (t,x,y,z): x (index 1) and z (index 3) flip.
+  const tnsr::a<double, 3> tensor_a{1};
+  const auto [tensor_a_list, a_even, a_odd] =
+      compute_parity_list<tnsr::a<double, 3>, true>();
+  const std::array<size_t, tensor_a.size() + 1> tensor_a_expected_list{1, 1, 1,
+                                                                       1, 0};
+  CHECK(tensor_a_list == tensor_a_expected_list);
+  CHECK(a_even == 2);
+  CHECK(a_odd == 2);
+
+  constexpr auto i_result =
+      make_component_parity_array<tnsr::i<DataVector, 3>, true>();
+  static_assert(i_result[0] == Parity::Odd);
+  static_assert(i_result[1] == Parity::Even);
+  static_assert(i_result[2] == Parity::Odd);
+
+  constexpr auto ii_result =
+      make_component_parity_array<tnsr::ii<DataVector, 3>, true>();
+  static_assert(ii_result[0] == Parity::Even);
+  static_assert(ii_result[1] == Parity::Odd);
+  static_assert(ii_result[2] == Parity::Even);
+  static_assert(ii_result[3] == Parity::Even);
+  static_assert(ii_result[4] == Parity::Odd);
+  static_assert(ii_result[5] == Parity::Even);
+}
+
 void test_gh_system() {
   using gh_tags = gh::System<3>::gradients_tags;
-  const auto [gh_list, gh_even, gh_odd] = compute_parity_list<gh_tags>();
 
-  const std::array<size_t,
-                   Variables<gh_tags>::number_of_independent_components + 1>
-      expected_list{1, 1, 3, 2, 4, 1, 3, 2, 3, 1, 3, 3, 2, 1, 2, 1, 3,
-                    2, 1, 3, 2, 1, 2, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-  CHECK(gh_list == expected_list);
-  CHECK(gh_even == 31);
-  CHECK(gh_odd == 19);
-  CHECK(gh_even + gh_odd ==
-        Variables<gh_tags>::number_of_independent_components);
+  // x-only parity (IncludeZ=false, default): only x (spacetime index 1,
+  // spatial index 0) flips.
+  {
+    const auto [gh_list, gh_even, gh_odd] = compute_parity_list<gh_tags>();
+    const std::array<size_t,
+                     Variables<gh_tags>::number_of_independent_components + 1>
+        expected_list{1, 1, 3, 2, 4, 1, 3, 2, 3, 1, 3, 3, 2, 1, 2, 1, 3,
+                      2, 1, 3, 2, 1, 2, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    CHECK(gh_list == expected_list);
+    CHECK(gh_even == 31);
+    CHECK(gh_odd == 19);
+    CHECK(gh_even + gh_odd ==
+          Variables<gh_tags>::number_of_independent_components);
+  }
+
+  // x+z parity (IncludeZ=true): rotation by pi about y-axis, both x
+  // (spacetime index 1, spatial index 0) and z (spacetime index 3, spatial
+  // index 2) flip.
+  {
+    const auto [gh_list, gh_even, gh_odd] =
+        compute_parity_list<gh_tags, true>();
+    const std::array<size_t,
+                     Variables<gh_tags>::number_of_independent_components + 1>
+        expected_list{1, 1, 1, 1, 1, 1, 2, 1, 2, 1, 1, 1, 1, 1, 2, 1, 1,
+                      1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                      1, 1, 1, 2, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0};
+    CHECK(gh_list == expected_list);
+    CHECK(gh_even == 26);
+    CHECK(gh_odd == 24);
+    CHECK(gh_even + gh_odd ==
+          Variables<gh_tags>::number_of_independent_components);
+  }
 }
 }  // namespace
 
@@ -198,6 +249,7 @@ SPECTRE_TEST_CASE("Unit.Numerical.Spectral.ParityFromSymmetry",
   test_basic_functionality();
   test_expected_properties();
   test_constexpr();
+  test_include_z_parity();
   test_gh_system();
   test_make_component_parity_array();
 }


### PR DESCRIPTION
## Proposed changes

The first commit discusses its purpose in the dox, but basically the cartoon pd test was failing without this extra flag, which is the way I found it in the first place.

This basis is used only in a `{Legendre, HalfFourier, Cartoon}` mesh, hence the logical derivative only checking for that pattern

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent was used, have a co-author trailer of the form
      "Co-Authored-By: <agent name> <agent email>" as the last line of the
      commit, e.g. "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>".

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
