### PR TITLE
Generalize Ccz4WrappedGr to handle solutions with negative lapse

### DIFF
--- a/src/Evolution/Systems/Ccz4/Ccz4WrappedGr.cpp
+++ b/src/Evolution/Systems/Ccz4/Ccz4WrappedGr.cpp
@@ -6,6 +6,7 @@
 #include "Evolution/Systems/Ccz4/Ccz4WrappedGr.tpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/GaugePlaneWave.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/GaugeWave.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/HighSpinKerrPuncture.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/TrumpetSchwarzschild.hpp"
@@ -14,5 +15,6 @@
 GENERATE_INSTANTIATIONS(CCZ4_WRAPPED_GR_INSTANTIATE,
                         (gr::Solutions::GaugeWave<3>,
                          gr::Solutions::GaugePlaneWave<3>,
+                         gr::Solutions::HighSpinKerrPuncture,
                          gr::Solutions::KerrSchild, gr::Solutions::Minkowski<3>,
                          gr::Solutions::TrumpetSchwarzschild))

--- a/src/Evolution/Systems/Ccz4/Ccz4WrappedGr.hpp
+++ b/src/Evolution/Systems/Ccz4/Ccz4WrappedGr.hpp
@@ -8,6 +8,7 @@
 #include <string>
 
 #include "DataStructures/DataBox/Prefixes.hpp"
+#include "DataStructures/DataVector.hpp"
 #include "DataStructures/TaggedTuple.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Evolution/Systems/Ccz4/Tags.hpp"
@@ -19,7 +20,6 @@
 #include "Utilities/TMPL.hpp"
 
 /// \cond
-class DataVector;
 namespace PUP {
 class er;
 }  // namespace PUP
