### PR TITLE
Fix handling git worktrees

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,8 +13,8 @@
   `-D CMAKE_BUILD_TYPE=Debug`. Prefer clang over gcc if both are available. More
   options in docs/Installation/BuildSystem.md.
 - In a git worktree, symlink the git-ignored CMakeUserPresets.json from the main
-  checkout and pass `-D USE_GIT_HOOKS=OFF` to CMake. Suggest adding a
-  `post-checkout` git hook in `.git/hooks` to create the symlink automatically.
+  checkout. Suggest adding a `post-checkout` git hook in `.git/hooks` to create
+  the symlink automatically.
 - Never build `all`. Build only the targets you need (find them in the closest
   CMakeLists.txt).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,9 @@
   CMakeUserPresets.json following support/Environments/, or fall back to
   `-D CMAKE_BUILD_TYPE=Debug`. Prefer clang over gcc if both are available. More
   options in docs/Installation/BuildSystem.md.
-- In a git worktree, symlink the git-ignored CMakeUserPresets.json from the main
-  checkout. Suggest adding a `post-checkout` git hook in `.git/hooks` to create
-  the symlink automatically.
+- Git worktrees work like the main checkout. If git-ignored personal files
+  (CMakeUserPresets.json, AGENTS.local.md) are missing, symlink them from the
+  main checkout; a git hook does this for new worktrees (see USE_GIT_HOOKS).
 - Never build `all`. Build only the targets you need (find them in the closest
   CMakeLists.txt).
 

--- a/cmake/SetupFormaline.cmake
+++ b/cmake/SetupFormaline.cmake
@@ -9,7 +9,6 @@ set(SPECTRE_FORMALINE_LOCATIONS
   .claude
   .clang-format
   .clang-tidy
-  .claude
   .codecov.yaml
   .codex
   .devcontainer

--- a/cmake/SetupGitHooks.cmake
+++ b/cmake/SetupGitHooks.cmake
@@ -46,5 +46,10 @@ if(USE_GIT_HOOKS AND EXISTS ${CMAKE_SOURCE_DIR}/.git)
       ${GIT_HOOKS_DIR}/CheckFileSize.py
       @ONLY
       )
+    configure_file(
+      ${CMAKE_SOURCE_DIR}/tools/Hooks/post-checkout.sh
+      ${GIT_HOOKS_DIR}/post-checkout
+      COPYONLY
+      )
   endif()
 endif()

--- a/cmake/SetupGitHooks.cmake
+++ b/cmake/SetupGitHooks.cmake
@@ -8,28 +8,42 @@ option(
   "Set up the git hooks for sanity checks."
   ON)
 
-if(USE_GIT_HOOKS)
-  # Check that the source dir is writable. If it is we set up git hooks, if not
-  # then there probably won't be any commits anyway...
-  EXECUTE_PROCESS(COMMAND test -w ${CMAKE_SOURCE_DIR}
-    RESULT_VARIABLE CHECK_SOURCE_DIR_WRITABLE_RESULT)
+if(USE_GIT_HOOKS AND EXISTS ${CMAKE_SOURCE_DIR}/.git)
+  find_package(Git)
+
+  # Hooks are shared between worktrees, so ask git for the repository dir.
+  # Not `--git-path hooks`: that follows `core.hooksPath` out of the repo.
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} rev-parse --git-common-dir
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    RESULT_VARIABLE GIT_COMMON_DIR_RESULT
+    OUTPUT_VARIABLE GIT_COMMON_DIR
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+    )
+  get_filename_component(GIT_COMMON_DIR "${GIT_COMMON_DIR}" ABSOLUTE
+    BASE_DIR ${CMAKE_SOURCE_DIR})
+
+  # Check that the repository dir is writable. If it is we set up git hooks,
+  # if not then there probably won't be any commits anyway...
+  execute_process(COMMAND test -w "${GIT_COMMON_DIR}"
+    RESULT_VARIABLE CHECK_GIT_DIR_WRITABLE_RESULT)
 
   # The logic is inverted because shell
-  if(NOT CHECK_SOURCE_DIR_WRITABLE_RESULT AND EXISTS ${CMAKE_SOURCE_DIR}/.git)
+  if(GIT_COMMON_DIR_RESULT EQUAL 0 AND NOT CHECK_GIT_DIR_WRITABLE_RESULT)
     find_package(ClangFormat)
