### PR TITLE
Update coefficients in ScriObserveInterpolated.cpp

### DIFF
--- a/src/Evolution/Systems/Cce/Actions/ScriObserveInterpolated.cpp
+++ b/src/Evolution/Systems/Cce/Actions/ScriObserveInterpolated.cpp
@@ -19,7 +19,7 @@ void correct_weyl_scalars_for_inertial_time(
   const auto& eth_u =
       get<Tags::EthInertialRetardedTime>(*weyl_correction_variables);
   get(psi_0) += 2.0 * get(eth_u) * get(psi_1) +
-               0.75 * square(get(eth_u)) * get(psi_2) +
+               1.5 * square(get(eth_u)) * get(psi_2) +
                0.5 * pow<3>(get(eth_u)) * get(psi_3) +
                0.0625 * pow<4>(get(eth_u)) * get(psi_4);
   get(psi_1) += 1.5 * get(eth_u) * get(psi_2) +

--- a/src/Evolution/Systems/Cce/Actions/ScriObserveInterpolated.hpp
+++ b/src/Evolution/Systems/Cce/Actions/ScriObserveInterpolated.hpp
@@ -80,10 +80,16 @@ void correct_weyl_scalars_for_inertial_time(
  * formulas, we need to adjust the signs and factors of two to be compatible
  * with our definitions of \f$\eth\f$ and choice of Newman-Penrose tetrad.
  *
+ * The coefficient of \f$\left(\eth u^\prime\right)^2\Psi_2^{(3)}\f$ in
+ * \f$\Psi_0^{\prime(5)}\f$ is incorrectly given as \f$3/4\f$ in
+ * \cite Moxon2020gha, Eq. (94b), and in \cite Moxon2021gbv, Eq. (B2g) of the
+ * arXiv version. The value \f$3/2\f$ below agrees with the BMS transformation
+ * in \cite Boyle:2015nqa, Eqs. (17a--e).
+ *
  * \f{align*}{
  * \Psi_0^{\prime (5)}
  * =&  \Psi_0^{(5)} + 2 \eth u^\prime \Psi_1^{(4)}
- * + \frac{3}{4} \left(\eth u^\prime\right)^2 \Psi_2^{(3)}
+ * + \frac{3}{2} \left(\eth u^\prime\right)^2 \Psi_2^{(3)}
  * + \frac{1}{2} \left( \eth u^\prime\right)^3  \Psi_3^{(2)}
  * + \frac{1}{16} \left(\eth u^\prime\right)^4 \Psi_4^{(1)}, \\
  * \Psi_1^{\prime (4)}

--- a/tests/Unit/Evolution/Systems/Cce/Actions/ScriObserveInterpolated.py
+++ b/tests/Unit/Evolution/Systems/Cce/Actions/ScriObserveInterpolated.py
@@ -165,7 +165,7 @@ def compute_ScriPlus_Psi0(
     return (
         psi0
         + 2.0 * psi1 * eth_u
-        + 0.75 * psi2 * eth_u**2
+        + 1.5 * psi2 * eth_u**2
         + 0.5 * psi3 * eth_u**3
         + 0.0625 * psi4 * eth_u**4
     )


### PR DESCRIPTION
## Fix incorrect `Psi0` inertial-time correction coefficient

The inertial-time Weyl-scalar correction in `ScriObserveInterpolated.cpp` uses an incorrect coefficient for the $(\eth u_I)^2\Psi_2$ contribution to `Psi0`.

SpECTRE currently applies

```math
\Psi_0'
=
\Psi_0
+2\eta\Psi_1
+\frac{3}{4}\eta^2\Psi_2
+\frac{1}{2}\eta^3\Psi_3
+\frac{1}{16}\eta^4\Psi_4,
\qquad
\eta=\eth u_I.
```

This agrees with the published CCE formulas in Moxon, Scheel, and Teukolsky (2020), Eq. (94b), and Moxon et al. (2023), Eq. (B2g) in the arXiv version. However, the coefficient is inconsistent with the BMS transformation of Boyle (2016), Eqs. (17a–e), and with the remaining Weyl-scalar transformations in the CCE papers themselves.

Boyle's transformation has the null-rotation structure

```math
\Psi_0'
\propto
\Psi_0
-4q\Psi_1
+6q^2\Psi_2
-4q^3\Psi_3
+q^4\Psi_4.
```

After accounting for the CCE conventions for $\eth$ and the Newman-Penrose tetrad, the lower Weyl-scalar transformations determine the effective null-rotation parameter. In particular, the CCE papers give

```math
\Psi_3'=\Psi_3+\frac{1}{2}\eta\Psi_4,
```

and the corresponding $\Psi_2$ and $\Psi_1$ transformations are

```math
\begin{aligned}
\Psi_2'
&=
\Psi_2+\eta\Psi_3+\frac{1}{4}\eta^2\Psi_4,\\
\Psi_1'
&=
\Psi_1+\frac{3}{2}\eta\Psi_2
+\frac{3}{4}\eta^2\Psi_3
+\frac{1}{8}\eta^3\Psi_4.
\end{aligned}
```

These are exactly the binomial null-rotation hierarchy with parameter

```math
a=\frac{\eta}{2}.
```

The corresponding `Psi0` transformation must therefore be

```math
\Psi_0'
=
\Psi_0
+4a\Psi_1
+6a^2\Psi_2
+4a^3\Psi_3
+a^4\Psi_4,
```

or

```math
\Psi_0'
=
\Psi_0
+2\eta\Psi_1
+\frac{3}{2}\eta^2\Psi_2
+\frac{1}{2}\eta^3\Psi_3
+\frac{1}{16}\eta^4\Psi_4.
```

All coefficients in the CCE transformation hierarchy agree with Boyle after the convention conversion except the quadratic `Psi2` term in `Psi0`. This coefficient should therefore be changed from `3/4` to `3/2`.

**References**

* M. Boyle, *Transformations of asymptotic gravitational-wave data*, Phys. Rev. D **93**, 084031 (2016), Eqs. (17a–e). DOI: `10.1103/PhysRevD.93.084031`, arXiv:`1509.00862`.
* J. Moxon, M. A. Scheel, and S. A. Teukolsky, *Improved Cauchy-characteristic evolution system for high-precision numerical relativity waveforms*, Phys. Rev. D **102**, 044052 (2020), Eq. (94b). DOI: `10.1103/PhysRevD.102.044052`, arXiv:`2007.01339`.
* J. Moxon et al., *SpECTRE Cauchy-characteristic evolution system for rapid, precise waveform extraction*, Phys. Rev. D **107**, 064013 (2023), Eq. (B2g) in the arXiv version. DOI: `10.1103/PhysRevD.107.064013`, arXiv:`2110.08635`.
* SpECTRE: `src/Evolution/Systems/Cce/Actions/ScriObserveInterpolated.cpp`

### Upgrade instructions

None

<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->