@@ -31,6 +31,15 @@ namespace Ccz4::Solutions {
  * the analytic solution and then adds a function that returns
  * any combination of the Ccz4 evolution variables.
  * Specifically, see `Ccz4::fd::System`.
+ *
+ * The wrapper returns the everywhere-nonnegative lapse
+ * \f$|\alpha|\f$ in place of the wrapped solution's lapse \f$\alpha\f$, with
+ * the lapse derivative and time derivative scaled by
+ * \f$\mathrm{sgn}(\alpha)\f$ (where \f$\mathrm{sgn}(0) := 0\f$). For
+ * solutions with positive lapse this is an exact no-op. For solutions whose
+ * lapse is negative somewhere (e.g. the lapse of
+ * `gr::Solutions::HighSpinKerrPuncture` inside its throat) the sign flip is
+ * pure gauge: the spatial metric and extrinsic curvature are unchanged.
  */
 template <typename SolutionType>
 class Ccz4WrappedGr : public virtual evolution::initial_data::InitialData,
@@ -95,10 +104,7 @@ class Ccz4WrappedGr : public virtual evolution::initial_data::InitialData,
   tuples::TaggedTuple<Tags...> variables(
       const tnsr::I<DataVector, volume_dim>& x, const double t,
       tmpl::list<Tags...> /*meta*/) const {
-    // Get the underlying solution's variables using the solution's tags list,
-    // store in IntermediateVariables
-    const IntermediateVars& intermediate_vars = SolutionType::variables(
-        x, t, typename SolutionType::template tags<DataVector>{});
+    const IntermediateVars intermediate_vars = make_intermediate_vars(x, t);
 
     return {
         get<Tags>(variables(x, t, tmpl::list<Tags>{}, intermediate_vars))...};
@@ -108,8 +114,7 @@ class Ccz4WrappedGr : public virtual evolution::initial_data::InitialData,
   tuples::TaggedTuple<Tag> variables(const tnsr::I<DataVector, volume_dim>& x,
                                      const double t,
                                      tmpl::list<Tag> /*meta*/) const {
-    const IntermediateVars& intermediate_vars = SolutionType::variables(
-        x, t, typename SolutionType::template tags<DataVector>{});
+    const IntermediateVars intermediate_vars = make_intermediate_vars(x, t);
     return {get<Tag>(variables(x, t, tmpl::list<Tag>{}, intermediate_vars))};
   }
 
@@ -119,10 +124,7 @@ class Ccz4WrappedGr : public virtual evolution::initial_data::InitialData,
   tuples::TaggedTuple<Tags...> variables(
       const tnsr::I<DataVector, volume_dim>& x,
       tmpl::list<Tags...> /*meta*/) const {
-    // Get the underlying solution's variables using the solution's tags list,
-    // store in IntermediateVariables
-    const IntermediateVars intermediate_vars = SolutionType::variables(
-        x, typename SolutionType::template tags<DataVector>{});
+    const IntermediateVars intermediate_vars = make_intermediate_vars(x);
 
     return {get<Tags>(variables(x, tmpl::list<Tags>{}, intermediate_vars))...};
   }
@@ -130,8 +132,7 @@ class Ccz4WrappedGr : public virtual evolution::initial_data::InitialData,
   template <typename Tag>
   tuples::TaggedTuple<Tag> variables(const tnsr::I<DataVector, volume_dim>& x,
                                      tmpl::list<Tag> /*meta*/) const {
-    const IntermediateVars intermediate_vars = SolutionType::variables(
-        x, typename SolutionType::template tags<DataVector>{});
+    const IntermediateVars intermediate_vars = make_intermediate_vars(x);
     return {get<Tag>(variables(x, tmpl::list<Tag>{}, intermediate_vars))};
   }
 
@@ -139,11 +140,37 @@ class Ccz4WrappedGr : public virtual evolution::initial_data::InitialData,
   void pup(PUP::er& p) override;
 
  private:
-  // Preprocessor logic to avoid declaring variables() functions for
-  // tags other than the three the wrapper adds (i.e., other than
-  // Ccz4::Tags::ConformalMetric, Ccz4::Tags::ConformalFactor,
-  // Ccz4:Tags::ATilde, gr::Tags::TraceExtrinsicCurvature,
-  // Ccz4::Tags::Theta, Ccz4::Tags::GammaHat)
+  // Computes the wrapped solution's variables and applies the nonnegative
+  // lapse: the lapse is replaced by its absolute
+  // value, and the lapse derivative and time derivative are scaled by
+  // sign(lapse), with sign(0) := 0. Every tag the wrapper returns,
+  // passed through or derived, must be computed from the IntermediateVars
+  // returned here, never by calling the solution directly, so that any
+  // lapse-dependent quantity added in the future automatically sees the
+  // corrected gauge.
+  template <typename... OptionalTime>
+  IntermediateVars make_intermediate_vars(
+      const tnsr::I<DataVector, volume_dim>& x, OptionalTime... time) const {
+    IntermediateVars vars = SolutionType::variables(
+        x, time..., typename SolutionType::template tags<DataVector>{});
+    // The sign must be taken before the lapse is replaced
+    const DataVector sgn_of_lapse =
+        sign(get(get<gr::Tags::Lapse<DataVector>>(vars)));
+    for (size_t i = 0; i < volume_dim; ++i) {
+      get<DerivLapse>(vars).get(i) *= sgn_of_lapse;
+    }
+    get(get<TimeDerivLapse>(vars)) *= sgn_of_lapse;
+    get(get<gr::Tags::Lapse<DataVector>>(vars)) =
+        abs(get(get<gr::Tags::Lapse<DataVector>>(vars)));
+    return vars;
+  }
+
+  // The generic overloads below pass the wrapped solution's tags through
+  // from the IntermediateVars; the explicit overloads compute the seven
+  // tags the wrapper adds (Ccz4::Tags::ConformalMetric,
+  // Ccz4::Tags::ConformalFactor, Ccz4::Tags::ATilde,
+  // gr::Tags::TraceExtrinsicCurvature, Ccz4::Tags::Theta,
+  // Ccz4::Tags::GammaHat, Ccz4::Tags::AuxiliaryShiftB)
   using TagShift = gr::Tags::Shift<DataVector, volume_dim>;
   using TagSpatialMetric = gr::Tags::SpatialMetric<DataVector, volume_dim>;
   using TagInverseSpatialMetric =

--- a/src/Evolution/Systems/Ccz4/Solutions/Factory.hpp
+++ b/src/Evolution/Systems/Ccz4/Solutions/Factory.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "Evolution/Systems/Ccz4/Ccz4WrappedGr.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/HighSpinKerrPuncture.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/KerrSchild.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/TrumpetSchwarzschild.hpp"
@@ -11,12 +12,13 @@
 
 namespace Ccz4::Solutions {
 /// \brief List of all Ccz4 analytic solutions
-/// Right now it only makes sense to do TrumpetSchwarzschild or time-independent
-/// solutions because we can either use 1+log slicing with Gamma-driver
-/// or not evolve the lapse and shift at all. We will allow analytic
-/// lapse and shift in the future.
+/// Right now it only makes sense to do TrumpetSchwarzschild,
+/// HighSpinKerrPuncture, or time-independent solutions because we can either
+/// use 1+log slicing with Gamma-driver or not evolve the gauge at all. We will
+/// allow analytic lapse and shift in the future.
 using all_solutions =
-    tmpl::list<Ccz4WrappedGr<gr::Solutions::KerrSchild>,
+    tmpl::list<Ccz4WrappedGr<gr::Solutions::HighSpinKerrPuncture>,
+               Ccz4WrappedGr<gr::Solutions::KerrSchild>,
                Ccz4WrappedGr<gr::Solutions::Minkowski<3>>,
                Ccz4WrappedGr<gr::Solutions::TrumpetSchwarzschild>>;
 }  // namespace Ccz4::Solutions

--- a/tests/Unit/Evolution/Systems/Ccz4/Test_Ccz4WrappedGr.cpp
+++ b/tests/Unit/Evolution/Systems/Ccz4/Test_Ccz4WrappedGr.cpp
@@ -4,22 +4,25 @@
 #include "Framework/TestingFramework.hpp"
 
 #include <array>
+#include <cstddef>
 #include <limits>
 #include <string>
+#include <type_traits>
 
 #include "DataStructures/DataBox/Prefixes.hpp"
 #include "DataStructures/DataVector.hpp"
 #include "DataStructures/Tensor/EagerMath/Trace.hpp"
 #include "DataStructures/Tensor/Tensor.hpp"
 #include "Evolution/Systems/Ccz4/ATilde.hpp"
+#include "Evolution/Systems/Ccz4/Ccz4WrappedGr.hpp"
 #include "Evolution/Systems/Ccz4/Christoffel.hpp"
 #include "Evolution/Systems/Ccz4/FiniteDifference/System.hpp"
 #include "Framework/TestCreation.hpp"
 #include "Framework/TestHelpers.hpp"
 #include "Helpers/DataStructures/MakeWithRandomValues.hpp"
-#include "Evolution/Systems/Ccz4/Ccz4WrappedGr.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/GaugePlaneWave.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/GaugeWave.hpp"
+#include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/HighSpinKerrPuncture.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/Minkowski.hpp"
 #include "PointwiseFunctions/AnalyticSolutions/GeneralRelativity/TrumpetSchwarzschild.hpp"
 #include "PointwiseFunctions/GeneralRelativity/Tags.hpp"
@@ -47,25 +50,51 @@ void test_copy_and_move(const SolutionType& solution) {
 template <typename SolutionType>
 void test_ccz4_solution(
     const SolutionType& solution,
-    const Ccz4::Solutions::Ccz4WrappedGr<SolutionType>& wrapped_solution) {
-  const DataVector data_vector{3.0, 4.0};
-  const tnsr::I<DataVector, SolutionType::volume_dim, Frame::Inertial> x{
-      data_vector};
+    const Ccz4::Solutions::Ccz4WrappedGr<SolutionType>& wrapped_solution,
+    const tnsr::I<DataVector, SolutionType::volume_dim, Frame::Inertial>& x) {
   // Don't set time to signaling NaN, since not all solutions tested here
   // are static
   const double t = 44.44;
 
-  // Check that the wrapped solution returns the same variables as
-  // the solution
   const auto vars = solution.variables(
       x, t, typename SolutionType::template tags<DataVector>{});
   const auto wrapped_vars = wrapped_solution.variables(
       x, t, typename SolutionType::template tags<DataVector>{});
 
+  // Check the wrapper's contract on the solution's tags: the lapse is
+  // returned as its absolute value, the lapse derivative and time
+  // derivative are scaled by sign(lapse), and every other tag passes
+  // through verbatim. For solutions with positive lapse this loop checks
+  // that the wrapper is an exact no-op on the solution's tags.
+  using LapseTag = gr::Tags::Lapse<DataVector>;
+  using DerivLapseTag =
+      ::Tags::deriv<gr::Tags::Lapse<DataVector>,
+                    tmpl::size_t<SolutionType::volume_dim>, Frame::Inertial>;
+  using DtLapseTag = ::Tags::dt<gr::Tags::Lapse<DataVector>>;
+  const DataVector sgn_of_lapse = sign(get(get<LapseTag>(vars)));
   tmpl::for_each<typename SolutionType::template tags<DataVector>>(
-      [&vars, &wrapped_vars](auto tag_v) {
+      [&vars, &wrapped_vars, &sgn_of_lapse](auto tag_v) {
         using tag = typename decltype(tag_v)::type;
-        CHECK(get<tag>(vars) == get<tag>(wrapped_vars));
+        if constexpr (std::is_same_v<tag, LapseTag>) {
+          auto expected = get<tag>(vars);
+          get(expected) = abs(get(expected));
+          CHECK(get<tag>(wrapped_vars) == expected);
+        } else if constexpr (std::is_same_v<tag, DtLapseTag>) {
+          // Only trivially exercised: no wrapped solution in the factory
+          // has both a negative lapse and a nonzero time derivative of
+          // the lapse
+          auto expected = get<tag>(vars);
+          get(expected) *= sgn_of_lapse;
+          CHECK(get<tag>(wrapped_vars) == expected);
+        } else if constexpr (std::is_same_v<tag, DerivLapseTag>) {
+          auto expected = get<tag>(vars);
+          for (size_t i = 0; i < SolutionType::volume_dim; ++i) {
+            expected.get(i) *= sgn_of_lapse;
+          }
+          CHECK(get<tag>(wrapped_vars) == expected);
+        } else {
+          CHECK(get<tag>(vars) == get<tag>(wrapped_vars));
+        }
       });
 
   // Check that the wrapped solution returns the correct extra Ccz4 tags
@@ -199,16 +228,26 @@ void test_ccz4_solution(
 
 template <typename SolutionType>
 void test_construct_from_options(
-    const Ccz4::Solutions::Ccz4WrappedGr<SolutionType>& wrapped_solution) {
+    const Ccz4::Solutions::Ccz4WrappedGr<SolutionType>& wrapped_solution,
+    const std::string& option_string) {
   const auto created =
       TestHelpers::test_creation<Ccz4::Solutions::Ccz4WrappedGr<SolutionType>>(
-          "Mass: 0.5\n"
-          "N: 2.5");
+          option_string);
 
   CHECK(created == wrapped_solution);
 }
 
-void test_gauge_plane_wave() {
+void test_gauge_wave(const tnsr::I<DataVector, 3, Frame::Inertial>& x) {
+  const double amplitude = 0.24;
+  const double wavelength = 4.4;
+  const gr::Solutions::GaugeWave<3> gauge_wave_solution{amplitude, wavelength};
+  const Ccz4::Solutions::Ccz4WrappedGr<gr::Solutions::GaugeWave<3>>
+      wrapped_gauge_wave_solution{amplitude, wavelength};
+  test_ccz4_solution<gr::Solutions::GaugeWave<3>>(
+      gauge_wave_solution, wrapped_gauge_wave_solution, x);
+}
+
+void test_gauge_plane_wave(const tnsr::I<DataVector, 3, Frame::Inertial>& x) {
   const auto wave_vector = std::array<double, 3>{{0.1, 0.2, 0.3}};
   const gr::Solutions::GaugePlaneWave<3> gauge_plane_wave_solution{
       wave_vector,
@@ -218,29 +257,19 @@ void test_gauge_plane_wave() {
           wave_vector,
           std::make_unique<MathFunctions::PowX<1, Frame::Inertial>>(2)};
   test_ccz4_solution<gr::Solutions::GaugePlaneWave<3>>(
-      gauge_plane_wave_solution, wrapped_gauge_plane_wave_solution);
+      gauge_plane_wave_solution, wrapped_gauge_plane_wave_solution, x);
 }
-}  // namespace
 
-// [[TimeOut, 40]]
-SPECTRE_TEST_CASE("Unit.Evolution.Systems.Ccz4.Ccz4WrappedGr",
-                  "[Evolution][Unit]") {
-  const double amplitude = 0.24;
-  const double wavelength = 4.4;
-  const gr::Solutions::GaugeWave<3> gauge_wave_solution{amplitude, wavelength};
-  const Ccz4::Solutions::Ccz4WrappedGr<gr::Solutions::GaugeWave<3>>
-      wrapped_gauge_wave_solution{amplitude, wavelength};
-  test_ccz4_solution<gr::Solutions::GaugeWave<3>>(gauge_wave_solution,
-                                                  wrapped_gauge_wave_solution);
-
-  test_gauge_plane_wave();
-
+void test_minkowski(const tnsr::I<DataVector, 3, Frame::Inertial>& x) {
   const gr::Solutions::Minkowski<3> minkowski_solution{};
   const Ccz4::Solutions::Ccz4WrappedGr<gr::Solutions::Minkowski<3>>
       wrapped_minkowski_solution{};
-  test_ccz4_solution<gr::Solutions::Minkowski<3>>(minkowski_solution,
-                                                  wrapped_minkowski_solution);
+  test_ccz4_solution<gr::Solutions::Minkowski<3>>(
+      minkowski_solution, wrapped_minkowski_solution, x);
+}
 
+void test_trumpet_schwarzschild(
+    const tnsr::I<DataVector, 3, Frame::Inertial>& x) {
   const double mass = 0.5;
   const double n = 2.5;
   const gr::Solutions::TrumpetSchwarzschild trumpet_schwarzschild_solution{mass,
@@ -248,8 +277,73 @@ SPECTRE_TEST_CASE("Unit.Evolution.Systems.Ccz4.Ccz4WrappedGr",
   const Ccz4::Solutions::Ccz4WrappedGr<gr::Solutions::TrumpetSchwarzschild>
       wrapped_trumpet_schwarzschild_solution{mass, n};
   test_ccz4_solution<gr::Solutions::TrumpetSchwarzschild>(
-      trumpet_schwarzschild_solution, wrapped_trumpet_schwarzschild_solution);
+      trumpet_schwarzschild_solution, wrapped_trumpet_schwarzschild_solution,
+      x);
 
-  test_construct_from_options<gr::Solutions::TrumpetSchwarzschild>(
-      wrapped_trumpet_schwarzschild_solution);
+  test_construct_from_options(wrapped_trumpet_schwarzschild_solution,
+                              "Mass: 0.5\n"
+                              "N: 2.5");
+}
+
+void test_high_spin_kerr_puncture(
+    const tnsr::I<DataVector, 3, Frame::Inertial>& x_outer) {
+  const double mass = 1.0;
+  const double dimensionless_spin = 0.99;
+  const gr::Solutions::HighSpinKerrPuncture solution{mass, dimensionless_spin};
+  const Ccz4::Solutions::Ccz4WrappedGr<gr::Solutions::HighSpinKerrPuncture>
+      wrapped_solution{mass, dimensionless_spin};
+
+  // The throat sits at r_+/4 = M (1 + sqrt(1 - chi^2))/4 ~ 0.2853 for
+  // chi = 0.99, M = 1. The generic points at r ~ 5.2 and 6.9 lie far
+  // outside it on the outer sheet, where the lapse is positive, so this
+  // run checks the wrapper is an exact no-op
+  test_ccz4_solution(solution, wrapped_solution, x_outer);
+
+  // Points on both sheets in a single DataVector to exercise the pointwise
+  // sign handling: the first three points lie inside the throat, the last
+  // two outside
+  const tnsr::I<DataVector, 3, Frame::Inertial> x{
+      {{DataVector{0.05, -0.1, 0.12, 2.0, -3.0},
+        DataVector{0.06, 0.15, -0.1, 1.5, 2.5},
+        DataVector{-0.04, 0.08, 0.13, -1.0, 4.0}}}};
+
+  // Guard the premise that these points actually sample a negative
+  // solution lapse inside the throat and a positive one outside
+  const auto solution_lapse = get<gr::Tags::Lapse<DataVector>>(
+      solution.variables(x, 0.0, tmpl::list<gr::Tags::Lapse<DataVector>>{}));
+  for (size_t i = 0; i < 3; ++i) {
+    CHECK(get(solution_lapse)[i] < 0.0);
+  }
+  for (size_t i = 3; i < 5; ++i) {
+    CHECK(get(solution_lapse)[i] > 0.0);
+  }
+
+  test_ccz4_solution(solution, wrapped_solution, x);
+
+  // The single-tag overload of variables() has its own body; check it
+  // also applies the lapse correction
+  const DataVector expected_abs_lapse = abs(get(solution_lapse));
+  CHECK(get(get<gr::Tags::Lapse<DataVector>>(wrapped_solution.variables(
+            x, 0.0, tmpl::list<gr::Tags::Lapse<DataVector>>{}))) ==
+        expected_abs_lapse);
+
+  test_construct_from_options(wrapped_solution,
+                              "Mass: 1.0\n"
+                              "DimensionlessSpin: 0.99");
+}
+}  // namespace
+
+// [[TimeOut, 40]]
+SPECTRE_TEST_CASE("Unit.Evolution.Systems.Ccz4.Ccz4WrappedGr",
+                  "[Evolution][Unit]") {
+  // Generic evaluation points (3,3,3) and (4,4,4) shared by all tests
+  // Individual tests may define more specific points to exercise particular
+  // features of the solution
+  const tnsr::I<DataVector, 3, Frame::Inertial> x{DataVector{3.0, 4.0}};
+
+  test_gauge_wave(x);
+  test_gauge_plane_wave(x);
+  test_minkowski(x);
+  test_trumpet_schwarzschild(x);
+  test_high_spin_kerr_puncture(x);
 }


### PR DESCRIPTION
## Proposed changes
Generalize `Ccz4WrappedGr` to handle solutions with negative lapse (such as black holes in isotropic-like coordinates). The wrapper returns the absolute value of the wrapped lapse and multiply the wrapped time and spatial derivatives of the lapse by `sgn(lapse)`.

<!--
At a high level, describe what this PR does.
-->

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent was used, have a co-author trailer of the form
      "Co-Authored-By: <agent name> <agent email>" as the last line of the
      commit, e.g. "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>".

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