-    find_package(Git)
+    set(GIT_HOOKS_DIR ${GIT_COMMON_DIR}/hooks)
 
     # We use several client-side git hooks to ensure commits are correct as
     # early as possible.
     configure_file(
       ${CMAKE_SOURCE_DIR}/tools/Hooks/pre-commit.sh
-      ${CMAKE_SOURCE_DIR}/.git/hooks/pre-commit
+      ${GIT_HOOKS_DIR}/pre-commit
       @ONLY
       )
-
     configure_file(
       ${CMAKE_SOURCE_DIR}/tools/Hooks/CheckFileSize.py
-      ${CMAKE_SOURCE_DIR}/.git/hooks/CheckFileSize.py
+      ${GIT_HOOKS_DIR}/CheckFileSize.py
       @ONLY
       )
   endif()

--- a/docs/Installation/BuildSystem.md
+++ b/docs/Installation/BuildSystem.md
@@ -358,7 +358,8 @@ alphabetical order):
   - Use git hooks to perform some sanity checks so that small goofs are caught
     before they are committed. These checks are particularly useful because they
     also run automatically on \ref github_actions_guide "CI" and must pass
-    before pull requests are merged.
+    before pull requests are merged. The hooks are shared between all git
+    worktrees of the repository and use the tools of the last configured build.
     (default is `ON`)
 - USE_LD
   - Override the automatically chosen linker. The options are `ld`, `gold`, and

--- a/docs/Installation/BuildSystem.md
+++ b/docs/Installation/BuildSystem.md
@@ -118,6 +118,8 @@ machine-specific configuration that supplies the compilers and dependency paths.
   the correct presets through `CMakePresets.json` in the repository root). Use
   the environment shell scripts in support/Environments/ to load
   modules and set `SPECTRE_MACHINE`.
+- **In git worktrees**, `CMakeUserPresets.json` is symlinked from the main
+  checkout by a git hook, see `USE_GIT_HOOKS` below.
 
 ## Commonly Used CMake flags {#common_cmake_flags}
 The following are common flags used to control building SpECTRE with CMake (in
@@ -360,6 +362,8 @@ alphabetical order):
     also run automatically on \ref github_actions_guide "CI" and must pass
     before pull requests are merged. The hooks are shared between all git
     worktrees of the repository and use the tools of the last configured build.
+    A `post-checkout` hook also symlinks git-ignored personal files such as
+    `CMakeUserPresets.json` from the main checkout into new worktrees.
     (default is `ON`)
 - USE_LD
   - Override the automatically chosen linker. The options are `ld`, `gold`, and

--- a/docs/Installation/Installation.md
+++ b/docs/Installation/Installation.md
@@ -384,14 +384,10 @@ To build with the Docker image:
     To add a new shell, run `docker exec -it CONTAINER_NAME /bin/bash`
     (or `docker exec -it CONTAINER_ID /bin/bash`) from
     a terminal outside the container.
-  * In step 4 above, technically docker allows you to say
-    `-v $SPECTRE_ROOT/:/my/new/path` to map `$SPECTRE_ROOT` outside the
-    container to any path you want inside the container, but **do not do this**.
-    Compiling inside the container sets up git hooks in SPECTRE_ROOT that
-    contain hardcoded pathnames to SPECTRE_ROOT *as seen from inside the
-    container*. So if your source paths inside and outside the container are
-    different, commands like `git commit` run *from outside the container* will
-    die with `No such file or directory`.
+  * Compiling inside the container sets up git hooks that contain paths to
+    tools like Python *as seen from inside the container*, so `git commit` run
+    *from outside the container* may fail with `No such file or directory`.
+    Pass `-D USE_GIT_HOOKS=OFF` to CMake to avoid this.
   * If you want to use Docker within VSCode, take a look at our
     [quick start guide](../DevGuide/QuickStartDockerVSCode.md) for using Docker
     with VSCode.

--- a/tools/CheckFiles.sh
+++ b/tools/CheckFiles.sh
@@ -212,6 +212,7 @@ fi
 # Exclude files that are generated, out of our control, etc.
 find . \
      -type f \
+     ! -path './.git' \
      ! -path './.git/*' \
      ! -path './build*' \
      ! -path './docs/*' \
@@ -224,6 +225,8 @@ find . \
      ! -name 'CircularOrbitCoeffs.cpp' \
      ! -name 'CircularOrbitConvertEffsource.cpp' \
      ! -name '*~' \
+     ! -name 'AGENTS.local.md' \
+     ! -name 'CLAUDE.local.md' \
      ! -name deploy_key.enc \
      -print0 \
         | run_checks "${standard_checks[@]}" "${ci_checks[@]}"

--- a/tools/Formaline.sh
+++ b/tools/Formaline.sh
@@ -8,7 +8,8 @@
 formaline_archive_name=spectre_$1
 formaline_dir=@CMAKE_BINARY_DIR@/tmp/
 pushd @CMAKE_SOURCE_DIR@ >/dev/null
-if [ -d "./.git" ]; then
+# .git is a file in worktrees
+if [ -e "./.git" ]; then
     git ls-tree --full-tree --name-only HEAD \
         | xargs tar -czf ${formaline_dir}/${formaline_archive_name}.tar.gz
 else

--- a/tools/Hooks/post-checkout.sh
+++ b/tools/Hooks/post-checkout.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# Distributed under the MIT License.
+# See LICENSE.txt for details.
+
+# Symlink git-ignored personal files from the main worktree into new worktrees
+
+# Nothing to do in the main worktree, where .git is a directory
+[ -d .git ] && exit 0
+
+# The main worktree is listed first
+main=$(git worktree list --porcelain | sed -n 's/^worktree //p' | head -n 1)
+
+for file in CMakeUserPresets.json AGENTS.local.md CLAUDE.local.md \
+            .claude/settings.local.json; do
+    # -e is false for dangling symlinks, which -f then replaces
+    if [ -e "$main/$file" ] && [ -d "$(dirname "$file")" ] \
+        && [ ! -e "$file" ]; then
+        ln -sf "$main/$file" "$file"
+    fi
+done

--- a/tools/Hooks/pre-commit.sh
+++ b/tools/Hooks/pre-commit.sh
@@ -3,7 +3,8 @@
 # Distributed under the MIT License.
 # See LICENSE.txt for details.
 
-. @CMAKE_SOURCE_DIR@/tools/FileTestDefs.sh
+# Git runs hooks from the top level of the worktree
+. ./tools/FileTestDefs.sh
 
 ###############################################################################
 # Get list of non-deleted file names, which we need below.
@@ -25,7 +26,7 @@ found_error=0
 
 ###############################################################################
 # Check the file size
-@Python_EXECUTABLE@ @CMAKE_SOURCE_DIR@/.git/hooks/CheckFileSize.py
+@Python_EXECUTABLE@ "$(dirname "$0")/CheckFileSize.py"
 [ "$?" -ne 0 ] && found_error=1
 
 printf '%s\0' "${commit_files[@]}" | run_checks "${standard_checks[@]}"
@@ -43,11 +44,11 @@ if [ $? -eq 0 ]; then
     if [ -n "$clang_format_diff" ] \
         && [[ "$clang_format_diff" != *"no modified files to format"* ]] \
         && [[ "$clang_format_diff" != *"did not modify any files"* ]]; then
-        echo "$clang_format_diff" > @CMAKE_SOURCE_DIR@/.clang_format_diff.patch
+        echo "$clang_format_diff" > .clang_format_diff.patch
         echo "Found C++ formatting errors."
         echo "Please run 'git clang-format' in the repository."
         echo "You can also apply the patch directly:"
-        echo "git apply @CMAKE_SOURCE_DIR@/.clang_format_diff.patch"
+        echo "git apply $PWD/.clang_format_diff.patch"
         echo ""
     fi
 fi


### PR DESCRIPTION
## Proposed changes

Fix some problems with git worktrees:
- Git hooks were broken in worktrees
- Formaline as well
- File-checks hit false positives
- Gitignored personal files didn't carry over to worktrees

### Upgrade instructions

<!--
If this PR makes changes that other people should be aware of when upgrading
their code, describe what they should do between the two UPGRADE INSTRUCTIONS
lines below.
-->
<!-- UPGRADE INSTRUCTIONS -->

<!-- UPGRADE INSTRUCTIONS -->

### Code review checklist

- [ ] The code is documented and the documentation renders correctly. Run
  `make doc` to generate the documentation locally into `BUILD_DIR/docs/html`.
  Then open `index.html`.
- [ ] The code follows the stylistic and code quality guidelines listed in the
  [code review guide](https://spectre-code.org/code_review_guide.html).
- [ ] The PR lists upgrade instructions and is labeled `bugfix` or
  `new feature` if appropriate.
- [ ] If a coding agent was used, have a co-author trailer of the form
      "Co-Authored-By: <agent name> <agent email>" as the last line of the
      commit, e.g. "Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>",
      "Co-Authored-by: Codex <noreply@openai.com>", or
      "Co-Authored-By: GitHub Copilot CLI <noreply@microsoft.com>".

### Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
